### PR TITLE
fix(pwa): harden offline recovery and learning shell safety

### DIFF
--- a/docs/superpowers/specs/2026-04-23-pwa-device-offline-gateway-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-23-pwa-device-offline-gateway-hardening-design.md
@@ -1,0 +1,61 @@
+# PWA Device-Offline Gateway Hardening Design
+
+Date: 2026-04-23
+
+Related issues:
+- #78 `bug(pwa): offline public course fallback collapses cached downloads to empty lists`
+- #79 `bug(pwa): offline fallback page links downloaded courses to non-existent learn route`
+- #91 `bug(pwa): device-offline still degrades into gateway timeouts and chunk fetch failures`
+
+## Problem
+
+When the user physically turns off the device network, Angular Service Worker can surface same-origin failures as `502/503/504` or dynamic import rejections instead of the classic `status = 0` browser network error.
+
+The current PWA stack still treats those responses as ordinary server failures in several places, so the app can miss its offline fallback path and leave the UI in a noisy or partially broken state.
+
+## Goals
+
+- Treat `device offline -> synthetic gateway timeout` as an offline-compatible transport failure.
+- Preserve the offline fallback and sync queue behavior that already exists for genuine network errors.
+- Ensure recovery navigation stays available even when lazy chunks fail offline.
+- Avoid reload loops or redundant retries while the device is offline.
+
+## Chosen Approach
+
+### 1. Harden offline transport detection at the interceptor boundary
+
+`offlineInterceptor` will classify a request as offline-compatible when:
+- the current behavior already matches (`status === 0`, `ProgressEvent`)
+- or the browser/device has just transitioned offline and NGSW surfaces the request as `502/503/504`
+
+This keeps IndexedDB fallback and mutation queueing centralized at the boundary where the rest of the app already expects offline semantics.
+
+### 2. Make network state react immediately to device-offline signals
+
+`NetworkStatusService` will expose a small piece of transient state describing a recent offline signal. This avoids a race where the browser fires the offline event but some in-flight requests still reach the interceptor before all computed UI state has caught up.
+
+### 3. Stop retrying synthetic gateway errors while offline
+
+`errorInterceptor` should not spend an extra second retrying requests that are already known to be offline-equivalent. This removes avoidable noise and reduces the chance of stacked failures during the transition.
+
+### 4. Keep the recovery route in the always-available app shell
+
+`/offline` is a critical recovery surface, so it should not depend on a lazy chunk that may itself fail to load while offline. The route will be eagerly available.
+
+### 5. Catch dynamic import failures caused by offline runtime
+
+`SwUpdateService` will also observe `unhandledrejection` for dynamic import failures. When the device is offline, it should route the user to the recovery surface instead of reloading or leaving the route outlet empty.
+
+## Out Of Scope
+
+- Reworking the entire PWA architecture
+- Redesigning offline UX copy from scratch
+- Production reverse-proxy or Docker DNS fixes unrelated to device-offline behavior
+
+## Verification Plan
+
+- Add focused unit tests for offline-compatible gateway status detection.
+- Add focused unit tests for runtime chunk-failure classification.
+- Run targeted frontend specs.
+- Run a frontend production build.
+- Smoke the offline transition in a browser context after the patch.

--- a/docs/superpowers/specs/2026-04-23-pwa-offline-fallback-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-23-pwa-offline-fallback-fixes-design.md
@@ -1,0 +1,54 @@
+# PWA Offline Fallback Fixes Design
+
+Date: 2026-04-23
+
+Related issues:
+- #78 `bug(pwa): offline public course fallback collapses cached downloads to empty lists`
+- #79 `bug(pwa): offline fallback page links downloaded courses to non-existent learn route`
+
+## Problem
+
+The offline path for `GET /api/v3/courses` returns a raw cached-course array while multiple frontend consumers assume a Spring-style page envelope. This collapses cached data to empty lists in offline browse/search flows.
+
+Separately, the `/offline` recovery page links downloaded courses to `/learn/course/:id`, but the canonical student learning route is `/student/learn/course/:id`.
+
+## Goals
+
+- Preserve cached courses when `/api/v3/courses` is intercepted offline.
+- Restore compatibility with existing consumers that read `res.data.content` and pagination metadata.
+- Fix the offline recovery navigation so a downloaded course opens a valid learning route.
+- Keep the patch small and isolated to the PWA/offline lane.
+
+## Chosen Approach
+
+### #78
+
+Normalize the offline `/api/v3/courses` fallback at the interceptor boundary instead of patching every consumer.
+
+The interceptor will:
+- parse `search`, `page`, and `size` from the request URL
+- filter cached courses by searchable fields that exist offline
+- paginate the filtered list
+- return a Spring-like `data` page object plus top-level `pagination`
+
+This keeps existing consumers such as `CourseApi.publicCourses()`, header search, and WebMCP search compatible without broad refactors.
+
+### #79
+
+Update the `/offline` downloaded-course link to the canonical student learning prefix `/student/learn/course`.
+
+Expose the route prefix as a constant so it can be covered by a focused unit test without introducing extra navigation logic.
+
+## Out Of Scope
+
+- Broader offline architecture refactors
+- Reworking cached course metadata beyond what already exists offline
+- Redesigning the `/offline` page
+
+## Verification Plan
+
+- Add focused frontend unit tests for:
+  - offline course listing response normalization
+  - offline fallback route prefix
+- Run targeted frontend tests for the new specs
+- Run a frontend build to catch template/type regressions

--- a/docs/superpowers/specs/2026-04-24-pwa-learning-shell-offline-icons-design.md
+++ b/docs/superpowers/specs/2026-04-24-pwa-learning-shell-offline-icons-design.md
@@ -1,0 +1,33 @@
+# PWA Learning Shell Offline Icons Hardening
+
+## Problem
+
+Khi learner đã mở gói offline hoặc tắt mạng thiết bị, màn học vẫn phụ thuộc vào `Material Symbols` theo kiểu ligature text. Nếu font icon không được lấy lại từ cache, UI lộ nguyên văn `arrow_back`, `check_circle`, `article`, `folder_open` thay vì icon. Cùng lúc đó, một số máy vẫn thấy log debug `[PWA] Network Status` từ app shell cũ.
+
+## Root Cause
+
+1. Learning shell (`course-learning`, `lesson-content`) đang dùng font icon ligature ở đúng các surface quan trọng nhất khi offline.
+2. Font icon là một dependency runtime riêng, nên khi shell/chunk còn chạy được nhưng asset font không sẵn sàng thì UI degrade theo cách rất lộ.
+3. Log debug đã được bỏ khỏi source mới, nhưng browser đang giữ shell cũ vẫn có thể tiếp tục in log cho tới khi nhận bản app shell mới.
+
+## Chosen Approach
+
+Tách learning shell khỏi font icon bằng SVG nội bộ:
+
+- Thay toàn bộ icon ligature ở `learning` surface bằng `app-icon` tự bundle.
+- Bổ sung các glyph còn thiếu (`eye`, `more-vertical`, `circle`, `folder`, `paperclip`, `play-circle`, `file-check`, `help-circle`) ngay trong icon component nội bộ.
+- Giữ nguyên logic PWA/offline hiện có; chỉ harden lớp hiển thị để offline không còn rơi về text thô.
+- Verify thêm bằng targeted spec cho icon component và grep zero-occurrence với `material-symbols-outlined` trong feature `learning`.
+
+## Why This Approach
+
+- Không phụ thuộc font/network ở đường đi quan trọng.
+- Scope gọn hơn việc thay toàn bộ hệ icon toàn app.
+- Phù hợp với clean architecture frontend: fix đúng boundary presentation của feature `learning`.
+- Shell mới sẽ tự cache-bust sau build/deploy, giúp các máy đang giữ bundle cũ thoát khỏi log debug sau refresh/update.
+
+## Verification Plan
+
+- Targeted unit test cho `IconComponent` với các glyph mới dùng trong learning shell.
+- Search xác nhận feature `learning` không còn `material-symbols-outlined`.
+- `npm run build` pass.

--- a/fe/src/app/api/interceptors/error.interceptor.spec.ts
+++ b/fe/src/app/api/interceptors/error.interceptor.spec.ts
@@ -1,0 +1,35 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { shouldRetryHttpRequest } from './error.interceptor';
+
+describe('shouldRetryHttpRequest', () => {
+  const onlineNetworkStatus = {
+    online: () => true,
+    hasRecentOfflineSignal: () => false,
+  };
+
+  it('retries genuine server errors while online', () => {
+    const error = new HttpErrorResponse({ status: 500, url: '/api/v3/courses' });
+
+    expect(shouldRetryHttpRequest(error, '/api/v3/courses', onlineNetworkStatus as any)).toBeTrue();
+  });
+
+  it('does not retry gateway timeouts when app transport is already offline', () => {
+    const error = new HttpErrorResponse({ status: 504, url: '/api/v3/courses' });
+    const offlineNetworkStatus = {
+      online: () => false,
+      hasRecentOfflineSignal: () => false,
+    };
+
+    expect(shouldRetryHttpRequest(error, '/api/v3/courses', offlineNetworkStatus as any)).toBeFalse();
+  });
+
+  it('does not retry when app state still carries a recent offline signal', () => {
+    const error = new HttpErrorResponse({ status: 504, url: '/api/v3/courses' });
+    const networkStatus = {
+      online: () => true,
+      hasRecentOfflineSignal: () => true,
+    };
+
+    expect(shouldRetryHttpRequest(error, '/api/v3/courses', networkStatus as any)).toBeFalse();
+  });
+});

--- a/fe/src/app/api/interceptors/error.interceptor.ts
+++ b/fe/src/app/api/interceptors/error.interceptor.ts
@@ -1,27 +1,40 @@
 import { HttpRequest, HttpErrorResponse, HttpHandlerFn, HttpEvent } from '@angular/common/http';
+import { inject } from '@angular/core';
 import { Observable, throwError, timer } from 'rxjs';
 import { catchError, retry } from 'rxjs/operators';
