### PR TITLE
fix(teacher-ui): align sidebar authoring with main content

### DIFF
--- a/fe/src/app/features/teacher/course-editor/components/sidebar/sidebar.component.ts
+++ b/fe/src/app/features/teacher/course-editor/components/sidebar/sidebar.component.ts
@@ -8,10 +8,9 @@ import { CdkScrollable } from '@angular/cdk/scrolling';
 import { ChapterApi } from '../../../../../api/client/chapter.api';
 import { LessonApi } from '../../../../../api/client/lesson.api';
 import { SectionApi } from '../../../../../api/client/section.api';
-import { ChapterDraftDTO, LessonDraftDTO, SectionDraftDTO, CourseAuthoringService } from '../../services/course-authoring.service';
+import { ChapterDraftDTO, LessonDraftDTO, SectionDraftDTO } from '../../services/course-authoring.service';
 import { CurriculumSelectionService } from '../../services/curriculum-selection.service';
 import { CurriculumEditorService } from '../../services/curriculum-editor.service';
-import { CONTENT_TYPE_CONFIG, ContentType } from '../../../../../core/constants/content-type.constant';
 
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { animate, state, style, transition, trigger } from '@angular/animations';
@@ -19,9 +18,6 @@ import { LucideAngularModule } from 'lucide-angular';
 import { ToastService } from '../../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../../core/services/confirm-dialog.service';
 import { DialogComponent } from '../../../../../shared/components/dialog/dialog.component';
-import { firstValueFrom } from 'rxjs';
-import { AssignmentApi } from '../../../../../api/client/assignment.api';
-import { QuizApi } from '../../../../../api/endpoints/quiz.api';
 import { buildCurriculumLabel, stripCurriculumPrefix } from '../../utils/curriculum-labels';
 import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/lesson-readiness';
 
@@ -458,7 +454,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                                     <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
                                     Đổi tên
                                   </button>
-                                  <button (click)="showAddLessonModal(chapter, chapterIdx); closeMenu()"
+                                  <button (click)="requestAddLessonFromSidebar(chapter); closeMenu()"
                                           class="w-full text-left px-3.5 py-2.5 hover:bg-slate-50 text-[13px] text-slate-700 font-medium flex items-center gap-2.5">
                                     <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
                                     Thêm bài học
