### PR TITLE
fix(deploy): force-recreate backend+frontend after GHCR pull

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,7 +162,10 @@ jobs:
           docker image prune -f 2>/dev/null || true
 
           # Deploy (no --build: uses pulled images)
-          docker compose "\${COMPOSE_ARGS[@]}" up -d --remove-orphans
+          # --force-recreate backend frontend: ensures containers restart with the new image.
+          # Without this, `up -d` may leave old containers running if Docker Compose
+          # doesn't detect the image digest change reliably.
+          docker compose "\${COMPOSE_ARGS[@]}" up -d --remove-orphans --force-recreate backend frontend
 
           # Wait for health
           echo "Waiting for backend health..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -106,7 +106,7 @@ if docker compose "${COMPOSE_ARGS[@]}" config --images 2>/dev/null | grep -q "gh
   echo "[5/7] Pulling pre-built images from GHCR..."
   docker compose "${COMPOSE_ARGS[@]}" pull backend frontend
   docker image prune -f 2>/dev/null || true
-  docker compose "${COMPOSE_ARGS[@]}" up -d --wait --remove-orphans
+  docker compose "${COMPOSE_ARGS[@]}" up -d --wait --remove-orphans --force-recreate backend frontend
 else
   echo "[5/7] Building and starting containers (no GHCR images configured)..."
   docker compose "${COMPOSE_ARGS[@]}" up -d --build --wait --remove-orphans


### PR DESCRIPTION
## Problem
Sau khi CI pull image mới từ GHCR, `docker compose up -d` không luôn recreate containers đang chạy. Docker Compose có thể bỏ qua bước restart nếu không detect được sự thay đổi image digest, dẫn đến container cũ vẫn chạy code cũ sau deploy.

Closes #13

## Root Cause
`docker compose up -d --remove-orphans` mà thiếu `--force-recreate` — Docker Compose dùng container name + config để quyết định có restart không, không phải image digest.

## Fix
Thêm `--force-recreate backend frontend` vào cả hai nơi:
- `.github/workflows/deploy.yml` — CI/CD deploy step
- `deploy.sh` — manual deploy script (đường GHCR pull)

Chỉ force-recreate `backend` và `frontend` (hai service có image thay đổi). Không động đến `db`, `caddy`, `gotenberg` — tránh unnecessary restarts.

## Verified
- [ ] Tested locally
- [ ] Checked prod logs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)