### PR TITLE
fix: student bugs, courses, quiz UX, SSR/SEO (issues #19-44)

### DIFF
--- a/backend/src/main/java/com/example/lms/course_authoring/domain/repository/CourseRepository.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/domain/repository/CourseRepository.java
@@ -161,6 +161,10 @@ public interface CourseRepository {
      */
     Page<Course> findByStatusAndTitleContaining(Course.CourseStatus status, String search, Pageable pageable);
 
+    Page<Course> findByStatusAndCategoryId(Course.CourseStatus status, UUID categoryId, Pageable pageable);
+
+    Page<Course> findByStatusAndCategoryIdAndTitleContaining(Course.CourseStatus status, UUID categoryId, String search, Pageable pageable);
+
     /**
      * Find all courses by title containing search text (any status).
      */

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/CourseRepositoryImpl.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/CourseRepositoryImpl.java
@@ -219,6 +219,19 @@ public class CourseRepositoryImpl implements CourseRepository {
     }
 
     @Override
+    public Page<Course> findByStatusAndCategoryId(Course.CourseStatus status, UUID categoryId, Pageable pageable) {
+        CourseJpaEntity.CourseStatus entityStatus = mapStatusToEntity(status);
+        return jpaRepository.findByStatusAndCategoryId(entityStatus, categoryId, pageable).map(mapper::toDomain);
+    }
+
+    @Override
+    public Page<Course> findByStatusAndCategoryIdAndTitleContaining(Course.CourseStatus status, UUID categoryId, String search, Pageable pageable) {
+        String entityStatus = mapStatusToEntity(status).name();
+        return jpaRepository.findByStatusAndCategoryIdAndTitleContaining(entityStatus, categoryId, search, pageable)
+                .map(mapper::toDomain);
+    }
+
+    @Override
     public int findMaxSequenceNumberByPrefix(String prefix) {
         Integer max = jpaRepository.findMaxSequenceNumberByPrefix(prefix);
         return max != null ? max : 0;

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/JpaCourseRepository.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/JpaCourseRepository.java
@@ -112,6 +112,15 @@ public interface JpaCourseRepository extends JpaRepository<CourseJpaEntity, UUID
 
     Page<CourseJpaEntity> findByStatus(CourseJpaEntity.CourseStatus status, Pageable pageable);
 
+    Page<CourseJpaEntity> findByStatusAndCategoryId(CourseJpaEntity.CourseStatus status, UUID categoryId, Pageable pageable);
+
+    @Query(value = "SELECT * FROM courses c WHERE c.status = :status AND c.category_id = :categoryId AND unaccent(LOWER(c.title)) LIKE unaccent(LOWER(CONCAT('%', :search, '%')))", nativeQuery = true)
+    Page<CourseJpaEntity> findByStatusAndCategoryIdAndTitleContaining(
+            @Param("status") String status,
+            @Param("categoryId") UUID categoryId,
+            @Param("search") String search,
+            Pageable pageable);
+
     @Query(value = """
   SELECT * FROM courses c
   WHERE c.status = 'PENDING'

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/repository/CourseCategoryJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/repository/CourseCategoryJpaRepository.java
@@ -28,4 +28,6 @@ public interface CourseCategoryJpaRepository extends JpaRepository<CourseCategor
     boolean existsByPrefix(String prefix);
 
     Optional<CourseCategoryJpaEntity> findByCode(String code);
+
+    Optional<CourseCategoryJpaEntity> findBySlug(String slug);
 }

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/service/CoursePublicationService.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/service/CoursePublicationService.java
@@ -285,7 +285,7 @@ public class CoursePublicationService {
 
             Map<String, Object> section = new LinkedHashMap<>();
             section.put("id", block.getId());
-            section.put("title", asString(data.get("title"), "Untitled"));
+            section.put("title", data.get("title"));
             section.put("type", block.getType() != null ? block.getType().toUpperCase(Locale.ROOT) : "TEXT");
             section.put("content", data.get("content"));
             section.put("videoUrl", data.get("videoUrl"));

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
@@ -72,15 +72,38 @@ public class CourseQueryControllerV3 {
     public ResponseEntity<ApiResponse<Page<CourseSummaryResponse>>> getPublicCourses(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam(required = false) String search
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false, defaultValue = "createdAt") String sort,
+            @RequestParam(required = false, defaultValue = "desc") String order
     ) {
+        UUID categoryId = null;
+        if (category != null && !category.isBlank()) {
+            categoryId = courseCategoryJpaRepository.findByCode(category.toUpperCase(Locale.ROOT))
+                    .or(() -> courseCategoryJpaRepository.findBySlug(category.toLowerCase(Locale.ROOT)))
+                    .map(c -> c.getId())
+                    .orElse(null);
+        }
+
+        String sortField = Set.of("createdAt", "title").contains(sort) ? sort : "createdAt";
+        Sort sortOrder = "asc".equalsIgnoreCase(order) ? Sort.by(sortField).ascending() : Sort.by(sortField).descending();
+        String nativeSortField = "title".equals(sortField) ? "title" : "created_at";
+        Sort nativeSortOrder = "asc".equalsIgnoreCase(order) ? Sort.by(nativeSortField).ascending() : Sort.by(nativeSortField).descending();
+
         Page<Course> courses;
-        if (search != null && !search.isBlank()) {
-            // Native query uses snake_case column names
-            PageRequest nativePageable = PageRequest.of(Math.max(0, page), Math.min(Math.max(1, size), 100), Sort.by("created_at").descending());
+        boolean hasSearch = search != null && !search.isBlank();
+
+        if (hasSearch && categoryId != null) {
+            PageRequest nativePageable = PageRequest.of(Math.max(0, page), Math.min(Math.max(1, size), 100), nativeSortOrder);
+            courses = courseRepository.findByStatusAndCategoryIdAndTitleContaining(Course.CourseStatus.APPROVED, categoryId, search, nativePageable);
+        } else if (hasSearch) {
+            PageRequest nativePageable = PageRequest.of(Math.max(0, page), Math.min(Math.max(1, size), 100), nativeSortOrder);
             courses = courseRepository.findByStatusAndTitleContaining(Course.CourseStatus.APPROVED, search, nativePageable);
+        } else if (categoryId != null) {
+            PageRequest pageable = PageRequest.of(Math.max(0, page), Math.min(Math.max(1, size), 100), sortOrder);
+            courses = courseRepository.findByStatusAndCategoryId(Course.CourseStatus.APPROVED, categoryId, pageable);
         } else {
-            PageRequest pageable = PageRequest.of(Math.max(0, page), Math.min(Math.max(1, size), 100), Sort.by("createdAt").descending());
+            PageRequest pageable = PageRequest.of(Math.max(0, page), Math.min(Math.max(1, size), 100), sortOrder);
             courses = courseRepository.findByStatus(Course.CourseStatus.APPROVED, pageable);
         }
         
@@ -974,7 +997,7 @@ public class CourseQueryControllerV3 {
             String videoType = resolveSectionVideoType(data, streamVideoUid);
             SectionResponse response = SectionResponse.builder()
                     .id(block.getId())
-                    .title((String) data.getOrDefault("title", "Untitled"))
+                    .title((String) data.get("title"))
                     .type(block.getType() != null ? block.getType().toUpperCase(Locale.ROOT) : "TEXT")
                     .content(showContent ? (String) data.get("content") : null)
                     .structuredContent(showContent ? new LinkedHashMap<>(data) : null)

--- a/fe/src/app/api/client/course.api.ts
+++ b/fe/src/app/api/client/course.api.ts
@@ -55,7 +55,7 @@ export class CourseApi {
     );
   }
 
-  publicCourses(params?: { page?: number; size?: number; search?: string; teacher?: string }): Observable<ApiResponse<CourseSummary[]>> {
+  publicCourses(params?: { page?: number; size?: number; search?: string; teacher?: string; category?: string; sort?: string; order?: string }): Observable<ApiResponse<CourseSummary[]>> {
     return this.api.getWithResponse<any>(COURSE_ENDPOINTS.BASE, { params }).pipe(
       map((res: ApiResponse<any>) => {
         const content: CourseSummary[] = res?.data?.content ?? [];

--- a/fe/src/app/features/courses/course-detail.component.ts
+++ b/fe/src/app/features/courses/course-detail.component.ts
@@ -330,5 +330,47 @@ export class CourseDetailComponent implements OnInit {
   private updateSeo(course: ExtendedCourse): void {
     const description = course.description?.slice(0, 160) || course.title;
     this.seo.setPageMeta(course.title, description, course.thumbnail);
+    this.seo.setCanonical(`https://holilihu.online/courses/${course.id}`);
+    this.injectCourseJsonLd(course);
+  }
+
+  private injectCourseJsonLd(course: ExtendedCourse): void {
+    const instructorName = typeof course.instructor === 'string'
+      ? course.instructor
+      : course.instructor?.name || 'Giảng viên';
+
+    const jsonLd: Record<string, unknown> = {
+      '@context': 'https://schema.org',
+      '@type': 'Course',
+      name: course.title,
+      description: (course.description || course.title).slice(0, 500),
+      url: `https://holilihu.online/courses/${course.id}`,
+      provider: {
+        '@type': 'Organization',
+        name: 'LMS Maritime',
+        sameAs: 'https://holilihu.online'
+      },
+      instructor: {
+        '@type': 'Person',
+        name: instructorName
+      },
+      inLanguage: 'vi',
+      isAccessibleForFree: !course.price || course.price === 0
+    };
+
+    if (course.thumbnail) {
+      jsonLd['image'] = course.thumbnail;
+    }
+
+    if (course.price && course.price > 0) {
+      jsonLd['offers'] = {
+        '@type': 'Offer',
+        price: course.salePrice ?? course.price,
+        priceCurrency: 'VND',
+        availability: 'https://schema.org/InStock'
+      };
+    }
+
+    this.seo.setJsonLd('jsonld-course-detail', jsonLd);
   }
 }

--- a/fe/src/app/features/courses/courses.component.html
+++ b/fe/src/app/features/courses/courses.component.html
@@ -33,12 +33,12 @@
                         aria-label="Lọc theo danh mục"
                         class="w-full px-3 py-2 border border-gray-800 rounded-md focus:outline-none focus:ring-2 focus:ring-[#0056D2]">
                   <option [ngValue]="undefined">Tất cả danh mục</option>
-                  <option [ngValue]="CourseCategory.MARINE_ENGINEERING">Kỹ thuật tàu biển</option>
-                  <option [ngValue]="CourseCategory.PORT_MANAGEMENT">Quản lý cảng</option>
-                  <option [ngValue]="CourseCategory.MARITIME_SAFETY">An toàn hàng hải</option>
                   <option [ngValue]="CourseCategory.NAVIGATION">Hàng hải</option>
-                  <option [ngValue]="CourseCategory.CARGO_HANDLING">Xếp dỡ hàng hóa</option>
-                  <option [ngValue]="CourseCategory.MARITIME_LAW">Luật hàng hải</option>
+                  <option [ngValue]="CourseCategory.ENGINEERING">Kỹ thuật tàu biển</option>
+                  <option [ngValue]="CourseCategory.SAFETY">An toàn hàng hải</option>
+                  <option [ngValue]="CourseCategory.LOGISTICS">Logistics & Cảng</option>
+                  <option [ngValue]="CourseCategory.LAW">Luật hàng hải</option>
+                  <option [ngValue]="CourseCategory.CERTIFICATES">Chứng chỉ STCW</option>
                 </select>
               </div>
 

--- a/fe/src/app/features/courses/courses.component.ts
+++ b/fe/src/app/features/courses/courses.component.ts
@@ -64,12 +64,12 @@ import { SeoService } from '../../core/services/seo.service';
                         class="w-full rounded-lg border border-gray-200 bg-white px-3.5 py-2.5 text-sm focus:border-[#0056D2] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20 transition-colors"
                         [class]="filters.category ? 'text-gray-900' : 'text-gray-400'">
                   <option [ngValue]="undefined" class="text-gray-400">Tất cả danh mục</option>
-                  <option [ngValue]="CourseCategory.MARINE_ENGINEERING" class="text-gray-900">Kỹ thuật tàu biển</option>
-                  <option [ngValue]="CourseCategory.PORT_MANAGEMENT" class="text-gray-900">Quản lý cảng</option>
-                  <option [ngValue]="CourseCategory.MARITIME_SAFETY" class="text-gray-900">An toàn hàng hải</option>
                   <option [ngValue]="CourseCategory.NAVIGATION" class="text-gray-900">Hàng hải</option>
-                  <option [ngValue]="CourseCategory.CARGO_HANDLING" class="text-gray-900">Xếp dỡ hàng hóa</option>
-                  <option [ngValue]="CourseCategory.MARITIME_LAW" class="text-gray-900">Luật hàng hải</option>
+                  <option [ngValue]="CourseCategory.ENGINEERING" class="text-gray-900">Kỹ thuật tàu biển</option>
+                  <option [ngValue]="CourseCategory.SAFETY" class="text-gray-900">An toàn hàng hải</option>
+                  <option [ngValue]="CourseCategory.LOGISTICS" class="text-gray-900">Logistics & Cảng</option>
+                  <option [ngValue]="CourseCategory.LAW" class="text-gray-900">Luật hàng hải</option>
+                  <option [ngValue]="CourseCategory.CERTIFICATES" class="text-gray-900">Chứng chỉ STCW</option>
                 </select>
               </div>
 

--- a/fe/src/app/features/courses/courses.component.ts
+++ b/fe/src/app/features/courses/courses.component.ts
@@ -1,5 +1,5 @@
 import { Component, signal, computed, inject, OnInit, ChangeDetectionStrategy } from '@angular/core';
-import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { DOCUMENT } from '@angular/common';
 import { RouterModule, ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { finalize } from 'rxjs/operators';
@@ -8,7 +8,6 @@ import { PaginationComponent, PaginationInfo } from '../../shared/components/pag
 import { Course, CourseCategory, FilterOptions, ExtendedCourse, LEVEL_LABELS } from '../../shared/types/course.types';
 import { Course as DomainCourse, CourseFilters, CourseSortOptions, PaginationOptions, PaginatedResult } from './domain'; // Import domain types
 import { CourseLevel } from './domain/types'; // Import enum as value
-import { PLATFORM_ID } from '@angular/core';
 import { StudentEnrollmentService } from '../student/services/enrollment.service';
 import { AuthService } from '../../core/services/auth.service';
 import { GetCoursesUseCase } from './application/use-cases/get-courses.use-case';
@@ -196,7 +195,6 @@ import { SeoService } from '../../core/services/seo.service';
 export class CoursesComponent implements OnInit {
   private seo = inject(SeoService);
   private document = inject<Document>(DOCUMENT);
-  private platformId = inject<Object>(PLATFORM_ID);
 
   protected getCoursesUseCase = inject(GetCoursesUseCase);
   protected authService = inject(AuthService);
@@ -275,8 +273,6 @@ export class CoursesComponent implements OnInit {
       this.priceMax = priceMax ? Number(priceMax) : null;
 
       this.loadCourses(page);
-      // Inject ItemList JSON-LD for current list
-      this.injectItemListJsonLd();
     });
   }
 
@@ -323,6 +319,7 @@ export class CoursesComponent implements OnInit {
 
           // Set courses data to signal with new reference for OnPush
           this.courses.set([...uiCourses]);
+          this.injectItemListJsonLd();
 
           // Update pagination info
           this.paginationInfo.set({
@@ -341,15 +338,16 @@ export class CoursesComponent implements OnInit {
   }
 
   private injectItemListJsonLd(): void {
-    if (!isPlatformBrowser(this.platformId)) return;
-    const items = this.courses().slice(0, 12).map((c, idx) => ({
+    const courseList = this.courses();
+    if (courseList.length === 0) return;
+    const items = courseList.slice(0, 12).map((c, idx) => ({
       '@type': 'ListItem',
       position: idx + 1,
       item: {
         '@type': 'Course',
         name: c.title,
-        description: c.shortDescription || c.description,
-        url: `${this.document.location.origin}/courses/${c.id}`,
+        description: (c.shortDescription || c.description || '').slice(0, 200),
+        url: `https://holilihu.online/courses/${c.id}`,
         provider: { '@type': 'Organization', name: 'LMS Maritime' }
       }
     }));

--- a/fe/src/app/features/courses/infrastructure/repositories/course.repository.impl.ts
+++ b/fe/src/app/features/courses/infrastructure/repositories/course.repository.impl.ts
@@ -48,10 +48,18 @@ export class CourseRepositoryImpl implements CourseRepository {
     const size = pagination?.limit ?? 12;
     const search = filters?.searchQuery || undefined;
     const teacher = filters?.instructorId?.[0] as unknown as string | undefined;
+    const category = filters?.category?.[0] || undefined;
+    const sortField = sort?.field === 'title' ? 'title' : 'createdAt';
+    const sortDirection = sort?.direction || 'desc';
 
     const params: Record<string, any> = { page, size };
     if (search) params['search'] = search;
     if (teacher) params['teacher'] = teacher;
+    if (category) params['category'] = category;
+    if (sortField !== 'createdAt' || sortDirection !== 'desc') {
+      params['sort'] = sortField;
+      params['order'] = sortDirection;
+    }
 
     return this.api.publicCourses(params).pipe(
       map((res: ApiResponse<any>) => {

--- a/fe/src/app/features/home/home-simple.component.ts
+++ b/fe/src/app/features/home/home-simple.component.ts
@@ -523,6 +523,30 @@ export class HomeSimpleComponent implements OnInit, AfterViewInit {
       'LMS hàng hải', 'đào tạo hàng hải', 'học hàng hải online',
       'STCW', 'thủy thủ', 'maritime education', 'holilihu'
     ]);
+    this.seo.setJsonLd('jsonld-organization', {
+      '@context': 'https://schema.org',
+      '@type': 'EducationalOrganization',
+      name: 'LMS Maritime',
+      url: 'https://holilihu.online',
+      logo: 'https://holilihu.online/icons/logo-master.png',
+      description: 'Nền tảng đào tạo hàng hải Việt Nam — tích hợp AI và hoạt động ngoại tuyến.',
+      sameAs: ['https://wiii.holilihu.online'],
+      parentOrganization: {
+        '@type': 'Organization',
+        name: 'The Wiii Lab'
+      }
+    });
+    this.seo.setJsonLd('jsonld-website', {
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      name: 'LMS Maritime',
+      url: 'https://holilihu.online',
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: 'https://holilihu.online/courses?q={search_term_string}',
+        'query-input': 'required name=search_term_string'
+      }
+    });
     this.loadFeaturedCourses();
   }
 

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
@@ -9,9 +9,11 @@
     <h1 class="text-xl md:text-2xl font-semibold text-gray-900 mb-2 leading-tight">
       {{ lessonNumber() }}: {{ lesson().title }}
     </h1>
+    @if (section.title) {
     <h3 class="text-xl md:text-xl font-semibold text-gray-700 mb-2 leading-tight">
       {{ section.title }}
     </h3>
+    }
     } @else {
     <h1 class="text-xl md:text-2xl font-semibold text-gray-900 mb-2 leading-tight">
       {{ lesson().title }}
@@ -89,7 +91,9 @@
       @if (section.type === 'QUIZ') {
       <div class="p-6 border border-amber-200 bg-amber-50 rounded-lg text-center">
         <span class="material-symbols-outlined text-4xl text-amber-600 mb-2">assignment</span>
+        @if (section.title) {
         <h3 class="text-lg font-bold text-slate-800 mb-1">{{ section.title }}</h3>
+        }
         @if (quizPresentation(); as quizMeta) {
         <div class="mb-3 flex flex-wrap items-center justify-center gap-2">
           <span class="rounded-full bg-white px-3 py-1 text-[11px] font-semibold text-slate-700">{{ quizMeta.label }}</span>
@@ -123,7 +127,7 @@
       <div class="p-4 border border-[#0056D2]/20 bg-[#0056D2]/5 rounded-lg">
         <div class="flex items-center gap-2 mb-3">
           <span class="material-symbols-outlined text-[#0056D2]">edit_note</span>
-          <h3 class="text-base font-bold text-slate-800">Bài tập: {{ section.title }}</h3>
+          <h3 class="text-base font-bold text-slate-800">Bài tập{{ section.title ? ': ' + section.title : '' }}</h3>
         </div>
         <div class="prose prose-slate max-w-none text-sm" [innerHTML]="getSanitizedHtml(section.content)"></div>
       </div>

--- a/fe/src/app/features/student/assignments/student-assignments-page.component.html
+++ b/fe/src/app/features/student/assignments/student-assignments-page.component.html
@@ -162,7 +162,7 @@
           <input type="text" autocomplete="off"
                  [value]="searchQuery()"
                  (input)="searchQuery.set($any($event.target).value)"
-                 placeholder="Tìm theo tên bài tập..."
+                 [placeholder]="contentTab() === 'quizzes' ? 'Tìm theo tên bài kiểm tra...' : 'Tìm theo tên bài tập...'"
                  class="w-full sm:w-44 rounded-full border border-gray-200 bg-white py-2 pl-9 pr-3 text-sm text-gray-900 placeholder:text-gray-400 focus:border-[#0056D2] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20 transition-colors" />
         </div>
         <select class="w-full sm:w-auto rounded-full border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 focus:border-[#0056D2] focus:outline-none"

--- a/fe/src/app/features/student/assignments/student-assignments-page.component.ts
+++ b/fe/src/app/features/student/assignments/student-assignments-page.component.ts
@@ -173,6 +173,12 @@ export class StudentAssignmentsPageComponent implements OnInit {
     this.activeTab.set('todo');
     this.expandedGroups.set(new Set());
     this.visibleGroupCount.set(this.INITIAL_GROUPS);
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: tab === 'assignments' ? {} : { tab },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
   }
 
   setTab(tab: TaskTab): void {

--- a/fe/src/app/features/student/grades/student-grades.component.html
+++ b/fe/src/app/features/student/grades/student-grades.component.html
@@ -16,7 +16,7 @@
     <button class="main-tab" [class.active]="activeTab() === 'certificates'"
             (click)="activeTab.set('certificates'); loadCertificates()" role="tab"
             [attr.aria-selected]="activeTab() === 'certificates'" type="button">
-      Chứng chỉ ({{ certificates().length }})
+      Chứng chỉ ({{ certBadgeCount() }})
     </button>
   </div>
 

--- a/fe/src/app/features/student/grades/student-grades.component.ts
+++ b/fe/src/app/features/student/grades/student-grades.component.ts
@@ -118,6 +118,8 @@ export class StudentGradesComponent implements OnInit {
     return g.length > 0 ? Math.round(g.reduce((s, c) => s + c.progress, 0) / g.length) : 0;
   });
 
+  certBadgeCount = computed(() => this.grades().filter(g => g.hasCertificate).length);
+
   // === Load More ===
   private readonly LOAD_MORE_COUNT = 5;
   visibleCount = signal(5);

--- a/fe/src/app/features/student/pages/course-detail.component.html
+++ b/fe/src/app/features/student/pages/course-detail.component.html
@@ -399,7 +399,7 @@
                 [class.expanded]="isSectionExpanded(section.id)">
                 <div class="section-left">
                   <span class="section-number">Chương {{ sectionIndex + 1 }}</span>
-                  <h3 class="section-name">{{ section.title }}</h3>
+                  <h3 class="section-name">{{ section.title || 'Chương ' + (sectionIndex + 1) }}</h3>
                   <span class="section-progress-text">
                     @if (chapterStats && chapterStats.completed > 0) {
                       <span [class.all-done]="chapterStats.completed === chapterStats.total">

--- a/fe/src/app/features/student/services/enrollment.service.ts
+++ b/fe/src/app/features/student/services/enrollment.service.ts
@@ -20,6 +20,7 @@ export class StudentEnrollmentService {
 
   private _enrolledCourses = signal<EnrolledCourse[]>([]);
   private _availableCourses = signal<CourseSummary[]>([]);
+  private _enrolledIdCache = signal<Set<string>>(new Set());
   private _isLoading = signal<boolean>(false);
   private _error = signal<string | null>(null);
   private _currentPage = signal<number>(1);
@@ -66,9 +67,7 @@ export class StudentEnrollmentService {
     this._enrolledCourses().filter(course => course.progress === 0)
   );
 
-  readonly enrolledCourseIds = computed(() =>
-    new Set(this._enrolledCourses().map(course => course.id))
-  );
+  readonly enrolledCourseIds = this._enrolledIdCache.asReadonly();
 
   async loadEnrolledCourses(page: number = 0, size: number = 50): Promise<void> {
     this._isLoading.set(true);
@@ -91,6 +90,11 @@ export class StudentEnrollmentService {
         this.mapToEnrolledCourse(course)
       );
       this._enrolledCourses.set(enrolledCourses);
+      this._enrolledIdCache.update(prev => {
+        const next = new Set(prev);
+        for (const c of enrolledCourses) next.add(c.id);
+        return next;
+      });
 
       if (response?.pagination) {
         this._currentPage.set(response.pagination.page || page);
@@ -145,6 +149,7 @@ export class StudentEnrollmentService {
 
     try {
       await firstValueFrom(this.courseApi.enrollCourse(courseId));
+      this._enrolledIdCache.update(prev => new Set(prev).add(courseId));
       await this.loadEnrolledCourses();
       this.errorService.showSuccess('Đăng ký khóa học thành công!', 'enrollment');
       return true;
@@ -190,7 +195,7 @@ export class StudentEnrollmentService {
   }
 
   isEnrolledInCourse(courseId: string): boolean {
-    return this._enrolledCourses().some(course => course.id === courseId);
+    return this._enrolledIdCache().has(courseId);
   }
 
   getEnrolledCourse(courseId: string): EnrolledCourse | undefined {
@@ -200,6 +205,7 @@ export class StudentEnrollmentService {
   clearState(): void {
     this._enrolledCourses.set([]);
     this._availableCourses.set([]);
+    this._enrolledIdCache.set(new Set());
     this._error.set(null);
     this._currentPage.set(1);
     this._totalPages.set(1);
@@ -248,6 +254,11 @@ export class StudentEnrollmentService {
 
       const enrolledCourses = downloads.map(download => this.mapOfflineDownloadToEnrolledCourse(download));
       this._enrolledCourses.set(enrolledCourses);
+      this._enrolledIdCache.update(prev => {
+        const next = new Set(prev);
+        for (const c of enrolledCourses) next.add(c.id);
+        return next;
+      });
       this._currentPage.set(0);
       this._totalPages.set(1);
       this._totalCount.set(enrolledCourses.length);

--- a/fe/src/app/features/student/student-my-courses.component.ts
+++ b/fe/src/app/features/student/student-my-courses.component.ts
@@ -71,8 +71,8 @@ interface EnhancedEnrolledCourse extends EnrolledCourse {
         }
         <!-- Page Header -->
         <div class="page-header">
-          <h1 class="page-title">Khóa học của tôi</h1>
-          <p class="page-subtitle">Quản lý và theo dõi tiến độ các khóa học đã đăng ký</p>
+          <h1 class="page-title">Tất cả khóa học</h1>
+          <p class="page-subtitle">Danh sách đầy đủ các khóa học đã đăng ký</p>
         </div>
 
         <!-- Search — matching Khám Phá design -->
@@ -283,7 +283,14 @@ interface EnhancedEnrolledCourse extends EnrolledCourse {
               <button class="load-more-btn" (click)="loadMore()">
                 Xem thêm {{ remainingCount() }} khóa học
               </button>
-              <p class="showing-count">Đang hiện {{ visibleCourses().length }} / {{ filteredCourses().length }}</p>
+              <p class="showing-count">Đang hiện {{ visibleCourses().length }} / {{ serverTotalCount() || filteredCourses().length }}</p>
+            </div>
+          } @else if (hasMoreServerPages) {
+            <div class="load-more-section">
+              <button class="load-more-btn" (click)="loadMoreFromServer()">
+                Tải thêm khóa học từ máy chủ
+              </button>
+              <p class="showing-count">Đang hiện {{ filteredCourses().length }} / {{ serverTotalCount() }}</p>
             </div>
           } @else if (filteredCourses().length > 0) {
             <p class="showing-count">Đã hiện tất cả {{ filteredCourses().length }} khóa học</p>
@@ -1069,6 +1076,7 @@ export class StudentMyCoursesComponent implements OnInit {
   enrolledCourses = signal<EnhancedEnrolledCourse[]>([]);
   activeTab = signal<string>('in-progress');
   isLoading = this.enrollmentService.isLoading;
+  serverTotalCount = this.enrollmentService.totalCount;
 
   // Load More state — initial 5 (fast first paint), then +10 each scroll
   private readonly INITIAL_COUNT = 5;
@@ -1153,21 +1161,46 @@ export class StudentMyCoursesComponent implements OnInit {
   }
 
 
+  private serverPage = 0;
+  private readonly SERVER_PAGE_SIZE = 50;
+  private hasMoreServerPages = true;
+
   private async loadCourses(): Promise<void> {
     try {
-      await this.enrollmentService.loadEnrolledCourses();
+      this.serverPage = 0;
+      this.hasMoreServerPages = true;
+      await this.enrollmentService.loadEnrolledCourses(0, this.SERVER_PAGE_SIZE);
       const courses = this.enrollmentService.enrolledCourses();
 
-      // Enhance courses with empty modules (will be loaded on demand)
       const enhancedCourses: EnhancedEnrolledCourse[] = courses.map((course: any) => ({
         ...course,
         showModules: false,
-        modules: [] // Empty initially, will load from API when expanded
+        modules: [],
       }));
 
       this.enrolledCourses.set(enhancedCourses);
+      this.hasMoreServerPages = this.enrollmentService.hasNextPage();
     } catch (err: any) {
       this.error.set(err?.message || 'Không thể tải danh sách khóa học. Vui lòng thử lại.');
+    }
+  }
+
+  async loadMoreFromServer(): Promise<void> {
+    if (!this.hasMoreServerPages) return;
+    try {
+      this.serverPage++;
+      await this.enrollmentService.loadEnrolledCourses(this.serverPage, this.SERVER_PAGE_SIZE);
+      const courses = this.enrollmentService.enrolledCourses();
+      const enhancedCourses: EnhancedEnrolledCourse[] = courses.map((course: any) => ({
+        ...course,
+        showModules: false,
+        modules: [],
+      }));
+      this.enrolledCourses.update(prev => [...prev, ...enhancedCourses]);
+      this.hasMoreServerPages = this.enrollmentService.hasNextPage();
+      this.visibleCount.set(this.enrolledCourses().length);
+    } catch {
+      this.hasMoreServerPages = false;
     }
   }
 

--- a/fe/src/app/features/teacher/quiz/containers/lesson-quiz-create/lesson-quiz-create.component.ts
+++ b/fe/src/app/features/teacher/quiz/containers/lesson-quiz-create/lesson-quiz-create.component.ts
@@ -10,6 +10,7 @@ import { PackageApi } from '../../../../../api/endpoints/package.api';
 import { QuizFormComponent, QuizFormConfig, QuizFormData } from '../../components/quiz-form/quiz-form.component';
 import { QuestionCreateComponent } from '../../question-create.component';
 import { ToastService } from '../../../../../core/services/toast.service';
+import { ConfirmDialogService } from '../../../../../core/services/confirm-dialog.service';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -73,6 +74,7 @@ export class LessonQuizCreateComponent implements OnInit {
     private lessonApi = inject(LessonApi);
     private packageApi = inject(PackageApi);
     private toast = inject(ToastService);
+    private confirmDialog = inject(ConfirmDialogService);
 
     readonly quizFormComponent = viewChild.required(QuizFormComponent);
 
@@ -255,12 +257,29 @@ export class LessonQuizCreateComponent implements OnInit {
         }
     }
 
+    private submitted = false;
+
     handleCancel() {
-        // Navigate back to previous page or lesson detail
-        // Since we don't have exact previous URL, we can use Location.back() or navigate to a known route
-        // For safety, let's try to navigate to course/lesson context if possible, 
-        // but simply history.back() is often best for "Cancel"
-        window.history.back();
+        this.submitted = true;
+        const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl');
+        if (returnUrl) {
+            this.router.navigateByUrl(returnUrl);
+        } else {
+            window.history.back();
+        }
+    }
+
+    async canDeactivate(): Promise<boolean> {
+        if (this.submitted) return true;
+        const formRef = this.quizFormComponent();
+        if (!formRef?.quizForm?.dirty) return true;
+        return this.confirmDialog.confirm({
+            title: 'Rời màn tạo bài kiểm tra',
+            message: 'Bạn có thay đổi chưa lưu. Nếu rời màn này, bài kiểm tra đang tạo sẽ bị mất.',
+            variant: 'warning',
+            confirmText: 'Rời màn này',
+            cancelText: 'Ở lại'
+        });
     }
 
     handleRequestCreateQuestion() {

--- a/fe/src/app/features/teacher/quiz/question-edit.component.ts
+++ b/fe/src/app/features/teacher/quiz/question-edit.component.ts
@@ -13,6 +13,7 @@ import { QuestionPreviewComponent } from '../../../shared/components/question-pr
 import { ContentBlock } from '../../../api/types/content-block.types';
 import { AuthImagePipe } from '../../../shared/pipes/auth-image.pipe';
 import { ToastService } from '../../../core/services/toast.service';
+import { ConfirmDialogService } from '../../../core/services/confirm-dialog.service';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -36,6 +37,7 @@ export class QuestionEditComponent implements OnInit {
   private questionApi = inject(QuestionApi);
   private toast = inject(ToastService);
   private questionBankApi = inject(QuestionBankApi);
+  private confirmDialog = inject(ConfirmDialogService);
 
   questionForm: FormGroup;
   isLoading = signal(false);
@@ -76,9 +78,13 @@ export class QuestionEditComponent implements OnInit {
     });
   }
 
+  private returnUrl: string | null = null;
+  private isDirty = false;
+
   ngOnInit(): void {
     this.questionId = this.route.snapshot.paramMap.get('questionId');
     this.packageId = this.route.snapshot.queryParamMap.get('packageId');
+    this.returnUrl = this.route.snapshot.queryParamMap.get('returnUrl');
     if (this.questionId) {
       this.loadQuestion();
     }
@@ -170,6 +176,7 @@ export class QuestionEditComponent implements OnInit {
   // --- Block Handlers ---
 
   onQuestionContentChange(blocks: ContentBlock[]) {
+    this.isDirty = true;
     this.questionBlocks.set(blocks);
     this.updateRawQuestionContent(blocks);
     this.updatePreviewOptions();
@@ -431,10 +438,9 @@ export class QuestionEditComponent implements OnInit {
 
     this.questionApi.updateQuestion(this.questionId!, request).subscribe({
       next: () => {
+        this.isDirty = false;
         this.toast.success('Đã cập nhật câu hỏi thành công!');
-        this.router.navigate(['/teacher/assessments/shared/question-bank'], {
-          queryParams: this.packageId ? { packageId: this.packageId } : {}
-        });
+        this.navigateBack();
       },
       error: (error) => {
         this.toast.error('Lỗi khi cập nhật câu hỏi: ' + (error?.error?.message || error?.message));
@@ -444,8 +450,27 @@ export class QuestionEditComponent implements OnInit {
   }
 
   onCancel(): void {
+    this.navigateBack();
+  }
+
+  private navigateBack(): void {
+    if (this.returnUrl) {
+      this.router.navigateByUrl(this.returnUrl);
+      return;
+    }
     this.router.navigate(['/teacher/assessments/shared/question-bank'], {
       queryParams: this.packageId ? { packageId: this.packageId } : {}
+    });
+  }
+
+  async canDeactivate(): Promise<boolean> {
+    if (!this.isDirty) return true;
+    return this.confirmDialog.confirm({
+      title: 'Rời màn chỉnh sửa câu hỏi',
+      message: 'Bạn có thay đổi chưa lưu. Nếu rời màn này, các chỉnh sửa sẽ bị mất.',
+      variant: 'warning',
+      confirmText: 'Rời màn này',
+      cancelText: 'Ở lại'
     });
   }
 

--- a/fe/src/app/features/teacher/quiz/quiz-bank.component.ts
+++ b/fe/src/app/features/teacher/quiz/quiz-bank.component.ts
@@ -795,7 +795,11 @@ export class QuizBankComponent implements OnInit {
   }
 
   editQuestion(question: Question | BankQuestionDTO) {
-    this.router.navigate(['/teacher/quiz/question', question.id, 'edit']);
+    const queryParams: any = {};
+    if (this.selectedBank()) queryParams.packageId = this.selectedBank()!.id;
+    if (this.addToQuizLessonId) queryParams.addToQuiz = this.addToQuizLessonId;
+    if (this.returnUrl) queryParams.returnUrl = this.returnUrl;
+    this.router.navigate(['/teacher/quiz/question', question.id, 'edit'], { queryParams });
   }
 
   async deleteQuestion(question: Question | BankQuestionDTO) {

--- a/fe/src/app/features/teacher/quiz/quiz-create.component.html
+++ b/fe/src/app/features/teacher/quiz/quiz-create.component.html
@@ -30,10 +30,9 @@
   <div class="mx-auto flex max-w-screen-xl flex-col gap-6 px-4 py-6 sm:px-6 lg:flex-row lg:items-start">
     <section class="flex-1 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
       <div class="mb-6 rounded-2xl border border-[#0056D2]/10 bg-[#0056D2]/5 p-4">
-        <p class="text-sm font-semibold text-[#004BB5]">Nguồn chân lý của quiz là lesson trong course.</p>
+        <p class="text-sm font-semibold text-[#004BB5]">Quiz nằm trong chương của khóa học.</p>
         <p class="mt-2 text-sm leading-6 text-slate-600">
-          Quiz nằm trong lesson/chương sẽ là nguồn học chính của learner. Đánh giá được giao thêm chỉ nên đi qua workspace
-          vận hành assessment và vẫn luôn online-only.
+          Chọn chương để tạo bài quiz mới. Quiz sẽ được thêm như một bài học trong chương đã chọn.
         </p>
       </div>
 
@@ -59,7 +58,7 @@
 
         <div>
           <label for="chapterId" class="mb-2 block text-sm font-semibold text-slate-800">
-            2. Chọn vị trí neo trong curriculum
+            2. Chọn chương
           </label>
           <select
             id="chapterId"
@@ -67,7 +66,7 @@
             (ngModelChange)="selectedChapterId.set($event)"
             [disabled]="!selectedCourseId() || isLoadingChapters()"
             class="h-11 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-[#0056D2] focus:ring-2 focus:ring-[#0056D2]/10 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400">
-            <option value="">-- Chọn chương/bài học --</option>
+            <option value="">-- Chọn chương --</option>
             @for (chapter of chapters(); track chapter.id) {
               <option [value]="chapter.id">{{ chapter.title }}</option>
             }

--- a/fe/src/app/features/teacher/quiz/quiz-create.component.ts
+++ b/fe/src/app/features/teacher/quiz/quiz-create.component.ts
@@ -130,19 +130,19 @@ export class QuizCreateComponent {
   }
 
   getPathTitle(path: QuizCreationPath): string {
-    return path === 'LESSON' ? 'Quiz trong lesson/chương' : 'Bài kiểm tra được giao';
+    return path === 'LESSON' ? 'Quiz trong chương' : 'Bài kiểm tra được giao';
   }
 
   getPathDescription(path: QuizCreationPath): string {
     if (path === 'LESSON') {
-      return 'Dùng cho quiz học tập nằm cố định trong nội dung khóa học: luyện tập, bài kiểm tra, hoặc bài thi.';
+      return 'Tạo bài quiz mới nằm trong chương đã chọn. Quiz sẽ thành một bài học mới trong chương.';
     }
-    return 'Dùng cho đánh giá được giao trong workspace vận hành. Flow này luôn online-only và không phải nguồn chân lý của lesson.';
+    return 'Dùng cho đánh giá được giao trong workspace vận hành. Flow này luôn online-only.';
   }
 
   getContinueLabel(): string {
     return this.selectedPath() === 'LESSON'
-      ? 'Tiếp tục tạo quiz trong lesson'
+      ? 'Tiếp tục tạo quiz trong chương'
       : 'Tiếp tục sang flow đánh giá được giao';
   }
 

--- a/fe/src/app/features/teacher/quiz/quiz.routes.ts
+++ b/fe/src/app/features/teacher/quiz/quiz.routes.ts
@@ -28,6 +28,7 @@ export const quizRoutes: Routes = [
         loadComponent: () => import('./containers/lesson-quiz-create/lesson-quiz-create.component')
           .then(m => m.LessonQuizCreateComponent),
         canActivate: [teacherGuard],
+        canDeactivate: [(component: any) => component.canDeactivate?.() ?? true],
         title: 'Tạo quiz cho bài học'
       },
       {
@@ -35,20 +36,20 @@ export const quizRoutes: Routes = [
         loadComponent: () => import('./containers/lesson-quiz-create/lesson-quiz-create.component')
           .then(m => m.LessonQuizCreateComponent),
         canActivate: [teacherGuard],
+        canDeactivate: [(component: any) => component.canDeactivate?.() ?? true],
         title: 'Tạo quiz cho chương'
       },
       {
         path: 'create/section/:sectionId',
-        loadComponent: () => import('./containers/lesson-quiz-create/lesson-quiz-create.component')
-          .then(m => m.LessonQuizCreateComponent),
-        canActivate: [teacherGuard],
-        title: 'Tạo quiz cho chương (legacy)'
+        redirectTo: 'create/chapter/:sectionId',
+        pathMatch: 'full'
       },
       {
         path: 'create/assignment/:courseId',
         loadComponent: () => import('./containers/assignment-quiz-create/assignment-quiz-create.component')
           .then(m => m.AssignmentQuizCreateComponent),
         canActivate: [teacherGuard],
+        canDeactivate: [(component: any) => component.canDeactivate?.() ?? true],
         title: 'Tạo bài tập'
       },
       {
@@ -68,12 +69,14 @@ export const quizRoutes: Routes = [
         path: 'question/create',
         loadComponent: () => import('./question-create.component').then(m => m.QuestionCreateComponent),
         canActivate: [teacherGuard],
+        canDeactivate: [(component: any) => component.canDeactivate?.() ?? true],
         title: 'Tạo câu hỏi mới'
       },
       {
         path: 'question/:questionId/edit',
         loadComponent: () => import('./question-edit.component').then(m => m.QuestionEditComponent),
         canActivate: [teacherGuard],
+        canDeactivate: [(component: any) => component.canDeactivate?.() ?? true],
         title: 'Chỉnh sửa câu hỏi'
       }
     ]

--- a/fe/src/app/shared/types/course.types.ts
+++ b/fe/src/app/shared/types/course.types.ts
@@ -77,12 +77,11 @@ export interface CourseFilter {
 
 // Course Category as enum for runtime values
 export enum CourseCategory {
-  MARINE_ENGINEERING = 'engineering',
-  PORT_MANAGEMENT = 'logistics',
-  MARITIME_SAFETY = 'safety',
   NAVIGATION = 'navigation',
-  CARGO_HANDLING = 'logistics',
-  MARITIME_LAW = 'law',
+  ENGINEERING = 'engineering',
+  SAFETY = 'safety',
+  LOGISTICS = 'logistics',
+  LAW = 'law',
   CERTIFICATES = 'certificates'
 }
 

--- a/fe/src/app/state/course.service.ts
+++ b/fe/src/app/state/course.service.ts
@@ -230,7 +230,7 @@ export class CourseService {
           rating: 4.5,
           studentsCount: course.enrolledCount || 0
         },
-        category: CourseCategory.MARINE_ENGINEERING,
+        category: CourseCategory.ENGINEERING,
         categoryName: course.categoryName,
         level: 'beginner' as CourseLevel,
         duration: '30h',
@@ -289,7 +289,7 @@ export class CourseService {
         rating: 4.5,
         studentsCount: course.enrolledCount || 0
       },
-      category: course.categoryName || CourseCategory.MARINE_ENGINEERING,
+      category: course.categoryName || CourseCategory.ENGINEERING,
       categoryName: course.categoryName,
       level: 'beginner' as CourseLevel,
       duration: '30h',


### PR DESCRIPTION
## Summary
Consolidates Waves 3-6 fixes across student experience, courses, quiz authoring, and SSR/SEO.

### Wave 3+4 — Student + Courses Bugs
- **#38**: Enrollment truth — `_enrolledIdCache` signal accumulates IDs across pages, `isEnrolledInCourse()` stays consistent
- **#41**: Null section titles — backend stops injecting "Untitled", FE guards with `@if` and fallback `Chương N`
- **#42**: My Courses library — h1 "Tất cả khóa học", server-side pagination with "Tải thêm", accurate total count
- **#44**: Certificate badge count from grades data (not certificate array)
- **#39**: CourseCategory enum simplified to 6 canonical entries matching DB taxonomy
- **#36**: Category + sort params wired to backend `getPublicCourses()` with whitelist validation

### Wave 5 — Quiz Authoring UX
- **#31,#32**: `canDeactivate` leave guards on quiz create/edit, question create/edit
- **#33**: `returnUrl` context preserved across quiz/question authoring flows
- **#34**: Quiz creation labels clarified (chương, not lesson/chương)
- **#43**: Student assignments page — tab state synced to URL, search placeholder dynamic

### Wave 6 — SSR/SEO
- **#37**: JSON-LD `isPlatformBrowser` guard removed — now renders during SSR. Call moved to after courses load. Course detail gets `@type: Course` JSON-LD with offers/instructor.
- **#19**: Homepage Organization + WebSite JSON-LD schemas (SSR-rendered for crawler TTFB)
- **#35**: Verified Angular 20 `provideClientHydration(withEventReplay())` auto-includes HTTP transfer cache — no manual TransferState needed

## Test plan
- [ ] Browse /courses with category filter — correct courses shown
- [ ] Course detail page — JSON-LD visible in page source (SSR)
- [ ] Homepage — Organization JSON-LD in page source
- [ ] Student My Courses — "Tải thêm" loads next page
- [ ] Quiz create → navigate away → unsaved changes dialog appears
- [ ] Question edit → save → returns to previous page (returnUrl)
- [ ] Student tasks page — switching quiz/assignment tab updates URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)