### PR TITLE
fix(caddy): avoid delete-set header collisions

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,14 +4,9 @@
 # =============================================================================
 
 (edge_response_headers) {
+    header -X-XSS-Protection
+
     header {
-        -Content-Security-Policy
-        -X-Frame-Options
-        -X-Content-Type-Options
-        -Cross-Origin-Opener-Policy
-        -Referrer-Policy
-        -Permissions-Policy
-        -X-XSS-Protection
         >Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com; style-src 'self' 'unsafe-inline' https://accounts.google.com https://fonts.googleapis.com; img-src 'self' data: blob: https: https://ui-avatars.com; connect-src 'self' https://accounts.google.com https://lh3.googleusercontent.com https://ui-avatars.com https://fonts.googleapis.com https://fonts.gstatic.com https://wiii.holilihu.online https://sandbox.vnpayment.vn https://pay.vnpay.vn https://qr.sepay.vn https://videodelivery.net wss:; media-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https: blob:; frame-ancestors 'self'; object-src 'none'; base-uri 'self';"
         >X-Frame-Options "SAMEORIGIN"
         >X-Content-Type-Options "nosniff"

--- a/docs/superpowers/specs/2026-04-24-caddy-header-delete-collision-fix.md
+++ b/docs/superpowers/specs/2026-04-24-caddy-header-delete-collision-fix.md
@@ -1,0 +1,60 @@
+# 2026-04-24 - Caddy Header Delete/Set Collision Fix
+
+## Problem
+
+Production responses still missed `Content-Security-Policy`, `X-Frame-Options`,
+`X-Content-Type-Options`, `Cross-Origin-Opener-Policy`, `Referrer-Policy`, and
+`Permissions-Policy` even after PR #98 moved security headers into deferred
+`header` handlers inside each proxied `handle`.
+
+This kept avatar blob previews fragile and left the edge response policy only
+partially applied.
+
+## Evidence
+
+- Runtime `/etc/caddy/Caddyfile` inside the production `caddy` container matched
+  the deferred-header config from PR #98.
+- Caddy admin JSON showed `headers.response.set` for all expected fields.
+- Live responses from both public origin and `--resolve holilihu.online:443:127.0.0.1`
+  still exposed only `Strict-Transport-Security`, while the other custom
+  security headers were absent.
+- A minimal local repro isolated the pattern: fields listed as both
+  `-Header-Name` and `>Header-Name` in the same `header` block disappear from the
+  final proxied response, while fields that are only deferred-set still appear.
+
+## Root Cause
+
+The Caddy snippet combined delete and deferred-set for the same response headers
+in one `header` handler:
+
+- `-Content-Security-Policy`
+- `>Content-Security-Policy ...`
+
+In practice, the delete operation won the collision for those fields, so the
+final response omitted them entirely. `Strict-Transport-Security` continued to
+appear because it was never deleted in that block.
+
+## Fix
+
+- Remove delete operations for headers that are already canonicalized via
+  deferred `>` set.
+- Keep `X-XSS-Protection` stripping as a separate `header -X-XSS-Protection`
+  directive, because we want it removed rather than replaced.
+
+## Why This Is Safer
+
+- Deferred `>` set already overwrites upstream values after proxy response
+  headers exist, so separate delete operations are unnecessary for the headers
+  we own.
+- The patch is smaller than the prior experiments and aligns with the behavior
+  proven in the isolated Caddy repro.
+
+## Verification Plan
+
+1. Validate Caddyfile syntax with `caddy validate`.
+2. Reproduce the header block locally against a proxied upstream.
+3. After deploy, confirm both:
+   - `curl -I https://holilihu.online/teacher/profile`
+   - `curl -skI --resolve holilihu.online:443:127.0.0.1 https://holilihu.online/teacher/profile`
+4. Confirm `Content-Security-Policy` now includes `img-src 'self' data: blob: https:`
+   and that avatar preview works again on shared profile routes.


### PR DESCRIPTION
﻿## Problem

Production responses still miss the intended security headers after `#98`, even though the runtime `Caddyfile` and Caddy admin JSON both show the deferred header config is loaded.

That leaves the edge response policy only partially applied and keeps avatar preview/edit fragile because the expected CSP is not actually reaching the browser.

Closes #99.

## Root Cause

The current `edge_response_headers` snippet mixes delete and deferred-set for the same fields in one `header` block, for example:

```caddy
header {
  -Content-Security-Policy
  >Content-Security-Policy "..."
}
```

A minimal isolated Caddy repro shows that this pattern causes the delete to win for that field on proxied responses. That matches production exactly:

- `Strict-Transport-Security` still appears because it is only deferred-set
- `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, `Cross-Origin-Opener-Policy`, `Referrer-Policy`, and `Permissions-Policy` disappear because they are both deleted and deferred-set in the same block

## Fix

- Remove delete operations for headers that are already canonicalized with deferred `>` set
- Keep `X-XSS-Protection` stripping as a separate header directive because we want it removed, not replaced
- Document the failure mode and verification plan in a focused spec note

## Verified

- [x] `caddy validate --config /etc/caddy/Caddyfile`
- [x] Minimal isolated Caddy repro for the failure mode
- [x] Minimal isolated Caddy repro for the fixed pattern
- [x] `git diff --check`
- [ ] Production header smoke after deploy
