### PR TITLE
fix(edge): stabilize security headers and deploy env parsing

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -3,11 +3,29 @@
 # Auto-HTTPS via Let's Encrypt for holilihu.online
 # =============================================================================
 
+(edge_response_headers) {
+    header_down -Content-Security-Policy
+    header_down -X-Frame-Options
+    header_down -X-Content-Type-Options
+    header_down -Cross-Origin-Opener-Policy
+    header_down -Referrer-Policy
+    header_down -Permissions-Policy
+    header_down -X-XSS-Protection
+    header_down Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://accounts.google.com https://fonts.googleapis.com; img-src 'self' data: blob: https: https://ui-avatars.com; connect-src 'self' https://accounts.google.com https://lh3.googleusercontent.com https://ui-avatars.com https://fonts.googleapis.com https://fonts.gstatic.com https://wiii.holilihu.online https://sandbox.vnpayment.vn https://pay.vnpay.vn https://qr.sepay.vn https://videodelivery.net wss:; media-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https: blob:; frame-ancestors 'self'; object-src 'none'; base-uri 'self';"
+    header_down X-Frame-Options "SAMEORIGIN"
+    header_down X-Content-Type-Options "nosniff"
+    header_down Cross-Origin-Opener-Policy "same-origin-allow-popups"
+    header_down Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    header_down Referrer-Policy "strict-origin-when-cross-origin"
+    header_down Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()"
+}
+
 holilihu.online {
     @adaptivePlayback path /api/v3/video-assets/*/adaptive/*
 
     handle @adaptivePlayback {
         reverse_proxy backend:8080 {
+            import edge_response_headers
             header_down Cache-Control "private, max-age=30"
             header_down -Pragma
             header_down -Expires
@@ -17,18 +35,22 @@ holilihu.online {
     # Backend API
     handle /api/* {
         reverse_proxy backend:8080 {
-            header_down -Content-Security-Policy
+            import edge_response_headers
         }
     }
 
     # Health check only (other actuator endpoints not exposed)
     handle /actuator/health {
-        reverse_proxy backend:8080
+        reverse_proxy backend:8080 {
+            import edge_response_headers
+        }
     }
 
     # File uploads (LocalStorageService)
     handle /uploads/* {
-        reverse_proxy backend:8080
+        reverse_proxy backend:8080 {
+            import edge_response_headers
+        }
     }
 
     # Block Swagger/API docs in production (springdoc disabled, but defense-in-depth)
@@ -42,29 +64,8 @@ holilihu.online {
     # Frontend (Angular SPA) — catch-all
     handle {
         reverse_proxy frontend:80 {
-            header_down -Content-Security-Policy
+            import edge_response_headers
         }
-    }
-
-    # Security headers — Caddy is the single source of truth.
-    # Strip any upstream CSP/security headers first (nginx, Spring Security),
-    # then set the canonical ones. Without the delete, browsers see duplicates
-    # and enforce the intersection (most restrictive).
-    header {
-        -Content-Security-Policy
-        -X-Frame-Options
-        -X-Content-Type-Options
-        -Cross-Origin-Opener-Policy
-        -Referrer-Policy
-        -Permissions-Policy
-        -X-XSS-Protection
-        X-Frame-Options "SAMEORIGIN"
-        X-Content-Type-Options "nosniff"
-        Cross-Origin-Opener-Policy "same-origin-allow-popups"
-        Strict-Transport-Security "max-age=31536000; includeSubDomains"
-        Referrer-Policy "strict-origin-when-cross-origin"
-        Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()"
-        Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://accounts.google.com https://fonts.googleapis.com; img-src 'self' data: blob: https: https://ui-avatars.com; connect-src 'self' https://accounts.google.com https://lh3.googleusercontent.com https://ui-avatars.com https://fonts.googleapis.com https://fonts.gstatic.com https://wiii.holilihu.online https://sandbox.vnpayment.vn https://pay.vnpay.vn https://qr.sepay.vn https://videodelivery.net wss:; media-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https: blob:; frame-ancestors 'self'; object-src 'none'; base-uri 'self';"
     }
     # Compression
     encode gzip zstd

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,67 +16,125 @@ if [ ! -f .env.prod ]; then
   exit 1
 fi
 
-set -a
-. ./.env.prod
-set +a
+read_env_value() {
+  local key="$1"
+  awk -v key="$key" '
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      if (line ~ /^[[:space:]]*#/ || line ~ /^[[:space:]]*$/) {
+        next
+      }
+      if (line ~ /^[[:space:]]*export[[:space:]]+/) {
+        sub(/^[[:space:]]*export[[:space:]]+/, "", line)
+      }
+      eq = index(line, "=")
+      if (eq == 0) {
+        next
+      }
+      current = substr(line, 1, eq - 1)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", current)
+      if (current == key) {
+        print substr(line, eq + 1)
+        exit
+      }
+    }
+  ' .env.prod
+}
+
+env_or_default() {
+  local key="$1"
+  local default_value="$2"
+  local value
+  value="$(read_env_value "$key")"
+  if [ -n "$value" ]; then
+    printf '%s' "$value"
+  else
+    printf '%s' "$default_value"
+  fi
+}
+
+POSTGRES_USER_VALUE="$(env_or_default POSTGRES_USER lms)"
+POSTGRES_PASSWORD_VALUE="$(read_env_value POSTGRES_PASSWORD)"
+POSTGRES_DB_VALUE="$(env_or_default POSTGRES_DB lms)"
+JWT_SECRET_VALUE="$(read_env_value JWT_SECRET)"
+GOOGLE_AUTH_ENABLED_VALUE="$(env_or_default GOOGLE_AUTH_ENABLED false)"
+GOOGLE_WEB_CLIENT_ID_VALUE="$(read_env_value GOOGLE_WEB_CLIENT_ID)"
+GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED_VALUE="$(env_or_default GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED false)"
+GOOGLE_CLIENT_SECRET_VALUE="$(read_env_value GOOGLE_CLIENT_SECRET)"
+GOOGLE_OAUTH_REDIRECT_URI_VALUE="$(read_env_value GOOGLE_OAUTH_REDIRECT_URI)"
+GOOGLE_OAUTH_FRONTEND_CALLBACK_VALUE="$(read_env_value GOOGLE_OAUTH_FRONTEND_CALLBACK)"
+CLOUDFLARE_R2_ENABLED_VALUE="$(env_or_default CLOUDFLARE_R2_ENABLED false)"
+CLOUDFLARE_R2_ACCOUNT_ID_VALUE="$(read_env_value CLOUDFLARE_R2_ACCOUNT_ID)"
+CLOUDFLARE_R2_ACCESS_KEY_VALUE="$(read_env_value CLOUDFLARE_R2_ACCESS_KEY)"
+CLOUDFLARE_R2_SECRET_KEY_VALUE="$(read_env_value CLOUDFLARE_R2_SECRET_KEY)"
+CLOUDFLARE_R2_BUCKET_VALUE="$(read_env_value CLOUDFLARE_R2_BUCKET)"
+CLOUDFLARE_R2_VIDEO_BUCKET_VALUE="$(read_env_value CLOUDFLARE_R2_VIDEO_BUCKET)"
+CLOUDFLARE_R2_PUBLIC_URL_VALUE="$(read_env_value CLOUDFLARE_R2_PUBLIC_URL)"
+WIII_WEBHOOK_ENABLED_VALUE="$(env_or_default WIII_WEBHOOK_ENABLED false)"
+WIII_WEBHOOK_URL_VALUE="$(read_env_value WIII_WEBHOOK_URL)"
+WIII_WEBHOOK_SECRET_VALUE="$(read_env_value WIII_WEBHOOK_SECRET)"
+WIII_SERVICE_TOKEN_VALUE="$(read_env_value WIII_SERVICE_TOKEN)"
+WIII_TOKEN_EXCHANGE_URL_VALUE="$(read_env_value WIII_TOKEN_EXCHANGE_URL)"
+ENABLE_LOCAL_VIDEO_WORKER_VALUE="$(env_or_default ENABLE_LOCAL_VIDEO_WORKER true)"
 
 COMPOSE_ARGS=(--env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml)
 IMAGE_SERVICES=(backend frontend)
 RUNTIME_SERVICES=(backend frontend caddy)
-if [ "${ENABLE_LOCAL_VIDEO_WORKER:-true}" = "true" ]; then
+if [ "$ENABLE_LOCAL_VIDEO_WORKER_VALUE" = "true" ]; then
   COMPOSE_ARGS+=(--profile video-worker)
   IMAGE_SERVICES+=(video-worker)
   RUNTIME_SERVICES+=(video-worker)
 fi
 
-if [ "${POSTGRES_PASSWORD:-}" = "CHANGE_ME_STRONG_PASSWORD" ] || [ -z "${POSTGRES_PASSWORD:-}" ]; then
+if [ "$POSTGRES_PASSWORD_VALUE" = "CHANGE_ME_STRONG_PASSWORD" ] || [ -z "$POSTGRES_PASSWORD_VALUE" ]; then
   echo "ERROR: POSTGRES_PASSWORD not set in .env.prod"
   exit 1
 fi
 
-if [ "${JWT_SECRET:-}" = "CHANGE_ME_256_BIT_SECRET" ] || [ -z "${JWT_SECRET:-}" ]; then
+if [ "$JWT_SECRET_VALUE" = "CHANGE_ME_256_BIT_SECRET" ] || [ -z "$JWT_SECRET_VALUE" ]; then
   echo "ERROR: JWT_SECRET not set in .env.prod"
   exit 1
 fi
 
-if [ "${WIII_WEBHOOK_ENABLED:-false}" = "true" ]; then
-  if [ -z "${WIII_WEBHOOK_URL:-}" ] || [ -z "${WIII_WEBHOOK_SECRET:-}" ] || [ -z "${WIII_SERVICE_TOKEN:-}" ] || [ -z "${WIII_TOKEN_EXCHANGE_URL:-}" ]; then
+if [ "$WIII_WEBHOOK_ENABLED_VALUE" = "true" ]; then
+  if [ -z "$WIII_WEBHOOK_URL_VALUE" ] || [ -z "$WIII_WEBHOOK_SECRET_VALUE" ] || [ -z "$WIII_SERVICE_TOKEN_VALUE" ] || [ -z "$WIII_TOKEN_EXCHANGE_URL_VALUE" ]; then
     echo "ERROR: WIII_WEBHOOK_ENABLED=true but one or more Wiii variables are missing."
     exit 1
   fi
 fi
 
-if [ "${GOOGLE_AUTH_ENABLED:-false}" = "true" ] && [ -z "${GOOGLE_WEB_CLIENT_ID:-}" ]; then
+if [ "$GOOGLE_AUTH_ENABLED_VALUE" = "true" ] && [ -z "$GOOGLE_WEB_CLIENT_ID_VALUE" ]; then
   echo "ERROR: GOOGLE_AUTH_ENABLED=true but GOOGLE_WEB_CLIENT_ID is missing."
   exit 1
 fi
 
-if [ "${GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED:-false}" = "true" ]; then
-  if [ "${GOOGLE_AUTH_ENABLED:-false}" != "true" ]; then
+if [ "$GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED_VALUE" = "true" ]; then
+  if [ "$GOOGLE_AUTH_ENABLED_VALUE" != "true" ]; then
     echo "ERROR: GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED=true requires GOOGLE_AUTH_ENABLED=true."
     exit 1
   fi
 
-  if [ -z "${GOOGLE_WEB_CLIENT_ID:-}" ] || [ -z "${GOOGLE_CLIENT_SECRET:-}" ] || [ -z "${GOOGLE_OAUTH_REDIRECT_URI:-}" ] || [ -z "${GOOGLE_OAUTH_FRONTEND_CALLBACK:-}" ]; then
+  if [ -z "$GOOGLE_WEB_CLIENT_ID_VALUE" ] || [ -z "$GOOGLE_CLIENT_SECRET_VALUE" ] || [ -z "$GOOGLE_OAUTH_REDIRECT_URI_VALUE" ] || [ -z "$GOOGLE_OAUTH_FRONTEND_CALLBACK_VALUE" ]; then
     echo "ERROR: GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED=true but one or more Google OAuth variables are missing."
     exit 1
   fi
 fi
 
-if [ "${GOOGLE_AUTH_ENABLED:-false}" != "true" ] && { [ -n "${GOOGLE_WEB_CLIENT_ID:-}" ] || [ "${GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED:-false}" = "true" ]; }; then
+if [ "$GOOGLE_AUTH_ENABLED_VALUE" != "true" ] && { [ -n "$GOOGLE_WEB_CLIENT_ID_VALUE" ] || [ "$GOOGLE_OAUTH_REDIRECT_FLOW_ENABLED_VALUE" = "true" ]; }; then
   echo "WARN: Google OAuth values are present but GOOGLE_AUTH_ENABLED=false."
   echo "      The frontend will show Google sign-in as unavailable and the authorize endpoint will stay disabled."
   echo ""
 fi
 
-if [ "${CLOUDFLARE_R2_ENABLED:-false}" = "true" ]; then
-  if [ -z "${CLOUDFLARE_R2_ACCOUNT_ID:-}" ] || [ -z "${CLOUDFLARE_R2_ACCESS_KEY:-}" ] || [ -z "${CLOUDFLARE_R2_SECRET_KEY:-}" ] || [ -z "${CLOUDFLARE_R2_BUCKET:-}" ] || [ -z "${CLOUDFLARE_R2_VIDEO_BUCKET:-}" ] || [ -z "${CLOUDFLARE_R2_PUBLIC_URL:-}" ]; then
+if [ "$CLOUDFLARE_R2_ENABLED_VALUE" = "true" ]; then
+  if [ -z "$CLOUDFLARE_R2_ACCOUNT_ID_VALUE" ] || [ -z "$CLOUDFLARE_R2_ACCESS_KEY_VALUE" ] || [ -z "$CLOUDFLARE_R2_SECRET_KEY_VALUE" ] || [ -z "$CLOUDFLARE_R2_BUCKET_VALUE" ] || [ -z "$CLOUDFLARE_R2_VIDEO_BUCKET_VALUE" ] || [ -z "$CLOUDFLARE_R2_PUBLIC_URL_VALUE" ]; then
     echo "ERROR: CLOUDFLARE_R2_ENABLED=true but one or more R2 variables are missing."
     exit 1
   fi
 fi
 
-if [ "${ENABLE_LOCAL_VIDEO_WORKER:-true}" != "true" ]; then
+if [ "$ENABLE_LOCAL_VIDEO_WORKER_VALUE" != "true" ]; then
   echo "WARN: ENABLE_LOCAL_VIDEO_WORKER=false"
   echo "      Ensure a dedicated worker VM is deployed before relying on video ingest."
   echo ""
@@ -97,7 +155,7 @@ if docker compose "${COMPOSE_ARGS[@]}" ps db --status running -q 2>/dev/null | g
   BACKUP_FILE="backups/lms-pre-deploy-$(date +%Y%m%d-%H%M%S).sql.gz"
   mkdir -p backups
   docker compose "${COMPOSE_ARGS[@]}" exec -T db \
-    pg_dump -U "${POSTGRES_USER:-lms}" "${POSTGRES_DB:-lms}" | gzip > "$BACKUP_FILE"
+    pg_dump -U "$POSTGRES_USER_VALUE" "$POSTGRES_DB_VALUE" | gzip > "$BACKUP_FILE"
   echo "  Backup saved: $BACKUP_FILE ($(du -h "$BACKUP_FILE" | cut -f1))"
 else
   echo "  Skipped (database not running — first deploy?)"
@@ -140,7 +198,7 @@ else
   echo "Caddy:   Unhealthy (check logs: docker compose ${COMPOSE_ARGS[*]} logs caddy --tail=50)"
 fi
 
-CSP_HEADER="$(curl -fsSI http://localhost:80/teacher/profile | tr -d '\r' | grep -i '^Content-Security-Policy:' || true)"
+CSP_HEADER="$(curl -skI --resolve holilihu.online:443:127.0.0.1 https://holilihu.online/teacher/profile | tr -d '\r' | grep -i '^Content-Security-Policy:' || true)"
 if printf '%s' "$CSP_HEADER" | grep -Fq "img-src 'self' data: blob:"; then
   echo "CSP:     HEALTHY (blob: allowed for avatar previews)"
 else

--- a/docs/superpowers/specs/2026-04-24-edge-security-headers-deploy-fix.md
+++ b/docs/superpowers/specs/2026-04-24-edge-security-headers-deploy-fix.md
@@ -1,0 +1,47 @@
+# 2026-04-24 - Edge Security Headers and Deploy Env Parsing Fix
+
+## Problem
+
+Production still had two operational gaps after the avatar CSP hotfix:
+
+1. `deploy.sh` could not run against the real `.env.prod` on the VM because it sourced the file as shell syntax.
+2. Proxied frontend/API responses did not reliably expose the expected security headers, even though the runtime Caddy config showed the intended policy.
+
+## Evidence
+
+- `bash ./deploy.sh` failed on the VM while parsing `.env.prod`.
+- `curl -I https://holilihu.online/teacher/profile` returned no `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, `Permissions-Policy`, or `Referrer-Policy`.
+- `docker compose ... exec -T caddy cat /etc/caddy/Caddyfile` and the Caddy admin JSON both showed the intended security policy was loaded.
+
+## Root Cause
+
+### Deploy script
+
+`.env.prod` is consumed as a Docker env-file, not a shell script. Sourcing it with:
+
+```bash
+set -a
+. ./.env.prod
+set +a
+```
+
+creates a hard dependency on shell-compatible syntax that production does not guarantee.
+
+### Caddy response headers
+
+The previous top-level `header { ... }` block was loaded, but its deferred response mutation did not reliably surface on proxied responses in the current runtime path. Setting the policy directly through `reverse_proxy header_down` is more deterministic for this stack because the header mutation happens at the exact point Caddy copies upstream response headers.
+
+## Fix
+
+- Replace `. ./.env.prod` with a small parser that reads Docker env-file values directly from `.env.prod`.
+- Reuse parsed values for deploy validations and database backup commands.
+- Move edge security headers into a reusable Caddy snippet imported inside each `reverse_proxy` block.
+- Upgrade the deploy smoke check to inspect the real HTTPS origin response using `--resolve holilihu.online:443:127.0.0.1`.
+
+## Verification
+
+- `bash -n deploy.sh`
+- `caddy validate --config /etc/caddy/Caddyfile`
+- Production smoke after deploy:
+  - `curl -skI --resolve holilihu.online:443:127.0.0.1 https://holilihu.online/teacher/profile`
+  - `curl -I https://holilihu.online/teacher/profile`


### PR DESCRIPTION
﻿## Problem
- `deploy.sh` không chạy được với `.env.prod` thật trên VM vì đang `source .env.prod` như bash script, trong khi file này được duy trì theo format Docker env-file.
- Sau khi recreate `caddy`, các response proxied vẫn không giữ ổn định security headers mong đợi. Avatar flow hết bị CSP cũ chặn, nhưng edge vẫn thiếu `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, `Permissions-Policy`, `Referrer-Policy`.

## Root Cause
- `set -a; . ./.env.prod; set +a` tạo dependency sai vào shell-compatible syntax của `.env.prod`.
- Việc set security headers qua top-level `header { ... }` không phản ánh ổn định trên response proxied của runtime hiện tại, dù config đã được Caddy load.

## Fix
- Parse `.env.prod` theo đúng env-file semantics thay vì `source`.
- Dùng các giá trị parse này cho validation và backup command trong `deploy.sh`.
- Chuyển security header policy sang snippet `edge_response_headers` và import trực tiếp trong từng `reverse_proxy` block.
- Đổi post-deploy CSP smoke check sang HTTPS thật trên origin với `--resolve holilihu.online:443:127.0.0.1`.
- Bổ sung design note cho reasoning và vận hành sau này.

## Verified
- [x] `bash -n deploy.sh`
- [x] `docker compose --env-file .env.prod.example -f docker-compose.yml -f docker-compose.prod.yml config -q`
- [x] `docker run --rm -v $PWD/Caddyfile:/etc/caddy/Caddyfile:ro caddy:2-alpine caddy validate --config /etc/caddy/Caddyfile`
- [x] `git diff --check`
- [ ] Chưa rollout production từ PR này

Closes #95
