### PR TITLE
fix(csp): single CSP source-of-truth in Caddyfile; add Google domains

### DIFF
--- a/fe/nginx.conf
+++ b/fe/nginx.conf
@@ -28,7 +28,8 @@ server {
     add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://accounts.google.com https://fonts.googleapis.com; img-src 'self' data: https: http://localhost:8088 http://127.0.0.1:8088; connect-src 'self' https://accounts.google.com https://lh3.googleusercontent.com https://fonts.googleapis.com https://fonts.gstatic.com http://localhost:8088 http://127.0.0.1:8088 http://localhost:8000 http://127.0.0.1:8000 https://wiii.holilihu.online https://sandbox.vnpayment.vn https://pay.vnpay.vn https://qr.sepay.vn https://videodelivery.net wss:; media-src 'self' data: blob: https: http://localhost:8088 http://127.0.0.1:8088; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https: http://localhost:8088 http://127.0.0.1:8088 http://localhost:8000 http://127.0.0.1:8000 blob:; object-src 'none'; base-uri 'self';" always;
+    # CSP is managed exclusively by Caddy for HTTPS traffic.
+    # nginx does not add Content-Security-Policy to avoid duplicate headers.
 
     # PWA Service Worker - must always be fresh
     # NOTE: add_header in child blocks overrides parent — re-add security headers


### PR DESCRIPTION
## Problem

Mỗi HTTP response trả về **2 `Content-Security-Policy` headers** — một từ Caddy, một từ nginx. Browser nhận 2 CSP thì evaluate cả hai và áp dụng policy nghiêm ngặt hơn (intersection), không phải policy mong muốn.

Đồng thời, 3 domain cần thiết bị thiếu khỏi `connect-src`, khiến NGSW service worker không cache được Google avatar và Google Fonts.

Closes #17
Closes #20
Supersedes #18

## Root Cause

Kiến trúc: `Browser → Caddy (CSP) → nginx (CSP) → Node.js SSR` → duplicate headers.

Thêm vào đó, NGSW dùng `fetch()` API để pre-cache resources — governed by `connect-src`, không phải `img-src`/`font-src`. Các domain Google thiếu trong `connect-src`.

## Fix

| File | Thay đổi |
|------|---------|
| `Caddyfile` | Thêm 3 domain vào `connect-src`: `lh3.googleusercontent.com`, `fonts.googleapis.com`, `fonts.gstatic.com` |
| `fe/nginx.conf` | Xóa `add_header Content-Security-Policy` — Caddy là nguồn duy nhất cho CSP trong production |

## Verification
```bash
curl -sI https://holilihu.online/ | grep -c 'content-security-policy'
# Expected: 1 (chỉ từ Caddy)

curl -sI https://holilihu.online/ | grep 'content-security-policy' | grep 'lh3.googleusercontent'
# Expected: xuất hiện domain Google avatar
```

## Notes

- `fe/nginx.conf` CSP tồn tại để bảo vệ khi truy cập nginx trực tiếp (dev). Nhưng trong production tất cả traffic đi qua Caddy, nên nginx không cần (và không nên) thêm CSP lần hai.
- `clear-site-data` location block trong nginx giữ nguyên CSP riêng của nó — đây là intentional (page đặc biệt cần policy tối giản).

🤖 Generated with [Claude Code](https://claude.com/claude-code)