### PR TITLE
fix(prod): harden invalid bearer token handling

### DIFF
--- a/backend/src/main/java/com/example/lms/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/lms/config/JwtAuthenticationFilter.java
@@ -2,6 +2,8 @@ package com.example.lms.config;
 
 import com.example.lms.identity.infrastructure.security.JwtService;
 import com.example.lms.identity.infrastructure.security.UserDetailsServiceImpl;
+import com.example.lms.shared.infrastructure.web.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,9 +27,14 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final String INVALID_TOKEN_MESSAGE =
+            "Phi\u00ean \u0111\u0103ng nh\u1eadp kh\u00f4ng h\u1ee3p l\u1ec7 ho\u1eb7c \u0111\u00e3 h\u1ebft h\u1ea1n. Vui l\u00f2ng \u0111\u0103ng nh\u1eadp l\u1ea1i.";
+
     private final JwtService jwtService;
     @Lazy
     private final UserDetailsServiceImpl userDetailsService;
+    private final PublicApiEndpointMatcher publicApiEndpointMatcher;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(
@@ -35,77 +42,81 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NonNull HttpServletResponse response,
             @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
-
-        // Skip JWT filter for public endpoints
         String path = request.getRequestURI();
-        if (shouldSkipFilter(path)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+        boolean publicEndpoint = publicApiEndpointMatcher.matches(request);
 
-        final String authHeader = request.getHeader("Authorization");
-        final String jwt;
-        final String username;
-
-        // Check if Authorization header exists and starts with "Bearer "
+        String authHeader = request.getHeader("Authorization");
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        // Extract JWT token
-        jwt = authHeader.substring(7);
+        String jwt = authHeader.substring(7);
 
         try {
-            username = jwtService.extractUsername(jwt);
+            String username = jwtService.extractUsername(jwt);
 
-            // If username is extracted and no authentication is set in SecurityContext
             if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-                UserDetails userDetails = this.userDetailsService.loadUserByUsername(username);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
 
-                // Skip authentication if user account is disabled or locked
                 if (!userDetails.isEnabled() || !userDetails.isAccountNonLocked()) {
-                    log.warn("User account disabled or locked: {}", username);
-                    filterChain.doFilter(request, response);
-                    return;
-                }
-
-                // Validate token
-                if (jwtService.isTokenValid(jwt, userDetails)) {
+                    if (handleAuthenticationFailure(
+                            response,
+                            publicEndpoint,
+                            path,
+                            "User account disabled or locked: " + username
+                    )) {
+                        return;
+                    }
+                } else if (!jwtService.isTokenValid(jwt, userDetails)) {
+                    if (handleAuthenticationFailure(
+                            response,
+                            publicEndpoint,
+                            path,
+                            "JWT token failed validation checks"
+                    )) {
+                        return;
+                    }
+                } else {
                     UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
                             userDetails,
                             null,
                             userDetails.getAuthorities()
                     );
-                    authToken.setDetails(
-                            new WebAuthenticationDetailsSource().buildDetails(request)
-                    );
+                    authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                     SecurityContextHolder.getContext().setAuthentication(authToken);
                 }
             }
         } catch (io.jsonwebtoken.JwtException | UsernameNotFoundException e) {
-            log.warn("Cannot set user authentication for request {}: {}", path, e.getMessage());
+            if (handleAuthenticationFailure(response, publicEndpoint, path, e.getMessage())) {
+                return;
+            }
         }
 
         filterChain.doFilter(request, response);
     }
 
-    /**
-     * Check if the request path should skip JWT authentication
-     */
-    private boolean shouldSkipFilter(String path) {
-        return path.startsWith("/v3/api-docs") ||
-               path.startsWith("/swagger-ui") ||
-               path.startsWith("/swagger-resources") ||
-               path.startsWith("/webjars") ||
-               path.equals("/actuator/health") ||
-               path.equals("/api/v3/ai/health") ||
-               path.equals("/api/v3/ai/ping") ||
-               path.startsWith("/api/v3/integration/") ||
-               path.equals("/api/v3/categories") ||
-               path.equals("/api/v3/payments/vnpay-ipn") ||
-               path.equals("/api/v3/payments/vnpay-return") ||
-               path.startsWith("/uploads/") ||
-               path.startsWith("/ws");
+    private boolean handleAuthenticationFailure(
+            HttpServletResponse response,
+            boolean publicEndpoint,
+            String path,
+            String reason
+    ) throws IOException {
+        SecurityContextHolder.clearContext();
+
+        if (publicEndpoint) {
+            log.debug("Ignoring invalid bearer token on public request {}: {}", path, reason);
+            return false;
+        }
+
+        log.warn("Rejecting invalid bearer token on protected request {}: {}", path, reason);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(
+                response.getWriter(),
+                ApiResponse.error("INVALID_TOKEN", INVALID_TOKEN_MESSAGE)
+        );
+        return true;
     }
 }