@@ -504,7 +500,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
 
                               <!-- Empty: no lessons in chapter -->
                               @if (chapter.lessons.length === 0) {
-                                <button (click)="showAddLessonModal(chapter, chapterIdx)"
+                                <button (click)="requestAddLessonFromSidebar(chapter)"
                                         class="flex items-center gap-2 w-full pl-8 pr-4 py-2.5 text-[12px] text-slate-400 hover:text-[#0056D2] hover:bg-slate-50 transition-colors text-left">
                                   <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
@@ -583,10 +579,10 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                                                     <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
                                                     Đổi tên
                                                   </button>
-                                                  <button (click)="showAddSectionModal(lesson, lesson.sections.length || 0, lessonIdx); closeMenu()"
+                                                  <button (click)="selectLesson(chapter, lesson); closeMenu()"
                                                           class="w-full text-left px-3.5 py-2.5 hover:bg-slate-50 text-[13px] text-slate-700 font-medium flex items-center gap-2.5">
                                                     <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
-                                                    Thêm nội dung
+                                                    Mở vùng soạn chính
                                                   </button>
                                                   <div class="border-t border-slate-100 my-1"></div>
                                                   <!-- Move Up/Down + Move To Chapter (WCAG 2.5.7) -->
@@ -678,112 +674,6 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
       </div>
     </app-dialog>
 
-    <!-- Lesson Modal -->
-    <app-dialog
-      [open]="showLessonModal()"
-      title="Thêm bài học"
-      [subtitle]="'Chương: ' + (currentChapterForLesson()?.title || '')"
-      size="sm"
-      [busy]="isCreating()"
-      (close)="closeModals()">
-      <label class="sidebar-field-label">Tên bài học</label>
-      <input type="text" [(ngModel)]="newLessonTitle"
-             (keydown.enter)="createLesson()"
-             class="sidebar-field-input"
-             placeholder="Nhập tên bài học...">
-      <p class="sidebar-field-hint">Sau khi tạo, bạn có thể thêm nội dung (văn bản, video, tài liệu, trắc nghiệm) vào bài học.</p>
-      <div dialogFooter>
-        <button type="button" (click)="closeModals()" class="sidebar-btn sidebar-btn--ghost">Hủy</button>
-        <button type="button" (click)="createLesson()"
-                [disabled]="isCreating()"
-                class="sidebar-btn sidebar-btn--primary">
-          @if (isCreating()) {
-            <svg class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-          }
-          Thêm bài học
-        </button>
-      </div>
-    </app-dialog>
-
-    <!-- Section Modal -->
-    <app-dialog
-      [open]="showSectionModal()"
-      title="Thêm nội dung"
-      [subtitle]="'Bài học: ' + (currentLessonForSection()?.title || '')"
-      size="md"
-      [busy]="isCreating()"
-      (close)="closeModals()">
-      <div class="sidebar-section-form">
-        <div>
-          <label class="sidebar-field-label">Tiêu đề</label>
-          <input type="text"
-                 [(ngModel)]="newSectionTitle"
-                 (keydown.enter)="createSection()"
-                 class="sidebar-field-input"
-                 placeholder="Nhập tiêu đề nội dung...">
-        </div>
-
-        <div>
-          <label class="sidebar-field-label sidebar-field-label--lg">Loại nội dung</label>
-          <div class="sidebar-type-grid">
-            @for (type of sectionTypes; track type) {
-              <button type="button" (click)="newSectionType = type"
-                      [class]="'sidebar-type-btn ' + (newSectionType === type ? 'sidebar-type-btn--active' : '')">
-                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  @switch (type) {
-                    @case ('TEXT') {
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
-                    }
-                    @case ('VIDEO') {
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
-                    }
-                    @case ('QUIZ') {
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"></path>
-                    }
-                    @case ('FILE') {
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"></path>
-                    }
-                  }
-                </svg>
-                <span class="text-[11px] font-bold uppercase">{{ type }}</span>
-              </button>
-            }
-          </div>
-
-          @if (newSectionType === 'FILE') {
-            <div class="sidebar-file-attach">
-              <label class="sidebar-file-attach__label">Đính kèm tài liệu</label>
-              @if (!selectedFile) {
-                <input type="file" (change)="onFileSelected($event)"
-                       class="block w-full text-xs text-slate-500 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:text-xs file:font-medium file:bg-amber-200 file:text-amber-800 hover:file:bg-amber-300 cursor-pointer">
-              } @else {
-                <div class="flex items-center justify-between bg-white p-2 rounded-lg border border-amber-200">
-                   <div class="flex items-center gap-2 overflow-hidden">
-                     <svg class="w-3.5 h-3.5 text-amber-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"></path></svg>
-                     <span class="text-xs text-slate-700 truncate font-medium">{{ selectedFile.name }}</span>
-                   </div>
-                   <button type="button" (click)="removeSelectedFile()" class="p-1 text-slate-400 hover:text-red-500 transition-colors flex-shrink-0">
-                     <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
-                   </button>
-                </div>
-              }
-            </div>
-          }
-        </div>
-      </div>
-      <div dialogFooter>
-        <button type="button" (click)="closeModals()" class="sidebar-btn sidebar-btn--ghost">Hủy</button>
-        <button type="button" (click)="createSection()"
-                [disabled]="!newSectionTitle.trim() || (newSectionType === 'FILE' && !selectedFile) || isCreating()"
-                class="sidebar-btn sidebar-btn--primary">
-          @if (isCreating()) {
-            <svg class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-          }
-          Tạo nội dung
-        </button>
-      </div>
-    </app-dialog>
-
     <!-- Move to Chapter Modal (Canvas "Move To" pattern - WCAG 2.5.7) -->
     <app-dialog
       [open]="showMoveToChapter()"
@@ -819,9 +709,6 @@ export class CourseEditorSidebarComponent implements OnDestroy {
   private chapterApi = inject(ChapterApi);
   private lessonApi = inject(LessonApi);
   private sectionApi = inject(SectionApi);
-  private assignmentApi = inject(AssignmentApi);
-  private quizApi = inject(QuizApi);
-  private authoringService = inject(CourseAuthoringService);
   private toast = inject(ToastService);
   private confirmDialog = inject(ConfirmDialogService);
 
@@ -868,29 +755,15 @@ export class CourseEditorSidebarComponent implements OnDestroy {
 
   // Modal states
   showChapterModal = signal(false);
-  showLessonModal = signal(false);
-  showSectionModal = signal(false);
-  currentChapterForLesson = signal<ChapterDraftDTO | null>(null);
-  currentLessonForSection = signal<LessonDraftDTO | null>(null);
 
   // Form data
   newChapterTitle = '';
   newChapterDescription = '';
-  newLessonTitle = '';
-  newLessonType: 'LECTURE' | 'QUIZ' | 'ASSIGNMENT' = 'LECTURE';
-  newSectionTitle = '';
-  newSectionType: 'TEXT' | 'VIDEO' | 'QUIZ' | 'FILE' = 'TEXT';
-  readonly sectionTypes: ('TEXT' | 'VIDEO' | 'QUIZ' | 'FILE')[] = ['TEXT', 'VIDEO', 'QUIZ', 'FILE'];
-  selectedFile: File | null = null;
-  tempSearch = '';
 
   // Inline editing
   editingChapterId = signal<string | null>(null);
   editingLessonId = signal<string | null>(null);
   editingValue = '';
-
-  // Pending new lesson for auto-opening section modal
-  private pendingNewLessonChapterId = signal<string | null>(null);
 
   // Touch device detection (Phase C)
   readonly isTouchDevice = 'ontouchstart' in globalThis || navigator.maxTouchPoints > 0;
@@ -901,17 +774,6 @@ export class CourseEditorSidebarComponent implements OnDestroy {
   moveToLessonTarget = signal<LessonDraftDTO | null>(null);
 
   constructor() {
-    // Bridge: chapter-editor requests lesson creation via shared service signal
-    effect(() => {
-      const chapter = this.editorSvc.pendingLessonCreateForChapter();
-      if (chapter) {
-        untracked(() => {
-          this.showAddLessonModal(chapter, 0);
-          this.editorSvc.pendingLessonCreateForChapter.set(null);
-        });
-      }
-    });
-
     // Auto-expand first chapter when data loads
     effect(() => {
       const chapters = this.store.chapters();
@@ -923,28 +785,6 @@ export class CourseEditorSidebarComponent implements OnDestroy {
       }
     });
 
-    // Auto-expand and open section modal when new lesson appears
-    effect(() => {
-      const chapters = this.store.chapters();
-      const pendingChapterId = this.pendingNewLessonChapterId();
-      if (!pendingChapterId) return;
-
-      const chapter = chapters.find(ch => ch.id === pendingChapterId);
-      if (chapter && chapter.lessons.length > 0) {
-        const lastLesson = chapter.lessons[chapter.lessons.length - 1];
-        const chapterIndex = chapters.indexOf(chapter);
-        untracked(() => {
-          this.pendingNewLessonChapterId.set(null);
-          // Auto-expand the new lesson
-          this.expandedLessons.update(set => {
-            const next = new Set(set);
-            next.add(lastLesson.id);
-            return next;
-          });
-          this.showAddSectionModal(lastLesson, 0, chapterIndex);
-        });
-      }
-    });
   }
 
   // --- Chapter expand/collapse (multi-expand) ---
@@ -1045,6 +885,17 @@ export class CourseEditorSidebarComponent implements OnDestroy {
 
     this.selectionService.selectChapter(chapter);
     this.navigateToCurriculum();
+    this.autoCollapseSidebarOnMobile();
+  }
+
+  async requestAddLessonFromSidebar(chapter: ChapterDraftDTO) {
+    if (!(await this.canChangeSelection())) {
+      return;
+    }
+
+    this.selectionService.selectChapter(chapter);
+    this.navigateToCurriculum();
+    this.editorSvc.pendingLessonCreateForChapter.set(chapter);
     this.autoCollapseSidebarOnMobile();
   }
 
@@ -1167,27 +1018,8 @@ export class CourseEditorSidebarComponent implements OnDestroy {
     this.showChapterModal.set(true);
   }
 
-  showAddLessonModal(chapter: ChapterDraftDTO, chapterIndex: number) {
-    this.currentChapterForLesson.set(chapter);
-    this.newLessonTitle = '';
-    this.newLessonType = 'LECTURE';
-    this.showLessonModal.set(true);
-  }
-
-  showAddSectionModal(lesson: LessonDraftDTO, sectionIndex: number, lessonIndex: number) {
-    this.currentLessonForSection.set(lesson);
-    this.newSectionTitle = '';
-    this.newSectionType = 'TEXT';
-    this.selectedFile = null;
-    this.showSectionModal.set(true);
-  }
-
   closeModals() {
     this.showChapterModal.set(false);
-    this.showLessonModal.set(false);
-    this.showSectionModal.set(false);
-    this.currentChapterForLesson.set(null);
-    this.currentLessonForSection.set(null);
   }
 
   createChapter() {
@@ -1213,36 +1045,6 @@ export class CourseEditorSidebarComponent implements OnDestroy {
     });
   }
 
-  async createLesson() {
-    const chapter = this.currentChapterForLesson();
-    const courseId = this.store.courseTree()?.id;
-    const title = this.newLessonTitle.trim();
-    if (!chapter || !courseId || !title) return;
-    this.isCreating.set(true);
-
-    try {
-      await firstValueFrom(this.lessonApi.createLesson(chapter.id, {
-        title,
-        type: 'LECTURE',
-        content: undefined
-      }));
-
-      this.closeModals();
-      this.toast.success('Đã tạo bài học mới');
-      this.expandedChapters.update(set => {
-        const next = new Set(set);
-        next.add(chapter.id);
-        return next;
-      });
-      this.pendingNewLessonChapterId.set(chapter.id);
-      await this.store.loadCourse(courseId, true);
-    } catch (err: any) {
-      this.toast.error('Tạo bài học thất bại: ' + (err?.error?.message || err?.message || ''));
-    } finally {
-      this.isCreating.set(false);
-    }
-  }
-
   private async canChangeSelection(): Promise<boolean> {
     if (this.store.saveStatus() !== 'unsaved') {
       return true;
@@ -1261,52 +1063,6 @@ export class CourseEditorSidebarComponent implements OnDestroy {
 
     return shouldDiscard;
   }
-
-  private async rollbackLessonCreation(lessonId: string, courseId: string): Promise<void> {
-    try {
-      await firstValueFrom(this.lessonApi.deleteLesson(lessonId, courseId));
-    } catch {
-      this.toast.error('Không thể hoàn tác lesson trung gian sau khi tạo assignment thất bại');
-    }
-  }
-
-  createSection() {
-    const lesson = this.currentLessonForSection();
-    if (!lesson || !this.newSectionTitle.trim()) return;
-    this.isCreating.set(true);
-
-    const formData = new FormData();
-    const payload = {
-      title: this.newSectionTitle.trim(),
-      type: this.newSectionType,
-      orderIndex: lesson.sections.length || 0
-    };
-    formData.append('data', new Blob([JSON.stringify(payload)], { type: 'application/json' }));
-    if (this.newSectionType === 'FILE' && this.selectedFile) {
-      formData.append('file', this.selectedFile);
-    }
-
-    this.sectionApi.createSection(lesson.id, formData).subscribe({
-      next: () => {
-        this.closeModals();
-        this.toast.success('Đã tạo nội dung mới');
-        // Auto-expand lesson to show new section
-        this.expandedLessons.update(set => {
-          const next = new Set(set);
-          next.add(lesson.id);
-          return next;
-        });
-        const courseId = this.store.courseTree()?.id;
-        if (courseId) this.store.loadCourse(courseId, true);
-        this.isCreating.set(false);
-      },
-      error: (err: any) => {
-        this.toast.error('Tạo nội dung thất bại: ' + (err?.error?.message || ''));
-        this.isCreating.set(false);
-      }
-    });
-  }
-
   // --- Delete handlers ---
   async deleteChapter(chapterId: string) {
     const confirmed = await this.confirmDialog.confirm({
@@ -1374,37 +1130,6 @@ export class CourseEditorSidebarComponent implements OnDestroy {
       error: (err: any) => this.toast.error('Xóa nội dung thất bại: ' + (err?.error?.message || ''))
     });
   }
-
-  // --- File Handler ---
-  private readonly MAX_FILE_SIZE = 50 * 1024 * 1024;
-  private readonly ALLOWED_FILE_TYPES = ['application/pdf', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'image/jpeg', 'image/png', 'video/mp4'];
-
-  onFileSelected(event: any) {
-    const file = event.target.files[0];
-    if (!file) return;
-    if (file.size > this.MAX_FILE_SIZE) {
-      this.toast.error('File quá lớn. Kích thước tối đa: 50MB');
-      event.target.value = '';
-      return;
-    }
-    if (!this.ALLOWED_FILE_TYPES.includes(file.type)) {
-      this.toast.error('Định dạng không hỗ trợ. Chỉ chấp nhận: PDF, DOCX, JPG, PNG, MP4');
-      event.target.value = '';
-      return;
-    }
-    this.selectedFile = file;
-  }
-
-  removeSelectedFile() {
-    this.selectedFile = null;
-  }
-
-  // --- Type color helper ---
-  getTypeColor(type: string): string {
-    const key = (type || 'TEXT').toUpperCase() as ContentType;
-    return CONTENT_TYPE_CONFIG[key]?.color || 'bg-slate-300';
-  }
-
   chapterLabel(index: number): string {
     return buildCurriculumLabel('chapter', index);
   }

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/chapter-editor/chapter-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/chapter-editor/chapter-editor.component.ts
@@ -11,6 +11,8 @@ import { FormsModule } from '@angular/forms';
 import { ChapterDraftDTO, LessonDraftDTO } from '../../../../services/course-authoring.service';
 import { buildCurriculumLabel, stripCurriculumPrefix } from '../../../../utils/curriculum-labels';
 
+type LessonComposerType = 'LECTURE' | 'QUIZ' | 'ASSIGNMENT';
+
 /**
  * Chapter Editor - focused component for editing a single chapter.
  *
@@ -66,7 +68,7 @@ import { buildCurriculumLabel, stripCurriculumPrefix } from '../../../../utils/c
       >
         <div style="display: flex; justify-content: space-between; align-items: center">
           <label class="editor-label">Bài học ({{ lessons().length }})</label>
-          @if (lessons().length > 0) {
+          @if (lessons().length > 0 && !showLessonComposer()) {
             <button type="button" (click)="addLesson.emit()" class="add-lesson-header-btn">
               <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
@@ -75,6 +77,72 @@ import { buildCurriculumLabel, stripCurriculumPrefix } from '../../../../utils/c
             </button>
           }
         </div>
+
+        @if (showLessonComposer()) {
+          <div class="lesson-composer">
+            <div class="lesson-composer__header">
+              <div>
+                <p class="lesson-composer__eyebrow">Tạo bài học mới</p>
+                <p class="lesson-composer__description">
+                  Chọn đúng loại bài học ngay từ đầu để flow soạn nội dung phía sau nhất quán với vùng soạn chính.
+                </p>
+              </div>
+            </div>
+
+            <div class="lesson-composer__type-grid">
+              @for (type of ['LECTURE', 'QUIZ', 'ASSIGNMENT']; track type) {
+                <button
+                  type="button"
+                  class="lesson-type-btn"
+                  [class.lesson-type-btn--active]="lessonDraftType() === type"
+                  (click)="selectLessonDraftType($any(type))"
+                >
+                  <span class="lesson-type-btn__title">{{ lessonTypeTitle($any(type)) }}</span>
+                  <span class="lesson-type-btn__hint">{{ lessonTypeHint($any(type)) }}</span>
+                </button>
+              }
+            </div>
+
+            <div class="editor-field" style="margin-bottom: 0">
+              <label for="lesson-draft-title" class="editor-label">
+                Tên bài học <span class="editor-field-error">*</span>
+              </label>
+              <input
+                id="lesson-draft-title"
+                type="text"
+                [ngModel]="lessonDraftTitle()"
+                (ngModelChange)="onLessonDraftTitleChange($event)"
+                (keydown.enter)="createLesson.emit()"
+                class="editor-input"
+                placeholder="Ví dụ: Giới thiệu công ước SOLAS"
+              />
+            </div>
+
+            <div class="lesson-composer__footer">
+              <button type="button" (click)="cancelLessonCreate.emit()" class="editor-secondary-button">
+                Hủy
+              </button>
+              <button
+                type="button"
+                (click)="createLesson.emit()"
+                [disabled]="isCreatingLesson() || !lessonDraftTitle().trim()"
+                class="editor-primary-button"
+              >
+                @if (isCreatingLesson()) {
+                  <svg class="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path
+                      class="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    ></path>
+                  </svg>
+                }
+                {{ lessonCreateLabel() }}
+              </button>
+            </div>
+          </div>
+        }
 
         @if (lessons().length > 0) {
           <div class="editor-stack" style="gap: 0.375rem">
@@ -97,7 +165,7 @@ import { buildCurriculumLabel, stripCurriculumPrefix } from '../../../../utils/c
               </button>
             }
           </div>
-        } @else {
+        } @else if (!showLessonComposer()) {
           <div class="editor-empty-state" style="padding: 1.5rem; text-align: center">
             <p style="font-size: 0.8125rem; color: rgb(100 116 139); margin-bottom: 0.75rem">
               Chưa có bài học trong chương này
@@ -170,6 +238,72 @@ import { buildCurriculumLabel, stripCurriculumPrefix } from '../../../../utils/c
     .add-lesson-header-btn:hover {
       border-color: rgba(0, 86, 210, 0.4);
       background: rgba(0, 86, 210, 0.04);
+    }
+    .lesson-composer {
+      display: flex;
+      flex-direction: column;
+      gap: 0.875rem;
+      margin-top: 0.875rem;
+      padding: 1rem;
+      border: 1px solid rgba(0, 86, 210, 0.14);
+      border-radius: var(--editor-control-radius);
+      background: linear-gradient(180deg, rgba(0, 86, 210, 0.05) 0%, rgba(255, 255, 255, 0.98) 100%);
+    }
+    .lesson-composer__eyebrow {
+      margin: 0 0 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+      color: rgb(0 86 210);
+    }
+    .lesson-composer__description {
+      margin: 0;
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      color: rgb(71 85 105);
+    }
+    .lesson-composer__type-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0.625rem;
+    }
+    .lesson-type-btn {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.25rem;
+      padding: 0.75rem;
+      border: 1px solid rgba(203, 213, 225, 0.9);
+      border-radius: var(--editor-control-radius);
+      background: rgb(255 255 255 / 0.92);
+      text-align: left;
+      cursor: pointer;
+      transition: border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
+    }
+    .lesson-type-btn:hover {
+      border-color: rgba(0, 86, 210, 0.28);
+      background: rgba(255, 255, 255, 1);
+    }
+    .lesson-type-btn--active {
+      border-color: rgba(0, 86, 210, 0.4);
+      background: rgba(0, 86, 210, 0.08);
+      box-shadow: inset 0 0 0 1px rgba(0, 86, 210, 0.08);
+    }
+    .lesson-type-btn__title {
+      font-size: 0.8125rem;
+      font-weight: 700;
+      color: rgb(15 23 42);
+    }
+    .lesson-type-btn__hint {
+      font-size: 0.75rem;
+      line-height: 1.4;
+      color: rgb(100 116 139);
+    }
+    .lesson-composer__footer {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.75rem;
     }
     .unsaved-hint {
       display: inline-flex;
@@ -256,6 +390,19 @@ import { buildCurriculumLabel, stripCurriculumPrefix } from '../../../../utils/c
     .chapter-lesson-row:hover .chapter-lesson-row__arrow {
       color: rgb(0 86 210);
     }
+    @media (max-width: 900px) {
+      .lesson-composer__type-grid {
+        grid-template-columns: 1fr;
+      }
+      .lesson-composer__footer {
+        flex-direction: column-reverse;
+      }
+      .lesson-composer__footer .editor-primary-button,
+      .lesson-composer__footer .editor-secondary-button {
+        width: 100%;
+        justify-content: center;
+      }
+    }
   `],
 })
 export class ChapterEditorComponent {
@@ -264,12 +411,20 @@ export class ChapterEditorComponent {
   readonly chapterLabel = input('');
   readonly isSaving = input(false);
   readonly isDirty = input(false);
+  readonly showLessonComposer = input(false);
+  readonly lessonDraftTitle = input('');
+  readonly lessonDraftType = input<LessonComposerType>('LECTURE');
+  readonly isCreatingLesson = input(false);
 
   readonly titleChange = output<string>();
   readonly descriptionChange = output<string>();
   readonly saveClicked = output<void>();
   readonly lessonClicked = output<LessonDraftDTO>();
   readonly addLesson = output<void>();
+  readonly lessonDraftTitleChange = output<string>();
+  readonly lessonDraftTypeChange = output<LessonComposerType>();
+  readonly createLesson = output<void>();
+  readonly cancelLessonCreate = output<void>();
 
   readonly title = signal('');
   readonly description = signal('');
@@ -308,5 +463,46 @@ export class ChapterEditorComponent {
 
   lessonLabel(index: number): string {
     return buildCurriculumLabel('lesson', index);
+  }
+
+  onLessonDraftTitleChange(value: string): void {
+    this.lessonDraftTitleChange.emit(value);
+  }
+
+  selectLessonDraftType(type: LessonComposerType): void {
+    this.lessonDraftTypeChange.emit(type);
+  }
+
+  lessonCreateLabel(): string {
+    switch (this.lessonDraftType()) {
+      case 'QUIZ':
+        return 'Tạo bài kiểm tra';
+      case 'ASSIGNMENT':
+        return 'Tạo bài tập';
+      default:
+        return 'Tạo bài học';
+    }
+  }
+
+  lessonTypeTitle(type: LessonComposerType): string {
+    switch (type) {
+      case 'QUIZ':
+        return 'Bài kiểm tra';
+      case 'ASSIGNMENT':
+        return 'Bài tập';
+      default:
+        return 'Bài giảng';
+    }
+  }
+
+  lessonTypeHint(type: LessonComposerType): string {
+    switch (type) {
+      case 'QUIZ':
+        return 'Thiết lập câu hỏi ở builder riêng sau khi tạo.';
+      case 'ASSIGNMENT':
+        return 'Thiết lập mô tả, hạn nộp và giao bài ở bước tiếp theo.';
+      default:
+        return 'Dùng để thêm mục văn bản, video, tài liệu hoặc trắc nghiệm.';
+    }
   }
 }

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lecture-sections-panel/lecture-sections-panel.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lecture-sections-panel/lecture-sections-panel.component.html
@@ -4,7 +4,7 @@
   <div class="add-content-wrapper">
     <button type="button" class="add-content-btn" (click)="toggleDropdown()">
       <lucide-icon name="plus" [size]="14"></lucide-icon>
-      Thêm nội dung
+      Thêm mục
       <lucide-icon name="chevron-down" [size]="12"></lucide-icon>
     </button>
 
@@ -56,8 +56,8 @@
 
 @if (sections().length === 0) {
   <div class="sections-empty">
-    <p style="font-size: 0.8125rem; font-weight: 500; color: rgb(100 116 139); margin-bottom: 0.25rem">Chưa có nội dung</p>
-    <p style="font-size: 0.75rem; color: rgb(148 163 184)">Nhấn "Thêm nội dung" để bắt đầu soạn bài học</p>
+    <p style="font-size: 0.8125rem; font-weight: 500; color: rgb(100 116 139); margin-bottom: 0.25rem">Chưa có mục nào</p>
+    <p style="font-size: 0.75rem; color: rgb(148 163 184)">Nhấn "Thêm mục" để bắt đầu soạn bài học</p>
   </div>
 } @else {
   <div

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.html
@@ -69,11 +69,19 @@
         [chapterLabel]="selectedChapterLabel()"
         [isSaving]="isSaving()"
         [isDirty]="editorDirty()"
+        [showLessonComposer]="lessonComposerOpen()"
+        [lessonDraftTitle]="lessonComposerTitle()"
+        [lessonDraftType]="lessonComposerType()"
+        [isCreatingLesson]="lessonComposerBusy()"
         (titleChange)="onChapterTitleChange($event)"
         (descriptionChange)="onChapterDescriptionChange($event)"
         (saveClicked)="saveChapter()"
         (lessonClicked)="selectLessonFromChapter($event)"
-        (addLesson)="requestAddLessonForCurrentChapter()">
+        (addLesson)="requestAddLessonForCurrentChapter()"
+        (lessonDraftTitleChange)="onLessonComposerTitleChange($event)"
+        (lessonDraftTypeChange)="onLessonComposerTypeChange($event)"
+        (createLesson)="createLessonFromComposer()"
+        (cancelLessonCreate)="cancelLessonComposer()">
       </app-chapter-editor>
     }
   }

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.ts
@@ -37,6 +37,7 @@ import { QuizPackageModalsComponent } from './components/quiz-package-modals/qui
 import { buildCurriculumLabel, stripCurriculumPrefix } from '../../utils/curriculum-labels';
 
 type SectionQuizAssessmentType = 'PRACTICE' | 'ASSESSMENT' | 'EXAM';
+type LessonComposerType = 'LECTURE' | 'QUIZ' | 'ASSIGNMENT';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -152,6 +153,10 @@ export class CourseCurriculumComponent implements OnDestroy {
   lessonTitle = '';
   lessonContent = '';
   lessonVideoUrl = '';
+  lessonComposerOpen = signal(false);
+  lessonComposerTitle = signal('');
+  lessonComposerType = signal<LessonComposerType>('LECTURE');
+  lessonComposerBusy = signal(false);
 
   // Quiz fields
   quizTimeLimit = signal(30);
@@ -248,6 +253,19 @@ export class CourseCurriculumComponent implements OnDestroy {
         this.chapterTitle = chapter.title;
         this.chapterDescription = chapter.description || '';
       }
+    });
+
+    effect(() => {
+      const chapter = this.editorSvc.pendingLessonCreateForChapter();
+      if (!chapter) {
+        return;
+      }
+
+      untracked(() => {
+        this.selectionService.selectChapter(chapter);
+        this.openLessonComposerForChapter(chapter);
+        this.editorSvc.pendingLessonCreateForChapter.set(null);
+      });
     });
 
     effect(() => {
@@ -605,13 +623,81 @@ export class CourseCurriculumComponent implements OnDestroy {
   }
 
   private hasPendingChanges(): boolean {
-    return this.editorDirty() || this.isSaving();
+    return this.editorDirty() || this.isSaving() || this.hasPendingLessonComposerDraft();
   }
   requestAddLessonForCurrentChapter() {
     const chapter = this.selectionService.selectedChapter();
     if (chapter) {
-      this.editorSvc.pendingLessonCreateForChapter.set(chapter);
+      this.openLessonComposerForChapter(chapter);
     }
+  }
+
+  private openLessonComposerForChapter(chapter: ChapterDraftDTO): void {
+    this.selectionService.selectChapter(chapter);
+    this.lessonComposerOpen.set(true);
+    this.lessonComposerTitle.set('');
+    this.lessonComposerType.set('LECTURE');
+    this.editorSvc.closeSectionSurface();
+    this.selectionService.clearSectionSelection();
+    this.syncEditorDirtyState();
+  }
+
+  cancelLessonComposer(): void {
+    this.lessonComposerOpen.set(false);
+    this.lessonComposerTitle.set('');
+    this.lessonComposerType.set('LECTURE');
+    this.syncEditorDirtyState();
+  }
+
+  onLessonComposerTitleChange(value: string): void {
+    this.lessonComposerTitle.set(value);
+    this.syncEditorDirtyState();
+  }
+
+  onLessonComposerTypeChange(type: LessonComposerType): void {
+    this.lessonComposerType.set(type);
+    this.syncEditorDirtyState();
+  }
+
+  async createLessonFromComposer(): Promise<void> {
+    const chapter = this.selectionService.selectedChapter();
+    const courseId = this.store.courseTree()?.id;
+    const title = this.lessonComposerTitle().trim();
+    if (!chapter || !courseId || !title) {
+      return;
+    }
+
+    this.lessonComposerBusy.set(true);
+    try {
+      const lessonType = this.lessonComposerType();
+      await firstValueFrom(this.lessonApi.createLesson(chapter.id, {
+        title,
+        type: lessonType,
+        content: undefined
+      }));
+
+      const createdTypeLabel = lessonType === 'QUIZ'
+        ? 'bài kiểm tra'
+        : lessonType === 'ASSIGNMENT'
+          ? 'bài tập'
+          : 'bài học';
+
+      this.cancelLessonComposer();
+      this.store.loadCourse(courseId, true);
+
+      this.toast.success(`Đã tạo ${createdTypeLabel} mới. Chọn mục vừa tạo trong vùng soạn để tiếp tục.`);
+    } catch (err: any) {
+      this.toast.error('Tạo bài học thất bại: ' + (err?.error?.message || err?.message || ''));
+    } finally {
+      this.lessonComposerBusy.set(false);
+    }
+  }
+
+  private hasPendingLessonComposerDraft(): boolean {
+    return this.lessonComposerOpen() && (
+      this.lessonComposerTitle().trim().length > 0
+      || this.lessonComposerType() !== 'LECTURE'
+    );
   }
 
   async selectLessonFromChapter(lesson: LessonDraftDTO) {
@@ -846,11 +932,20 @@ export class CourseCurriculumComponent implements OnDestroy {
 
     const chapter = this.selectionService.selectedChapter();
     if (chapter) {
+      const composerDraft = this.hasPendingLessonComposerDraft()
+        ? [
+            'lesson-composer',
+            this.lessonComposerTitle().trim(),
+            this.lessonComposerType()
+          ].join('|')
+        : '';
+
       return [
         'chapter',
         chapter.id,
         this.chapterTitle.trim(),
-        this.chapterDescription.trim()
+        this.chapterDescription.trim(),
+        composerDraft
       ].join('|');
     }
 

--- a/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
+++ b/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
@@ -55,7 +55,7 @@ export class CurriculumEditorService {
   });
 
   // ── Cross-component bridge ───────────────────────────────────────────
-  /** Set by chapter-editor (via parent) to request sidebar opens lesson modal */
+  /** Set by navigation surfaces to request the main curriculum workspace opens lesson creation */
   readonly pendingLessonCreateForChapter = signal<ChapterDraftDTO | null>(null);
 
   // ── Section surface state ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- make the main curriculum workspace the canonical place to create lessons and lesson sections
- turn the sidebar into a navigation and intent surface instead of a second authoring flow
- improve first-time teacher affordances with clearer Thêm bài học / Thêm mục entry points and consistent wording
- protect inline lesson drafts from being lost silently when the teacher navigates away

Replaces #28 (auto-closed when stacked base branch was merged). Original review and context preserved.

Refs #26, #27

## Verification
- [x] `npm run build`
- [x] Verified no remaining sidebar lesson/section creation modal references
- [x] Verified the curriculum route handles chapter/lesson/section context correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)