+import { NetworkStatusService } from '../../core/services/network-status.service';
+import { isOfflineCompatibleHttpError } from '../../core/utils/offline-http-error';
+
+export function shouldRetryHttpRequest(
+  error: unknown,
+  requestUrl: string,
+  networkStatus: Pick<NetworkStatusService, 'online' | 'hasRecentOfflineSignal'>,
+): boolean {
+  if (!(error instanceof HttpErrorResponse)) {
+    return false;
+  }
+
+  if (error.status < 500) {
+    return false;
+  }
+
+  return !isOfflineCompatibleHttpError(error, requestUrl, {
+    navigatorOnline: typeof navigator === 'undefined' ? true : navigator.onLine,
+    appOnline: networkStatus.online(),
+    hasRecentOfflineSignal: networkStatus.hasRecentOfflineSignal(),
+  });
+}
 
 export const errorInterceptor = (req: HttpRequest<any>, next: HttpHandlerFn): Observable<HttpEvent<any>> => {
+  const networkStatus = inject(NetworkStatusService);
+
   return next(req).pipe(
-    retry({ count: 1, delay: (error) => error.status >= 500 ? timer(1000) : throwError(() => error) }),
-    catchError((error: HttpErrorResponse) => {
-      let errorMessage = 'Đã xảy ra lỗi không xác định';
-
-      if (error.error instanceof ErrorEvent) {
-        errorMessage = `Client Error: ${error.error.message}`;
-      } else {
-        if (error.error?.message) {
-          errorMessage = error.error.message;
-        } else if (typeof error.error === 'string') {
-          errorMessage = error.error;
-        } else {
-          errorMessage = `Server Error: ${error.status} - ${error.message}`;
-        }
-      }
-
-      // Preserve HttpErrorResponse for other interceptors (offline interceptor needs status/type)
-      return throwError(() => error);
-    })
+    retry({
+      count: 1,
+      delay: (error) => shouldRetryHttpRequest(error, req.url, networkStatus)
+        ? timer(1000)
+        : throwError(() => error),
+    }),
+    catchError((error: HttpErrorResponse) => throwError(() => error)),
   );
 };

--- a/fe/src/app/api/interceptors/offline.interceptor.spec.ts
+++ b/fe/src/app/api/interceptors/offline.interceptor.spec.ts
@@ -1,0 +1,75 @@
+import type { OfflineCourse } from '../../core/db/lms-offline.db';
+import { buildOfflineCoursesListingResponse } from './offline.interceptor';
+
+describe('buildOfflineCoursesListingResponse', () => {
+  const cachedCourses: OfflineCourse[] = [
+    {
+      id: '11111111-1111-1111-1111-111111111111',
+      title: 'An toan hang hai co ban',
+      description: 'Tong quan ve thao tac an toan tren tau',
+      teacherName: 'Tran Hai',
+      totalLessons: 6,
+      downloadedAt: new Date('2026-04-20T10:00:00.000Z'),
+      version: 1,
+      sizeBytes: 1024,
+      userId: 'student-1',
+      deliveryMode: 'SELF_PACED',
+      thumbnailUrl: 'https://example.com/cover-1.png',
+    },
+    {
+      id: '22222222-2222-2222-2222-222222222222',
+      title: 'Dieu khien tau nang cao',
+      description: 'Luyen tap radar va dieu huong',
+      teacherName: 'Nguyen Lan',
+      totalLessons: 8,
+      downloadedAt: new Date('2026-04-21T10:00:00.000Z'),
+      version: 1,
+      sizeBytes: 2048,
+      userId: 'student-1',
+      deliveryMode: 'INSTRUCTOR_LED',
+    },
+  ];
+
+  it('returns a Spring-like page envelope for cached course listings', () => {
+    const response = buildOfflineCoursesListingResponse(
+      cachedCourses,
+      '/api/v3/courses?page=0&size=1',
+      '2026-04-23T10:00:00.000Z',
+    );
+
+    expect(response.success).toBeTrue();
+    expect(response.message).toBe('Dữ liệu ngoại tuyến');
+    expect(response.data.content.length).toBe(1);
+    expect(response.data.totalElements).toBe(2);
+    expect(response.data.totalPages).toBe(2);
+    expect(response.data.number).toBe(0);
+    expect(response.pagination.limit).toBe(1);
+    expect(response.pagination.totalItems).toBe(2);
+    expect(response._offline).toBeTrue();
+    expect(response.timestamp).toBe('2026-04-23T10:00:00.000Z');
+  });
+
+  it('filters cached courses by search and teacher params before pagination', () => {
+    const response = buildOfflineCoursesListingResponse(
+      cachedCourses,
+      '/api/v3/courses?search=radar&teacher=nguyen&page=0&size=12',
+    );
+
+    expect(response.data.content.length).toBe(1);
+    expect(response.data.content[0].id).toBe('22222222-2222-2222-2222-222222222222');
+    expect(response.data.totalElements).toBe(1);
+    expect(response.data.empty).toBeFalse();
+  });
+
+  it('keeps an empty page instead of collapsing to a null response when cached data exists', () => {
+    const response = buildOfflineCoursesListingResponse(
+      cachedCourses,
+      '/api/v3/courses?search=khong-khop&page=0&size=12',
+    );
+
+    expect(response.data.content).toEqual([]);
+    expect(response.data.totalElements).toBe(0);
+    expect(response.data.empty).toBeTrue();
+    expect(response.pagination.totalItems).toBe(0);
+  });
+});