--- a/backend/src/main/java/com/example/lms/config/PublicApiEndpointMatcher.java
+++ b/backend/src/main/java/com/example/lms/config/PublicApiEndpointMatcher.java
@@ -1,0 +1,70 @@
+package com.example.lms.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Shared registry for permit-all API routes.
+ *
+ * <p>SecurityConfig uses these matchers to define public routes, while
+ * JwtAuthenticationFilter uses the same source of truth to decide whether an
+ * invalid bearer token should downgrade to anonymous access or fail fast with 401.</p>
+ */
+@Component
+public class PublicApiEndpointMatcher {
+
+    private static final List<String> PUBLIC_ENDPOINT_PATTERNS = List.of(
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/api/v3/auth/**",
+            "/api/v3/ai/health",
+            "/api/v3/ai/ping",
+            "/api/v3/courses",
+            "/api/v3/courses/*",
+            "/api/v3/courses/*/content",
+            "/api/v3/courses/lessons/*",
+            "/api/v3/courses/chapters/*",
+            "/api/v3/categories",
+            "/api/v3/course-categories",
+            "/api/v3/course-categories/**",
+            "/api/v3/course-tags",
+            "/uploads/**",
+            "/api/v3/student/certificates/*/verify",
+            "/api/v3/certificates/verify/*",
+            "/api/v3/courses/*/reviews",
+            "/api/v3/courses/*/reviews/summary",
+            "/actuator/health",
+            "/api/v3/integration/**",
+            "/api/v3/payments/vnpay-ipn",
+            "/api/v3/payments/vnpay-return",
+            "/api/v3/payments/sepay/webhook",
+            "/api/v3/invites/validate",
+            "/api/v3/invites/validate-token",
+            "/api/v3/video-assets/*/adaptive/**",
+            "/ws/**"
+    );
+
+    private final List<RequestMatcher> requestMatchers = PUBLIC_ENDPOINT_PATTERNS.stream()
+            .<RequestMatcher>map(AntPathRequestMatcher::new)
+            .toList();
+    private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+
+    public boolean matches(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        if (path == null || path.isBlank()) {
+            return false;
+        }
+        return PUBLIC_ENDPOINT_PATTERNS.stream()
+                .anyMatch(pattern -> antPathMatcher.match(pattern, path));
+    }
+
+    public RequestMatcher[] asArray() {
+        return requestMatchers.toArray(RequestMatcher[]::new);
+    }
+}

--- a/backend/src/main/java/com/example/lms/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/lms/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.lms.config;
 
 import com.example.lms.identity.infrastructure.security.UserDetailsServiceImpl;
 import com.example.lms.learning_delivery.infrastructure.web.VideoPlaybackCacheHeaderFilter;
+import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -22,8 +23,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import jakarta.servlet.DispatcherType;
-
 import java.util.List;
 
 @Configuration
@@ -34,6 +33,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthFilter;
     private final RateLimitingFilter rateLimitingFilter;
+    private final PublicApiEndpointMatcher publicApiEndpointMatcher;
     private final UserDetailsServiceImpl userDetailsService;
     private final PasswordEncoder passwordEncoder;
     private final VideoPlaybackCacheHeaderFilter videoPlaybackCacheHeaderFilter;
