### PR TITLE
fix(ci): reuse verified production deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,53 +133,19 @@ jobs:
           DEPLOY_SHA: ${{ github.sha }}
         run: |
           ssh -i ~/.ssh/id_ed25519 -o BatchMode=yes -o StrictHostKeyChecking=yes \
-            "$DEPLOY_USER@$DEPLOY_HOST" << DEPLOY_EOF
+            "$DEPLOY_USER@$DEPLOY_HOST" \
+            "DEPLOY_APP_DIR='$DEPLOY_APP_DIR' DEPLOY_SHA='$DEPLOY_SHA' bash -se" <<'DEPLOY_EOF'
           set -euo pipefail
           cd "$DEPLOY_APP_DIR"
 
           echo "=== LMS Maritime — CI/CD Deploy ==="
           echo "Revision: $DEPLOY_SHA"
 
-          # Update compose files, Caddyfile
+          # Pin the VM to the pushed revision, then delegate the rollout to the
+          # same script used for verified manual production deploys.
           git fetch --prune origin
           git checkout --force "$DEPLOY_SHA"
-
-          COMPOSE_ARGS=(--env-file .env.prod -f docker-compose.yml -f docker-compose.prod.yml)
-
-          # Backup database (if running)
-          if docker compose "\${COMPOSE_ARGS[@]}" ps db --status running -q 2>/dev/null | grep -q .; then
-            BACKUP_FILE="backups/lms-pre-deploy-\$(date +%Y%m%d-%H%M%S).sql.gz"
-            mkdir -p backups
-            docker compose "\${COMPOSE_ARGS[@]}" exec -T db \
-              pg_dump -U "\${POSTGRES_USER:-lms}" "\${POSTGRES_DB:-lms}" | gzip > "\$BACKUP_FILE"
-            echo "Backup: \$BACKUP_FILE"
-          fi
-
-          # Pull pre-built images from GHCR
-          docker compose "\${COMPOSE_ARGS[@]}" pull backend frontend
-
-          # Prune old images to save disk
-          docker image prune -f 2>/dev/null || true
-
-          # Deploy (no --build: uses pulled images)
-          # --force-recreate backend frontend: ensures containers restart with the new image.
-          # Without this, `up -d` may leave old containers running if Docker Compose
-          # doesn't detect the image digest change reliably.
-          docker compose "\${COMPOSE_ARGS[@]}" up -d --remove-orphans --force-recreate backend frontend caddy
-
-          # Wait for health
-          echo "Waiting for backend health..."
-          for i in \$(seq 1 30); do
-            if curl -sf http://localhost/actuator/health > /dev/null 2>&1; then
-              echo "Backend: HEALTHY"
-              break
-            fi
-            [ "\$i" -eq 30 ] && echo "WARNING: Health check timed out"
-            sleep 5
-          done
-
-          docker compose "\${COMPOSE_ARGS[@]}" ps
-          echo "=== Deploy Complete ==="
+          bash ./deploy.sh
           DEPLOY_EOF
 
       - name: Post-deploy summary

--- a/docs/superpowers/specs/2026-04-24-deploy-workflow-use-verified-script.md
+++ b/docs/superpowers/specs/2026-04-24-deploy-workflow-use-verified-script.md
@@ -1,0 +1,60 @@
+# 2026-04-24 - Deploy Workflow Should Reuse Verified Production Script
+
+## Problem
+
+GitHub Actions `Build & Deploy` reported success for production deploys even when
+the SSH deploy body did not complete successfully. This left the VM checked out
+to the new revision while the running containers continued serving stale runtime
+state, including old Caddy configuration.
+
+## Production Evidence
+
+- The merge for PR #100 reached `main` and the `Build & Deploy` workflow
+  reported success.
+- The VM repository advanced to `eb50b0e8`, but the running `caddy` container
+  still served the previous `Caddyfile` content.
+- Public and origin header checks still missed the intended edge security
+  headers until a manual `bash ./deploy.sh` was run on the VM.
+
+## CI Log Evidence
+
+The deploy job log contained:
+
+```text
+/home/runner/work/_temp/...sh: line 1: up: command not found
+```
+
+but the job still ended as successful and published a deploy summary.
+
+## Root Cause
+
+The workflow duplicated deployment logic inline inside an SSH heredoc. That path
+had drifted from the verified `deploy.sh` behavior and was brittle around shell
+expansion and remote execution. Because the workflow used a separate deploy
+implementation from the one operators actually trust in production, failures
+could leave stale runtime state behind without a reliable signal.
+
+## Fix
+
+- Keep the remote checkout to the pushed SHA in the workflow.
+- Replace the duplicated inline deploy body with a call to `bash ./deploy.sh`
+  on the remote host.
+- Quote the heredoc delimiter so the remote body is not subject to accidental
+  local shell expansion.
+
+## Why This Is Better
+
+- One deploy path instead of two diverging paths.
+- Manual recovery deploys and CI/CD deploys now exercise the same logic.
+- If `deploy.sh` fails, SSH fails and the workflow fails instead of reporting a
+  misleading success.
+
+## Verification Plan
+
+1. Validate the workflow file structure locally.
+2. Confirm the quoted heredoc renders the remote script verbatim.
+3. Merge a production-safe change and verify:
+   - the VM checks out the target SHA
+   - `deploy.sh` output appears in the action log
+   - containers show fresh creation times
+   - public/origin smoke checks reflect the deployed configuration


### PR DESCRIPTION
﻿## Problem

`Build & Deploy` can report success while production runtime remains stale.

In the `#100` rollout, the VM git checkout advanced to `eb50b0e8`, but the running `caddy` container still served the previous `Caddyfile` until a manual `bash ./deploy.sh` was executed. The deploy log also contained `line 1: up: command not found`, yet the workflow still published a successful deploy summary.

Closes #101.

## Root Cause

The workflow duplicates production deploy logic inline inside an SSH heredoc instead of reusing `deploy.sh`, which is the production path we already verified on the VM. That inline path drifted from the real deploy script and is brittle around shell expansion and remote execution, so the action can look green while runtime state is still old.

## Fix

- Keep the VM checkout pinned to `github.sha`
- Replace the duplicated inline deploy body with `bash ./deploy.sh` on the remote host
- Quote the heredoc delimiter so the remote script is passed verbatim and not subject to accidental local shell expansion
- Document the failure mode and the reasoning behind the fix

## Verified

- [x] `git diff --check`
- [x] `actionlint`
- [x] Production evidence captured from the failed-green `#100` auto deploy and the successful manual recovery deploy
- [ ] End-to-end proof from the next auto deploy run