--- a/fe/src/app/api/interceptors/offline.interceptor.ts
+++ b/fe/src/app/api/interceptors/offline.interceptor.ts
@@ -2,12 +2,12 @@ import { HttpRequest, HttpHandlerFn, HttpEvent, HttpResponse, HttpErrorResponse 
 import { Observable, from, of, throwError } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 import { inject } from '@angular/core';
-import { ensureOfflineDbReady, offlineDb, getCurrentUserId } from '../../core/db/lms-offline.db';
-import { NetworkStatusService } from '../../core/services/network-status.service';
+import { ensureOfflineDbReady, offlineDb, getCurrentUserId, type OfflineCourse } from '../../core/db/lms-offline.db';
 import { OfflineSyncService } from '../../core/services/offline-sync.service';
 
 /** Paths that must never be intercepted offline (auth, health checks) */
 const NEVER_INTERCEPT_PREFIXES = ['/api/v3/auth/', '/api/v3/sync/', '/actuator/'];
+const DEFAULT_OFFLINE_COURSES_PAGE_SIZE = 12;
 
 /**
  * Offline interceptor — catches network errors and falls back to IndexedDB.
@@ -21,7 +21,6 @@ const NEVER_INTERCEPT_PREFIXES = ['/api/v3/auth/', '/api/v3/sync/', '/actuator/'
  * Must be registered AFTER baseUrlInterceptor and authInterceptor.
  */
 export const offlineInterceptor = (req: HttpRequest<any>, next: HttpHandlerFn): Observable<HttpEvent<any>> => {
-  const network = inject(NetworkStatusService);
   const syncService = inject(OfflineSyncService);
 
   // If online, proceed normally but catch network failures
@@ -112,12 +111,7 @@ async function getOfflineFallback(url: string): Promise<any | null> {
       const userId = getCurrentUserId();
       const courses = await offlineDb.courses.where('userId').equals(userId).toArray();
       if (courses.length > 0) {
-        return {
-          success: true,
-          data: courses,
-          message: 'Dữ liệu ngoại tuyến',
-          _offline: true,
-        };
+        return buildOfflineCoursesListingResponse(courses, path);
       }
     }
 
@@ -432,6 +426,213 @@ function extractApiPath(fullUrl: string): string | null {
     if (fullUrl.startsWith('/api/')) return fullUrl;
     return null;
   }
+}
+
+type OfflineCourseSummary = {
+  id: string;
+  code: string;
+  title: string;
+  description: string;
+  status: 'APPROVED';
+  teacherName: string;
+  enrolledCount: number;
+  createdAt: string;
+  updatedAt: string;
+  enrolled: true;
+  isEnrolled: true;
+  deliveryMode?: 'SELF_PACED' | 'INSTRUCTOR_LED';
+  allowOfflineDownload: true;
+  lessonCount: number;
+  totalLessons: number;
+  completedLessons: number;
+  thumbnailUrl?: string;
+};
+
+type OfflineCoursesPageResponse = {
+  success: true;
+  message: string;
+  data: {
+    content: OfflineCourseSummary[];
+    totalElements: number;
+    totalPages: number;
+    size: number;
+    number: number;
+    first: boolean;
+    last: boolean;
+    empty: boolean;
+  };
+  pagination: {
+    page: number;
+    limit: number;
+    totalItems: number;
+    totalPages: number;
+    first: boolean;
+    last: boolean;
+  };
+  timestamp: string;
+  _offline: true;
+};
+
+export function buildOfflineCoursesListingResponse(
+  courses: OfflineCourse[],
+  path: string,
+  timestamp = new Date().toISOString(),
+): OfflineCoursesPageResponse {
+  const searchParams = getPathSearchParams(path);
+  const search = normalizeOfflineSearchTerm(searchParams.get('search'));
+  const teacher = normalizeOfflineSearchTerm(searchParams.get('teacher'));
+  const sort = searchParams.get('sort');
+  const order = searchParams.get('order');
+  const page = parseNonNegativeInt(searchParams.get('page'));
+  const size = parsePositiveInt(searchParams.get('size'), DEFAULT_OFFLINE_COURSES_PAGE_SIZE);
+
+  const filteredCourses = sortOfflineCourses(
+    courses.filter(course => matchesOfflineCourseSearch(course, search, teacher)),
+    sort,
+    order,
+  );
+
+  const totalItems = filteredCourses.length;
+  const totalPages = totalItems === 0 ? 0 : Math.ceil(totalItems / size);
+  const startIndex = page * size;
+  const pagedCourses = filteredCourses.slice(startIndex, startIndex + size).map(mapOfflineCourseToSummary);
+  const last = totalPages === 0 ? true : page >= totalPages - 1;
+
+  return {
+    success: true,
+    message: 'Dữ liệu ngoại tuyến',
+    data: {
+      content: pagedCourses,
+      totalElements: totalItems,
+      totalPages,
+      size,
+      number: page,
+      first: page === 0,
+      last,
+      empty: pagedCourses.length === 0,
+    },
+    pagination: {
+      page,
+      limit: size,
+      totalItems,
+      totalPages,
+      first: page === 0,
+      last,
+    },
+    timestamp,
+    _offline: true,
+  };
+}
+
+function mapOfflineCourseToSummary(course: OfflineCourse): OfflineCourseSummary {
+  const normalizedTimestamp = toIsoTimestamp(course.downloadedAt);
+
+  return {
+    id: course.id,
+    code: `OFFLINE-${course.id.slice(0, 8).toUpperCase()}`,
+    title: course.title,
+    description: course.description || '',
+    status: 'APPROVED',
+    teacherName: course.teacherName || 'LMS Maritime',
+    enrolledCount: 1,
+    createdAt: normalizedTimestamp,
+    updatedAt: normalizedTimestamp,
+    enrolled: true,
+    isEnrolled: true,
+    deliveryMode: course.deliveryMode,
+    allowOfflineDownload: true,
+    lessonCount: course.totalLessons ?? 0,
+    totalLessons: course.totalLessons ?? 0,
+    completedLessons: 0,
+    thumbnailUrl: course.thumbnailUrl,
+  };
+}
+
+function matchesOfflineCourseSearch(
+  course: OfflineCourse,
+  search: string,
+  teacher: string,
+): boolean {
+  const searchableValues = [
+    course.title,
+    course.description,
+    course.teacherName,
+  ]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .map(normalizeOfflineSearchTerm);
+
+  if (search && !searchableValues.some(value => value.includes(search))) {
+    return false;
+  }
+
+  if (teacher && !normalizeOfflineSearchTerm(course.teacherName).includes(teacher)) {
+    return false;
+  }
+
+  return true;
+}
+
+function sortOfflineCourses(
+  courses: OfflineCourse[],
+  sort: string | null,
+  order: string | null,
+): OfflineCourse[] {
+  const direction = order?.toLowerCase() === 'asc' ? 1 : -1;
+  const next = [...courses];
+
+  next.sort((left, right) => {
+    if (sort === 'title') {
+      return direction * left.title.localeCompare(right.title, 'vi', { sensitivity: 'base' });
+    }
+
+    return direction * (toTimestampValue(left.downloadedAt) - toTimestampValue(right.downloadedAt));
+  });
+
+  return next;
+}
+
+function getPathSearchParams(path: string): URLSearchParams {
+  const queryIndex = path.indexOf('?');
+  return new URLSearchParams(queryIndex >= 0 ? path.slice(queryIndex + 1) : '');
+}
+
+function normalizeOfflineSearchTerm(value: string | null | undefined): string {
+  return (value ?? '').trim().toLocaleLowerCase('vi');
+}
+
+function parseNonNegativeInt(value: string | null | undefined): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function parsePositiveInt(value: string | null | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function toIsoTimestamp(value: Date | string | undefined): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value;
+  }
+
+  return new Date(0).toISOString();
+}
+
+function toTimestampValue(value: Date | string | undefined): number {
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+
+  return 0;
 }
 
 type SyncDescriptor = {

--- a/fe/src/app/api/interceptors/offline.interceptor.ts
+++ b/fe/src/app/api/interceptors/offline.interceptor.ts
@@ -4,6 +4,8 @@ import { catchError, switchMap } from 'rxjs/operators';
 import { inject } from '@angular/core';
 import { ensureOfflineDbReady, offlineDb, getCurrentUserId, type OfflineCourse } from '../../core/db/lms-offline.db';
 import { OfflineSyncService } from '../../core/services/offline-sync.service';
+import { NetworkStatusService } from '../../core/services/network-status.service';
+import { isOfflineCompatibleHttpError } from '../../core/utils/offline-http-error';
 
 /** Paths that must never be intercepted offline (auth, health checks) */
 const NEVER_INTERCEPT_PREFIXES = ['/api/v3/auth/', '/api/v3/sync/', '/actuator/'];
@@ -22,18 +24,24 @@ const DEFAULT_OFFLINE_COURSES_PAGE_SIZE = 12;
  */
 export const offlineInterceptor = (req: HttpRequest<any>, next: HttpHandlerFn): Observable<HttpEvent<any>> => {
   const syncService = inject(OfflineSyncService);
+  const networkStatus = inject(NetworkStatusService);
 
   // If online, proceed normally but catch network failures
   return next(req).pipe(
     catchError((error: HttpErrorResponse) => {
-      // Only handle network errors (status 0 = no connection, or TypeError)
-      const isNetworkError = error.status === 0 || error.error instanceof ProgressEvent;
-      if (!isNetworkError) {
+      const path = extractApiPath(req.url) || req.url;
+      const isOfflineError = isOfflineCompatibleHttpError(error, req.url, {
+        navigatorOnline: typeof navigator === 'undefined' ? true : navigator.onLine,
+        appOnline: networkStatus.online(),
+        hasRecentOfflineSignal: networkStatus.hasRecentOfflineSignal(),
+      });
+      if (!isOfflineError) {
         return throwError(() => error);
       }
 
+      networkStatus.markOfflineFromTransportFailure();
+
       // Never intercept auth or health-check endpoints
-      const path = extractApiPath(req.url) || req.url;
       if (NEVER_INTERCEPT_PREFIXES.some(prefix => path.startsWith(prefix))) {
         return throwError(() => error);
       }

--- a/fe/src/app/app.routes.spec.ts
+++ b/fe/src/app/app.routes.spec.ts
@@ -1,0 +1,12 @@
+import { routes } from './app.routes';
+import { OfflineFallbackComponent } from './shared/components/offline-fallback/offline-fallback.component';
+
+describe('app routes', () => {
+  it('keeps the offline recovery route eagerly available', () => {
+    const offlineRoute = routes.find((route) => route.path === 'offline');
+
+    expect(offlineRoute).toBeDefined();
+    expect(offlineRoute?.component).toBe(OfflineFallbackComponent);
+    expect(offlineRoute?.loadComponent).toBeUndefined();
+  });
+});

--- a/fe/src/app/app.routes.ts
+++ b/fe/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { authGuard } from './core/guards/role.guard';
 import { HomepageLayoutComponent } from './shared/components/layout/homepage-layout/homepage-layout.component';
+import { OfflineFallbackComponent } from './shared/components/offline-fallback/offline-fallback.component';
 
 /**
  * Main Application Routes Configuration
@@ -153,7 +154,7 @@ export const routes: Routes = [
   // ========================================
   {
     path: 'offline',
-    loadComponent: () => import('./shared/components/offline-fallback/offline-fallback.component').then(m => m.OfflineFallbackComponent),
+    component: OfflineFallbackComponent,
     title: 'Ngoáº¡i tuyáº¿n - LMS Maritime'
   },
 

--- a/fe/src/app/core/services/network-status.service.spec.ts
+++ b/fe/src/app/core/services/network-status.service.spec.ts
@@ -1,10 +1,19 @@
-import { NetworkStatusService, ConnectionTier } from './network-status.service';
+import { NetworkStatusService } from './network-status.service';
 
 describe('NetworkStatusService', () => {
   let service: NetworkStatusService;
+  let fetchSpy: jasmine.Spy<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>;
 
   beforeEach(() => {
+    fetchSpy = spyOn(window, 'fetch').and.callFake(async () =>
+      new Response('', { status: 200 }),
+    );
     service = new NetworkStatusService();
+  });
+
+  afterEach(() => {
+    service.ngOnDestroy();
+    fetchSpy.calls.reset();
   });
 
   describe('Initial state', () => {
@@ -96,6 +105,18 @@ describe('NetworkStatusService', () => {
       service.online.set(true);
       service.effectiveBandwidthMbps.set(1000);
       expect(service.connectionTier()).toBe('fast');
+    });
+  });
+
+  describe('offline signal tracking', () => {
+    it('should mark the app as effectively offline after a transport failure', () => {
+      service.online.set(true);
+
+      service.markOfflineFromTransportFailure();
+
+      expect(service.online()).toBeFalse();
+      expect(service.hasRecentOfflineSignal()).toBeTrue();
+      expect(service.isEffectivelyOffline()).toBeTrue();
     });
   });
 });

--- a/fe/src/app/core/services/network-status.service.ts
+++ b/fe/src/app/core/services/network-status.service.ts
@@ -5,7 +5,7 @@ export type ConnectionTransport = 'wifi' | 'ethernet' | 'cellular' | 'unknown';
 
 @Injectable({ providedIn: 'root' })
 export class NetworkStatusService implements OnDestroy {
-  readonly online = signal(typeof navigator !== 'undefined' ? navigator.onLine : true);
+  readonly online = signal(this.getBrowserOnlineHint());
   readonly effectiveBandwidthMbps = signal(2);
   readonly connectionTransport = signal<ConnectionTransport>('unknown');
   readonly saveDataEnabled = signal(false);
@@ -28,16 +28,29 @@ export class NetworkStatusService implements OnDestroy {
 
   readonly connectionLabel = computed(() => {
     switch (this.connectionTier()) {
-      case 'none': return 'Ngoại tuyến';
-      case 'slow': return 'Kết nối chậm';
-      case 'fast': return 'Trực tuyến';
+      case 'none':
+        return 'Ngoại tuyến';
+      case 'slow':
+        return 'Kết nối chậm';
+      case 'fast':
+        return 'Trực tuyến';
     }
   });
 
+  private readonly recentOfflineSignalAt = signal<number | null>(
+    this.getBrowserOnlineHint() ? null : Date.now(),
+  );
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private probeInterval: ReturnType<typeof setInterval> | null = null;
-  private readonly onlineHandler = () => this.debouncedUpdate();
-  private readonly offlineHandler = () => this.debouncedUpdate();
+  private readonly onlineHandler = () => {
+    this.recentOfflineSignalAt.set(null);
+    this.updateStatus();
+    this.probeLatency();
+  };
+  private readonly offlineHandler = () => {
+    this.markOfflineState();
+    this.updateStatus();
+  };
   private readonly connectionChangeHandler = () => this.debouncedUpdate();
   private connectionRef: { removeEventListener?: (type: string, listener: EventListenerOrEventListenerObject) => void } | null = null;
 
@@ -55,14 +68,14 @@ export class NetworkStatusService implements OnDestroy {
 
     this.updateStatus();
 
-    // Only probe when online (avoid waking iOS SW unnecessarily)
-    if (navigator.onLine) {
+    if (this.getBrowserOnlineHint()) {
       this.probeLatency();
     }
 
-    // Periodic re-probe every 2 minutes (was 30s — too aggressive for iOS SW keepalive)
     this.probeInterval = setInterval(() => {
-      if (navigator.onLine) this.probeLatency();
+      if (this.getBrowserOnlineHint()) {
+        this.probeLatency();
+      }
     }, 120_000);
   }
 
@@ -81,97 +94,92 @@ export class NetworkStatusService implements OnDestroy {
     }
   }
 
+  hasRecentOfflineSignal(windowMs = 15_000): boolean {
+    const lastOfflineSignalAt = this.recentOfflineSignalAt();
+    return lastOfflineSignalAt != null && Date.now() - lastOfflineSignalAt <= windowMs;
+  }
+
+  isEffectivelyOffline(windowMs = 15_000): boolean {
+    return !this.getBrowserOnlineHint()
+      || !this.online()
+      || this.hasRecentOfflineSignal(windowMs);
+  }
+
+  markOfflineFromTransportFailure(): void {
+    this.markOfflineState();
+  }
+
   private debouncedUpdate(): void {
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     this.debounceTimer = setTimeout(() => this.updateStatus(), 150);
   }
 
   private updateStatus(): void {
-    this.online.set(navigator.onLine);
-
+    const browserOnline = this.getBrowserOnlineHint();
     const conn = (navigator as any).connection;
+
     this.connectionTransport.set(this.normalizeConnectionTransport(conn?.type));
     this.saveDataEnabled.set(conn?.saveData === true);
     this.effectiveNetworkType.set(typeof conn?.effectiveType === 'string' ? conn.effectiveType : null);
 
-    if (!navigator.onLine) {
-      this.effectiveBandwidthMbps.set(0);
-    } else if (conn?.downlink != null) {
-      // conn.downlink measures physical link, not app server speed.
-      // Use it as hint but floor at 1.5 to avoid false "slow" on fast localhost.
-      // probeLatency() will correct this with actual measured RTT.
+    if (!browserOnline) {
+      this.markOfflineState();
+      return;
+    }
+
+    this.online.set(true);
+    if (conn?.downlink != null) {
       this.effectiveBandwidthMbps.set(Math.max(conn.downlink, 1.5));
     } else {
       this.effectiveBandwidthMbps.set(2);
     }
   }
 
-  /**
-   * Probe actual latency via network request.
-   *
-   * IMPORTANT: Uses cache: 'no-store' to bypass SW cache and get real network status.
-   * Falls back to API health check if icon probe succeeds (to verify internet connectivity).
-   *
-   * Multi-strategy detection:
-   * 1. Static resource with no-store (bypass SW cache)
-   * 2. If that succeeds, verify with API health endpoint
-   * 3. On iOS: SW can be evicted after ~5min background. Rely on navigator.onLine events (no aggressive probe).
-   */
   private probeLatency(): void {
-    if (!navigator.onLine) return;
+    if (!this.getBrowserOnlineHint()) return;
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000);
-
     const start = performance.now();
 
-    // Use cache: 'no-store' to bypass SW cache and get real network status
     fetch('/icons/icon-192x192.png', {
       method: 'HEAD',
       signal: controller.signal,
-      cache: 'no-store'
+      cache: 'no-store',
     })
-      .then(async () => {
+      .then(async (iconResponse) => {
+        this.ensureSuccessfulProbeResponse(iconResponse);
         clearTimeout(timeoutId);
-        const rtt = performance.now() - start;
 
-        // Verify internet connectivity with API health check
-        // This catches the case where WiFi is connected but no internet
+        const rtt = performance.now() - start;
+        const apiController = new AbortController();
+        const apiTimeoutId = setTimeout(() => apiController.abort(), 3000);
+
         try {
-          const apiController = new AbortController();
-          const apiTimeoutId = setTimeout(() => apiController.abort(), 3000);
-          await fetch('/actuator/health', {
+          const apiResponse = await fetch('/actuator/health', {
             method: 'GET',
             signal: apiController.signal,
-            cache: 'no-store'
+            cache: 'no-store',
           });
-          clearTimeout(apiTimeoutId);
-
-          this.online.set(true);
-          if (rtt > 500) {
-            this.effectiveBandwidthMbps.set(0.5);   // genuinely slow
-          } else if (rtt > 200) {
-            this.effectiveBandwidthMbps.set(1.5);   // moderate
-          } else {
-            this.effectiveBandwidthMbps.set(10);
-          }
+          this.ensureSuccessfulProbeResponse(apiResponse);
+          this.markMeasuredOnlineState(rtt);
         } catch {
-          // API health check failed → WiFi connected but no internet
-          this.online.set(false);
-          this.effectiveBandwidthMbps.set(0);
+          this.markOfflineState();
+        } finally {
+          clearTimeout(apiTimeoutId);
         }
       })
-      .catch((err) => {
+      .catch((error) => {
         clearTimeout(timeoutId);
-        // Only mark offline on genuine network failure, not abort timeout
-        if (err instanceof TypeError) {
-          this.online.set(false);
-          this.effectiveBandwidthMbps.set(0);
-        }
-        // AbortError (timeout 5s) → mark as slow, not offline
-        if (err?.name === 'AbortError') {
+
+        if (error?.name === 'AbortError') {
+          this.online.set(true);
+          this.recentOfflineSignalAt.set(null);
           this.effectiveBandwidthMbps.set(0.3);
+          return;
         }
+
+        this.markOfflineState();
       });
   }
 
@@ -181,5 +189,34 @@ export class NetworkStatusService implements OnDestroy {
     }
 
     return 'unknown';
+  }
+
+  private getBrowserOnlineHint(): boolean {
+    return typeof navigator !== 'undefined' ? navigator.onLine : true;
+  }
+
+  private ensureSuccessfulProbeResponse(response: Response): void {
+    if (!response.ok) {
+      throw new Error(`probe-response-${response.status}`);
+    }
+  }
+
+  private markMeasuredOnlineState(rtt: number): void {
+    this.online.set(true);
+    this.recentOfflineSignalAt.set(null);
+
+    if (rtt > 500) {
+      this.effectiveBandwidthMbps.set(0.5);
+    } else if (rtt > 200) {
+      this.effectiveBandwidthMbps.set(1.5);
+    } else {
+      this.effectiveBandwidthMbps.set(10);
+    }
+  }
+
+  private markOfflineState(): void {
+    this.online.set(false);
+    this.effectiveBandwidthMbps.set(0);
+    this.recentOfflineSignalAt.set(Date.now());
   }
 }

--- a/fe/src/app/core/services/sw-update.service.spec.ts
+++ b/fe/src/app/core/services/sw-update.service.spec.ts
@@ -1,0 +1,21 @@
+import { isRuntimeChunkLoadFailure } from './sw-update.service';
+
+describe('isRuntimeChunkLoadFailure', () => {
+  it('detects dynamic import failures surfaced via unhandled rejection', () => {
+    expect(isRuntimeChunkLoadFailure({
+      message: 'Failed to fetch dynamically imported module: https://holilihu.online/chunk-ABC.js',
+    })).toBeTrue();
+  });
+
+  it('detects classic ChunkLoadError messages', () => {
+    expect(isRuntimeChunkLoadFailure({
+      message: 'ChunkLoadError: Loading chunk 42 failed.',
+    })).toBeTrue();
+  });
+
+  it('ignores unrelated runtime failures', () => {
+    expect(isRuntimeChunkLoadFailure({
+      message: 'WebSocket connection to wss://holilihu.online/ws failed',
+    })).toBeFalse();
+  });
+});

--- a/fe/src/app/core/services/sw-update.service.ts
+++ b/fe/src/app/core/services/sw-update.service.ts
@@ -1,18 +1,68 @@
 import { Injectable, inject } from '@angular/core';
+import { Router } from '@angular/router';
 import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
 import { filter, interval, switchMap } from 'rxjs';
 import { from } from 'rxjs';
 import { ToastService } from './toast.service';
 import { StorageManagerService } from './storage-manager.service';
 import { ConfirmDialogService } from './confirm-dialog.service';
+import { NetworkStatusService } from './network-status.service';
+
+const RUNTIME_CHUNK_FAILURE_MARKERS = [
+  'ChunkLoadError',
+  'Loading chunk',
+  'Failed to fetch dynamically imported module',
+  'Importing a module script failed',
+  'error loading dynamically imported module',
+] as const;
+
+export function isRuntimeChunkLoadFailure(errorLike: unknown): boolean {
+  const message = getRuntimeFailureMessage(errorLike).toLowerCase();
+  return RUNTIME_CHUNK_FAILURE_MARKERS.some((marker) =>
+    message.includes(marker.toLowerCase()),
+  );
+}
+
+function getRuntimeFailureMessage(errorLike: unknown): string {
+  if (typeof errorLike === 'string') {
+    return errorLike;
+  }
+
+  if (!errorLike || typeof errorLike !== 'object') {
+    return '';
+  }
+
+  const record = errorLike as Record<string, unknown>;
+  const message = record['message'];
+  if (typeof message === 'string') {
+    return message;
+  }
+
+  const reason = record['reason'];
+  if (typeof reason === 'string') {
+    return reason;
+  }
+
+  if (reason && typeof reason === 'object') {
+    const nestedMessage = (reason as Record<string, unknown>)['message'];
+    if (typeof nestedMessage === 'string') {
+      return nestedMessage;
+    }
+  }
+
+  return '';
+}
 
 @Injectable({ providedIn: 'root' })
 export class SwUpdateService {
   private readonly swUpdate = inject(SwUpdate, { optional: true });
+  private readonly router = inject(Router);
   private readonly toast = inject(ToastService);
   private readonly storage = inject(StorageManagerService);
   private readonly confirmDialog = inject(ConfirmDialogService);
+  private readonly networkStatus = inject(NetworkStatusService);
   private initialized = false;
+  private runtimeRecoveryTriggered = false;
   private readonly visibilityChangeHandler = async () => {
     if (document.visibilityState !== 'visible') return;
 
@@ -36,13 +86,19 @@ export class SwUpdateService {
     }
   };
   private readonly windowErrorHandler = (event: ErrorEvent) => {
-    const msg = event.message || '';
-    if (msg.includes('ChunkLoadError') || msg.includes('Loading chunk')) {
-      console.warn('[PWA] ChunkLoadError detected, reloading...');
-      if (navigator.onLine) {
-        document.location.reload();
-      }
+    if (!isRuntimeChunkLoadFailure(event)) {
+      return;
     }
+
+    this.handleRuntimeChunkFailure(event);
+  };
+  private readonly unhandledRejectionHandler = (event: PromiseRejectionEvent) => {
+    if (!isRuntimeChunkLoadFailure(event.reason)) {
+      return;
+    }
+
+    event.preventDefault();
+    this.handleRuntimeChunkFailure(event.reason);
   };
 
   initialize(): void {
@@ -61,12 +117,10 @@ export class SwUpdateService {
     if (!this.swUpdate?.isEnabled) return;
     const sw = this.swUpdate;
 
-    // Check for updates every 6 hours (maritime connectivity windows)
     interval(6 * 60 * 60 * 1000).pipe(
       switchMap(() => from(sw.checkForUpdate())),
     ).subscribe();
 
-    // Prompt user when new version ready (prevents data loss during quiz/assignment)
     sw.versionUpdates.pipe(
       filter((evt): evt is VersionReadyEvent => evt.type === 'VERSION_READY'),
     ).subscribe(async () => {
@@ -85,35 +139,26 @@ export class SwUpdateService {
       }
     });
 
-    // Handle unrecoverable state (Angular #42094, iOS SW eviction)
-    // iOS kills SW after ~5min background → unrecoverable fires
-    // NEVER reload offline — it will show browser's "No Connection" page
     sw.unrecoverable.subscribe(async (event) => {
       console.error('[SW] Unrecoverable state:', event.reason);
 
       if (navigator.onLine) {
-        // Clear stale NGSW caches before reload to prevent re-entering unrecoverable
         await this.clearNgswCaches();
         this.toast.error('Ứng dụng gặp lỗi. Đang tải lại...');
         setTimeout(() => document.location.reload(), 1000);
       } else {
-        // Queue reload for when we come back online
         this.toast.info('Ứng dụng sẽ cập nhật khi có kết nối mạng');
         const onlineHandler = () => {
           window.removeEventListener('online', onlineHandler);
-          // Confirm we're truly online with a probe before reload
           fetch('/icons/icon-192x192.png', { method: 'HEAD' })
             .then(() => document.location.reload())
-            .catch(() => { /* still offline, wait more */ });
+            .catch(() => {});
         };
         window.addEventListener('online', onlineHandler);
       }
     });
 
-    // Request persistent storage — critical for iOS (prevents 7-day eviction)
     this.storage.requestPersistence();
-
-    // One-time "offline ready" toast — shows only on first SW install per device
     this.showOfflineReadyToast();
   }
 
@@ -141,63 +186,77 @@ export class SwUpdateService {
     }
   }
 
-  /**
-   * Show a one-time toast when SW first becomes active (all prefetch assets cached).
-   * Uses localStorage flag so it only fires once per device, ever.
-   * navigator.serviceWorker.ready resolves when SW is active = prefetch complete.
-   */
   private showOfflineReadyToast(): void {
     if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
     try {
       if (localStorage.getItem('pwa-ready-shown')) return;
-    } catch { return; }
+    } catch {
+      return;
+    }
 
     navigator.serviceWorker.ready.then(() => {
       this.toast.success('Sẵn sàng ngoại tuyến — trang web hoạt động kể cả khi mất mạng');
-      try { localStorage.setItem('pwa-ready-shown', '1'); } catch {}
+      try {
+        localStorage.setItem('pwa-ready-shown', '1');
+      } catch {}
     });
   }
 
-  /**
-   * iOS WebKit evicts SW after ~5min background (Apple WebKit policy).
-   * On resume (visibilitychange → visible), check if SW is still alive.
-   * If dead and online → reload to re-register SW and re-cache app shell.
-   * If dead and offline → do nothing (app continues from memory).
-   *
-   * Source: https://webkit.org/blog/14403/updates-to-storage-policy/
-   */
   private setupVisibilityHandler(): void {
     if (typeof document === 'undefined') return;
 
     document.addEventListener('visibilitychange', this.visibilityChangeHandler);
   }
 
-  /**
-   * Angular NGSW's unrecoverable event sometimes does NOT fire for
-   * lazy-loaded chunk mismatches (Angular #42094). Catch ChunkLoadError
-   * globally and reload to get fresh chunks.
-   */
   private setupChunkErrorHandler(): void {
     if (typeof window === 'undefined') return;
 
     window.addEventListener('error', this.windowErrorHandler);
+    window.addEventListener('unhandledrejection', this.unhandledRejectionHandler);
   }
 
-  /**
-   * Clear all NGSW caches before reload to prevent re-entering
-   * unrecoverable state with stale/partial cache.
-   */
   private async clearNgswCaches(): Promise<void> {
     try {
       const cacheNames = await caches.keys();
       await Promise.all(
         cacheNames
-          .filter(name => name.startsWith('ngsw:'))
-          .map(name => caches.delete(name))
+          .filter((name) => name.startsWith('ngsw:'))
+          .map((name) => caches.delete(name)),
       );
-      console.info('[SW] Cleared', cacheNames.filter(n => n.startsWith('ngsw:')).length, 'NGSW caches');
+      console.info('[SW] Cleared', cacheNames.filter((name) => name.startsWith('ngsw:')).length, 'NGSW caches');
     } catch {
       // Cache cleanup failed, continue anyway
     }
+  }
+
+  private handleRuntimeChunkFailure(reason: unknown): void {
+    if (this.runtimeRecoveryTriggered) {
+      return;
+    }
+
+    this.runtimeRecoveryTriggered = true;
+
+    if (this.networkStatus.isEffectivelyOffline()) {
+      this.networkStatus.markOfflineFromTransportFailure();
+      console.warn('[PWA] Runtime chunk request failed while offline, redirecting to offline recovery.', reason);
+      this.toast.info('Bạn đang ngoại tuyến. Đang mở trang ngoại tuyến đã tải xuống.');
+      this.navigateToOfflineRecovery();
+      return;
+    }
+
+    console.warn('[PWA] Runtime chunk load failure detected, reloading app shell.', reason);
+
+    if (typeof navigator === 'undefined' || navigator.onLine) {
+      document.location.reload();
+      return;
+    }
+
+    this.navigateToOfflineRecovery();
+  }
+
+  private navigateToOfflineRecovery(): void {
+    void this.router.navigateByUrl('/offline').catch(() => {
+      document.location.assign('/offline');
+    });
   }
 }

--- a/fe/src/app/core/utils/offline-http-error.spec.ts
+++ b/fe/src/app/core/utils/offline-http-error.spec.ts
@@ -1,0 +1,46 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  isOfflineCompatibleGatewayError,
+  isOfflineCompatibleHttpError,
+  isSameOriginRequestUrl,
+  isRawOfflineTransportError,
+} from './offline-http-error';
+
+describe('offline-http-error utils', () => {
+  it('treats status 0 as an offline transport error', () => {
+    const error = new HttpErrorResponse({ status: 0, error: new ProgressEvent('error') });
+
+    expect(isRawOfflineTransportError(error)).toBeTrue();
+    expect(isOfflineCompatibleHttpError(error, '/api/v3/courses', {
+      navigatorOnline: true,
+      appOnline: true,
+      hasRecentOfflineSignal: false,
+    })).toBeTrue();
+  });
+
+  it('treats same-origin 504 as offline-compatible when the browser is offline', () => {
+    const error = new HttpErrorResponse({ status: 504, url: '/api/v3/courses' });
+
+    expect(isOfflineCompatibleGatewayError(error, '/api/v3/courses', {
+      navigatorOnline: false,
+      appOnline: true,
+      hasRecentOfflineSignal: false,
+      currentOrigin: 'https://holilihu.online',
+    })).toBeTrue();
+  });
+
+  it('does not treat cross-origin 504 as an offline-compatible LMS request', () => {
+    const error = new HttpErrorResponse({ status: 504, url: 'https://cdn.example.com/chunk.js' });
+
+    expect(isOfflineCompatibleGatewayError(error, 'https://cdn.example.com/chunk.js', {
+      navigatorOnline: false,
+      appOnline: false,
+      hasRecentOfflineSignal: true,
+      currentOrigin: 'https://holilihu.online',
+    })).toBeFalse();
+  });
+
+  it('keeps same-origin detection for relative LMS URLs', () => {
+    expect(isSameOriginRequestUrl('/api/v3/courses', 'https://holilihu.online')).toBeTrue();
+  });
+});

--- a/fe/src/app/core/utils/offline-http-error.ts
+++ b/fe/src/app/core/utils/offline-http-error.ts
@@ -1,0 +1,72 @@
+import { HttpErrorResponse } from '@angular/common/http';
+
+const OFFLINE_COMPATIBLE_GATEWAY_STATUSES = new Set([502, 503, 504]);
+
+export type OfflineHttpSignal = {
+  navigatorOnline: boolean;
+  appOnline: boolean;
+  hasRecentOfflineSignal: boolean;
+  currentOrigin?: string | null;
+};
+
+export function isRawOfflineTransportError(error: HttpErrorResponse): boolean {
+  return error.status === 0 || error.error instanceof ProgressEvent;
+}
+
+export function isOfflineGatewayStatus(status: number): boolean {
+  return OFFLINE_COMPATIBLE_GATEWAY_STATUSES.has(status);
+}
+
+export function isSameOriginRequestUrl(
+  requestUrl: string,
+  currentOrigin = getCurrentOrigin(),
+): boolean {
+  if (requestUrl.startsWith('/')) {
+    return true;
+  }
+
+  if (!currentOrigin) {
+    return false;
+  }
+
+  try {
+    return new URL(requestUrl, currentOrigin).origin === currentOrigin;
+  } catch {
+    return false;
+  }
+}
+
+export function isOfflineCompatibleGatewayError(
+  error: HttpErrorResponse,
+  requestUrl: string,
+  signal: OfflineHttpSignal,
+): boolean {
+  if (!isOfflineGatewayStatus(error.status)) {
+    return false;
+  }
+
+  if (!isSameOriginRequestUrl(requestUrl, signal.currentOrigin)) {
+    return false;
+  }
+
+  return signal.navigatorOnline === false
+    || signal.appOnline === false
+    || signal.hasRecentOfflineSignal;
+}
+
+export function isOfflineCompatibleHttpError(
+  error: HttpErrorResponse,
+  requestUrl: string,
+  signal: OfflineHttpSignal,
+): boolean {
+  return isRawOfflineTransportError(error)
+    || isOfflineCompatibleGatewayError(error, requestUrl, signal);
+}
+
+function getCurrentOrigin(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return window.location.origin;
+}

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
@@ -26,7 +26,7 @@
         [class.text-[#0056D2]]="activeTab() === 'overview'" [class.text-slate-500]="activeTab() !== 'overview'"
         [class.hover:text-slate-700]="activeTab() !== 'overview'" (click)="activeTab.set('overview')">
         <span class="flex items-center gap-1.5">
-          <span class="material-symbols-outlined text-[18px]">article</span>
+          <app-icon name="file-text" size="sm"></app-icon>
           Tổng quan
         </span>
         @if (activeTab() === 'overview') {
@@ -38,7 +38,7 @@
         [class.text-[#0056D2]]="activeTab() === 'notes'" [class.text-slate-500]="activeTab() !== 'notes'"
         [class.hover:text-slate-700]="activeTab() !== 'notes'" (click)="activeTab.set('notes')">
         <span class="flex items-center gap-1.5">
-          <span class="material-symbols-outlined text-[18px]">edit_note</span>
+          <app-icon name="edit" size="sm"></app-icon>
           Ghi chú
           @if (lessonNotes().length > 0) {
           <span class="ml-0.5 px-1.5 py-0 text-[10px] font-bold rounded-full bg-slate-100 text-slate-600">
@@ -55,7 +55,7 @@
         [class.text-[#0056D2]]="activeTab() === 'materials'" [class.text-slate-500]="activeTab() !== 'materials'"
         [class.hover:text-slate-700]="activeTab() !== 'materials'" (click)="activeTab.set('materials')">
         <span class="flex items-center gap-1.5">
-          <span class="material-symbols-outlined text-[18px]">folder_open</span>
+          <app-icon name="folder" size="sm"></app-icon>
           Tài liệu
           @if (lesson().attachments && lesson().attachments.length > 0) {
           <span class="ml-0.5 px-1.5 py-0 text-[10px] font-bold rounded-full bg-slate-100 text-slate-600">
@@ -90,7 +90,7 @@
 
       @if (section.type === 'QUIZ') {
       <div class="p-6 border border-amber-200 bg-amber-50 rounded-lg text-center">
-        <span class="material-symbols-outlined text-4xl text-amber-600 mb-2">assignment</span>
+        <app-icon name="file-check" size="xl" class="mb-2 text-amber-600"></app-icon>
         @if (section.title) {
         <h3 class="text-lg font-bold text-slate-800 mb-1">{{ section.title }}</h3>
         }
@@ -118,7 +118,7 @@
           [disabled]="isQuizActionBlocked()"
           class="inline-flex items-center gap-2 px-6 py-2.5 bg-[#0056D2] text-white font-semibold rounded-lg hover:bg-[#004BB5] transition-colors disabled:cursor-not-allowed disabled:opacity-50">
           <span>Làm bài trắc nghiệm</span>
-          <span class="material-symbols-outlined text-base">arrow_forward</span>
+          <app-icon name="arrow-right" size="sm"></app-icon>
         </button>
       </div>
       }
@@ -126,7 +126,7 @@
       @if (section.type === 'ASSIGNMENT' && section.content) {
       <div class="p-4 border border-[#0056D2]/20 bg-[#0056D2]/5 rounded-lg">
         <div class="flex items-center gap-2 mb-3">
-          <span class="material-symbols-outlined text-[#0056D2]">edit_note</span>
+          <app-icon name="edit" size="md" class="text-[#0056D2]"></app-icon>
           <h3 class="text-base font-bold text-slate-800">Bài tập{{ section.title ? ': ' + section.title : '' }}</h3>
         </div>
         <div class="prose prose-slate max-w-none text-sm" [innerHTML]="getSanitizedHtml(section.content)"></div>
@@ -142,7 +142,7 @@
     <!-- Quiz Button (non-section QUIZ lessons) -->
     @if ((hasQuiz() || lesson().lessonType === LessonType.QUIZ) && !hasSections()) {
     <div class="p-6 border border-amber-200 bg-amber-50 rounded-lg text-center mt-6 mb-6">
-      <span class="material-symbols-outlined text-4xl text-amber-600 mb-2">assignment</span>
+      <app-icon name="file-check" size="xl" class="mb-2 text-amber-600"></app-icon>
       @if (quizPresentation(); as quizMeta) {
       <h3 class="text-lg font-bold text-slate-800 mb-1">{{ quizMeta.label }}</h3>
       <div class="mb-3 flex flex-wrap items-center justify-center gap-2">
@@ -168,7 +168,7 @@
         [disabled]="isQuizActionBlocked()"
         class="inline-flex items-center gap-2 px-6 py-2.5 bg-[#0056D2] text-white font-semibold rounded-lg hover:bg-[#004BB5] transition-colors disabled:cursor-not-allowed disabled:opacity-50">
         <span>Làm bài trắc nghiệm</span>
-        <span class="material-symbols-outlined text-base">arrow_forward</span>
+        <app-icon name="arrow-right" size="sm"></app-icon>
       </button>
     </div>
     }
@@ -186,7 +186,7 @@
             (ngModelChange)="newNoteContent.set($event)"></textarea>
           <div class="flex items-center justify-between px-3 py-2 bg-slate-50 border-t border-gray-100">
             <span class="text-[11px] text-slate-400">
-              <span class="material-symbols-outlined text-[13px] align-middle mr-0.5">info</span>
+              <app-icon name="info" size="xs" class="align-middle mr-0.5"></app-icon>
               Ghi chú chỉ hiển thị cho bạn
             </span>
             <button
@@ -238,11 +238,11 @@
               <div class="flex items-center gap-1">
                 <button class="p-1 text-slate-400 hover:text-[#0056D2] rounded transition-colors" title="Chỉnh sửa"
                   (click)="startEditNote(note)">
-                  <span class="material-symbols-outlined text-[16px]">edit</span>
+                  <app-icon name="edit" size="sm"></app-icon>
                 </button>
                 <button class="p-1 text-slate-400 hover:text-red-500 rounded transition-colors" title="Xóa"
                   (click)="deleteNote(note.id)">
-                  <span class="material-symbols-outlined text-[16px]">delete</span>
+                  <app-icon name="trash" size="sm"></app-icon>
                 </button>
               </div>
             </div>
@@ -333,14 +333,14 @@
         <div class="mt-3 flex items-center justify-between px-1">
           @if (isCurrentSectionCompleted()) {
           <span class="flex items-center gap-1.5 text-xs font-semibold text-green-600">
-            <span class="material-symbols-outlined text-sm">check_circle</span>
+            <app-icon name="circle-check" size="sm"></app-icon>
             Đã xem tài liệu
           </span>
           } @else {
           <span class="text-xs text-amber-600 font-medium">Bắt buộc hoàn thành</span>
           <button type="button" (click)="markFileComplete()"
             class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-[#0056D2] bg-[#0056D2]/5 border border-[#0056D2]/20 rounded-lg hover:bg-[#0056D2]/10 transition-colors">
-            <span class="material-symbols-outlined text-sm">task_alt</span>
+            <app-icon name="circle-check" size="sm"></app-icon>
             Đánh dấu đã xem
           </button>
           }
@@ -389,9 +389,11 @@
             [class.text-red-600]="attachment.fileType.includes('pdf')"
             [class.bg-blue-50]="!attachment.fileType.includes('pdf')"
             [class.text-blue-600]="!attachment.fileType.includes('pdf')">
-            <span class="material-symbols-outlined text-xl">
-              {{ attachment.fileType.includes('pdf') ? 'picture_as_pdf' : 'attach_file' }}
-            </span>
+            @if (attachment.fileType.includes('pdf')) {
+            <app-icon name="file-text" size="md"></app-icon>
+            } @else {
+            <app-icon name="paperclip" size="md"></app-icon>
+            }
           </div>
           <div class="flex-1 min-w-0">
             <div class="text-sm font-semibold text-slate-700 group-hover:text-[#0056D2] truncate">
@@ -403,7 +405,7 @@
           </div>
           <div
             class="flex items-center gap-1.5 px-3 py-1.5 bg-slate-50 group-hover:bg-[#0056D2] text-slate-500 group-hover:text-white text-xs font-medium rounded-lg transition-colors shrink-0">
-            <span class="material-symbols-outlined text-base">download</span>
+            <app-icon name="download" size="sm"></app-icon>
             Tải xuống
           </div>
         </a>
@@ -411,7 +413,7 @@
       </div>
       } @else {
       <div class="flex flex-col items-center py-12 text-slate-400 text-center">
-        <span class="material-symbols-outlined text-4xl mb-2">folder_open</span>
+        <app-icon name="folder" size="xl" class="mb-2"></app-icon>
         <p class="text-sm font-medium text-slate-500">Chưa có tài liệu đính kèm</p>
         <p class="text-xs text-slate-400 mt-1">Giáo viên chưa thêm tài liệu cho bài học này</p>
       </div>

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
@@ -18,6 +18,7 @@ import { QuizApi } from '../../../../api/endpoints/quiz.api';
 import { ToastService } from '../../../../core/services/toast.service';
 import { NetworkStatusService } from '../../../../core/services/network-status.service';
 import { PdfViewerService } from '../../../../shared/services/pdf-viewer.service';
+import { IconComponent } from '../../../../shared/components/icon/icon.component';
 
 /**
  * Lesson Content Component
@@ -29,7 +30,7 @@ import { PdfViewerService } from '../../../../shared/services/pdf-viewer.service
  */
 @Component({
   selector: 'app-lesson-content',
-  imports: [AdaptiveVideoPlayerComponent, YouTubePlayerComponent, CommonModule, FormsModule],
+  imports: [AdaptiveVideoPlayerComponent, YouTubePlayerComponent, CommonModule, FormsModule, IconComponent],
   templateUrl: './lesson-content.component.html',
   styleUrls: ['./lesson-content.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/fe/src/app/features/learning/pages/course-learning.component.html
+++ b/fe/src/app/features/learning/pages/course-learning.component.html
@@ -1,7 +1,7 @@
 @if (isPreview()) {
   <div class="flex items-center justify-between px-4 py-2 bg-amber-50 border-b border-amber-200 shrink-0 z-30">
     <div class="flex items-center gap-2 text-sm text-amber-800">
-      <span class="material-symbols-outlined text-base">visibility</span>
+      <app-icon name="eye" size="sm"></app-icon>
       <span class="font-semibold">Chế độ xem trước</span>
       <span class="hidden sm:inline text-amber-700">— Đây là giao diện học viên sẽ thấy</span>
     </div>
@@ -17,11 +17,11 @@
   <!-- Mobile Header (md:hidden) -->
   <header class="md:hidden flex items-center justify-between px-4 py-3 border-b border-gray-200 bg-white z-20 shrink-0">
     <button class="text-slate-700 p-1" (click)="toggleSidebar()">
-      <span class="material-symbols-outlined">menu</span>
+      <app-icon name="menu" size="md"></app-icon>
     </button>
     <h1 class="text-sm font-bold truncate text-[#0056D2] max-w-[220px]">{{ course()?.title || 'Đang tải...' }}</h1>
     <button class="text-slate-700 p-1">
-      <span class="material-symbols-outlined">more_vert</span>
+      <app-icon name="more-vertical" size="md"></app-icon>
     </button>
   </header>
 
@@ -47,7 +47,7 @@
     <div class="px-4 py-4 border-b border-gray-200">
       <div class="flex items-center text-xs font-medium text-slate-500 mb-3 cursor-pointer hover:text-[#0056D2] transition-colors"
         (click)="goBack()">
-        <span class="material-symbols-outlined text-sm mr-1">arrow_back</span>
+        <app-icon name="arrow-left" size="sm" class="mr-1"></app-icon>
         Chi tiết khóa học
       </div>
       <h2 class="font-bold text-[#0056D2] text-base leading-tight mb-3">{{ course()?.title || 'Đang tải...' }}</h2>
@@ -64,14 +64,14 @@
     @if (coursePaid() && !hasPaid()) {
     <div class="mx-4 mt-3 px-3 py-2 bg-amber-50 border border-amber-200 rounded-lg flex items-center gap-2 cursor-pointer hover:bg-amber-100 transition-colors text-sm text-amber-800"
       (click)="showPaymentModal.set(true)">
-      <span class="material-symbols-outlined text-base">lock</span>
+      <app-icon name="lock" size="sm"></app-icon>
       <span class="flex-1 font-medium">Mở khóa toàn bộ khóa học</span>
-      <span class="material-symbols-outlined text-sm">chevron_right</span>
+      <app-icon name="chevron-right" size="sm"></app-icon>
     </div>
     } @else if (awaitingManualActivation()) {
     <div class="mx-4 mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
       <div class="flex items-start gap-2">
-        <span class="material-symbols-outlined mt-0.5 text-base">pending_actions</span>
+        <app-icon name="clock" size="sm" class="mt-0.5"></app-icon>
         <div class="min-w-0">
           <p class="font-medium">Thanh toan da duoc ghi nhan</p>
           <p class="mt-0.5 text-xs text-amber-700">Khoa hoc dang lop hoc se mo khi ban duoc xep lop hoac kich hoat.</p>
@@ -81,7 +81,7 @@
     } @else if (accessPending()) {
     <div class="mx-4 mt-3 rounded-lg border border-[#0056D2]/20 bg-[#0056D2]/5 px-3 py-2 text-sm text-slate-700">
       <div class="flex items-start gap-2">
-        <span class="material-symbols-outlined mt-0.5 text-base text-[#0056D2]">sync</span>
+        <app-icon name="refresh" size="sm" class="mt-0.5 text-[#0056D2]"></app-icon>
         <div class="min-w-0">
           <p class="font-medium">Da ghi nhan thanh toan</p>
           <p class="mt-0.5 text-xs text-slate-600">Quyen hoc cua ban van dang duoc kich hoat. Hay kiem tra lai trong it phut toi tai lich su thanh toan.</p>
@@ -107,7 +107,7 @@
       </div>
       } @else if (courseError()) {
       <div class="flex flex-col items-center justify-center py-12 text-red-500 px-4">
-        <span class="material-symbols-outlined text-3xl mb-2">error</span>
+        <app-icon name="error" size="xl" class="mb-2"></app-icon>
         <p class="text-sm text-center">{{ courseError() }}</p>
       </div>
       } @else {
@@ -131,12 +131,13 @@
               {{ getCompletedLessonCount(section) }}/{{ section.lessons.length }} bài học
             </p>
           </div>
-          <span class="material-symbols-outlined text-sm transition-transform duration-200 shrink-0"
+          <app-icon
+            name="chevron-down"
+            size="sm"
+            class="shrink-0 transition-transform duration-200"
             [class.text-[#0056D2]]="isSectionExpanded(section.id)"
             [class.text-slate-400]="!isSectionExpanded(section.id)"
-            [class.rotate-180]="isSectionExpanded(section.id)">
-            expand_more
-          </span>
+            [class.rotate-180]="isSectionExpanded(section.id)"></app-icon>
         </button>
 
         <!-- Level 2 + Level 3: Lessons + Sections -->
@@ -154,13 +155,13 @@
 
             <!-- Status Icon -->
             @if (isLessonLocked(lesson)) {
-            <span class="material-symbols-outlined text-slate-400 text-[18px] shrink-0 mt-0.5">lock</span>
+            <app-icon name="lock" size="md" class="shrink-0 mt-0.5 text-slate-400"></app-icon>
             } @else if (learningService.isLessonCompleted(lesson.id)()) {
-            <span class="material-symbols-outlined text-green-600 text-[18px] shrink-0 mt-0.5">check_circle</span>
+            <app-icon name="circle-check" size="md" class="shrink-0 mt-0.5 text-green-600"></app-icon>
             } @else if (currentLesson()?.id === lesson.id) {
-            <span class="material-symbols-outlined text-[#0056D2] text-[18px] shrink-0 mt-0.5">play_circle</span>
+            <app-icon name="play-circle" size="md" class="shrink-0 mt-0.5 text-[#0056D2]"></app-icon>
             } @else {
-            <span class="material-symbols-outlined text-slate-400 text-[18px] shrink-0 mt-0.5">radio_button_unchecked</span>
+            <app-icon name="circle" size="md" class="shrink-0 mt-0.5 text-slate-400"></app-icon>
             }
 
             <!-- Lesson Info -->
@@ -178,10 +179,11 @@
 
             <!-- Expand icon for lessons with sections -->
             @if (lesson.sections && lesson.sections.length > 0) {
-            <span class="material-symbols-outlined text-slate-400 text-sm transition-transform duration-200 shrink-0"
-              [class.rotate-180]="isLessonExpanded(lesson.id)">
-              expand_more
-            </span>
+            <app-icon
+              name="chevron-down"
+              size="sm"
+              class="shrink-0 text-slate-400 transition-transform duration-200"
+              [class.rotate-180]="isLessonExpanded(lesson.id)"></app-icon>
             }
           </button>
 
@@ -200,17 +202,17 @@
             (click)="selectSectionInSidebar(sectionIndex, $event)">
               <span class="font-bold text-[10px] text-[#0056D2] min-w-[20px]">{{ lessonIdx + 1 }}.{{ sectionIndex + 1 }}</span>
               @if (isSectionLockedByPrereqs(lesson, sectionIndex)) {
-              <span class="material-symbols-outlined text-[14px] text-slate-400">lock</span>
+              <app-icon name="lock" size="xs" class="text-slate-400"></app-icon>
               } @else if (isSectionCompleted(sectionItem.id)) {
-              <span class="material-symbols-outlined text-[14px] text-green-600">check_circle</span>
+              <app-icon name="circle-check" size="xs" class="text-green-600"></app-icon>
               } @else if (sectionItem.type === 'VIDEO') {
-              <span class="material-symbols-outlined text-[14px]">play_circle</span>
+              <app-icon name="play-circle" size="xs"></app-icon>
               } @else if (sectionItem.type === 'TEXT') {
-              <span class="material-symbols-outlined text-[14px]">description</span>
+              <app-icon name="file-text" size="xs"></app-icon>
               } @else if (sectionItem.type === 'QUIZ') {
-              <span class="material-symbols-outlined text-[14px]">quiz</span>
+              <app-icon name="help-circle" size="xs"></app-icon>
               } @else {
-              <span class="material-symbols-outlined text-[14px]">attach_file</span>
+              <app-icon name="paperclip" size="xs"></app-icon>
               }
               <span class="truncate flex-1">{{ sectionItem.title }}</span>
               @if (sectionItem.isRequired && !isSectionCompleted(sectionItem.id)) {
@@ -224,7 +226,7 @@
           @if (hasQuiz(lesson.id)) {
           <button class="flex items-center gap-2 w-full pl-12 pr-4 py-1.5 text-xs text-amber-600 hover:text-amber-700 cursor-pointer transition-colors"
             (click)="goToQuiz(lesson.id, $event)">
-            <span class="material-symbols-outlined text-[14px]">assignment</span>
+            <app-icon name="file-check" size="xs"></app-icon>
             <span>Làm bài trắc nghiệm</span>
           </button>
           }
@@ -282,7 +284,7 @@
       </div>
       } @else if (lessonError()) {
       <div class="flex flex-col items-center justify-center py-20 px-6 text-center">
-        <span class="material-symbols-outlined text-4xl text-red-400 mb-3">error</span>
+        <app-icon name="error" size="xl" class="mb-3 text-red-400"></app-icon>
         <h3 class="text-lg font-bold text-slate-800 mb-1">Lỗi tải bài học</h3>
         <p class="text-sm text-slate-500 mb-4">{{ lessonError() }}</p>
         <button class="px-6 py-2 bg-[#0056D2] text-white rounded-lg text-sm font-medium hover:bg-[#004BB5] transition-colors"
@@ -309,7 +311,7 @@
       </app-lesson-content>
       } @else {
       <div class="flex flex-col items-center justify-center py-20 text-slate-400">
-        <span class="material-symbols-outlined text-5xl mb-3">menu_book</span>
+        <app-icon name="book" size="xl" class="mb-3"></app-icon>
         <h3 class="text-lg font-semibold text-slate-700 mb-1">Chọn bài học để bắt đầu</h3>
         <p class="text-sm">Chọn một bài học từ danh sách bên trái</p>
       </div>
@@ -323,7 +325,7 @@
         <button class="flex items-center gap-1 px-3 py-2 rounded text-slate-500 hover:text-[#0056D2] hover:bg-slate-50 transition-colors disabled:opacity-40 disabled:pointer-events-none"
           [disabled]="!canGoPrevious() && currentSectionIndex() === 0"
           (click)="previousLesson()">
-          <span class="material-symbols-outlined text-xl">arrow_back</span>
+          <app-icon name="arrow-left" size="md"></app-icon>
           <span class="hidden sm:inline text-sm font-medium">Bài trước</span>
         </button>
 
@@ -332,11 +334,11 @@
           [class.bg-[#0056D2]]="!learningService.isLessonCompleted(currentLesson()!.id)()"
           (click)="onMarkComplete()">
           @if (learningService.isLessonCompleted(currentLesson()!.id)()) {
-          <span class="material-symbols-outlined text-base">check</span>
+          <app-icon name="check" size="sm"></app-icon>
           <span>Đã hoàn thành</span>
           } @else {
           <span>Đánh dấu hoàn thành</span>
-          <span class="material-symbols-outlined text-base">check</span>
+          <app-icon name="check" size="sm"></app-icon>
           }
         </button>
 
@@ -344,7 +346,7 @@
           [disabled]="!canGoNext() && (!currentLesson()?.sections || currentSectionIndex() >= (currentLesson()?.sections?.length || 0) - 1)"
           (click)="nextLesson()">
           <span class="hidden sm:inline text-sm font-medium">Bài tiếp theo</span>
-          <span class="material-symbols-outlined text-xl">arrow_forward</span>
+          <app-icon name="arrow-right" size="md"></app-icon>
         </button>
       </div>
     </div>

--- a/fe/src/app/features/learning/pages/course-learning.component.ts
+++ b/fe/src/app/features/learning/pages/course-learning.component.ts
@@ -25,6 +25,7 @@ import { CourseDownloadService } from '../../../core/services/course-download.se
 import { NetworkStatusService } from '../../../core/services/network-status.service';
 import { OfflineSyncService } from '../../../core/services/offline-sync.service';
 import { getOfflineCourseStaleCopy } from '../../../core/utils/offline-course-staleness';
+import { IconComponent } from '../../../shared/components/icon/icon.component';
 
 /**
  * Course Learning Component
@@ -34,7 +35,7 @@ import { getOfflineCourseStaleCopy } from '../../../core/utils/offline-course-st
  */
 @Component({
   selector: 'app-course-learning',
-  imports: [RouterModule, LessonContentComponent, PaymentModalComponent],
+  imports: [RouterModule, LessonContentComponent, PaymentModalComponent, IconComponent],
   templateUrl: './course-learning.component.html',
   styleUrls: ['./course-learning.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/fe/src/app/shared/components/icon/icon.component.spec.ts
+++ b/fe/src/app/shared/components/icon/icon.component.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from '@angular/core/testing';
+
+import { IconComponent } from './icon.component';
+
+describe('IconComponent', () => {
+  it('renders newly added offline-safe learning glyphs as svg without ligature text', () => {
+    TestBed.configureTestingModule({
+      imports: [IconComponent],
+    });
+
+    const fixture = TestBed.createComponent(IconComponent);
+    fixture.componentRef.setInput('name', 'folder');
+    fixture.componentRef.setInput('size', 'md');
+    fixture.componentRef.setInput('ariaLabel', 'Folder');
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const svg = host.querySelector('svg');
+
+    expect(svg).withContext('expected folder icon to render an inline svg').not.toBeNull();
+    expect(svg?.getAttribute('aria-label')).toBe('Folder');
+    expect(host.textContent).not.toContain('folder_open');
+    expect(host.textContent).not.toContain('arrow_back');
+  });
+
+  it('supports play-circle and help-circle icons used in the learning shell', () => {
+    TestBed.configureTestingModule({
+      imports: [IconComponent],
+    });
+
+    const fixture = TestBed.createComponent(IconComponent);
+    fixture.componentRef.setInput('name', 'play-circle');
+    fixture.componentRef.setInput('ariaLabel', 'Current lesson');
+    fixture.detectChanges();
+
+    let svg = fixture.nativeElement.querySelector('svg') as SVGElement | null;
+    expect(svg?.getAttribute('aria-label')).toBe('Current lesson');
+
+    fixture.componentRef.setInput('name', 'help-circle');
+    fixture.componentRef.setInput('ariaLabel', 'Quiz section');
+    fixture.detectChanges();
+
+    svg = fixture.nativeElement.querySelector('svg');
+    expect(svg?.getAttribute('aria-label')).toBe('Quiz section');
+  });
+});

--- a/fe/src/app/shared/components/icon/icon.component.ts
+++ b/fe/src/app/shared/components/icon/icon.component.ts
@@ -13,7 +13,8 @@ export type IconName =
   | 'fire' | 'trophy' | 'graduation-cap' | 'target' | 'zap' | 'sparkles' | 'party'
   | 'file-text' | 'bar-chart' | 'video' | 'image' | 'music' | 'presentation'
   | 'lock' | 'shield' | 'lightbulb' | 'rocket' | 'briefcase' | 'smartphone'
-  | 'anchor' | 'ship' | 'footprints' | 'circle-check' | 'circle-x' | 'users' | 'plug';
+  | 'anchor' | 'ship' | 'footprints' | 'circle-check' | 'circle-x' | 'users' | 'plug'
+  | 'eye' | 'more-vertical' | 'circle' | 'folder' | 'paperclip' | 'play-circle' | 'file-check' | 'help-circle';
 
 export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
@@ -69,10 +70,19 @@ export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
           <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/>
           <path d="M2 12h20"/>
         }
+        @case ('eye') {
+          <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/>
+          <circle cx="12" cy="12" r="3"/>
+        }
         @case ('menu') {
           <line x1="4" x2="20" y1="6" y2="6"/>
           <line x1="4" x2="20" y1="12" y2="12"/>
           <line x1="4" x2="20" y1="18" y2="18"/>
+        }
+        @case ('more-vertical') {
+          <circle cx="12" cy="5" r="1.5"/>
+          <circle cx="12" cy="12" r="1.5"/>
+          <circle cx="12" cy="19" r="1.5"/>
         }
         @case ('x') {
           <path d="M18 6 6 18M6 6l12 12"/>
@@ -161,6 +171,9 @@ export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
         }
         @case ('check') {
           <polyline points="20,6 9,17 4,12"/>
+        }
+        @case ('circle') {
+          <circle cx="12" cy="12" r="9"/>
         }
         @case ('alert') {
           <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
@@ -299,6 +312,11 @@ export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
           <line x1="16" x2="8" y1="17" y2="17"/>
           <line x1="10" x2="8" y1="9" y2="9"/>
         }
+        @case ('file-check') {
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+          <polyline points="14,2 14,8 20,8"/>
+          <polyline points="9,15 11,17 15,13"/>
+        }
         @case ('bar-chart') {
           <line x1="12" x2="12" y1="20" y2="10"/>
           <line x1="18" x2="18" y1="20" y2="4"/>
@@ -326,6 +344,21 @@ export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
         @case ('lock') {
           <rect width="18" height="11" x="3" y="11" rx="2" ry="2"/>
           <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+        }
+        @case ('folder') {
+          <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/>
+        }
+        @case ('paperclip') {
+          <path d="M21.44 11.05 12.25 20.24a6 6 0 1 1-8.49-8.49l8.48-8.48a4 4 0 0 1 5.66 5.66l-8.49 8.48a2 2 0 1 1-2.82-2.82l7.78-7.78"/>
+        }
+        @case ('play-circle') {
+          <circle cx="12" cy="12" r="10"/>
+          <polygon points="10,8 16,12 10,16"/>
+        }
+        @case ('help-circle') {
+          <circle cx="12" cy="12" r="10"/>
+          <path d="M9.09 9a3 3 0 1 1 5.82 1c0 2-3 3-3 3"/>
+          <path d="M12 17h.01"/>
         }
         @case ('shield') {
           <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>

--- a/fe/src/app/shared/components/offline-fallback/offline-fallback.component.spec.ts
+++ b/fe/src/app/shared/components/offline-fallback/offline-fallback.component.spec.ts
@@ -1,0 +1,7 @@
+import { OFFLINE_FALLBACK_COURSE_ROUTE_PREFIX } from './offline-fallback.component';
+
+describe('OfflineFallbackComponent route constants', () => {
+  it('uses the canonical student learning route for downloaded courses', () => {
+    expect(OFFLINE_FALLBACK_COURSE_ROUTE_PREFIX).toBe('/student/learn/course');
+  });
+});

--- a/fe/src/app/shared/components/offline-fallback/offline-fallback.component.ts
+++ b/fe/src/app/shared/components/offline-fallback/offline-fallback.component.ts
@@ -1,9 +1,10 @@
 import { Component, ChangeDetectionStrategy, inject, computed } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { CourseDownloadService, DownloadableCourse } from '../../../core/services/course-download.service';
+import { CourseDownloadService } from '../../../core/services/course-download.service';
 import { StorageManagerService } from '../../../core/services/storage-manager.service';
-import { NetworkStatusService } from '../../../core/services/network-status.service';
 import { OfflineSyncService } from '../../../core/services/offline-sync.service';
+
+export const OFFLINE_FALLBACK_COURSE_ROUTE_PREFIX = '/student/learn/course';
 
 @Component({
   selector: 'app-offline-fallback',
@@ -60,7 +61,7 @@ import { OfflineSyncService } from '../../../core/services/offline-sync.service'
             </div>
 
             @for (course of downloadedCourses(); track course.id) {
-              <a [routerLink]="['/learn/course', course.id]"
+              <a [routerLink]="[courseRoutePrefix, course.id]"
                  class="flex items-center gap-3 px-4 py-3 hover:bg-slate-50 transition-colors border-b border-gray-50 last:border-b-0">
                 <div class="flex-shrink-0 w-10 h-10 bg-[#0056D2]/10 rounded-lg flex items-center justify-center">
                   <svg class="w-5 h-5 text-[#0056D2]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -127,6 +128,7 @@ export class OfflineFallbackComponent {
   private readonly storageManager = inject(StorageManagerService);
   private readonly syncService = inject(OfflineSyncService);
 
+  protected readonly courseRoutePrefix = OFFLINE_FALLBACK_COURSE_ROUTE_PREFIX;
   protected readonly downloadedCourses = computed(() => this.courseDownload.downloadedCourses());
   protected readonly downloadCount = computed(() => this.downloadedCourses().length);
   protected readonly pendingSync = computed(() => this.syncService.pendingCount());

--- a/fe/src/app/shared/components/offline-indicator/offline-indicator.component.ts
+++ b/fe/src/app/shared/components/offline-indicator/offline-indicator.component.ts
@@ -49,14 +49,9 @@ export class OfflineIndicatorComponent {
   private readonly syncService = inject(OfflineSyncService);
   private readonly sessionService = inject(SessionExpiredService);
 
-  // Multi-strategy offline detection:
-  // 1. connectionTier === 'none' (from NetworkStatusService)
-  // 2. navigator.onLine === false (fallback)
   protected readonly isOffline = computed(() => {
     const tier = this.network.connectionTier();
     if (tier === 'none') return true;
-    // Additional safety check: if navigator.onLine is false, treat as offline
-    // even if our probe thinks otherwise
     if (typeof navigator !== 'undefined' && !navigator.onLine) return true;
     return false;
   });
@@ -64,5 +59,4 @@ export class OfflineIndicatorComponent {
   protected readonly isSlow = computed(() => this.network.connectionTier() === 'slow');
   protected readonly pendingSyncCount = computed(() => this.syncService.pendingCount());
   protected readonly hasExpiredBanner = computed(() => this.sessionService.showExpiredBanner());
-
 }


### PR DESCRIPTION
﻿## Problem

Production PWA/offline flow still had multiple breakpoints across recovery and learner UX:

- Cached public courses could collapse to empty lists offline (`#78`).
- `/offline` linked downloaded courses to a non-existent route (`#79`).
- Device-offline cases on laptop/desktop could surface as `502/503/504` and chunk-load failures instead of activating offline recovery (`#91`).
- Learning shell still relied on Material ligature icons, so offline/degraded sessions could leak raw text like `arrow_back`, `check_circle`, `article`, `folder_open`; some browsers also kept showing the old `[PWA] Network Status` debug log from stale app shells (`#92`).

## Root Cause

- Offline fallback contracts were inconsistent with the live API contract.
- Recovery logic treated `status = 0` correctly, but synthetic gateway errors from device-offline/service-worker paths were not consistently classified as offline.
- Runtime chunk failures were not always routed to an eager offline-safe surface.
- Learner-facing learning surfaces still depended on font-based ligature icons instead of bundled SVG icons.

## Fix

- Normalized offline fallback for `GET /api/v3/courses` to a Spring-page-compatible shape and fixed downloaded course routing.
- Hardened offline detection so same-origin `502/503/504` can activate offline handling when the browser/app is effectively offline.
- Prevented useless retries for offline-compatible gateway failures.
- Routed dynamic import failures to `/offline` and kept `/offline` eager so recovery remains available even when lazy chunks fail.
- Removed debug logging from the current source path and replaced learning-shell ligature icons with bundled inline SVG icons via `app-icon`, extending the local icon set with the missing glyphs needed by the learner workflow.
- Added a design note plus targeted regression tests for icon rendering and the existing PWA/offline recovery path.

## Verified

- [x] `npm test -- --watch=false --browsers=ChromeHeadless --include src/app/shared/components/icon/icon.component.spec.ts --include src/app/core/utils/offline-http-error.spec.ts --include src/app/api/interceptors/error.interceptor.spec.ts --include src/app/core/services/network-status.service.spec.ts --include src/app/core/services/sw-update.service.spec.ts --include src/app/app.routes.spec.ts --include src/app/api/interceptors/offline.interceptor.spec.ts --include src/app/shared/components/offline-fallback/offline-fallback.component.spec.ts`
- [x] `npm run build`
- [x] Verified source search returns zero `[PWA] Network Status` in `fe/src`
- [x] Verified `feature/learning` no longer contains `material-symbols-outlined`
- [x] Previous production smoke for `/offline`, `/student/courses`, `/student/storage`, and login remained healthy on the deployed branch snapshot

Closes #78
Closes #79
Closes #91
Closes #92