@@ -44,77 +44,29 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-            .cors(org.springframework.security.config.Customizer.withDefaults())
-            .csrf(AbstractHttpConfigurer::disable)
-            .headers(headers -> headers
-                .frameOptions(frame -> frame.sameOrigin())
-                .contentTypeOptions(content -> {})
-                .httpStrictTransportSecurity(hsts -> hsts
-                    .includeSubDomains(true)
-                    .maxAgeInSeconds(31536000)
+                .cors(org.springframework.security.config.Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .headers(headers -> headers
+                        .frameOptions(frame -> frame.sameOrigin())
+                        .contentTypeOptions(content -> {})
+                        .httpStrictTransportSecurity(hsts -> hsts
+                                .includeSubDomains(true)
+                                .maxAgeInSeconds(31536000)
+                        )
+                        .contentSecurityPolicy(csp -> csp
+                                .policyDirectives("default-src 'none'; frame-ancestors 'self' http://localhost:4200 https://holilihu.online; frame-src https://wiii.holilihu.online https://www.youtube.com")
+                        )
                 )
-                .contentSecurityPolicy(csp -> csp
-                    .policyDirectives("default-src 'none'; frame-ancestors 'self' http://localhost:4200 https://holilihu.online; frame-src https://wiii.holilihu.online https://www.youtube.com")
+                .authorizeHttpRequests(auth -> auth
+                        .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
+                        .requestMatchers(publicApiEndpointMatcher.asArray()).permitAll()
+                        .anyRequest().authenticated()
                 )
-            )
-            .authorizeHttpRequests(auth -> auth
-                // Sprint 220: Permit async dispatch for SSE streaming (SecurityContext lost in virtual threads)
-                .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
-                .requestMatchers(
-                    // API Documentation
-                    "/v3/api-docs/**",
-                    "/swagger-ui/**",
-                    "/swagger-ui.html",
-                    // Auth endpoints (V3 only)
-                    "/api/v3/auth/**",
-                    // AI health endpoints
-                    "/api/v3/ai/health",
-                    "/api/v3/ai/ping",
-                    // Public course endpoints (CourseQueryControllerV3)
-                    "/api/v3/courses",
-                    "/api/v3/courses/*",
-                    "/api/v3/courses/*/content",
-                    "/api/v3/courses/lessons/*",
-                    "/api/v3/courses/chapters/*",
-                    // Categories (legacy + new hierarchical + tags)
-                    "/api/v3/categories",
-                    "/api/v3/course-categories",
-                    "/api/v3/course-categories/**",
-                    "/api/v3/course-tags",
-                    // Package endpoints now require authentication (P0-12)
-                    // Uploaded files (static resources)
-                    "/uploads/**",
-                    // Certificate verification (public)
-                    "/api/v3/student/certificates/*/verify",
-                    "/api/v3/certificates/verify/*",
-                    // Course reviews (public read)
-                    "/api/v3/courses/*/reviews",
-                    "/api/v3/courses/*/reviews/summary",
-                    // Actuator health check (Docker HEALTHCHECK)
-                    "/actuator/health",
-                    // Question bank search now requires authentication (P0-12)
-                    // Wiii AI integration (service-to-service, auth via WiiiServiceAuthFilter)
-                    "/api/v3/integration/**",
-                    // VNPay callbacks (server-to-server IPN + browser return)
-                    "/api/v3/payments/vnpay-ipn",
-                    "/api/v3/payments/vnpay-return",
-                    // SePay webhook (server-to-server, authenticated via Apikey header — NOT JWT)
-                    "/api/v3/payments/sepay/webhook",
-                    // Public invite validation (rate-limited)
-                    "/api/v3/invites/validate",
-                    "/api/v3/invites/validate-token",
-                    // Tokenized adaptive video playback validates access via playback token, not JWT auth
-                    "/api/v3/video-assets/*/adaptive/**",
-                    // WebSocket handshake (JWT validated inside STOMP interceptor)
-                    "/ws/**"
-                ).permitAll()
-                .anyRequest().authenticated()
-            )
-            .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .authenticationProvider(authenticationProvider())
-            .addFilterAfter(videoPlaybackCacheHeaderFilter, HeaderWriterFilter.class)
-            .addFilterBefore(rateLimitingFilter, UsernamePasswordAuthenticationFilter.class)
-            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authenticationProvider(authenticationProvider())
+                .addFilterAfter(videoPlaybackCacheHeaderFilter, HeaderWriterFilter.class)
+                .addFilterBefore(rateLimitingFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/test/java/com/example/lms/config/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/example/lms/config/JwtAuthenticationFilterTest.java
@@ -1,0 +1,143 @@
+package com.example.lms.config;
+
+import com.example.lms.identity.infrastructure.security.JwtService;
+import com.example.lms.identity.infrastructure.security.UserDetailsServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtAuthenticationFilter Tests")
+class JwtAuthenticationFilterTest {
+
+    private static final String INVALID_TOKEN_MESSAGE =
+            "Phi\u00ean \u0111\u0103ng nh\u1eadp kh\u00f4ng h\u1ee3p l\u1ec7 ho\u1eb7c \u0111\u00e3 h\u1ebft h\u1ea1n";
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private UserDetailsServiceImpl userDetailsService;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("invalid bearer token on protected route returns 401 and stops the chain")
+    void invalidBearerOnProtectedRouteReturns401() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(
+                jwtService,
+                userDetailsService,
+                new PublicApiEndpointMatcher(),
+                testObjectMapper()
+        );
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v3/student/courses/enrolled");
+        request.addHeader("Authorization", "Bearer invalid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+        FilterChain chain = (req, res) -> chainCalled.set(true);
+
+        given(jwtService.extractUsername("invalid-token"))
+                .willThrow(new SignatureException("JWT signature does not match locally computed signature."));
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(chainCalled.get()).isFalse();
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("INVALID_TOKEN");
+        assertThat(response.getContentAsString()).contains(INVALID_TOKEN_MESSAGE);
+    }
+
+    @Test
+    @DisplayName("invalid bearer token on public route falls back to anonymous access")
+    void invalidBearerOnPublicRouteFallsBackToAnonymous() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(
+                jwtService,
+                userDetailsService,
+                new PublicApiEndpointMatcher(),
+                testObjectMapper()
+        );
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v3/courses");
+        request.addHeader("Authorization", "Bearer invalid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+        FilterChain chain = (req, res) -> {
+            chainCalled.set(true);
+            ((MockHttpServletResponse) res).setStatus(200);
+        };
+
+        given(jwtService.extractUsername("invalid-token"))
+                .willThrow(new SignatureException("JWT signature does not match locally computed signature."));
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(chainCalled.get()).isTrue();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    @DisplayName("valid bearer token still authenticates optional-auth public routes")
+    void validBearerStillAuthenticatesPublicRoute() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(
+                jwtService,
+                userDetailsService,
+                new PublicApiEndpointMatcher(),
+                testObjectMapper()
+        );
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v3/courses/123/content");
+        request.addHeader("Authorization", "Bearer valid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicReference<Authentication> authenticationRef = new AtomicReference<>();
+        FilterChain chain = (req, res) -> {
+            authenticationRef.set(SecurityContextHolder.getContext().getAuthentication());
+            ((MockHttpServletResponse) res).setStatus(200);
+        };
+
+        UserDetails userDetails = User.withUsername("student@maritime.edu")
+                .password("ignored")
+                .authorities("ROLE_STUDENT")
+                .build();
+
+        given(jwtService.extractUsername("valid-token")).willReturn("student@maritime.edu");
+        given(userDetailsService.loadUserByUsername("student@maritime.edu")).willReturn(userDetails);
+        given(jwtService.isTokenValid("valid-token", userDetails)).willReturn(true);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(authenticationRef.get()).isNotNull();
+        assertThat(authenticationRef.get().getName()).isEqualTo("student@maritime.edu");
+    }
+
+    private ObjectMapper testObjectMapper() {
+        return JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
Hardens JWT bearer-token handling so production traffic behaves consistently across public and protected APIs.

Closes #11.

## Problem
Production backend logs show repeated invalid-JWT warnings on both public and protected routes, for example:

```text
backend-1  | 2026-04-21T13:58:49.585Z  WARN ... JwtAuthenticationFilter : Cannot set user authentication for request /api/v3/student/courses/enrolled: JWT signature does not match locally computed signature.
backend-1  | 2026-04-21T13:58:49.586Z  WARN ... JwtAuthenticationFilter : Cannot set user authentication for request /api/v3/courses: JWT signature does not match locally computed signature.
backend-1  | 2026-04-21T13:59:11.759Z  WARN ... JwtAuthenticationFilter : Cannot set user authentication for request /api/v3/gamification/notifications/unread-count: JWT signature does not match locally computed signature.
```

This creates two operational problems:
- public routes emit noisy WARN logs when clients send stale bearer tokens
- protected routes do not fail fast with a consistent `401 INVALID_TOKEN` response

## Root Cause
`SecurityConfig` and `JwtAuthenticationFilter` were maintaining separate definitions of what counts as a public endpoint. On top of that, the filter treated invalid bearer tokens as a warning-and-continue case instead of distinguishing between:
- public endpoints that should gracefully downgrade to anonymous access
- protected endpoints that should stop immediately with 401

## Fix
- Added `PublicApiEndpointMatcher` as the single source of truth for permit-all API routes.
- Updated `SecurityConfig` to consume the shared matcher registry instead of duplicating route definitions inline.
- Updated `JwtAuthenticationFilter` so:
  - invalid bearer on public routes clears auth context and continues anonymously
  - invalid bearer on protected routes returns a structured `401 INVALID_TOKEN` response
  - valid bearer tokens still authenticate optional-auth public routes
- Added focused regression tests for all three behaviors.

## Why This Approach
This keeps optional-auth UX intact on public content endpoints while reducing production log noise and making protected-route failures deterministic for clients.

## Verification
- [x] Reproduced the warning pattern from production backend logs on `2026-04-21`
- [x] `mvn -Dtest=JwtAuthenticationFilterTest,AuthControllerV3Test test`
- [x] Confirmed the new tests cover:
  - protected invalid token -> 401
  - public invalid token -> anonymous fallback
  - public valid token -> authenticated optional-auth path

## Risk Assessment
Low to medium.

The change is isolated to auth filtering and route classification. Main risk is misclassifying a route as public or protected, which is why the matcher registry is now shared between the security config and the filter.

## Out of Scope
- Rotating JWT secrets or cleaning up stale tokens on clients
- Any production config or secret changes
- Deploying directly to production