### PR TITLE
fix(caddy): defer security headers on proxied routes

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,28 +4,30 @@
 # =============================================================================
 
 (edge_response_headers) {
-    header_down -Content-Security-Policy
-    header_down -X-Frame-Options
-    header_down -X-Content-Type-Options
-    header_down -Cross-Origin-Opener-Policy
-    header_down -Referrer-Policy
-    header_down -Permissions-Policy
-    header_down -X-XSS-Protection
-    header_down Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://accounts.google.com https://fonts.googleapis.com; img-src 'self' data: blob: https: https://ui-avatars.com; connect-src 'self' https://accounts.google.com https://lh3.googleusercontent.com https://ui-avatars.com https://fonts.googleapis.com https://fonts.gstatic.com https://wiii.holilihu.online https://sandbox.vnpayment.vn https://pay.vnpay.vn https://qr.sepay.vn https://videodelivery.net wss:; media-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https: blob:; frame-ancestors 'self'; object-src 'none'; base-uri 'self';"
-    header_down X-Frame-Options "SAMEORIGIN"
-    header_down X-Content-Type-Options "nosniff"
-    header_down Cross-Origin-Opener-Policy "same-origin-allow-popups"
-    header_down Strict-Transport-Security "max-age=31536000; includeSubDomains"
-    header_down Referrer-Policy "strict-origin-when-cross-origin"
-    header_down Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()"
+    header {
+        -Content-Security-Policy
+        -X-Frame-Options
+        -X-Content-Type-Options
+        -Cross-Origin-Opener-Policy
+        -Referrer-Policy
+        -Permissions-Policy
+        -X-XSS-Protection
+        >Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://accounts.google.com https://fonts.googleapis.com; img-src 'self' data: blob: https: https://ui-avatars.com; connect-src 'self' https://accounts.google.com https://lh3.googleusercontent.com https://ui-avatars.com https://fonts.googleapis.com https://fonts.gstatic.com https://wiii.holilihu.online https://sandbox.vnpayment.vn https://pay.vnpay.vn https://qr.sepay.vn https://videodelivery.net wss:; media-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https: blob:; frame-ancestors 'self'; object-src 'none'; base-uri 'self';"
+        >X-Frame-Options "SAMEORIGIN"
+        >X-Content-Type-Options "nosniff"
+        >Cross-Origin-Opener-Policy "same-origin-allow-popups"
+        >Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        >Referrer-Policy "strict-origin-when-cross-origin"
+        >Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()"
+    }
 }
 
 holilihu.online {
     @adaptivePlayback path /api/v3/video-assets/*/adaptive/*
 
     handle @adaptivePlayback {
+        import edge_response_headers
         reverse_proxy backend:8080 {
-            import edge_response_headers
             header_down Cache-Control "private, max-age=30"
             header_down -Pragma
             header_down -Expires
@@ -34,23 +36,20 @@ holilihu.online {
 
     # Backend API
     handle /api/* {
-        reverse_proxy backend:8080 {
-            import edge_response_headers
-        }
+        import edge_response_headers
+        reverse_proxy backend:8080
     }
 
     # Health check only (other actuator endpoints not exposed)
     handle /actuator/health {
-        reverse_proxy backend:8080 {
-            import edge_response_headers
-        }
+        import edge_response_headers
+        reverse_proxy backend:8080
     }
 
     # File uploads (LocalStorageService)
     handle /uploads/* {
-        reverse_proxy backend:8080 {
-            import edge_response_headers
-        }
+        import edge_response_headers
+        reverse_proxy backend:8080
     }
 
     # Block Swagger/API docs in production (springdoc disabled, but defense-in-depth)
@@ -63,9 +62,8 @@ holilihu.online {
 
     # Frontend (Angular SPA) — catch-all
     handle {
-        reverse_proxy frontend:80 {
-            import edge_response_headers
-        }
+        import edge_response_headers
+        reverse_proxy frontend:80
     }
     # Compression
     encode gzip zstd

--- a/docs/superpowers/specs/2026-04-24-caddy-deferred-security-headers-follow-up.md
+++ b/docs/superpowers/specs/2026-04-24-caddy-deferred-security-headers-follow-up.md
@@ -1,0 +1,46 @@
+# 2026-04-24 - Caddy Deferred Security Headers Follow-up
+
+## Problem
+
+`deploy.sh` is fixed, but proxied responses on production still do not emit the expected security headers after PR #96.
+
+Observed responses for both public edge and direct origin access still miss:
+
+- `Content-Security-Policy`
+- `X-Frame-Options`
+- `X-Content-Type-Options`
+- `Permissions-Policy`
+- `Referrer-Policy`
+
+## Evidence
+
+- `curl -I https://holilihu.online/teacher/profile`
+- `curl -skI --resolve holilihu.online:443:127.0.0.1 https://holilihu.online/teacher/profile`
+- `curl -skI --resolve holilihu.online:443:127.0.0.1 https://holilihu.online/api/v3/auth/google/config`
+
+All of them still omit the expected headers, despite the Caddy admin JSON showing the intended policy in runtime config.
+
+## Root Cause
+
+Using `reverse_proxy header_down` was not sufficient for this stack/runtime path.
+
+The official Caddy guidance is more explicit:
+
+- use the `header` directive to manipulate HTTP response headers
+- use the `>` prefix to defer overrides until after the upstream response is written
+
+That pattern is a better fit here than relying on `header_down` response mutation alone.
+
+## Fix
+
+- Keep the shared `edge_response_headers` snippet.
+- Convert it to a `header { ... }` block.
+- Use `>` for the security headers that must override proxied responses.
+- Import the snippet inside each `handle` before `reverse_proxy`.
+
+## Verification
+
+- `caddy validate --config /etc/caddy/Caddyfile`
+- Production smoke after deploy:
+  - `curl -skI --resolve holilihu.online:443:127.0.0.1 https://holilihu.online/teacher/profile`
+  - `curl -I https://holilihu.online/teacher/profile`


### PR DESCRIPTION
﻿## Problem
- PR #96 đã sửa được `deploy.sh`, nhưng proxied responses trên production vẫn không phát ra `Content-Security-Policy` và các security headers liên quan.
- Điều này khiến edge policy vẫn không đúng như thiết kế, dù runtime config của Caddy đã load policy đó.

## Root Cause
- Pattern dùng `reverse_proxy header_down` chưa đủ đáng tin cậy cho case này.
- Theo tài liệu chính thức của Caddy, response headers nên dùng `header` directive; khi cần override sau proxy phải dùng defer (`>` prefix).

## Fix
- Chuyển snippet `edge_response_headers` sang `header { ... }`.
- Dùng `>` cho các header phải được ghi deferred sau khi upstream trả response.
- Import snippet trực tiếp trong từng `handle` trước `reverse_proxy`.
- Bổ sung design note cho follow-up này.

## Verified
- [x] `docker run --rm -v $PWD/Caddyfile:/etc/caddy/Caddyfile:ro caddy:2-alpine caddy validate --config /etc/caddy/Caddyfile`
- [x] `git diff --check`
- [ ] Chưa rollout production từ PR này

Closes #97
