### PR TITLE
fix(deploy): recreate proxy on manual prod deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -21,8 +21,12 @@ set -a
 set +a
 
 COMPOSE_ARGS=(--env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml)
+IMAGE_SERVICES=(backend frontend)
+RUNTIME_SERVICES=(backend frontend caddy)
 if [ "${ENABLE_LOCAL_VIDEO_WORKER:-true}" = "true" ]; then
   COMPOSE_ARGS+=(--profile video-worker)
+  IMAGE_SERVICES+=(video-worker)
+  RUNTIME_SERVICES+=(video-worker)
 fi
 
 if [ "${POSTGRES_PASSWORD:-}" = "CHANGE_ME_STRONG_PASSWORD" ] || [ -z "${POSTGRES_PASSWORD:-}" ]; then
@@ -104,12 +108,16 @@ docker system prune -f --volumes 2>/dev/null || true
 
 if docker compose "${COMPOSE_ARGS[@]}" config --images 2>/dev/null | grep -q "ghcr.io"; then
   echo "[5/7] Pulling pre-built images from GHCR..."
-  docker compose "${COMPOSE_ARGS[@]}" pull backend frontend
+  docker compose "${COMPOSE_ARGS[@]}" pull "${IMAGE_SERVICES[@]}"
   docker image prune -f 2>/dev/null || true
-  docker compose "${COMPOSE_ARGS[@]}" up -d --wait --remove-orphans --force-recreate backend frontend
+  # Recreate Caddy whenever host-mounted config such as Caddyfile changes.
+  docker compose "${COMPOSE_ARGS[@]}" up -d --wait --remove-orphans --force-recreate "${RUNTIME_SERVICES[@]}"
 else
   echo "[5/7] Building and starting containers (no GHCR images configured)..."
-  docker compose "${COMPOSE_ARGS[@]}" up -d --build --wait --remove-orphans
+  # Keep the manual deploy path aligned with CI/CD: app containers + Caddy
+  # must restart together so edge headers never drift from the checked-out
+  # revision on disk.
+  docker compose "${COMPOSE_ARGS[@]}" up -d --build --wait --remove-orphans --force-recreate "${RUNTIME_SERVICES[@]}"
 fi
 
 echo "[6/7] Container status..."
@@ -130,6 +138,13 @@ if curl -sf -o /dev/null http://localhost:80 > /dev/null 2>&1; then
   echo "Caddy:   HEALTHY"
 else
   echo "Caddy:   Unhealthy (check logs: docker compose ${COMPOSE_ARGS[*]} logs caddy --tail=50)"
+fi
+
+CSP_HEADER="$(curl -fsSI http://localhost:80/teacher/profile | tr -d '\r' | grep -i '^Content-Security-Policy:' || true)"
+if printf '%s' "$CSP_HEADER" | grep -Fq "img-src 'self' data: blob:"; then
+  echo "CSP:     HEALTHY (blob: allowed for avatar previews)"
+else
+  echo "CSP:     WARNING (missing blob: in img-src; avatar preview/edit may fail)"
 fi
 
 echo ""

--- a/docs/superpowers/specs/2026-04-24-profile-avatar-csp-deploy-fix.md
+++ b/docs/superpowers/specs/2026-04-24-profile-avatar-csp-deploy-fix.md
@@ -1,0 +1,43 @@
+# 2026-04-24 - Profile Avatar CSP Deploy Fix
+
+## Problem
+
+Editing avatar images stopped working across `student`, `teacher`, `admin`, and `org-admin` profiles in production.
+
+The shared profile flow relies on `blob:` preview URLs during avatar crop/edit, but production was still serving an older Caddy `Content-Security-Policy` header with:
+
+```text
+img-src 'self' data: https:
+```
+
+That blocks browser rendering of `blob:` images and breaks avatar preview/cropping for every role.
+
+## Evidence
+
+- Production header from `https://holilihu.online/teacher/profile` omitted `blob:` in `img-src`.
+- `/home/Admin/LMS_hohulili/Caddyfile` on the VM already contained the fixed CSP with `blob:`.
+- The running `caddy` container still had the stale config without `blob:`.
+- All role routes reuse the same frontend profile component, so the blast radius is system-wide.
+
+## Root Cause
+
+`deploy.sh` only recreated `backend` and `frontend` in the GHCR fast path, and rebuilt without forcing `caddy` recreation in the local-build path.
+
+Because `Caddyfile` is bind-mounted, updating the file on disk does not reload the running `caddy` container automatically. This created config drift:
+
+- checked-out revision on VM: correct
+- running reverse proxy: stale
+
+## Fix
+
+- Define explicit runtime services for manual deploys: `backend`, `frontend`, `caddy`, plus `video-worker` when enabled.
+- Recreate those services in both deploy modes so edge config always matches the checked-out revision.
+- Add a post-deploy CSP smoke check that validates `img-src 'self' data: blob:` is actually live at the edge.
+
+## Verification
+
+- `bash -n deploy.sh`
+- Confirmed current production mismatch before the fix:
+  - external header missing `blob:`
+  - host `Caddyfile` already had `blob:`
+  - running container config still stale


### PR DESCRIPTION
﻿## Problem
- Chỉnh sửa ảnh đại diện hỏng trên tất cả hồ sơ `student`, `teacher`, `admin`, `org-admin`.
- Console production báo CSP chặn `blob:` preview URL trong avatar crop/edit flow.
- Root cause không nằm ở role-specific UI; production đang chạy `caddy` với CSP cũ dù `Caddyfile` trên VM đã được cập nhật.

## Root Cause
- `deploy.sh` chỉ pull/recreate `backend` và `frontend` ở fast path GHCR.
- Ở local-build path, script cũng không force-recreate `caddy`.
- Vì `Caddyfile` là bind-mounted config, file trên disk thay đổi không tự reload vào `caddy` process đang chạy.
- Hệ quả là manual deploy có thể để edge runtime lệch revision so với source checkout, làm CSP `img-src` vẫn thiếu `blob:` và chặn avatar preview.

## Fix
- Thêm danh sách `IMAGE_SERVICES` và `RUNTIME_SERVICES` để manual deploy luôn cập nhật đúng tập service runtime.
- Recreate `caddy` trong cả GHCR path và local-build path.
- Giữ `video-worker` cùng revision khi profile `video-worker` đang bật.
- Thêm post-deploy CSP smoke check để xác nhận `img-src 'self' data: blob:` đang live ở edge.
- Bổ sung design note ngắn ghi lại bằng chứng và reasoning cho lần review này.

## Verified
- [x] Reproduced production mismatch: external header thiếu `blob:` nhưng host `Caddyfile` trên VM đã có `blob:`.
- [x] Confirmed running `caddy` container vẫn nạp config cũ.
- [x] `bash -n deploy.sh`
- [x] `git diff --check`
- [ ] Chưa chạy production redeploy từ PR này

Closes #93
