### PR TITLE
fix(prod): harden Google login availability

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -21,9 +21,13 @@ SPRING_PROFILES_ACTIVE=prod
 # === App URLs ===
 APP_BASE_URL=https://holilihu.online
 APP_CORS_ORIGINS=https://holilihu.online
+# If false, /api/v3/auth/google/config reports Google sign-in unavailable and the login page
+# will show a fallback notice instead of a live Google button.
 GOOGLE_AUTH_ENABLED=false
+# Required whenever GOOGLE_AUTH_ENABLED=true.
 GOOGLE_WEB_CLIENT_ID=
 # === Google OAuth (server-side authorization code flow — Wiii-style redirect) ===
+# Requires GOOGLE_AUTH_ENABLED=true and GOOGLE_WEB_CLIENT_ID.
 # Required only if GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED=true.
 # Authorized redirect URI must match exactly what's registered in Google Cloud Console.
 GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED=false

--- a/backend/src/main/java/com/example/lms/identity/application/dto/DiscoverAuthOptionsResponse.java
+++ b/backend/src/main/java/com/example/lms/identity/application/dto/DiscoverAuthOptionsResponse.java
@@ -6,7 +6,8 @@ public record DiscoverAuthOptionsResponse(
         boolean accountExists,
         boolean passwordLoginAvailable,
         boolean googleSignInAvailable,
-        String nextStep
+        String nextStep,
+        String googleUnavailableMessage
 ) {
     public static DiscoverAuthOptionsResponse password(String email, String displayName) {
         return new DiscoverAuthOptionsResponse(
@@ -15,7 +16,8 @@ public record DiscoverAuthOptionsResponse(
                 true,
                 true,
                 false,
-                "PASSWORD"
+                "PASSWORD",
+                null
         );
     }
 
@@ -26,7 +28,8 @@ public record DiscoverAuthOptionsResponse(
                 true,
                 false,
                 true,
-                "GOOGLE"
+                "GOOGLE",
+                null
         );
     }
 
@@ -37,7 +40,8 @@ public record DiscoverAuthOptionsResponse(
                 false,
                 false,
                 false,
-                "REGISTER"
+                "REGISTER",
+                null
         );
     }
 }

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/web/AuthControllerV3.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/web/AuthControllerV3.java
@@ -136,6 +136,22 @@ public class AuthControllerV3 {
         DiscoverAuthOptionsResponse response = discoverAuthOptionsUseCase.execute(
                 new DiscoverAuthOptionsCommand(request.email())
         );
+
+        if ("GOOGLE".equals(response.nextStep())) {
+            GoogleAuthAvailability availability = googleAuthAvailability();
+            if (!availability.enabled()) {
+                response = new DiscoverAuthOptionsResponse(
+                        response.email(),
+                        response.displayName(),
+                        response.accountExists(),
+                        response.passwordLoginAvailable(),
+                        false,
+                        response.nextStep(),
+                        "Tài khoản này dùng Google để đăng nhập, nhưng Google sign-in hiện tạm thời chưa khả dụng. Vui lòng thử lại sau hoặc liên hệ quản trị viên."
+                );
+            }
+        }
+
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -153,16 +169,15 @@ public class AuthControllerV3 {
     @GetMapping("/google/config")
     @Operation(summary = "Lay cau hinh Google sign-in cho frontend")
     public ResponseEntity<ApiResponse<GoogleAuthConfigResponse>> getGoogleAuthConfig() {
-        boolean enabled = googleAuthEnabled
-                && googleWebClientId != null
-                && !googleWebClientId.isBlank();
+        GoogleAuthAvailability availability = googleAuthAvailability();
         // Redirect flow only advertised when fully configured — FE falls back to GSI button otherwise.
-        boolean redirectFlow = enabled && googleOAuthProperties.isFullyConfigured();
         return ResponseEntity.ok(ApiResponse.success(new GoogleAuthConfigResponse(
-                enabled,
-                enabled ? googleWebClientId : null,
-                redirectFlow,
-                redirectFlow ? "/api/v3/auth/google/authorize" : null
+                availability.enabled(),
+                availability.enabled() ? googleWebClientId : null,
+                availability.redirectFlowEnabled(),
+                availability.redirectFlowEnabled() ? "/api/v3/auth/google/authorize" : null,
+                availability.unavailableReason(),
+                availability.unavailableMessage()
         )));
     }
 
@@ -365,6 +380,43 @@ public class AuthControllerV3 {
             /** True when the server-side authorization-code flow is configured and FE should prefer it. */
             boolean redirectFlowEnabled,
             /** Path to navigate to for the redirect flow, e.g. "/api/v3/auth/google/authorize". */
-            String authorizeUrl
+            String authorizeUrl,
+            /** Stable reason code when Google auth is unavailable, e.g. GOOGLE_AUTH_DISABLED. */
+            String unavailableReason,
+            /** User-facing fallback copy for the login page when Google auth is unavailable. */
+            String unavailableMessage
+    ) {}
+
+    private GoogleAuthAvailability googleAuthAvailability() {
+        boolean hasClientId = googleWebClientId != null && !googleWebClientId.isBlank();
+        boolean enabled = googleAuthEnabled && hasClientId;
+        boolean redirectFlowEnabled = enabled && googleOAuthProperties.isFullyConfigured();
+
+        if (enabled) {
+            return new GoogleAuthAvailability(true, redirectFlowEnabled, null, null);
+        }
+
+        if (!googleAuthEnabled) {
+            return new GoogleAuthAvailability(
+                    false,
+                    false,
+                    "GOOGLE_AUTH_DISABLED",
+                    "Đăng nhập Google hiện tạm thời chưa khả dụng. Vui lòng dùng email và mật khẩu."
+            );
+        }
+
+        return new GoogleAuthAvailability(
+                false,
+                false,
+                "GOOGLE_CLIENT_ID_MISSING",
+                "Đăng nhập Google hiện chưa được cấu hình đầy đủ. Vui lòng dùng email và mật khẩu."
+        );
+    }
+
+    private record GoogleAuthAvailability(
+            boolean enabled,
+            boolean redirectFlowEnabled,
+            String unavailableReason,
+            String unavailableMessage
     ) {}
 }

--- a/backend/src/test/java/com/example/lms/identity/infrastructure/web/AuthControllerV3Test.java
+++ b/backend/src/test/java/com/example/lms/identity/infrastructure/web/AuthControllerV3Test.java
@@ -96,7 +96,9 @@ class AuthControllerV3Test {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.enabled").value(false))
-                .andExpect(jsonPath("$.data.clientId").doesNotExist());
+                .andExpect(jsonPath("$.data.clientId").doesNotExist())
+                .andExpect(jsonPath("$.data.unavailableReason").value("GOOGLE_AUTH_DISABLED"))
+                .andExpect(jsonPath("$.data.unavailableMessage").value("Đăng nhập Google hiện tạm thời chưa khả dụng. Vui lòng dùng email và mật khẩu."));
     }
 
     @Test
@@ -109,7 +111,8 @@ class AuthControllerV3Test {
                         true,
                         true,
                         false,
-                        "PASSWORD"
+                        "PASSWORD",
+                        null
                 ));
 
         mockMvc.perform(post("/api/v3/auth/lookup")
@@ -123,5 +126,33 @@ class AuthControllerV3Test {
                 .andExpect(jsonPath("$.data.nextStep").value("PASSWORD"))
                 .andExpect(jsonPath("$.data.passwordLoginAvailable").value(true))
                 .andExpect(jsonPath("$.data.googleSignInAvailable").value(false));
+    }
+
+    @Test
+    @DisplayName("lookup returns fallback message when Google account exists but Google auth is unavailable")
+    void lookupReturnsFallbackMessageForGoogleAccountWhenUnavailable() throws Exception {
+        given(discoverAuthOptionsUseCase.execute(new com.example.lms.identity.application.dto.DiscoverAuthOptionsCommand("student@maritime.edu")))
+                .willReturn(new com.example.lms.identity.application.dto.DiscoverAuthOptionsResponse(
+                        "student@maritime.edu",
+                        "Student Maritime",
+                        true,
+                        false,
+                        true,
+                        "GOOGLE",
+                        null
+                ));
+
+        mockMvc.perform(post("/api/v3/auth/lookup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"email":"student@maritime.edu"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.nextStep").value("GOOGLE"))
+                .andExpect(jsonPath("$.data.googleSignInAvailable").value(false))
+                .andExpect(jsonPath("$.data.googleUnavailableMessage").value(
+                        "Tài khoản này dùng Google để đăng nhập, nhưng Google sign-in hiện tạm thời chưa khả dụng. Vui lòng thử lại sau hoặc liên hệ quản trị viên."
+                ));
     }
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -42,6 +42,29 @@ if [ "${WIII_WEBHOOK_ENABLED:-false}" = "true" ]; then
   fi
 fi
 
+if [ "${GOOGLE_AUTH_ENABLED:-false}" = "true" ] && [ -z "${GOOGLE_WEB_CLIENT_ID:-}" ]; then
+  echo "ERROR: GOOGLE_AUTH_ENABLED=true but GOOGLE_WEB_CLIENT_ID is missing."
+  exit 1
+fi
+
+if [ "${GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED:-false}" = "true" ]; then
+  if [ "${GOOGLE_AUTH_ENABLED:-false}" != "true" ]; then
+    echo "ERROR: GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED=true requires GOOGLE_AUTH_ENABLED=true."
+    exit 1
+  fi
+
+  if [ -z "${GOOGLE_WEB_CLIENT_ID:-}" ] || [ -z "${GOOGLE_CLIENT_SECRET:-}" ] || [ -z "${GOOGLE_OAUTH_REDIRECT_URI:-}" ] || [ -z "${GOOGLE_OAUTH_FRONTEND_CALLBACK:-}" ]; then
+    echo "ERROR: GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED=true but one or more Google OAuth variables are missing."
+    exit 1
+  fi
+fi
+
+if [ "${GOOGLE_AUTH_ENABLED:-false}" != "true" ] && { [ -n "${GOOGLE_WEB_CLIENT_ID:-}" ] || [ "${GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED:-false}" = "true" ]; }; then
+  echo "WARN: Google OAuth values are present but GOOGLE_AUTH_ENABLED=false."
+  echo "      The frontend will show Google sign-in as unavailable and the authorize endpoint will stay disabled."
+  echo ""
+fi
+
 if [ "${CLOUDFLARE_R2_ENABLED:-false}" = "true" ]; then
   if [ -z "${CLOUDFLARE_R2_ACCOUNT_ID:-}" ] || [ -z "${CLOUDFLARE_R2_ACCESS_KEY:-}" ] || [ -z "${CLOUDFLARE_R2_SECRET_KEY:-}" ] || [ -z "${CLOUDFLARE_R2_BUCKET:-}" ] || [ -z "${CLOUDFLARE_R2_VIDEO_BUCKET:-}" ] || [ -z "${CLOUDFLARE_R2_PUBLIC_URL:-}" ]; then
     echo "ERROR: CLOUDFLARE_R2_ENABLED=true but one or more R2 variables are missing."

--- a/fe/src/app/core/services/auth.service.ts
+++ b/fe/src/app/core/services/auth.service.ts
@@ -47,6 +47,7 @@ export interface AuthLookupResponse {
   passwordLoginAvailable: boolean;
   googleSignInAvailable: boolean;
   nextStep: 'PASSWORD' | 'GOOGLE' | 'REGISTER';
+  googleUnavailableMessage?: string | null;
 }
 
 @Injectable({

--- a/fe/src/app/core/services/google-identity.service.ts
+++ b/fe/src/app/core/services/google-identity.service.ts
@@ -16,6 +16,10 @@ export interface GoogleAuthConfig {
   redirectFlowEnabled?: boolean;
   /** Path to navigate to for the redirect flow (e.g. "/api/v3/auth/google/authorize"). */
   authorizeUrl?: string | null;
+  /** Stable reason code when Google auth is unavailable. */
+  unavailableReason?: string | null;
+  /** User-facing fallback copy to show on the login page when Google auth is unavailable. */
+  unavailableMessage?: string | null;
 }
 
 export interface GoogleButtonExperience {
@@ -102,8 +106,22 @@ export class GoogleIdentityService {
   getConfig(): Observable<GoogleAuthConfig> {
     if (!this.googleConfig$) {
       this.googleConfig$ = this.http.get<ApiResponse<GoogleAuthConfig>>(AUTH_ENDPOINTS.GOOGLE_CONFIG).pipe(
-        map(response => response.data ?? { enabled: false, clientId: null, redirectFlowEnabled: false, authorizeUrl: null }),
-        catchError(() => of({ enabled: false, clientId: null, redirectFlowEnabled: false, authorizeUrl: null } as GoogleAuthConfig)),
+        map(response => response.data ?? {
+          enabled: false,
+          clientId: null,
+          redirectFlowEnabled: false,
+          authorizeUrl: null,
+          unavailableReason: null,
+          unavailableMessage: null
+        }),
+        catchError(() => of({
+          enabled: false,
+          clientId: null,
+          redirectFlowEnabled: false,
+          authorizeUrl: null,
+          unavailableReason: null,
+          unavailableMessage: null
+        } as GoogleAuthConfig)),
         shareReplay({ bufferSize: 1, refCount: false })
       );
     }

--- a/fe/src/app/features/auth/components/google-signin-button.component.ts
+++ b/fe/src/app/features/auth/components/google-signin-button.component.ts
@@ -21,7 +21,7 @@ type GoogleButtonSurface = 'card' | 'bare';
 @Component({
   selector: 'app-google-signin-button',
   template: `
-    <div class="google-auth-shell" [class.google-auth-shell-hidden]="!isAvailable() && !errorMessage()">
+    <div class="google-auth-shell" [class.google-auth-shell-hidden]="!isAvailable() && !noticeMessage() && !errorMessage()">
       @if (showDivider()) {
         <div class="google-divider">
           <span class="google-divider-line" aria-hidden="true"></span>
@@ -31,7 +31,8 @@ type GoogleButtonSurface = 'card' | 'bare';
       }
 
       <div class="google-surface" [class.google-surface-card]="surface() === 'card'">
-        @if (useRedirectFlow()) {
+        @if (isAvailable()) {
+          @if (useRedirectFlow()) {
           <!-- Redirect-flow mode: a normal <button> that navigates the browser to the BE
                authorize endpoint. No Google JS SDK runs in this mode — bypasses FedCM,
                popups, third-party-cookie restrictions entirely. -->
@@ -74,6 +75,13 @@ type GoogleButtonSurface = 'card' | 'bare';
             class="google-button-host"
             [class.google-button-host-disabled]="isPending() || disabled()"
           ></div>
+          }
+        } @else if (noticeMessage()) {
+          <div class="google-unavailable" role="status" aria-live="polite">
+            <p class="google-unavailable-title">Đăng nhập Google tạm thời chưa khả dụng</p>
+            <p class="google-unavailable-copy">{{ noticeMessage() }}</p>
+          </div>
+          <div #buttonContainer class="google-button-host-noop" aria-hidden="true"></div>
         }
       </div>
 
@@ -232,6 +240,30 @@ type GoogleButtonSurface = 'card' | 'bare';
       display: none;
     }
 
+    .google-unavailable {
+      display: grid;
+      gap: 6px;
+      padding: 14px 16px;
+      border: 1px solid #dbeafe;
+      border-radius: 14px;
+      background: #eff6ff;
+    }
+
+    .google-unavailable-title {
+      margin: 0;
+      color: #1d4ed8;
+      font-size: 0.88rem;
+      font-weight: 700;
+      line-height: 1.5;
+    }
+
+    .google-unavailable-copy {
+      margin: 0;
+      color: #1e3a8a;
+      font-size: 0.82rem;
+      line-height: 1.6;
+    }
+
     .google-helper {
       margin: 0;
       color: #6b7280;
@@ -280,12 +312,14 @@ export class GoogleSigninButtonComponent implements AfterViewInit {
   readonly buttonText = input<GoogleButtonText>('continue_with');
   readonly surface = input<GoogleButtonSurface>('card');
   readonly buttonWidth = input<number | string | null>(null);
+  readonly unavailableMessageOverride = input<string | null | undefined>(undefined);
   readonly authenticated = output<AuthResponse>();
   readonly authError = output<string>();
 
   protected readonly isAvailable = signal(false);
   protected readonly isPending = signal(false);
   protected readonly errorMessage = signal('');
+  protected readonly noticeMessage = signal('');
   protected readonly helperText = signal('');
   /** True when the BE advertises the server-side authorization-code flow. Drives template branching. */
   protected readonly useRedirectFlow = signal(false);
@@ -308,12 +342,26 @@ export class GoogleSigninButtonComponent implements AfterViewInit {
 
     try {
       const config = await firstValueFrom(this.googleIdentityService.getConfig());
-      if (this.destroyed || !config.enabled || !config.clientId) {
+      if (this.destroyed) {
         return;
       }
 
       this.googleConfig = config;
+      if (!config.enabled || !config.clientId) {
+        this.isAvailable.set(false);
+        this.useRedirectFlow.set(false);
+        this.helperText.set('');
+        this.noticeMessage.set(
+          this.unavailableMessageOverride()?.trim()
+            || config.unavailableMessage?.trim()
+            || 'Đăng nhập Google tạm thời chưa khả dụng. Vui lòng dùng email và mật khẩu.'
+        );
+        return;
+      }
+
+      this.noticeMessage.set('');
       this.isAvailable.set(true);
+      this.useRedirectFlow.set(false);
 
       // Prefer the server-side redirect flow when the BE advertises it. No GSI script,
       // no popup, no FedCM — just a normal navigation. Fall back to the in-page button
@@ -333,6 +381,7 @@ export class GoogleSigninButtonComponent implements AfterViewInit {
       await this.renderButton();
     } catch {
       if (!this.destroyed) {
+        this.noticeMessage.set('');
         this.errorMessage.set('Đăng nhập Google tạm thời chưa khả dụng.');
       }
     }

--- a/fe/src/app/features/auth/login/login.component.html
+++ b/fe/src/app/features/auth/login/login.component.html
@@ -777,6 +777,7 @@
                 [showHelperText]="false"
                 [surface]="'bare'"
                 [buttonText]="'signin_with'"
+                [unavailableMessageOverride]="lookupResult()?.googleUnavailableMessage"
                 (authenticated)="onGoogleAuthenticated($event)"
                 (authError)="onGoogleAuthError($event)"
               />


### PR DESCRIPTION
## Summary
This PR hardens the Google login path so production cannot silently lose the Google sign-in option without clear feedback to users or operators.

## Production Evidence
On April 21, 2026, production reported Google auth as unavailable:
- `GET https://holilihu.online/api/v3/auth/google/config` returned `enabled=false`, `clientId=null`, `redirectFlowEnabled=false`
- `GET https://holilihu.online/api/v3/auth/google/authorize` returned `503 Service Unavailable`
- The login page therefore hid the Google button completely, which made the incident look like a frontend regression even though the primary issue was runtime configuration drift

## Problem
When Google auth is disabled or incompletely configured in production, the system currently degrades poorly:
- the backend only exposes `enabled=false` with no operator-facing reason or user-facing fallback copy
- the frontend silently hides the Google sign-in entry point
- deploy validation does not fail fast when Google OAuth is partially configured
- Google-linked accounts can still be routed to the Google login step without a clear explanation when Google auth is unavailable

## Root Cause
The incident is caused by production config drift rather than a pure UI bug.
However, the codebase lacked guardrails to make that drift visible and actionable.

## Changes
### Backend contract hardening
- extend `DiscoverAuthOptionsResponse` with `googleUnavailableMessage`
- enrich `/api/v3/auth/google/config` with `unavailableReason` and `unavailableMessage`
- downgrade Google-linked lookup responses to `googleSignInAvailable=false` when Google auth is currently unavailable, while preserving the `GOOGLE` next step for correct UX context

### Frontend fallback UX
- extend FE Google auth config typing to consume availability metadata
- update `app-google-signin-button` so disabled Google auth renders a deliberate fallback notice instead of disappearing silently
- pass account-specific unavailable messaging into the dedicated Google-login step

### Deploy guardrails
- fail fast when `GOOGLE_AUTH_ENABLED=true` but `GOOGLE_WEB_CLIENT_ID` is missing
- fail fast when redirect-flow mode is enabled without the required Google OAuth variables
- warn when Google OAuth values are present but `GOOGLE_AUTH_ENABLED=false`
- document these constraints in `.env.prod.example`

## Why This Approach
This keeps the PR focused on code-level resilience:
- it does not touch `.env.prod` or secrets
- it does not claim to restore production instantly without fixing runtime config
- it improves operator feedback, user feedback, and deploy safety at the same time

## Scope
Included:
- auth contract updates
- login UX fallback
- deploy validation
- regression tests for the controller contract

Out of scope:
- changing production secrets or `.env.prod`
- re-enabling Google login on the live VM directly
- deploying or restarting containers

## Risk Assessment
Low to medium.
The PR changes auth availability metadata and login-page rendering, but it does not alter the successful Google login flow when configuration is valid.

## Verification
- [x] `mvn -Dtest=AuthControllerV3Test test`
- [x] `npm run build`
- [x] Production evidence rechecked via `/api/v3/auth/google/config` and `/api/v3/auth/google/authorize`

## Rollout
1. Review and merge this PR
2. Fix production Google auth runtime configuration on the VM / secret source
3. Re-check `GET /api/v3/auth/google/config` until it reports `enabled=true`
4. Smoke-test login page and Google redirect / sign-in flow

## Backout
Revert this PR if it causes unexpected login UX regressions. No schema or secret changes are involved.
