### PR TITLE
fix(prod): hide unavailable Wiii AI entrypoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
 
 permissions:

--- a/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
@@ -7,6 +7,7 @@ import { SidebarComponent } from '../../../../shared/components/navigation/sideb
 import { getSidebarConfig } from '../../../../shared/components/navigation/sidebar.config';
 import { ChatPanelComponent } from '../../../ai-chat/presentation/components/chat-panel/chat-panel.component';
 import { FloatingChatBubbleComponent } from '../../../ai-chat/presentation/components/floating-chat-bubble/floating-chat-bubble.component';
+import { AiAvailabilityService } from '../../../ai-chat/application/services/ai-availability.service';
 
 @Component({
   selector: 'app-admin-layout-simple',
@@ -272,6 +273,7 @@ import { FloatingChatBubbleComponent } from '../../../ai-chat/presentation/compo
 })
 export class AdminLayoutSimpleComponent implements OnInit, OnDestroy {
   protected authService = inject(AuthService);
+  private aiAvailability = inject(AiAvailabilityService);
   private router = inject(Router);
   protected isMobileSidebarOpen = signal(false);
 
@@ -306,7 +308,9 @@ export class AdminLayoutSimpleComponent implements OnInit, OnDestroy {
     const isOperationalAdminRoute = route.startsWith('/admin/offline-storage')
       || route.startsWith('/admin/settings')
       || route.startsWith('/admin/logs');
-    return !this.shouldHideSidebar() && !isOperationalAdminRoute;
+    return this.aiAvailability.isAvailable()
+      && !this.shouldHideSidebar()
+      && !isOperationalAdminRoute;
   });
 
   ngOnInit(): void {

--- a/fe/src/app/features/ai-chat/application/services/ai-availability.service.ts
+++ b/fe/src/app/features/ai-chat/application/services/ai-availability.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { ChatApiClient } from '../../infrastructure/api/chat-api.client';
+
+type AiAvailabilityStatus = 'checking' | 'available' | 'unavailable';
+
+@Injectable({ providedIn: 'root' })
+export class AiAvailabilityService {
+  private readonly apiClient = inject(ChatApiClient);
+
+  private readonly _status = signal<AiAvailabilityStatus>('checking');
+
+  readonly status = this._status.asReadonly();
+  readonly isAvailable = computed(() => this._status() === 'available');
+  readonly hasResolved = computed(() => this._status() !== 'checking');
+
+  constructor() {
+    this.refresh();
+  }
+
+  refresh(): void {
+    this.apiClient.checkHealth().subscribe({
+      next: (health) => {
+        const isAvailable = health.status === 'healthy'
+          && health.aiServiceStatus === 'available';
+        this._status.set(isAvailable ? 'available' : 'unavailable');
+      },
+      error: () => {
+        this._status.set('unavailable');
+      }
+    });
+  }
+}

--- a/fe/src/app/features/ai-chat/application/services/chat.service.ts
+++ b/fe/src/app/features/ai-chat/application/services/chat.service.ts
@@ -1346,7 +1346,7 @@ export class ChatService {
       next: (health) => {
         this._serviceState.update((state) => ({
           ...state,
-          isHealthy: health.status === 'healthy',
+          isHealthy: health.status === 'healthy' && health.aiServiceStatus === 'available',
         }));
       },
       error: () => {

--- a/fe/src/app/features/ai-chat/application/services/index.ts
+++ b/fe/src/app/features/ai-chat/application/services/index.ts
@@ -3,3 +3,4 @@
  */
 export { SessionManagementService } from './session-management.service';
 export { ChatService } from './chat.service';
+export { AiAvailabilityService } from './ai-availability.service';

--- a/fe/src/app/features/ai-chat/infrastructure/api/chat-api.client.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/chat-api.client.ts
@@ -141,10 +141,16 @@ export class ChatApiClient {
    */
   checkHealth(): Observable<HealthStatus> {
     return this.http
-      .get<HealthStatus>(
+      .get<HealthStatus | { data?: HealthStatus }>(
         `${AI_CHAT_CONFIG.baseUrl}/health`
       )
       .pipe(
+        map((response) => {
+          if ('data' in response && response.data) {
+            return response.data;
+          }
+          return response as HealthStatus;
+        }),
         timeout(10000),
         tap(() => {
           this.isServerAwake = true;

--- a/fe/src/app/features/student/shared/student-layout-simple.component.ts
+++ b/fe/src/app/features/student/shared/student-layout-simple.component.ts
@@ -11,6 +11,7 @@ import { ChatPanelComponent } from '../../ai-chat/presentation/components/chat-p
 import { OfflineSyncService } from '../../../core/services/offline-sync.service';
 import { NetworkStatusService } from '../../../core/services/network-status.service';
 import { ConfirmDialogService } from '../../../core/services/confirm-dialog.service';
+import { AiAvailabilityService } from '../../ai-chat/application/services/ai-availability.service';
 
 @Component({
   selector: 'app-student-layout-simple',
@@ -112,7 +113,7 @@ import { ConfirmDialogService } from '../../../core/services/confirm-dialog.serv
                   </svg>
                   <span class="tab-label">Cần làm</span>
                 </a>
-                @if (enableAssistant) {
+                @if (enableAssistant()) {
                   <button
                     (click)="toggleMobilePanel()"
                     aria-label="Trợ lý Wiii AI"
@@ -152,7 +153,7 @@ import { ConfirmDialogService } from '../../../core/services/confirm-dialog.serv
         </div>
 
         <!-- AI Sidebar (Desktop) — always rendered, animated via CSS -->
-        @if (enableAssistant && isAiSidebarOpen()) {
+        @if (enableAssistant() && isAiSidebarOpen()) {
           <aside class="ai-sidebar ai-sidebar-open hidden md:flex md:flex-col"
                  [class.ai-sidebar-resizing]="isResizing()"
                  [style.width.px]="aiSidebarWidth()"
@@ -165,7 +166,7 @@ import { ConfirmDialogService } from '../../../core/services/confirm-dialog.serv
         }
 
         <!-- Resize handle — fixed position at sidebar's left edge -->
-        @if (enableAssistant && isAiSidebarOpen()) {
+        @if (enableAssistant() && isAiSidebarOpen()) {
           <div class="resize-handle-track"
                [style.right.px]="aiSidebarWidth() - 6"
                [class.resize-active]="isResizing()"
@@ -176,13 +177,13 @@ import { ConfirmDialogService } from '../../../core/services/confirm-dialog.serv
         }
 
         <!-- Resize overlay — blocks iframe from stealing mouse events during drag -->
-        @if (enableAssistant && isResizing()) {
+        @if (enableAssistant() && isResizing()) {
           <div class="resize-overlay"></div>
         }
       </div>
 
       <!-- Desktop: Toggle tab — always rendered, animated -->
-      @if (enableAssistant) {
+      @if (enableAssistant()) {
       <button
         class="ai-sidebar-toggle hidden md:flex"
         [class.ai-toggle-hidden]="isAiSidebarOpen()"
@@ -198,7 +199,7 @@ import { ConfirmDialogService } from '../../../core/services/confirm-dialog.serv
       <!-- ============================================================
            MOBILE: Chat panel with slide-up animation
            ============================================================ -->
-      @if (enableAssistant) {
+      @if (enableAssistant()) {
         <div class="mobile-ai-overlay md:hidden"
              [class.open]="isMobilePanelOpen()">
           <div class="mobile-ai-backdrop" (click)="closeMobilePanel()"></div>
@@ -436,9 +437,8 @@ import { ConfirmDialogService } from '../../../core/services/confirm-dialog.serv
 })
 export class StudentLayoutSimpleComponent implements OnInit, OnDestroy {
   protected authService = inject(AuthService);
-  // Students should get the same embedded Wiii assistant surface as teachers.
-  // Role-specific behavior is handled by host context and backend policies, not by hiding the entrypoint.
-  protected readonly enableAssistant = true;
+  private aiAvailability = inject(AiAvailabilityService);
+  protected readonly enableAssistant = this.aiAvailability.isAvailable;
   private router = inject(Router);
   private notificationService = inject(NotificationService);
   private messagingService = inject(MessagingService);

--- a/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
+++ b/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
@@ -8,6 +8,7 @@ import { teacherSidebarConfig as baseTeacherSidebarConfig } from '../../../share
 import { NotificationService } from '../../../core/services/notification.service';
 import { MessagingService } from '../../../core/services/messaging.service';
 import { ChatPanelComponent } from '../../ai-chat/presentation/components/chat-panel/chat-panel.component';
+import { AiAvailabilityService } from '../../ai-chat/application/services/ai-availability.service';
 
 @Component({
   selector: 'app-teacher-layout-simple',
@@ -144,6 +145,7 @@ import { ChatPanelComponent } from '../../ai-chat/presentation/components/chat-p
         </div>
 
         <!-- AI Sidebar (Desktop) — always rendered, animated via CSS -->
+        @if (enableAssistant()) {
         <aside class="ai-sidebar hidden md:flex md:flex-col"
                [class.ai-sidebar-open]="isAiSidebarOpen()"
                [class.ai-sidebar-resizing]="isResizing()"
@@ -172,9 +174,11 @@ import { ChatPanelComponent } from '../../ai-chat/presentation/components/chat-p
         @if (isResizing()) {
           <div class="resize-overlay"></div>
         }
+        }
       </div>
 
       <!-- Desktop: Toggle tab — always rendered, animated -->
+      @if (enableAssistant()) {
       <button
         class="ai-sidebar-toggle hidden md:flex"
         [class.ai-toggle-hidden]="isAiSidebarOpen()"
@@ -185,10 +189,12 @@ import { ChatPanelComponent } from '../../ai-chat/presentation/components/chat-p
           <path fill-rule="evenodd" d="M9 4.5a.75.75 0 01.721.544l.813 2.846a3.75 3.75 0 002.576 2.576l2.846.813a.75.75 0 010 1.442l-2.846.813a3.75 3.75 0 00-2.576 2.576l-.813 2.846a.75.75 0 01-1.442 0l-.813-2.846a3.75 3.75 0 00-2.576-2.576l-2.846-.813a.75.75 0 010-1.442l2.846-.813A3.75 3.75 0 007.466 7.89l.813-2.846A.75.75 0 019 4.5zM18 1.5a.75.75 0 01.728.568l.258 1.036c.236.94.97 1.674 1.91 1.91l1.036.258a.75.75 0 010 1.456l-1.036.258c-.94.236-1.674.97-1.91 1.91l-.258 1.036a.75.75 0 01-1.456 0l-.258-1.036a2.625 2.625 0 00-1.91-1.91l-1.036-.258a.75.75 0 010-1.456l1.036-.258a2.625 2.625 0 001.91-1.91l.258-1.036A.75.75 0 0118 1.5z" clip-rule="evenodd" />
         </svg>
       </button>
+      }
 
       <!-- ============================================================
            MOBILE: Slide-up AI panel (triggered from bottom nav tab)
            ============================================================ -->
+      @if (enableAssistant()) {
       <div class="mobile-ai-overlay md:hidden"
            [class.open]="isMobilePanelOpen()">
         <div class="mobile-ai-backdrop" (click)="closeMobilePanel()"></div>
@@ -201,6 +207,7 @@ import { ChatPanelComponent } from '../../ai-chat/presentation/components/chat-p
           }
         </div>
       </div>
+      }
     </div>
     `,
   styles: [`
@@ -428,9 +435,11 @@ import { ChatPanelComponent } from '../../ai-chat/presentation/components/chat-p
 })
 export class TeacherLayoutSimpleComponent implements OnInit, OnDestroy {
   protected authService = inject(AuthService);
+  private aiAvailability = inject(AiAvailabilityService);
   private router = inject(Router);
   private notificationService = inject(NotificationService);
   private messagingService = inject(MessagingService);
+  protected readonly enableAssistant = this.aiAvailability.isAvailable;
   protected isMobileSidebarOpen = signal(false);
   protected sidebarCollapsed = signal(false);
 


### PR DESCRIPTION
## Problem
Production is still exposing Wiii AI entrypoints even when the AI token-exchange path is not configured.

Observed on prod:
- `GET /api/v3/ai/health` returns `aiServiceStatus: not_configured`, `webhookEnabled: false`.
- `POST /api/v3/ai/token` with a valid student JWT returns `AI_TOKEN_FAILED`.
- Backend logs show repeated `Wiii webhook secret not configured — cannot sign token exchange` after `AI token exchange requested`.

## Root Cause
- Student/teacher/admin layouts kept rendering AI entrypoints by default.
- The AI health client did not unwrap the backend `ApiResponse.data` payload.
- AI chat health state only checked `status === healthy` and ignored `aiServiceStatus`.

## Fix
- Add a small shared `AiAvailabilityService` backed by `/api/v3/ai/health`.
- Treat AI as available only when `aiServiceStatus === available`.
- Gate student/teacher/admin AI entrypoints on that availability signal.
- Unwrap `/api/v3/ai/health` responses correctly in the chat API client.
- Align AI chat service health state with real AI availability.

## Verified
- [x] Checked prod logs and health endpoints
- [x] Reproduced `AI_TOKEN_FAILED` against production with a valid student JWT
- [x] `cd fe && npm run build`

Closes #45.