### PR TITLE
fix(teacher-ui): improve curriculum authoring hierarchy and return flow

### DIFF
--- a/fe/src/app/features/teacher/course-editor/components/sidebar/sidebar.component.ts
+++ b/fe/src/app/features/teacher/course-editor/components/sidebar/sidebar.component.ts
@@ -22,6 +22,7 @@ import { DialogComponent } from '../../../../../shared/components/dialog/dialog.
 import { firstValueFrom } from 'rxjs';
 import { AssignmentApi } from '../../../../../api/client/assignment.api';
 import { QuizApi } from '../../../../../api/endpoints/quiz.api';
+import { buildCurriculumLabel, stripCurriculumPrefix } from '../../utils/curriculum-labels';
 import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/lesson-readiness';
 
 @Component({
@@ -50,12 +51,12 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
     .sidebar-row {
       display: flex;
       align-items: center;
-      gap: 0.125rem;
-      padding: 0 0.5rem 0 0;
+      gap: 0.25rem;
+      padding: 0 0.375rem 0 0;
       transition: background-color 160ms ease;
     }
     .sidebar-row:hover { background: rgb(248 250 252); }
-    .sidebar-row--lesson { padding-left: 0.75rem; }
+    .sidebar-row--lesson { padding-left: 1rem; }
     .sidebar-row--selected {
       background: rgba(0, 86, 210, 0.06);
       border-left: 2px solid rgb(0 86 210);
@@ -100,10 +101,16 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
       padding: 0.375rem;
       border-radius: 0.25rem;
       color: rgb(203 213 225);
-      transition: color 160ms ease, background 160ms ease;
+      opacity: 0;
+      transition: color 160ms ease, background 160ms ease, opacity 160ms ease;
       border: none;
       background: transparent;
       cursor: pointer;
+    }
+    .group\\/ch:hover .sidebar-kebab,
+    .group\\/ls:hover .sidebar-kebab,
+    .sidebar-row--selected .sidebar-kebab {
+      opacity: 1;
     }
     .sidebar-kebab:hover {
       color: rgb(71 85 105);
@@ -129,7 +136,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
 
     /* ── Section items (Mục) — indented one level deeper than Bài ── */
     .sidebar-sections {
-      padding: 0.125rem 0.5rem 0.375rem 3.25rem;
+      padding: 0.125rem 0.5rem 0.375rem 3.9rem;
     }
     .sidebar-section-row {
       display: flex;
@@ -389,7 +396,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
 
                       <!-- Drag Preview -->
                       <div *cdkDragPreview class="bg-white shadow-lg rounded-lg px-4 py-2 border border-[#0056D2] text-sm font-medium text-slate-800 max-w-[280px] line-clamp-2 break-words">
-                        Chương {{ chapterIdx + 1 }} · {{ getChapterDisplayTitle(chapter.title, chapterIdx) }}
+                        {{ chapterLabel(chapterIdx) }} · {{ getChapterDisplayTitle(chapter.title, chapterIdx) }}
                       </div>
                       <!-- Drag Placeholder (insertion line) -->
                       <div *cdkDragPlaceholder class="h-0.5 bg-[#0056D2] rounded-full mx-2 my-1"></div>
@@ -427,7 +434,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                                          class="w-full text-sm font-semibold text-slate-800 bg-white border border-[#0056D2] rounded px-2 py-0.5 outline-none focus:ring-2 focus:ring-[#0056D2]/30"
                                          #editInput>
                               } @else {
-                                  <h4 class="text-[15px] font-semibold text-slate-800 leading-snug line-clamp-2 break-words"><span class="text-[13px] font-semibold text-[#0056D2]">Chương {{ chapterIdx + 1 }}</span> · {{ getChapterDisplayTitle(chapter.title, chapterIdx) }}</h4>
+                                  <h4 class="text-[15px] font-semibold text-slate-800 leading-snug line-clamp-2 break-words"><span class="text-[13px] font-semibold text-[#0056D2]">{{ chapterLabel(chapterIdx) }}</span> · {{ getChapterDisplayTitle(chapter.title, chapterIdx) }}</h4>
                               }
                           </div>
 
@@ -515,7 +522,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
 
                                       <!-- Drag Preview -->
                                       <div *cdkDragPreview class="bg-white shadow-lg rounded-lg px-4 py-2 border border-[#0056D2] text-xs font-medium text-slate-700 max-w-[260px] line-clamp-2 break-words">
-                                        Bài {{ chapterIdx + 1 }}.{{ lessonIdx + 1 }} · {{ getLessonDisplayTitle(lesson.title, lessonIdx) }}
+                                        {{ lessonLabel(lessonIdx) }} · {{ getLessonDisplayTitle(lesson.title, lessonIdx) }}
                                       </div>
                                       <!-- Drag Placeholder (insertion line) -->
                                       <div *cdkDragPlaceholder class="h-0.5 bg-[#0056D2] rounded-full mx-2 my-1"></div>
@@ -553,7 +560,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                                                        class="w-full text-[13px] font-medium text-slate-700 bg-white border border-[#0056D2] rounded px-2 py-0.5 outline-none focus:ring-2 focus:ring-[#0056D2]/30"
                                                        #editInput>
                                             } @else {
-                                                <p class="text-sm font-medium text-slate-600 leading-snug line-clamp-2 break-words group-hover/ls:text-slate-900"><span class="text-xs font-semibold text-[#0056D2]">Bài {{ chapterIdx + 1 }}.{{ lessonIdx + 1 }}</span> {{ getLessonDisplayTitle(lesson.title, lessonIdx) }} <span class="inline-block w-1.5 h-1.5 rounded-full align-middle ml-1" [style.background]="getLessonReadinessColor(lesson)"></span></p>
+                                                <p class="text-sm font-medium text-slate-600 leading-snug line-clamp-2 break-words group-hover/ls:text-slate-900"><span class="text-xs font-semibold text-[#0056D2]">{{ lessonLabel(lessonIdx) }}</span> {{ getLessonDisplayTitle(lesson.title, lessonIdx) }} <span class="inline-block w-1.5 h-1.5 rounded-full align-middle ml-1" [style.background]="getLessonReadinessColor(lesson)"></span></p>
                                             }
                                           </div>
 
@@ -617,13 +624,13 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                                       </div>
 
                                       <!-- SECTIONS (L3) — clean list, click to select -->
-                                      @if (isLessonExpanded(lesson.id) && lesson.sections?.length) {
+                                      @if (isLessonExpanded(lesson.id) && lesson.sections.length) {
                                         <div class="sidebar-sections">
                                           @for (section of lesson.sections; track section.id; let secIdx = $index) {
                                             <button class="sidebar-section-row"
                                                  [class.sidebar-section-row--selected]="selectedSectionId() === section.id"
                                                  (click)="selectSection(chapter, lesson, section); $event.stopPropagation()">
-                                              <span class="sidebar-section-row__num">{{ chapterIdx + 1 }}.{{ lessonIdx + 1 }}.{{ secIdx + 1 }}</span>
+                                              <span class="sidebar-section-row__num">{{ sectionLabel(secIdx) }}</span>
                                               <span class="sidebar-section-row__title">{{ getSectionDisplayTitle(section.title) }}</span>
                                               <span class="sidebar-section-row__type">{{ section.type === 'TEXT' ? 'văn bản' : section.type === 'VIDEO' ? 'video' : section.type === 'FILE' ? 'tệp' : section.type === 'QUIZ' ? 'trắc nghiệm' : section.type }}</span>
                                             </button>
@@ -1398,42 +1405,31 @@ export class CourseEditorSidebarComponent implements OnDestroy {
     return CONTENT_TYPE_CONFIG[key]?.color || 'bg-slate-300';
   }
 
+  chapterLabel(index: number): string {
+    return buildCurriculumLabel('chapter', index);
+  }
+
+  lessonLabel(index: number): string {
+    return buildCurriculumLabel('lesson', index);
+  }
+
+  sectionLabel(index: number): string {
+    return buildCurriculumLabel('section', index);
+  }
+
   // Helper to strip chapter prefix if already present in title
-  getChapterDisplayTitle(title: string, index: number): string {
-    // If title already starts with "Chương X:" or "Chương X.", strip it to avoid duplication
-    // Match patterns like "Chương 1:", "Chương 1.", "CHƯƠNG 1:" etc.
-    const chapterPattern = /^chương\s+\d+[.:.]/i;
-    if (chapterPattern.test(title)) {
-      // Find where the prefix ends and return the rest
-      const match = title.match(/^chương\s+\d+[.:.]\s*/i);
-      if (match) {
-        return title.slice(match[0].length).trim();
-      }
-    }
-    return title;
+  getChapterDisplayTitle(title: string, _index: number): string {
+    return stripCurriculumPrefix(title, 'chapter');
   }
 
   // Helper to strip section prefix (e.g. "1.2: ", "2.1: ", "2.1:") from title
   getSectionDisplayTitle(title: string): string {
-    const sectionPattern = /^\d+\.\d+[.:.]\s*/;
-    const match = title.match(sectionPattern);
-    if (!match) return title;
-    const stripped = title.slice(match[0].length).trim();
-    return stripped || 'Chưa đặt tên';
+    return stripCurriculumPrefix(title, 'section');
   }
 
   // Helper to strip lesson prefix if already present in title
-  getLessonDisplayTitle(title: string, index: number): string {
-    // If title already starts with "Bài X:" or "Bài X.", strip it to avoid duplication
-    // Match patterns like "Bài 1:", "Bài 1.", "BÀI 1:" etc.
-    const lessonPattern = /^bài\s+\d+[.:.]/i;
-    if (lessonPattern.test(title)) {
-      const match = title.match(/^bài\s+\d+[.:.]\s*/i);
-      if (match) {
-        return title.slice(match[0].length).trim();
-      }
-    }
-    return title;
+  getLessonDisplayTitle(title: string, _index: number): string {
+    return stripCurriculumPrefix(title, 'lesson');
   }
 
   private autoCollapseSidebarOnMobile(): void {

--- a/fe/src/app/features/teacher/course-editor/layouts/course-editor-layout/course-editor-layout.component.scss
+++ b/fe/src/app/features/teacher/course-editor/layouts/course-editor-layout/course-editor-layout.component.scss
@@ -1,13 +1,13 @@
 :host {
   display: block;
   min-height: 100%;
-  --editor-sidebar-width: 280px;
+  --editor-sidebar-width: clamp(14rem, 19vw, 16rem);
   --editor-nav-padding: 1.5rem;
 }
 
 @media (min-width: 1280px) {
   :host {
-    --editor-sidebar-width: 360px;
+    --editor-sidebar-width: clamp(15rem, 21vw, 17.5rem);
   }
 }
 
@@ -18,7 +18,7 @@
   top: 48px; // header height (h-12)
   left: 0;
   bottom: 0;
-  width: 300px;
+  width: min(280px, calc(100vw - 24px));
   overflow: hidden;
   background: white;
   border-right: 1px solid rgb(226 232 240);

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/chapter-editor/chapter-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/chapter-editor/chapter-editor.component.ts
@@ -1,7 +1,6 @@
 import {
   Component,
   ChangeDetectionStrategy,
-  inject,
   input,
   output,
   signal,
@@ -10,9 +9,10 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ChapterDraftDTO, LessonDraftDTO } from '../../../../services/course-authoring.service';
+import { buildCurriculumLabel, stripCurriculumPrefix } from '../../../../utils/curriculum-labels';
 
 /**
- * Chapter Editor — focused component for editing a single chapter.
+ * Chapter Editor - focused component for editing a single chapter.
  *
  * Responsibilities:
  * - Chapter title + description form
@@ -28,98 +28,116 @@ import { ChapterDraftDTO, LessonDraftDTO } from '../../../../services/course-aut
   imports: [FormsModule],
   template: `
     <div class="chapter-workspace">
-      <!-- Breadcrumb -->
-      <p class="chapter-breadcrumb"><span class="chapter-breadcrumb__type">Chương</span> · {{ title() || 'Chưa đặt tên' }}</p>
+      <p class="chapter-breadcrumb">
+        <span class="chapter-breadcrumb__type">{{ chapterLabel() || 'Chương' }}</span>
+        ·
+        {{ title() || 'Chưa đặt tên' }}
+      </p>
 
-      <!-- Tên chương -->
       <div class="editor-field">
-          <label for="chapter-title" class="editor-label">
-            Tên chương <span class="editor-field-error">*</span>
-          </label>
-          <input id="chapter-title" type="text"
-            [ngModel]="title()"
-            (ngModelChange)="onTitleChange($event)"
-            class="editor-input"
-            placeholder="Nhập tên chương..." />
+        <label for="chapter-title" class="editor-label">
+          Tên chương <span class="editor-field-error">*</span>
+        </label>
+        <input
+          id="chapter-title"
+          type="text"
+          [ngModel]="title()"
+          (ngModelChange)="onTitleChange($event)"
+          class="editor-input"
+          placeholder="Nhập tên chương..."
+        />
+      </div>
+
+      <div class="editor-field">
+        <label for="chapter-desc" class="editor-label">Mô tả</label>
+        <textarea
+          id="chapter-desc"
+          [ngModel]="description()"
+          (ngModelChange)="onDescriptionChange($event)"
+          rows="3"
+          class="editor-textarea"
+          placeholder="Mô tả ngắn về nội dung chương..."
+        ></textarea>
+      </div>
+
+      <div
+        class="editor-field"
+        style="padding-top: 0.5rem; border-top: 1px solid var(--editor-card-header-border, rgb(226 232 240))"
+      >
+        <div style="display: flex; justify-content: space-between; align-items: center">
+          <label class="editor-label">Bài học ({{ lessons().length }})</label>
+          @if (lessons().length > 0) {
+            <button type="button" (click)="addLesson.emit()" class="add-lesson-header-btn">
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+              </svg>
+              Thêm bài học
+            </button>
+          }
         </div>
 
-        <!-- Description -->
-        <div class="editor-field">
-          <label for="chapter-desc" class="editor-label">Mô tả</label>
-          <textarea id="chapter-desc"
-            [ngModel]="description()"
-            (ngModelChange)="onDescriptionChange($event)"
-            rows="3"
-            class="editor-textarea"
-            placeholder="Mô tả ngắn về nội dung chương..."></textarea>
-        </div>
-
-        <!-- Lesson list -->
-        <div class="editor-field" style="padding-top: 0.5rem; border-top: 1px solid var(--editor-card-header-border, rgb(226 232 240))">
-          <div style="display: flex; justify-content: space-between; align-items: center">
-            <label class="editor-label">Bài học ({{ lessons().length }})</label>
-            @if (lessons().length > 0) {
-              <button type="button" (click)="addLesson.emit()" class="add-lesson-header-btn">
-                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+        @if (lessons().length > 0) {
+          <div class="editor-stack" style="gap: 0.375rem">
+            @for (lesson of lessons(); track lesson.id; let i = $index) {
+              <button type="button" (click)="lessonClicked.emit(lesson)" class="chapter-lesson-row">
+                <span
+                  class="chapter-lesson-row__dot"
+                  [class.chapter-lesson-row__dot--ready]="lesson.sections.length > 0"
+                ></span>
+                <span class="chapter-lesson-row__title">
+                  <span style="color: rgb(148 163 184); font-size: 0.6875rem; font-weight: 600">
+                    {{ lessonLabel(i) }}
+                  </span>
+                  {{ stripLessonPrefix(lesson.title) }}
+                </span>
+                <span class="chapter-lesson-row__meta">{{ lessonsSectionCount(lesson) }} mục</span>
+                <svg class="chapter-lesson-row__arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
                 </svg>
-                Thêm bài học
               </button>
             }
           </div>
-
-          @if (lessons().length > 0) {
-            <div class="editor-stack" style="gap: 0.375rem">
-              @for (lesson of lessons(); track lesson.id; let i = $index) {
-                <button type="button"
-                  (click)="lessonClicked.emit(lesson)"
-                  class="chapter-lesson-row">
-                  <span class="chapter-lesson-row__dot" [class.chapter-lesson-row__dot--ready]="(lesson.sections?.length || 0) > 0"></span>
-                  <span class="chapter-lesson-row__title">
-                    <span style="color: rgb(148 163 184); font-size: 0.6875rem; font-weight: 600">Bài {{ i + 1 }}</span>
-                    {{ stripLessonPrefix(lesson.title) }}
-                  </span>
-                  <span class="chapter-lesson-row__meta">{{ lesson.sections?.length || 0 }} mục</span>
-                  <svg class="chapter-lesson-row__arrow" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/>
-                  </svg>
-                </button>
-              }
-            </div>
-          } @else {
-            <div class="editor-empty-state" style="padding: 1.5rem; text-align: center">
-              <p style="font-size: 0.8125rem; color: rgb(100 116 139); margin-bottom: 0.75rem">Chưa có bài học trong chương này</p>
-              <button type="button" (click)="addLesson.emit()" class="editor-primary-button" style="font-size: 0.8125rem">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
-                </svg>
-                Thêm bài học đầu tiên
-              </button>
-            </div>
-          }
-        </div>
-
-        <!-- Lưu -->
-        <div class="chapter-footer">
-          @if (isDirty()) {
-            <span class="unsaved-hint">
-              <span class="unsaved-hint__dot"></span>
-              Có thay đổi chưa lưu
-            </span>
-          }
-          <button type="button"
-            (click)="saveClicked.emit()"
-            [disabled]="isSaving() || !title().trim()"
-            class="editor-primary-button">
-            @if (isSaving()) {
-              <svg class="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        } @else {
+          <div class="editor-empty-state" style="padding: 1.5rem; text-align: center">
+            <p style="font-size: 0.8125rem; color: rgb(100 116 139); margin-bottom: 0.75rem">
+              Chưa có bài học trong chương này
+            </p>
+            <button type="button" (click)="addLesson.emit()" class="editor-primary-button" style="font-size: 0.8125rem">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
               </svg>
-            }
-            Lưu thay đổi
-          </button>
-        </div>
+              Thêm bài học đầu tiên
+            </button>
+          </div>
+        }
+      </div>
+
+      <div class="chapter-footer">
+        @if (isDirty()) {
+          <span class="unsaved-hint">
+            <span class="unsaved-hint__dot"></span>
+            Có thay đổi chưa lưu
+          </span>
+        }
+        <button
+          type="button"
+          (click)="saveClicked.emit()"
+          [disabled]="isSaving() || !title().trim()"
+          class="editor-primary-button"
+        >
+          @if (isSaving()) {
+            <svg class="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              ></path>
+            </svg>
+          }
+          Lưu thay đổi
+        </button>
+      </div>
     </div>
   `,
   styles: [`
@@ -181,8 +199,6 @@ import { ChapterDraftDTO, LessonDraftDTO } from '../../../../services/course-aut
       border-top: 1px solid rgb(226 232 240);
       margin-top: auto;
     }
-    @import '../../../course-info/editor-shared';
-
     .chapter-lesson-row {
       display: flex;
       align-items: center;
@@ -243,33 +259,28 @@ import { ChapterDraftDTO, LessonDraftDTO } from '../../../../services/course-aut
   `],
 })
 export class ChapterEditorComponent {
-  // Inputs
   readonly isLoading = input(false);
   readonly chapter = input.required<ChapterDraftDTO>();
+  readonly chapterLabel = input('');
   readonly isSaving = input(false);
   readonly isDirty = input(false);
 
-  // Outputs
   readonly titleChange = output<string>();
   readonly descriptionChange = output<string>();
   readonly saveClicked = output<void>();
   readonly lessonClicked = output<LessonDraftDTO>();
   readonly addLesson = output<void>();
 
-  // Local form state derived from chapter input
   readonly title = signal('');
   readonly description = signal('');
 
   readonly lessons = computed(() => this.chapter().lessons || []);
 
   constructor() {
-    // Sync form when chapter input changes (new selection)
-    // Strip legacy "Chương N:" prefix to avoid user confusion
-    // (sidebar auto-numbers chapters by position)
     effect(() => {
-      const ch = this.chapter();
-      this.title.set(this.stripChapterPrefix(ch.title || ''));
-      this.description.set(ch.description || '');
+      const chapter = this.chapter();
+      this.title.set(this.stripChapterPrefix(chapter.title || ''));
+      this.description.set(chapter.description || '');
     });
   }
 
@@ -283,33 +294,19 @@ export class ChapterEditorComponent {
     this.descriptionChange.emit(value);
   }
 
-  getLessonTypeLabel(lesson: LessonDraftDTO): string {
-    const type = (lesson.type || 'LECTURE').toUpperCase();
-    switch (type) {
-      case 'QUIZ': return 'Trắc nghiệm';
-      case 'ASSIGNMENT': return 'Bài tập';
-      default: return 'Bài giảng';
-    }
+  lessonsSectionCount(lesson: LessonDraftDTO): number {
+    return lesson.sections?.length || 0;
   }
 
   stripChapterPrefix(title: string): string {
-    const pattern = /^chương\s+\d+[.:.]\s*/i;
-    const match = title.match(pattern);
-    return match ? title.slice(match[0].length).trim() : title;
+    return stripCurriculumPrefix(title, 'chapter');
   }
 
   stripLessonPrefix(title: string): string {
-    const pattern = /^bài\s+\d+[.:.]\s*/i;
-    const match = title.match(pattern);
-    return match ? title.slice(match[0].length).trim() : title;
+    return stripCurriculumPrefix(title, 'lesson');
   }
 
-  getLessonTypeBadgeClass(lesson: LessonDraftDTO): string {
-    const type = (lesson.type || 'LECTURE').toUpperCase();
-    switch (type) {
-      case 'QUIZ': return 'bg-purple-100 text-purple-700';
-      case 'ASSIGNMENT': return 'bg-green-100 text-green-700';
-      default: return 'bg-[#0056D2]/10 text-[#004BB5]';
-    }
+  lessonLabel(index: number): string {
+    return buildCurriculumLabel('lesson', index);
   }
 }

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lecture-sections-panel/lecture-sections-panel.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lecture-sections-panel/lecture-sections-panel.component.html
@@ -1,8 +1,6 @@
-<!-- Section list header -->
 <div class="sections-header">
   <label class="editor-label">Nội dung ({{ sections().length }} mục)</label>
 
-  <!-- P1: Single dropdown instead of 4 buttons -->
   <div class="add-content-wrapper">
     <button type="button" class="add-content-btn" (click)="toggleDropdown()">
       <lucide-icon name="plus" [size]="14"></lucide-icon>
@@ -21,6 +19,7 @@
             <span class="add-content-option__hint">Nội dung văn bản, hình ảnh</span>
           </div>
         </button>
+
         <button type="button" class="add-content-option" (click)="onCreateSection('VIDEO')">
           <div class="add-content-option__icon" style="background: rgba(0, 86, 210, 0.08)">
             <lucide-icon name="play-circle" [size]="14" style="color: rgb(0 86 210)"></lucide-icon>
@@ -30,6 +29,7 @@
             <span class="add-content-option__hint">Tải lên video bài giảng</span>
           </div>
         </button>
+
         <button type="button" class="add-content-option" (click)="onCreateSection('FILE')">
           <div class="add-content-option__icon" style="background: rgba(245, 158, 11, 0.08)">
             <lucide-icon name="file-text" [size]="14" style="color: rgb(180 83 9)"></lucide-icon>
@@ -39,6 +39,7 @@
             <span class="add-content-option__hint">PDF, Word, Excel, PowerPoint</span>
           </div>
         </button>
+
         <button type="button" class="add-content-option" (click)="onCreateSection('QUIZ')">
           <div class="add-content-option__icon" style="background: rgba(139, 92, 246, 0.08)">
             <lucide-icon name="help-circle" [size]="14" style="color: rgb(109 40 217)"></lucide-icon>
@@ -53,33 +54,35 @@
   </div>
 </div>
 
-<!-- Section list -->
 @if (sections().length === 0) {
   <div class="sections-empty">
     <p style="font-size: 0.8125rem; font-weight: 500; color: rgb(100 116 139); margin-bottom: 0.25rem">Chưa có nội dung</p>
     <p style="font-size: 0.75rem; color: rgb(148 163 184)">Nhấn "Thêm nội dung" để bắt đầu soạn bài học</p>
   </div>
 } @else {
-  <div class="sections-list"
-       cdkDropList cdkDropListLockAxis="y"
-       [cdkDropListData]="sections()"
-       (cdkDropListDropped)="onDropSection($event)">
-    @for (section of sections(); track section.id) {
-      <div class="section-row"
-           [class.section-row--active]="activeSectionId() === section.id"
-           (click)="onEditSection(section)" cdkDrag>
-        <!-- Drag handle -->
+  <div
+    class="sections-list"
+    cdkDropList
+    cdkDropListLockAxis="y"
+    [cdkDropListData]="sections()"
+    (cdkDropListDropped)="onDropSection($event)"
+  >
+    @for (section of sections(); track section.id; let idx = $index) {
+      <div class="section-row" [class.section-row--active]="activeSectionId() === section.id" (click)="onEditSection(section)" cdkDrag>
         <div class="section-row__handle" cdkDragHandle>
           <lucide-icon name="grip-vertical" [size]="14"></lucide-icon>
         </div>
 
-        <!-- Content with preview -->
         <div class="section-row__content">
-          <!-- Top line: status dot + title + badges -->
           <div class="section-row__top">
-            <span class="section-row__status"
-                  [style.background]="hasContent(section) ? 'rgb(16 185 129)' : 'rgb(203 213 225)'"></span>
-            <span class="section-row__title">{{ stripSectionPrefix(section.title) }}</span>
+            <span
+              class="section-row__status"
+              [style.background]="hasContent(section) ? 'rgb(16 185 129)' : 'rgb(203 213 225)'"
+            ></span>
+            <span class="section-row__title">
+              <span class="section-row__label">{{ sectionLabel(idx) }}</span>
+              {{ stripSectionPrefix(section.title) }}
+            </span>
             <div class="section-row__meta">
               <span class="section-row__type">{{ getSectionTypeLabel(section.type) }}</span>
               @if (section.isRequired) {
@@ -87,15 +90,15 @@
               }
             </div>
           </div>
-          <!-- Bottom line: content snippet -->
           <span class="section-row__snippet">{{ getSectionSnippet(section) }}</span>
         </div>
 
-        <!-- Delete -->
-        <button type="button"
+        <button
+          type="button"
           (click)="onDeleteSection(section.id, $event)"
           class="section-row__delete"
-          aria-label="Xóa">
+          aria-label="Xóa"
+        >
           <lucide-icon name="trash-2" [size]="14"></lucide-icon>
         </button>
       </div>

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lecture-sections-panel/lecture-sections-panel.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lecture-sections-panel/lecture-sections-panel.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, input, output, signal, ElementRef, 
 import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
 import { LucideAngularModule } from 'lucide-angular';
 import { SectionDraftDTO } from '../../../../services/course-authoring.service';
+import { buildCurriculumLabel, stripCurriculumPrefix } from '../../../../utils/curriculum-labels';
 
 type SectionEditorType = 'TEXT' | 'VIDEO' | 'FILE' | 'QUIZ';
 
@@ -28,7 +29,6 @@ type SectionEditorType = 'TEXT' | 'VIDEO' | 'FILE' | 'QUIZ';
       margin-bottom: 0.625rem;
     }
 
-    /* ── P1: Add content dropdown ── */
     .add-content-wrapper { position: relative; }
     .add-content-btn {
       display: inline-flex;
@@ -116,7 +116,6 @@ type SectionEditorType = 'TEXT' | 'VIDEO' | 'FILE' | 'QUIZ';
       gap: 0.375rem;
     }
 
-    /* ── P0: Redesigned section rows with preview ── */
     .section-row {
       display: flex;
       align-items: flex-start;
@@ -171,6 +170,12 @@ type SectionEditorType = 'TEXT' | 'VIDEO' | 'FILE' | 'QUIZ';
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+    .section-row__label {
+      color: rgb(148 163 184);
+      font-size: 0.6875rem;
+      font-weight: 600;
+      margin-right: 0.375rem;
+    }
     .section-row__meta {
       display: flex;
       gap: 0.375rem;
@@ -218,7 +223,6 @@ type SectionEditorType = 'TEXT' | 'VIDEO' | 'FILE' | 'QUIZ';
       background: rgb(254 242 242);
     }
 
-    /* CDK Drag */
     .cdk-drag-preview {
       box-shadow: 0 4px 16px rgba(15, 23, 42, 0.12);
       border-radius: var(--editor-control-radius);
@@ -239,11 +243,10 @@ export class LectureSectionsPanelComponent {
   deleteSection = output<string>();
   dropSection = output<CdkDragDrop<SectionDraftDTO[]>>();
 
-  // P1: Dropdown state
   isDropdownOpen = signal(false);
 
   toggleDropdown(): void {
-    this.isDropdownOpen.update(v => !v);
+    this.isDropdownOpen.update(value => !value);
   }
 
   onDocumentClick(event: Event): void {
@@ -282,11 +285,11 @@ export class LectureSectionsPanelComponent {
   }
 
   stripSectionPrefix(title: string): string {
-    const pattern = /^\d+\.\d+[.:.]\s*/;
-    const match = title.match(pattern);
-    if (!match) return title;
-    const stripped = title.slice(match[0].length).trim();
-    return stripped || 'Chưa đặt tên';
+    return stripCurriculumPrefix(title, 'section');
+  }
+
+  sectionLabel(index: number): string {
+    return buildCurriculumLabel('section', index);
   }
 
   getSectionTypeLabel(type: string): string {
@@ -299,7 +302,6 @@ export class LectureSectionsPanelComponent {
     }
   }
 
-  // P0: Content preview snippet
   getSectionSnippet(section: SectionDraftDTO): string {
     switch (section.type) {
       case 'TEXT':
@@ -320,18 +322,18 @@ export class LectureSectionsPanelComponent {
           return name.length > 60 ? name.slice(0, 57) + '...' : name;
         }
         return 'Chưa có tài liệu';
-      case 'QUIZ':
-        const qd = section.quizData;
-        if (qd?.questions?.length) {
-          return `${qd.questions.length} câu hỏi`;
+      case 'QUIZ': {
+        const quizData = section.quizData;
+        if (quizData?.questions?.length) {
+          return `${quizData.questions.length} câu hỏi`;
         }
         return 'Chưa có câu hỏi';
+      }
       default:
         return '';
     }
   }
 
-  // P0: Status — has content or not
   hasContent(section: SectionDraftDTO): boolean {
     switch (section.type) {
       case 'TEXT': return !!section.content?.trim();
@@ -346,5 +348,4 @@ export class LectureSectionsPanelComponent {
     const tmp = html.replace(/<[^>]*>/g, ' ').replace(/&nbsp;/g, ' ');
     return tmp.replace(/\s+/g, ' ').trim();
   }
-
 }

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lesson-editor/lesson-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lesson-editor/lesson-editor.component.ts
@@ -1,12 +1,12 @@
 import {
   Component,
   ChangeDetectionStrategy,
-  inject,
   input,
   output,
   signal,
   computed,
   effect,
+  inject,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { LessonDraftDTO, SectionDraftDTO } from '../../../../services/course-authoring.service';
@@ -17,9 +17,10 @@ import { CurriculumAssignmentDetailsComponent } from '../curriculum-assignment-d
 import { CurriculumQuizManagerComponent } from '../curriculum-quiz-manager/curriculum-quiz-manager.component';
 import { SectionEditorComponent } from '../section-editor/section-editor.component';
 import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
+import { stripCurriculumPrefix } from '../../../../utils/curriculum-labels';
 
 /**
- * Lesson Editor — focused component for editing a single lesson.
+ * Lesson Editor - focused component for editing a single lesson.
  *
  * Routes content by lesson type:
  * - LECTURE: sections panel + inline section-editor
@@ -104,143 +105,159 @@ import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
   `],
   template: `
     <div class="lesson-workspace">
-      <!-- Breadcrumb -->
       <div class="lesson-breadcrumb">
-        @if (chapterTitle()) {
+        @if (chapterTitle() || chapterLabel()) {
           <button type="button" class="lesson-breadcrumb__back" (click)="backClicked.emit()">
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
             </svg>
-            {{ chapterTitle() }}
+            {{ chapterLabel() || chapterTitle() }}
           </button>
           <span class="lesson-breadcrumb__sep">›</span>
         }
-        <span class="lesson-breadcrumb__type">{{ getTypeLabel() }}</span>
+        <span class="lesson-breadcrumb__type">{{ lessonLabel() || 'Bài học' }}</span>
+        <span class="lesson-breadcrumb__sep">·</span>
+        <span>{{ getTypeLabel() }}</span>
       </div>
 
-      <!-- Tiêu đề -->
       <div class="editor-field">
         <label for="lesson-title" class="editor-label">
           Tiêu đề <span class="editor-field-error">*</span>
         </label>
-        <input id="lesson-title" type="text"
+        <input
+          id="lesson-title"
+          type="text"
           [value]="title()"
           (input)="onTitleChange($any($event.target).value)"
           class="editor-input"
-          placeholder="Nhập tiêu đề bài học..." />
+          placeholder="Nhập tiêu đề bài học..."
+        />
       </div>
 
-        <!-- LECTURE -->
-        @if (lessonType() === 'LECTURE') {
-          <!-- Legacy video warning -->
-          @if (hasLegacyVideo()) {
-            <div class="editor-callout--warning" style="display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-between; gap: 0.75rem; padding: 0.75rem 1rem; border: 1px solid rgba(217,119,6,0.22); border-radius: var(--editor-control-radius); background: rgba(245,158,11,0.1)">
-              <div style="min-width: 0">
-                <p style="font-size: 0.8125rem; font-weight: 600; color: rgb(146 64 14)">Video cũ ở bài học</p>
-                <p style="margin-top: 0.25rem; font-size: 0.8125rem; color: rgb(146 64 14)">{{ legacyVideoCopy() }}</p>
-              </div>
-              @if (!hasVideoSections()) {
-                <button type="button" (click)="createSection.emit('VIDEO')"
-                  class="editor-secondary-button" style="font-size: 0.75rem; min-height: 2rem; padding: 0.25rem 0.75rem">
-                  Tạo mục video mới
-                </button>
-              }
+      @if (lessonType() === 'LECTURE') {
+        @if (hasLegacyVideo()) {
+          <div
+            class="editor-callout--warning"
+            style="display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-between; gap: 0.75rem; padding: 0.75rem 1rem; border: 1px solid rgba(217,119,6,0.22); border-radius: var(--editor-control-radius); background: rgba(245,158,11,0.1)"
+          >
+            <div style="min-width: 0">
+              <p style="font-size: 0.8125rem; font-weight: 600; color: rgb(146 64 14)">Video cũ ở bài học</p>
+              <p style="margin-top: 0.25rem; font-size: 0.8125rem; color: rgb(146 64 14)">{{ legacyVideoCopy() }}</p>
             </div>
-          }
-
-          <!-- Sections panel -->
-          <app-lecture-sections-panel
-            [sections]="lesson().sections || []"
-            [activeSectionId]="editorSvc.editingSectionId()"
-            (createSection)="createSection.emit($event)"
-            (editSection)="editSection.emit($event)"
-            (deleteSection)="deleteSection.emit($event)"
-            (dropSection)="dropSection.emit($event)">
-          </app-lecture-sections-panel>
-
-          <!-- Inline section editor -->
-          @if (editorSvc.isSectionSurfaceOpen()) {
-            <app-section-editor
-              [lessonId]="lesson().id"
-              [courseId]="courseId()"
-              (saved)="sectionSaved.emit()"
-              (closed)="sectionClosed.emit()">
-            </app-section-editor>
-          }
-        }
-
-        <!-- QUIZ -->
-        @if (lessonType() === 'QUIZ') {
-          <app-curriculum-assessment-summary
-            accent="purple"
-            eyebrow="Bài kiểm tra trong bài học"
-            title="Thiết lập bài kiểm tra tại đây, quản lý câu hỏi ở trang riêng"
-            [description]="quizFlowDescription()"
-            [placementLabel]="placementLabel()"
-            [audienceLabel]="audienceLabel()"
-            [distributionLabel]="distributionLabel()"
-            actionLabel="Mở trang quản lý bài kiểm tra"
-            (actionClick)="goToQuizBuilder.emit()">
-          </app-curriculum-assessment-summary>
-
-          <app-curriculum-quiz-manager
-            [timeLimit]="quizTimeLimit()"
-            [passingScore]="quizPassingScore()"
-            [maxAttempts]="quizMaxAttempts()"
-            [questions]="quizQuestions()"
-            [loading]="quizQuestionsLoading()"
-            (timeLimitChange)="quizTimeLimitChange.emit(+$event)"
-            (passingScoreChange)="quizPassingScoreChange.emit(+$event)"
-            (maxAttemptsChange)="quizMaxAttemptsChange.emit(+$event)">
-          </app-curriculum-quiz-manager>
-        }
-
-        <!-- ASSIGNMENT -->
-        @if (lessonType() === 'ASSIGNMENT') {
-          <app-curriculum-assessment-summary
-            accent="green"
-            eyebrow="Bài tập trong bài học"
-            title="Thiết lập bài tập tại đây, giao bài cho học viên ở trang riêng"
-            [description]="assignmentFlowDescription()"
-            [placementLabel]="placementLabel()"
-            [audienceLabel]="audienceLabel()"
-            [distributionLabel]="distributionLabel()"
-            actionLabel="Mở cài đặt bài tập"
-            (actionClick)="goToAssignmentSettings.emit()">
-          </app-curriculum-assessment-summary>
-
-          <app-curriculum-assignment-details
-            [description]="assignmentDescription()"
-            [instructions]="assignmentInstructions()"
-            [dueDate]="assignmentDueDate()"
-            [maxScore]="assignmentMaxScore()"
-            (descriptionChange)="assignmentDescriptionChange.emit($event)"
-            (instructionsChange)="assignmentInstructionsChange.emit($event)"
-            (dueDateChange)="assignmentDueDateChange.emit($event)"
-            (maxScoreChange)="assignmentMaxScoreChange.emit(+$event)">
-          </app-curriculum-assignment-details>
-        }
-
-        <!-- Lưu -->
-        <div class="lesson-footer">
-          @if (isDirty()) {
-            <span class="unsaved-hint">
-              <span class="unsaved-hint__dot"></span>
-              Có thay đổi chưa lưu
-            </span>
-          }
-          <button type="button" (click)="saveClicked.emit()"
-            [disabled]="isSaving() || !title().trim()"
-            class="editor-primary-button">
-            @if (isSaving()) {
-              <svg class="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-              </svg>
+            @if (!hasVideoSections()) {
+              <button
+                type="button"
+                (click)="createSection.emit('VIDEO')"
+                class="editor-secondary-button"
+                style="font-size: 0.75rem; min-height: 2rem; padding: 0.25rem 0.75rem"
+              >
+                Tạo mục video mới
+              </button>
             }
-            Lưu thay đổi
-          </button>
-        </div>
+          </div>
+        }
+
+        <app-lecture-sections-panel
+          [sections]="lesson().sections || []"
+          [activeSectionId]="editorSvc.editingSectionId()"
+          (createSection)="createSection.emit($event)"
+          (editSection)="editSection.emit($event)"
+          (deleteSection)="deleteSection.emit($event)"
+          (dropSection)="dropSection.emit($event)"
+        >
+        </app-lecture-sections-panel>
+
+        @if (editorSvc.isSectionSurfaceOpen()) {
+          <app-section-editor
+            [lessonId]="lesson().id"
+            [courseId]="courseId()"
+            (saved)="sectionSaved.emit()"
+            (closed)="sectionClosed.emit()"
+          >
+          </app-section-editor>
+        }
+      }
+
+      @if (lessonType() === 'QUIZ') {
+        <app-curriculum-assessment-summary
+          accent="purple"
+          eyebrow="Bài kiểm tra trong bài học"
+          title="Thiết lập bài kiểm tra tại đây, quản lý câu hỏi ở trang riêng"
+          [description]="quizFlowDescription()"
+          [placementLabel]="placementLabel()"
+          [audienceLabel]="audienceLabel()"
+          [distributionLabel]="distributionLabel()"
+          actionLabel="Mở trang quản lý bài kiểm tra"
+          (actionClick)="goToQuizBuilder.emit()"
+        >
+        </app-curriculum-assessment-summary>
+
+        <app-curriculum-quiz-manager
+          [timeLimit]="quizTimeLimit()"
+          [passingScore]="quizPassingScore()"
+          [maxAttempts]="quizMaxAttempts()"
+          [questions]="quizQuestions()"
+          [loading]="quizQuestionsLoading()"
+          (timeLimitChange)="quizTimeLimitChange.emit(+$event)"
+          (passingScoreChange)="quizPassingScoreChange.emit(+$event)"
+          (maxAttemptsChange)="quizMaxAttemptsChange.emit(+$event)"
+        >
+        </app-curriculum-quiz-manager>
+      }
+
+      @if (lessonType() === 'ASSIGNMENT') {
+        <app-curriculum-assessment-summary
+          accent="green"
+          eyebrow="Bài tập trong bài học"
+          title="Thiết lập bài tập tại đây, giao bài cho học viên ở trang riêng"
+          [description]="assignmentFlowDescription()"
+          [placementLabel]="placementLabel()"
+          [audienceLabel]="audienceLabel()"
+          [distributionLabel]="distributionLabel()"
+          actionLabel="Mở cài đặt bài tập"
+          (actionClick)="goToAssignmentSettings.emit()"
+        >
+        </app-curriculum-assessment-summary>
+
+        <app-curriculum-assignment-details
+          [description]="assignmentDescription()"
+          [instructions]="assignmentInstructions()"
+          [dueDate]="assignmentDueDate()"
+          [maxScore]="assignmentMaxScore()"
+          (descriptionChange)="assignmentDescriptionChange.emit($event)"
+          (instructionsChange)="assignmentInstructionsChange.emit($event)"
+          (dueDateChange)="assignmentDueDateChange.emit($event)"
+          (maxScoreChange)="assignmentMaxScoreChange.emit(+$event)"
+        >
+        </app-curriculum-assignment-details>
+      }
+
+      <div class="lesson-footer">
+        @if (isDirty()) {
+          <span class="unsaved-hint">
+            <span class="unsaved-hint__dot"></span>
+            Có thay đổi chưa lưu
+          </span>
+        }
+        <button
+          type="button"
+          (click)="saveClicked.emit()"
+          [disabled]="isSaving() || !title().trim()"
+          class="editor-primary-button"
+        >
+          @if (isSaving()) {
+            <svg class="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              ></path>
+            </svg>
+          }
+          Lưu thay đổi
+        </button>
+      </div>
     </div>
   `,
 })
@@ -248,30 +265,27 @@ export class LessonEditorComponent {
   readonly isLoading = input(false);
   readonly editorSvc = inject(CurriculumEditorService);
 
-  // Core inputs
   readonly lesson = input.required<LessonDraftDTO>();
   readonly courseId = input.required<string>();
   readonly chapterTitle = input('');
+  readonly chapterLabel = input('');
+  readonly lessonLabel = input('');
   readonly isSaving = input(false);
   readonly isDirty = input(false);
 
-  // Lesson form state (managed by parent, passed as inputs)
   readonly title = signal('');
 
-  // Quiz inputs (from parent)
   readonly quizTimeLimit = input(30);
   readonly quizPassingScore = input(60);
   readonly quizMaxAttempts = input(1);
   readonly quizQuestions = input<any[]>([]);
   readonly quizQuestionsLoading = input(false);
 
-  // Assignment inputs (from parent)
   readonly assignmentDescription = input('');
   readonly assignmentInstructions = input('');
   readonly assignmentDueDate = input('');
   readonly assignmentMaxScore = input(100);
 
-  // Context labels (from parent)
   readonly quizFlowDescription = input('');
   readonly assignmentFlowDescription = input('');
   readonly placementLabel = input('');
@@ -279,12 +293,10 @@ export class LessonEditorComponent {
   readonly distributionLabel = input('');
   readonly legacyVideoCopy = input('');
 
-  // Core outputs
   readonly titleChange = output<string>();
   readonly saveClicked = output<void>();
   readonly backClicked = output<void>();
 
-  // Section outputs (LECTURE type)
   readonly createSection = output<string>();
   readonly editSection = output<SectionDraftDTO>();
   readonly deleteSection = output<string>();
@@ -292,20 +304,17 @@ export class LessonEditorComponent {
   readonly sectionSaved = output<void>();
   readonly sectionClosed = output<void>();
 
-  // Quiz outputs
   readonly goToQuizBuilder = output<void>();
   readonly quizTimeLimitChange = output<number>();
   readonly quizPassingScoreChange = output<number>();
   readonly quizMaxAttemptsChange = output<number>();
 
-  // Assignment outputs
   readonly goToAssignmentSettings = output<void>();
   readonly assignmentDescriptionChange = output<string>();
   readonly assignmentInstructionsChange = output<string>();
   readonly assignmentDueDateChange = output<string>();
   readonly assignmentMaxScoreChange = output<number>();
 
-  // Derived
   readonly lessonType = computed(() => {
     const type = (this.lesson().type || 'LECTURE').toUpperCase();
     if (type === 'QUIZ' || type === 'ASSIGNMENT') return type;
@@ -313,11 +322,10 @@ export class LessonEditorComponent {
   });
 
   readonly hasVideoSections = computed(() =>
-    (this.lesson().sections || []).some(s => s.type === 'VIDEO')
+    (this.lesson().sections || []).some(section => section.type === 'VIDEO')
   );
 
   constructor() {
-    // Strip legacy "Bài N:" prefix — sidebar auto-numbers by position
     effect(() => {
       const lesson = this.lesson();
       this.title.set(this.stripLessonPrefix(lesson.title || ''));
@@ -325,8 +333,8 @@ export class LessonEditorComponent {
   }
 
   hasLegacyVideo(): boolean {
-    const l = this.lesson();
-    return !!(l.videoUrl || l.streamVideoUid);
+    const lesson = this.lesson();
+    return !!(lesson.videoUrl || lesson.streamVideoUid);
   }
 
   onTitleChange(value: string): void {
@@ -335,9 +343,7 @@ export class LessonEditorComponent {
   }
 
   private stripLessonPrefix(title: string): string {
-    const pattern = /^bài\s+\d+[.:.]\s*/i;
-    const match = title.match(pattern);
-    return match ? title.slice(match[0].length).trim() : title;
+    return stripCurriculumPrefix(title, 'lesson');
   }
 
   getTypeLabel(): string {

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.html
@@ -66,6 +66,7 @@
     @if (selectionService.selectedChapter(); as chapter) {
       <app-chapter-editor
         [chapter]="chapter"
+        [chapterLabel]="selectedChapterLabel()"
         [isSaving]="isSaving()"
         [isDirty]="editorDirty()"
         (titleChange)="onChapterTitleChange($event)"
@@ -98,6 +99,8 @@
         [lesson]="lesson"
         [courseId]="store.courseTree()?.id || ''"
         [chapterTitle]="selectionService.selectedChapter()?.title || ''"
+        [chapterLabel]="selectedChapterLabel()"
+        [lessonLabel]="selectedLessonLabel()"
         [isSaving]="isSaving()"
         [isDirty]="editorDirty()"
         [quizTimeLimit]="quizTimeLimit()"

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.ts
@@ -30,14 +30,11 @@ import { WiiiContextService } from '../../../../ai-chat/infrastructure/api/wiii-
 import { ConfirmDialogService } from '../../../../../core/services/confirm-dialog.service';
 import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 import { isOfflineVideoProfileId, type OfflineVideoProfileDescriptor } from '../../../../../core/models/video-quality';
-import { LectureSectionsPanelComponent } from './components/lecture-sections-panel/lecture-sections-panel.component';
-import { CurriculumAssessmentSummaryComponent } from './components/curriculum-assessment-summary/curriculum-assessment-summary.component';
-import { CurriculumAssignmentDetailsComponent } from './components/curriculum-assignment-details/curriculum-assignment-details.component';
-import { CurriculumQuizManagerComponent } from './components/curriculum-quiz-manager/curriculum-quiz-manager.component';
 import { ChapterEditorComponent } from './components/chapter-editor/chapter-editor.component';
 import { LessonEditorComponent } from './components/lesson-editor/lesson-editor.component';
 import { CurriculumEditorService } from '../../services/curriculum-editor.service';
 import { QuizPackageModalsComponent } from './components/quiz-package-modals/quiz-package-modals.component';
+import { buildCurriculumLabel, stripCurriculumPrefix } from '../../utils/curriculum-labels';
 
 type SectionQuizAssessmentType = 'PRACTICE' | 'ASSESSMENT' | 'EXAM';
 
@@ -48,10 +45,6 @@ type SectionQuizAssessmentType = 'PRACTICE' | 'ASSESSMENT' | 'EXAM';
     FormsModule,
     LucideAngularModule,
     DragDropModule,
-    LectureSectionsPanelComponent,
-    CurriculumAssessmentSummaryComponent,
-    CurriculumAssignmentDetailsComponent,
-    CurriculumQuizManagerComponent,
     ChapterEditorComponent,
     LessonEditorComponent,
     QuizPackageModalsComponent
@@ -186,6 +179,20 @@ export class CourseCurriculumComponent implements OnDestroy {
     if (!chapterId) return [];
     const chapter = this.store.chapters().find(c => c.id === chapterId);
     return chapter?.lessons || [];
+  });
+  selectedChapterLabel = computed(() => {
+    const chapterId = this.selectedChapterId();
+    if (!chapterId) return '';
+    const chapterIndex = this.store.chapters().findIndex(chapter => chapter.id === chapterId);
+    return chapterIndex >= 0 ? buildCurriculumLabel('chapter', chapterIndex) : '';
+  });
+  selectedLessonLabel = computed(() => {
+    const chapterId = this.selectedChapterId();
+    const lessonId = this.selectedLessonId();
+    if (!chapterId || !lessonId) return '';
+    const chapter = this.store.chapters().find(item => item.id === chapterId);
+    const lessonIndex = chapter?.lessons.findIndex(lesson => lesson.id === lessonId) ?? -1;
+    return lessonIndex >= 0 ? buildCurriculumLabel('lesson', lessonIndex) : '';
   });
 
   hasLegacyLessonLevelVideo(): boolean {
@@ -1110,7 +1117,7 @@ export class CourseCurriculumComponent implements OnDestroy {
       }
       await firstValueFrom(this.chapterApi.updateChapter(chapterId, {
         courseId: courseId,
-        title: this.chapterTitle.trim(),
+        title: stripCurriculumPrefix(this.chapterTitle.trim(), 'chapter'),
         description: this.chapterDescription.trim()
       }));
       this.refreshEditorBaselineWithOptions(true);
@@ -1150,11 +1157,12 @@ export class CourseCurriculumComponent implements OnDestroy {
       }
       const chapterId = lessonContext.chapter.id;
       const lessonType = this.getLessonType(lesson);
+      const normalizedLessonTitle = stripCurriculumPrefix(this.lessonTitle.trim(), 'lesson');
       const updateData: any = {
         courseId: courseId,
         chapterId: chapterId,
         lessonType: lessonType,
-        title: this.lessonTitle.trim()
+        title: normalizedLessonTitle
       };
 
       if (lessonType === 'LECTURE') {
@@ -1167,7 +1175,7 @@ export class CourseCurriculumComponent implements OnDestroy {
       if (lessonType === 'QUIZ') {
         const quizId = await this.resolveQuizIdForLesson(lesson.id);
         await firstValueFrom(this.quizApi.updateQuizSettings(quizId, {
-          title: this.lessonTitle.trim(),
+          title: normalizedLessonTitle,
           timeLimitMinutes: this.quizTimeLimit() || null,
           passingScore: this.quizPassingScore(),
           maxAttempts: this.quizMaxAttempts()
@@ -1175,7 +1183,7 @@ export class CourseCurriculumComponent implements OnDestroy {
       } else if (lessonType === 'ASSIGNMENT') {
         const assignmentId = await this.ensureAssignmentIdForLesson(lesson, courseId);
         await firstValueFrom(this.assignmentApi.updateAssignment(assignmentId, {
-          title: this.lessonTitle.trim(),
+          title: normalizedLessonTitle,
           description: this.assignmentDescription,
           instructions: this.assignmentInstructions,
           dueDate: this.toIsoInstantOrUndefined(this.assignmentDueDate),
@@ -1214,7 +1222,7 @@ export class CourseCurriculumComponent implements OnDestroy {
       }
 
       await firstValueFrom(this.quizApi.createLessonQuizV3(lessonId, {
-        title: this.lessonTitle.trim() || lesson.title || 'Bai kiem tra moi',
+        title: stripCurriculumPrefix(this.lessonTitle.trim(), 'lesson') || lesson.title || 'Bai kiem tra moi',
         description: '',
         timeLimitMinutes: this.quizTimeLimit() || 30,
         maxAttempts: this.quizMaxAttempts(),
@@ -1250,7 +1258,7 @@ export class CourseCurriculumComponent implements OnDestroy {
     try {
       const response = await firstValueFrom(this.assignmentApi.createAssignment(courseId, {
         lessonId: lesson.id,
-        title: this.lessonTitle.trim() || lesson.title || 'Bai tap moi',
+        title: stripCurriculumPrefix(this.lessonTitle.trim(), 'lesson') || lesson.title || 'Bai tap moi',
         description: this.assignmentDescription,
         instructions: this.assignmentInstructions,
         dueDate: this.toIsoInstantOrUndefined(this.assignmentDueDate),
@@ -1564,7 +1572,27 @@ export class CourseCurriculumComponent implements OnDestroy {
 
     try {
       const quizId = await this.resolveQuizIdForLesson(lesson.id);
-      this.router.navigate(['/teacher/quiz', quizId, 'edit']);
+      const queryParams: Record<string, string> = {
+        returnTo: 'curriculum'
+      };
+      const courseId = this.store.courseTree()?.id;
+      const chapterId = this.selectedChapterId();
+      const sectionId = this.selectedSectionId();
+
+      if (courseId) {
+        queryParams['returnCourseId'] = courseId;
+      }
+      if (chapterId) {
+        queryParams['returnChapterId'] = chapterId;
+      }
+      if (lesson.id) {
+        queryParams['returnLessonId'] = lesson.id;
+      }
+      if (sectionId) {
+        queryParams['returnSectionId'] = sectionId;
+      }
+
+      this.router.navigate(['/teacher/quiz', quizId, 'edit'], { queryParams });
     } catch {
       this.toast.error('Không thể mở trình quản lý bài kiểm tra');
     }

--- a/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
+++ b/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
@@ -17,6 +17,7 @@ import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
 import type { OfflineVideoProfileDescriptor } from '../../../../core/models/video-quality';
 import type { ApiResponse } from '../../../../api/types/common.types';
+import { stripCurriculumPrefix } from '../utils/curriculum-labels';
 
 export type EditorMode = 'empty' | 'chapter' | 'lesson';
 export type SectionSurfaceMode = 'closed' | 'create' | 'edit';
@@ -345,7 +346,7 @@ export class CurriculumEditorService {
 
   private buildSectionPayload(type: SectionEditorType): Record<string, any> {
     const payload: Record<string, any> = {
-      title: this.sectionTitle().trim(),
+      title: stripCurriculumPrefix(this.sectionTitle().trim(), 'section'),
       type,
       isRequired: this.sectionIsRequired(),
     };
@@ -470,10 +471,7 @@ export class CurriculumEditorService {
   }
 
   private stripSectionPrefix(title: string): string {
-    // Strip "N.M:" or "N.M." prefix (e.g., "1.1: Introduction" → "Introduction")
-    const pattern = /^\d+\.\d+[.:.]\s*/;
-    const match = title.match(pattern);
-    return match ? title.slice(match[0].length).trim() : title;
+    return stripCurriculumPrefix(title, 'section');
   }
 
   private resetQuizFields(): void {

--- a/fe/src/app/features/teacher/course-editor/utils/curriculum-labels.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/curriculum-labels.ts
@@ -1,0 +1,39 @@
+export type CurriculumLevel = 'chapter' | 'lesson' | 'section';
+
+const LEVEL_LABELS: Record<CurriculumLevel, string> = {
+  chapter: 'Chương',
+  lesson: 'Bài',
+  section: 'Mục',
+};
+
+const LEVEL_PREFIX_PATTERNS: Record<CurriculumLevel, RegExp[]> = {
+  chapter: [
+    /^chương\s+\d+[.:\-)]\s*/i,
+    /^\d+[.:\-)]\s*/,
+  ],
+  lesson: [
+    /^bài\s+\d+(?:\.\d+)?[.:\-)]\s*/i,
+    /^\d+(?:\.\d+)?[.:\-)]\s*/,
+  ],
+  section: [
+    /^mục\s+\d+(?:\.\d+){0,2}[.:\-)]\s*/i,
+    /^\d+(?:\.\d+){1,2}[.:\-)]\s*/,
+  ],
+};
+
+export function buildCurriculumLabel(level: CurriculumLevel, index: number): string {
+  return `${LEVEL_LABELS[level]} ${index + 1}`;
+}
+
+export function stripCurriculumPrefix(title: string, level: CurriculumLevel): string {
+  const normalizedTitle = title.trim();
+
+  for (const pattern of LEVEL_PREFIX_PATTERNS[level]) {
+    if (pattern.test(normalizedTitle)) {
+      const stripped = normalizedTitle.replace(pattern, '').trim();
+      return stripped || 'Chưa đặt tên';
+    }
+  }
+
+  return normalizedTitle || 'Chưa đặt tên';
+}

--- a/fe/src/app/features/teacher/quiz/quiz-edit.component.ts
+++ b/fe/src/app/features/teacher/quiz/quiz-edit.component.ts
@@ -408,6 +408,30 @@ export class QuizEditComponent implements OnInit {
       return;
     }
 
+    const returnTo = this.route.snapshot.queryParamMap.get('returnTo');
+    const returnCourseId = this.route.snapshot.queryParamMap.get('returnCourseId');
+    const returnChapterId = this.route.snapshot.queryParamMap.get('returnChapterId');
+    const returnLessonId = this.route.snapshot.queryParamMap.get('returnLessonId');
+    const returnSectionId = this.route.snapshot.queryParamMap.get('returnSectionId');
+
+    if (returnTo === 'curriculum' && returnCourseId) {
+      const queryParams: Record<string, string> = {};
+      if (returnChapterId) {
+        queryParams['chapterId'] = returnChapterId;
+      }
+      if (returnLessonId) {
+        queryParams['lessonId'] = returnLessonId;
+      }
+      if (returnSectionId) {
+        queryParams['sectionId'] = returnSectionId;
+      }
+      void this.router.navigate(
+        ['/teacher/courses', returnCourseId, 'editor', 'curriculum'],
+        { queryParams }
+      );
+      return;
+    }
+
     const quiz = this.quiz();
 
     if (quiz?.courseId) {


### PR DESCRIPTION
## Summary
This PR addresses the two curriculum-authoring UX issues already tracked in GitHub:
- the sidebar was too dominant and visually overloaded for desktop authoring
- hierarchy numbering and quiz-builder navigation were inconsistent across the teacher editing flow

Closes #23
Closes #24

## Problem
Teacher feedback and a code audit showed three concrete authoring problems:
1. the left sidebar consumed too much width and exposed too many actions at once
2. chapter / lesson / section labels were rendered differently across sidebar, chapter editor, lesson editor, and section surfaces
3. entering the dedicated quiz builder broke the teacher's exact curriculum context on return

## Root Cause
- Hierarchy labels were derived independently in multiple components instead of from one shared presentation rule.
- Legacy numeric prefixes were handled ad hoc at render time, which kept numbering and persisted titles partially entangled.
- Quiz-builder navigation did not carry explicit return context back to the curriculum route.

## What Changed
- Added a shared `curriculum-labels.ts` utility to centralize local numbering (`Chuong N`, `B�i N`, `M?c N`) and legacy prefix normalization.
- Reduced the sidebar footprint with responsive width clamps, increased nested indentation, and hid secondary row actions until hover/selection.
- Updated sidebar labels to local per-level numbering instead of composite `chapter.lesson.section` numbering.
- Updated chapter, lesson, and section authoring surfaces to use the shared label model so the same hierarchy reads consistently across the editor.
- Preserved `chapterId`, `lessonId`, and `sectionId` when navigating into the quiz builder and restored that context when the teacher cancels back to curriculum.
- Normalized chapter, lesson, and section titles before save so new edits do not persist presentation numbering back into content titles.

## User Impact
- Teachers get more space for the main authoring canvas on desktop.
- The course outline reads as a clear hierarchy with deeper visual nesting for lessons and sections.
- Lesson and section labels are easier to scan because numbering is now stable and local to each level.
- Moving from a lesson-owned quiz into the dedicated builder is reversible without losing the current chapter / lesson / section context.

## Verification
- [x] `npm run build`
- [x] Verified the curriculum route still hydrates `chapterId`, `lessonId`, and `sectionId` from query params
- [x] Verified new title saves normalize numbering prefixes for chapter, lesson, and section flows touched by this PR

## Out of Scope
- Historical persisted titles that already contain numbering remain render-normalized until those items are edited and saved again.
- This PR does not redesign the entire course-editor information architecture or remove every secondary sidebar action.
- Existing unrelated Angular/Sass/CommonJS warnings shown during `npm run build` remain unchanged.

## Risk Assessment
Low to medium.
The changes are frontend-only and scoped to teacher authoring surfaces, but they do touch several curriculum editor components that share navigation state.

## Rollback
Revert this PR to restore the previous sidebar density, composite numbering, and quiz return behavior.
