### PR TITLE
fix(prod): reduce backend startup warning noise

### DIFF
--- a/backend/src/main/java/com/example/lms/assessment/infrastructure/persistence/entity/AssignmentRubricJpaEntity.java
+++ b/backend/src/main/java/com/example/lms/assessment/infrastructure/persistence/entity/AssignmentRubricJpaEntity.java
@@ -56,6 +56,7 @@ public class AssignmentRubricJpaEntity {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @EqualsAndHashCode
     public static class RubricCriterion {
         private String name;
         private String description;
@@ -68,6 +69,7 @@ public class AssignmentRubricJpaEntity {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @EqualsAndHashCode
     public static class RubricLevel {
         private String label;
         private String description;

--- a/backend/src/main/java/com/example/lms/config/HibernateJsonConfig.java
+++ b/backend/src/main/java/com/example/lms/config/HibernateJsonConfig.java
@@ -8,7 +8,7 @@ import io.hypersistence.utils.hibernate.type.util.ObjectMapperSupplier;
 /**
  * Custom ObjectMapper supplier for Hypersistence Utils' JsonType.
  * Registers JavaTimeModule for proper Instant/LocalDateTime serialization in JSONB columns.
- * Referenced via hibernate property: hibernate.types.jackson.object.mapper
+ * Referenced via hibernate property: hypersistence.utils.jackson.object.mapper
  */
 public class HibernateJsonConfig implements ObjectMapperSupplier {
 

--- a/backend/src/main/java/com/example/lms/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/lms/config/SecurityConfig.java
@@ -12,7 +12,6 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -148,17 +147,5 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
-    }
-
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring().requestMatchers(
-            "/v3/api-docs/**",
-            "/v3/api-docs",
-            "/swagger-ui/**",
-            "/swagger-ui.html",
-            "/swagger-resources/**",
-            "/webjars/**"
-        );
     }
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -26,7 +26,6 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: false
         # Fix Hibernate 6.4 UUID array ClassCastException (HHH-17557)
         dialect.native_param_markers: false
@@ -36,7 +35,7 @@ spring:
         order_inserts: true             # Group inserts by entity type
         order_updates: true             # Group updates by entity type
         # Hypersistence Utils: Custom ObjectMapper with JavaTimeModule for JSONB
-        types.jackson.object.mapper: com.example.lms.config.HibernateJsonConfig
+        hypersistence.utils.jackson.object.mapper: com.example.lms.config.HibernateJsonConfig
     # CRITICAL: Disable Open Session In View anti-pattern
     # Reference: Netflix/Google explicitly disable this
     open-in-view: false

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -28,7 +28,6 @@ spring:
     open-in-view: false
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: false
         show_sql: false
         default_batch_fetch_size: 16

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -31,7 +31,7 @@ spring:
         format_sql: false
         dialect.native_param_markers: false
         # Hypersistence Utils: Custom ObjectMapper with JavaTimeModule for JSONB
-        types.jackson.object.mapper: com.example.lms.config.HibernateJsonConfig
+        hypersistence.utils.jackson.object.mapper: com.example.lms.config.HibernateJsonConfig
   flyway:
     enabled: true
     baseline-on-migrate: true  # Required for existing databases


### PR DESCRIPTION
## Summary
This PR removes a focused set of recurring backend startup warnings observed during the production inspection on 2026-04-21.

These warnings were non-fatal, but they materially reduce signal-to-noise in the startup log and make real regressions harder to spot during incident response.

## Production Evidence
From the latest backend startup log sample on production:
- 13x `Hibernate Types` warnings for the deprecated JSON mapper property
- 6x `Spring Security` warnings for `WebSecurityCustomizer#ignoring(...)`
- 1x Hibernate deprecation warning for explicit `PostgreSQLDialect`
- 1x Hypersistence warning for missing value-based `equals/hashCode` on rubric JSON classes

## Problem
Production log review showed repeated framework-level warnings that are safe individually but create operational noise:
- deprecated Hypersistence JSON mapper property
- deprecated explicit PostgreSQL dialect configuration
- deprecated Swagger exposure pattern through `web.ignoring()`
- missing value semantics for JSON-backed rubric objects

## Root Cause
The backend still contained a few pre-Hibernate-6.4 / pre-Spring-Security-6 configuration patterns.

Those patterns are not breaking startup today, but they are now explicitly warned by the framework stack used by this repository.

## Why This Approach
This change removes the warning sources at the configuration/entity level instead of suppressing logs.

That keeps the fix aligned with current Spring Boot 3.2 + Hibernate 6.4 expectations while preserving existing runtime behavior.

## Changes
- switch the JSON mapper property from `hibernate.types.jackson.object.mapper` to `hypersistence.utils.jackson.object.mapper`
- remove explicit `org.hibernate.dialect.PostgreSQLDialect` from dev/prod config and rely on Hibernate auto-detection
- remove `WebSecurityCustomizer#ignoring(...)` and keep Swagger/public access controlled by the existing `authorizeHttpRequests(...).requestMatchers(...).permitAll()` rules already present in `SecurityConfig`
- add value-based `equals/hashCode` for `AssignmentRubricJpaEntity.RubricCriterion` and `RubricLevel`
- update the `HibernateJsonConfig` inline reference comment to match the new property name

## Scope
In scope:
- backend startup warning cleanup
- configuration modernization with no intended API or schema change

Out of scope:
- Flyway duplicate relation/column warnings from historical migrations
- production runtime video-stack drift (`CLOUDFLARE_R2_ENABLED=false` on prod)
- `.env.prod`, secrets, or direct production configuration edits

## Risk Assessment
Risk is low.

Why:
- no database schema change
- no domain logic change
- no controller contract change
- Swagger/public endpoint exposure remains covered by the existing `permitAll()` matcher list in `SecurityConfig`
- rubric equality is tightened only for JSON value semantics, which is the behavior Hypersistence expects

## Verification
Completed:
- [x] Reviewed production backend logs before preparing the change
- [x] `cd backend && mvn -DskipTests compile -B`
- [x] Confirmed change scope is limited to 6 backend files

Recommended after merge/deploy:
- [ ] confirm the four warning categories above disappear from backend startup logs
- [ ] confirm Swagger/public endpoints still behave as before in the target environment

## Rollout
- merge PR
- deploy through the normal reviewed production workflow
- re-check backend startup logs on the next production boot

## Backout
Revert commit `cb307e97` if the deployment shows any unexpected auth/config regression.

## Notes For Reviewers
This PR intentionally does **not** claim to fix the production video-stack finding from the prod inspection.

That finding is a runtime/environment issue and should be handled separately from this code cleanup PR.
