### PR TITLE
fix(tests): sync mocks with prod deps + ORG_ADMIN quiz ownership bypass

### DIFF
--- a/backend/src/main/java/com/example/lms/assessment/application/usecase/QuizManagementUseCase.java
+++ b/backend/src/main/java/com/example/lms/assessment/application/usecase/QuizManagementUseCase.java
@@ -170,8 +170,9 @@ public class QuizManagementUseCase {
     private void validateTeacherOwnership(Quiz quiz, UUID userId, String userRole) {
         if (userId == null || userRole == null) return; // Internal calls without user context
 
-        // ADMIN bypasses ownership
-        if ("ADMIN".equals(userRole) || "ROLE_ADMIN".equals(userRole)) {
+        // ADMIN and ORG_ADMIN bypass ownership
+        if ("ADMIN".equals(userRole) || "ROLE_ADMIN".equals(userRole)
+                || "ORG_ADMIN".equals(userRole) || "ROLE_ORG_ADMIN".equals(userRole)) {
             return;
         }
 

--- a/backend/src/test/java/com/example/lms/assessment/infrastructure/web/AssignmentSecurityTest.java
+++ b/backend/src/test/java/com/example/lms/assessment/infrastructure/web/AssignmentSecurityTest.java
@@ -1,13 +1,16 @@
 package com.example.lms.assessment.infrastructure.web;
 
 import com.example.lms.assessment.application.port.StudentAssessmentAccessPort;
+import com.example.lms.assessment.application.usecase.GradeSubmissionUseCase;
 import com.example.lms.assessment.infrastructure.persistence.entity.AssignmentJpaEntity;
 import com.example.lms.assessment.infrastructure.persistence.entity.AssignmentSubmissionJpaEntity;
 import com.example.lms.assessment.infrastructure.persistence.repository.AssignmentJpaRepository;
 import com.example.lms.assessment.infrastructure.persistence.repository.AssignmentSubmissionJpaRepository;
+import com.example.lms.assessment.infrastructure.persistence.repository.GradingAuditLogJpaRepository;
 import com.example.lms.course_authoring.infrastructure.persistence.JpaCourseRepository;
 import com.example.lms.course_authoring.infrastructure.persistence.entity.CourseJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
+import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -38,6 +41,9 @@ class AssignmentSecurityTest {
     @Mock private AssignmentSubmissionJpaRepository submissionRepository;
     @Mock private AssignmentJpaRepository assignmentRepository;
     @Mock private JpaCourseRepository courseJpaRepository;
+    @Mock private GradeSubmissionUseCase gradeSubmissionUseCase;
+    @Mock private UserJpaRepository userJpaRepository;
+    @Mock private GradingAuditLogJpaRepository gradingAuditLogRepository;
 
     @InjectMocks
     private AssignmentSubmissionControllerV3 controller;

--- a/backend/src/test/java/com/example/lms/communication/infrastructure/web/CommunicationSecurityTest.java
+++ b/backend/src/test/java/com/example/lms/communication/infrastructure/web/CommunicationSecurityTest.java
@@ -1,9 +1,15 @@
 package com.example.lms.communication.infrastructure.web;
 
+import com.example.lms.communication.application.service.MessageAuthorizationService;
+import com.example.lms.communication.application.service.WebSocketMessageService;
+import com.example.lms.communication.application.usecase.ListMessageRecipientsUseCase;
 import com.example.lms.communication.application.usecase.SendMessageUseCaseV3;
 import com.example.lms.communication.domain.model.*;
 import com.example.lms.communication.domain.repository.ConversationRepository;
 import com.example.lms.communication.domain.repository.MessageRepository;
+import com.example.lms.communication.infrastructure.persistence.repository.MessageJpaRepositoryV3;
+import com.example.lms.communication.infrastructure.persistence.repository.MessageReactionJpaRepository;
+import com.example.lms.config.WebSocketEventListener;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
 import com.example.lms.shared.infrastructure.web.ApiResponse;
@@ -32,9 +38,15 @@ import static org.mockito.Mockito.*;
 class CommunicationSecurityTest {
 
     @Mock private SendMessageUseCaseV3 sendMessageUseCase;
+    @Mock private ListMessageRecipientsUseCase listMessageRecipientsUseCase;
+    @Mock private MessageAuthorizationService messageAuthorizationService;
     @Mock private ConversationRepository conversationRepository;
     @Mock private MessageRepository messageRepository;
     @Mock private UserJpaRepository userJpaRepository;
+    @Mock private WebSocketMessageService webSocketMessageService;
+    @Mock private WebSocketEventListener webSocketEventListener;
+    @Mock private MessageReactionJpaRepository reactionRepository;
+    @Mock private MessageJpaRepositoryV3 messageJpaRepository;
 
     @InjectMocks
     private CommunicationControllerV3 controller;

--- a/backend/src/test/java/com/example/lms/course_authoring/application/usecase/ApproveCourseUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/application/usecase/ApproveCourseUseCaseTest.java
@@ -4,6 +4,7 @@ import com.example.lms.course_authoring.application.dto.CourseResponse;
 import com.example.lms.course_authoring.application.port.CoursePublicationPort;
 import com.example.lms.course_authoring.domain.model.Course;
 import com.example.lms.course_authoring.domain.repository.CourseRepository;
+import com.example.lms.course_authoring.infrastructure.persistence.repository.CourseReviewEventJpaRepository;
 import com.example.lms.shared.domain.valueobject.CourseCode;
 import com.example.lms.shared.exception.BusinessRuleException;
 import com.example.lms.shared.exception.EntityNotFoundException;
@@ -36,6 +37,9 @@ class ApproveCourseUseCaseTest {
 
     @Mock
     private CoursePublicationPort coursePublicationPort;
+
+    @Mock
+    private CourseReviewEventJpaRepository reviewEventRepository;
 
     @InjectMocks
     private ApproveCourseUseCase useCase;

--- a/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3Test.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3Test.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.http.ResponseEntity;
 
 import java.math.BigDecimal;
@@ -59,6 +61,7 @@ class AdminCoursesControllerV3Test {
 
     @Nested
     @DisplayName("Analytics - ADMIN (System-wide)")
+    @MockitoSettings(strictness = Strictness.LENIENT)
     class AnalyticsAdminTests {
 
         @BeforeEach

--- a/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/CreateLearningClassUseCaseV3Test.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/CreateLearningClassUseCaseV3Test.java
@@ -1,8 +1,10 @@
 package com.example.lms.learning_delivery.application.usecase;
 
 import com.example.lms.course_authoring.application.port.CoursePublicationPort;
+import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
 import com.example.lms.learning_delivery.domain.model.LearningClass;
 import com.example.lms.learning_delivery.domain.repository.LearningClassRepository;
+import com.example.lms.learning_delivery.infrastructure.persistence.ClassTeacherJpaRepository;
 import com.example.lms.shared.exception.BusinessRuleException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +35,12 @@ class CreateLearningClassUseCaseV3Test {
 
     @Mock
     private CoursePublicationPort coursePublicationPort;
+
+    @Mock
+    private ClassTeacherJpaRepository classTeacherJpaRepository;
+
+    @Mock
+    private UserJpaRepository userJpaRepository;
 
     @InjectMocks
     private CreateLearningClassUseCaseV3 useCase;

--- a/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/ClassControllerSecurityTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/ClassControllerSecurityTest.java
@@ -5,6 +5,7 @@ import com.example.lms.course_authoring.infrastructure.persistence.entity.Course
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
 import com.example.lms.learning_delivery.application.usecase.*;
+import com.example.lms.learning_delivery.infrastructure.persistence.ClassTeacherJpaRepository;
 import com.example.lms.learning_delivery.infrastructure.persistence.JpaEnrollmentRepository;
 import com.example.lms.learning_delivery.infrastructure.persistence.JpaLearningClassRepository;
 import com.example.lms.learning_delivery.infrastructure.persistence.entity.LearningClassJpaEntity;
@@ -47,6 +48,8 @@ class ClassControllerSecurityTest {
     @Mock private com.example.lms.course_authoring.infrastructure.persistence.repository.CoursePublicationJpaRepository coursePublicationJpaRepository;
     @Mock private UserJpaRepository userJpaRepository;
     @Mock private JpaEnrollmentRepository enrollmentJpaRepository;
+    @Mock private ManageClassTeachersUseCase manageClassTeachersUseCase;
+    @Mock private ClassTeacherJpaRepository classTeacherJpaRepository;
 
     @InjectMocks
     private ClassControllerV3 controller;


### PR DESCRIPTION
## Summary

- **5 test classes**: added missing `@Mock` fields to match `@RequiredArgsConstructor` deps added to production code (`ClassTeacherJpaRepository`, `UserJpaRepository`, `CourseReviewEventJpaRepository`, `GradeSubmissionUseCase`, `GradingAuditLogJpaRepository`, `MessageAuthorizationService`, `WebSocketMessageService`, `WebSocketEventListener`, `MessageReactionJpaRepository`, `MessageJpaRepositoryV3`). Without them, Mockito `@InjectMocks` cannot instantiate the SUT → `NullPointerException` before any test body runs.
- **`AdminCoursesControllerV3Test.AnalyticsAdminTests`**: marked `@MockitoSettings(strictness = Strictness.LENIENT)` — `@BeforeEach` stubs `sumTotalRevenue`/`sumRevenueByDateRange` which `revenueShouldHandleNullGracefully` intentionally overrides; strict stubbing flags them as unnecessary.
- **`QuizManagementUseCase.validateTeacherOwnership`**: `ORG_ADMIN` / `ROLE_ORG_ADMIN` now bypasses ownership check, matching the multi-tier admin policy enforced everywhere else in the codebase.

## Files Changed

| File | Change |
|------|--------|
| `ClassControllerSecurityTest.java` | +2 `@Mock` fields (`ManageClassTeachersUseCase`, `ClassTeacherJpaRepository`) |
| `ApproveCourseUseCaseTest.java` | +1 `@Mock` field (`CourseReviewEventJpaRepository`) |
| `CreateLearningClassUseCaseV3Test.java` | +2 `@Mock` fields (`ClassTeacherJpaRepository`, `UserJpaRepository`) |
| `CommunicationSecurityTest.java` | +6 `@Mock` fields (auth service, WS service, WS listener, reactions repo, message JPA repo, list recipients use case) |
| `AssignmentSecurityTest.java` | +3 `@Mock` fields (`GradeSubmissionUseCase`, `UserJpaRepository`, `GradingAuditLogJpaRepository`) |
| `AdminCoursesControllerV3Test.java` | `@MockitoSettings(LENIENT)` on `AnalyticsAdminTests` inner class |
| `QuizManagementUseCase.java` | ORG_ADMIN/ROLE_ORG_ADMIN bypass in `validateTeacherOwnership()` |

## Test Plan

- [ ] CI backend tests pass (target: 0 failures, was 28 failures + 11 errors)
- [ ] `QuizAttemptUseCaseTest.OwnershipValidationTests.shouldBypassForOrgAdmin` passes
- [ ] `AdminCoursesControllerV3Test.AnalyticsAdminTests.revenueShouldHandleNullGracefully` passes

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)