### PR TITLE
fix(prod): harden invalid refresh token handling

### DIFF
--- a/backend/src/main/java/com/example/lms/identity/infrastructure/security/TokenServiceAdapter.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/security/TokenServiceAdapter.java
@@ -1,6 +1,7 @@
 package com.example.lms.identity.infrastructure.security;
 
 import com.example.lms.identity.application.port.TokenService;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -23,13 +24,21 @@ public class TokenServiceAdapter implements TokenService {
 
     @Override
     public String extractEmail(String token) {
-        return jwtService.extractUsername(token);
+        try {
+            return jwtService.extractUsername(token);
+        } catch (JwtException | IllegalArgumentException ex) {
+            return null;
+        }
     }
 
     @Override
     public boolean isTokenValid(String token, String email) {
         UserDetails userDetails = toUserDetails(email);
-        return jwtService.isTokenValid(token, userDetails);
+        try {
+            return jwtService.isTokenValid(token, userDetails);
+        } catch (JwtException | IllegalArgumentException ex) {
+            return false;
+        }
     }
 
     @Override

--- a/backend/src/test/java/com/example/lms/identity/application/usecase/RefreshTokenUseCaseV2Test.java
+++ b/backend/src/test/java/com/example/lms/identity/application/usecase/RefreshTokenUseCaseV2Test.java
@@ -93,6 +93,21 @@ class RefreshTokenUseCaseV2Test {
     }
 
     @Test
+    @DisplayName("Should reject malformed refresh token with INVALID_TOKEN error")
+    void shouldRejectMalformedRefreshToken() {
+        when(tokenService.extractEmail(OLD_REFRESH_TOKEN)).thenReturn(null);
+
+        assertThatThrownBy(() -> useCase.execute(OLD_REFRESH_TOKEN))
+                .isInstanceOfSatisfying(BusinessRuleException.class,
+                        exception -> assertThat(exception.getRuleName()).isEqualTo("INVALID_TOKEN"));
+
+        verify(userRepository, never()).findByEmail(anyString());
+        verify(tokenService, never()).isTokenValid(anyString(), anyString());
+        verify(tokenService, never()).generateAccessToken(any(), anyString(), anyString(), any());
+        verify(tokenService, never()).generateRefreshToken(any(), anyString(), anyString(), anyLong());
+    }
+
+    @Test
     @DisplayName("Should refresh tokens successfully for enabled user")
     void shouldRefreshTokenForEnabledUser() {
         User enabledUser = User.builder()

--- a/backend/src/test/java/com/example/lms/identity/infrastructure/security/TokenServiceAdapterTest.java
+++ b/backend/src/test/java/com/example/lms/identity/infrastructure/security/TokenServiceAdapterTest.java
@@ -1,0 +1,51 @@
+package com.example.lms.identity.infrastructure.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TokenServiceAdapter Tests")
+class TokenServiceAdapterTest {
+
+    private static final String PRIMARY_SECRET = Base64.getEncoder()
+            .encodeToString("12345678901234567890123456789012".getBytes(StandardCharsets.UTF_8));
+    private static final String SECONDARY_SECRET = Base64.getEncoder()
+            .encodeToString("abcdefghijklmnopqrstuvwxyz123456".getBytes(StandardCharsets.UTF_8));
+
+    @Test
+    @DisplayName("extractEmail returns null for malformed JWT")
+    void extractEmailReturnsNullForMalformedJwt() {
+        TokenServiceAdapter adapter = new TokenServiceAdapter(jwtService(PRIMARY_SECRET));
+
+        assertThat(adapter.extractEmail("not-a-jwt")).isNull();
+    }
+
+    @Test
+    @DisplayName("isTokenValid returns false for JWT signed with a different secret")
+    void isTokenValidReturnsFalseForJwtSignedWithDifferentSecret() {
+        TokenServiceAdapter adapter = new TokenServiceAdapter(jwtService(PRIMARY_SECRET));
+        UserDetails userDetails = User.withUsername("student@maritime.edu")
+                .password("")
+                .authorities("ROLE_USER")
+                .build();
+        String signedByOtherSecret = jwtService(SECONDARY_SECRET).generateRefreshToken(userDetails);
+
+        assertThat(adapter.extractEmail(signedByOtherSecret)).isNull();
+        assertThat(adapter.isTokenValid(signedByOtherSecret, userDetails.getUsername())).isFalse();
+    }
+
+    private static JwtService jwtService(String secret) {
+        JwtService jwtService = new JwtService();
+        ReflectionTestUtils.setField(jwtService, "secretKey", secret);
+        ReflectionTestUtils.setField(jwtService, "jwtExpiration", 3_600_000L);
+        ReflectionTestUtils.setField(jwtService, "refreshExpiration", 86_400_000L);
+        return jwtService;
+    }
+}

--- a/backend/src/test/java/com/example/lms/identity/infrastructure/web/AuthControllerV3Test.java
+++ b/backend/src/test/java/com/example/lms/identity/infrastructure/web/AuthControllerV3Test.java
@@ -13,6 +13,7 @@ import com.example.lms.identity.application.usecase.SendVerificationEmailUseCase
 import com.example.lms.identity.application.usecase.UpdateProfileUseCaseV2;
 import com.example.lms.identity.application.usecase.VerifyEmailUseCase;
 import com.example.lms.shared.application.port.EmailServicePort;
+import com.example.lms.shared.exception.BusinessRuleException;
 import com.example.lms.shared.infrastructure.web.GlobalExceptionHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -154,5 +155,22 @@ class AuthControllerV3Test {
                 .andExpect(jsonPath("$.data.googleUnavailableMessage").value(
                         "Tài khoản này dùng Google để đăng nhập, nhưng Google sign-in hiện tạm thời chưa khả dụng. Vui lòng thử lại sau hoặc liên hệ quản trị viên."
                 ));
+    }
+
+    @Test
+    @DisplayName("refresh returns 422 when refresh token is invalid")
+    void refreshReturnsUnprocessableEntityForInvalidToken() throws Exception {
+        given(refreshTokenUseCase.execute("not-a-jwt"))
+                .willThrow(new BusinessRuleException("INVALID_TOKEN", "Token khong hop le"));
+
+        mockMvc.perform(post("/api/v3/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"refreshToken":"not-a-jwt"}
+                                """))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Token khong hop le"))
+                .andExpect(jsonPath("$.error.code").value("BUSINESS_RULE_VIOLATION"));
     }
 }


### PR DESCRIPTION
## Problem
Production returns `500 INTERNAL_ERROR` for `POST /api/v3/auth/refresh` when a refresh token is malformed or signed with the wrong key. Reproduced against `https://holilihu.online` with `{ "refreshToken": "not-a-jwt" }`, and backend logs show the same failure path surfacing from `RefreshTokenUseCaseV2`.

## Root Cause
`TokenServiceAdapter` lets `JwtException` and `IllegalArgumentException` escape from `JwtService`. That leaks infrastructure-level JWT parsing failures into the application use case, so `RefreshTokenUseCaseV2` never reaches its normal invalid-token business flow and `GlobalExceptionHandler` turns the exception into HTTP 500.

## Fix
- make `TokenServiceAdapter.extractEmail()` return `null` when JWT parsing/signature validation fails
- make `TokenServiceAdapter.isTokenValid()` return `false` for the same invalid token cases
- add regression coverage for adapter behavior, refresh use-case behavior, and `/api/v3/auth/refresh` controller behavior

## Verified
- [x] Tested locally (`mvn "-Dtest=TokenServiceAdapterTest,RefreshTokenUseCaseV2Test,AuthControllerV3Test" test`)
- [x] Checked prod logs

Closes #50
