### PR TITLE
fix(pwa): remove offline indicator debug logs from production console

### DIFF
--- a/fe/src/app/shared/components/offline-indicator/offline-indicator.component.ts
+++ b/fe/src/app/shared/components/offline-indicator/offline-indicator.component.ts
@@ -65,26 +65,4 @@ export class OfflineIndicatorComponent {
   protected readonly pendingSyncCount = computed(() => this.syncService.pendingCount());
   protected readonly hasExpiredBanner = computed(() => this.sessionService.showExpiredBanner());
 
-  constructor() {
-    // Log network status changes for debugging
-    if (typeof window !== 'undefined') {
-      const logStatus = () => {
-        console.log('[PWA] Network Status:', {
-          online: this.network.online(),
-          tier: this.network.connectionTier(),
-          navigatorOnLine: navigator.onLine,
-          timestamp: new Date().toISOString()
-        });
-      };
-      logStatus();
-      window.addEventListener('online', () => {
-        console.log('[PWA] Network: online event fired');
-        logStatus();
-      });
-      window.addEventListener('offline', () => {
-        console.log('[PWA] Network: offline event fired');
-        logStatus();
-      });
-    }
-  }
 }


### PR DESCRIPTION
﻿## Problem
Production console vẫn lộ debug log nội bộ của PWA trên các trang như `/student/profile`:

```text
[PWA] Network Status: { online: true, tier: 'fast', navigatorOnLine: true, ... }
```

Điều này làm console prod bị nhiễu và gây khó khăn khi triage lỗi thật.

Closes #103

## Root Cause
`OfflineIndicatorComponent` còn giữ lại constructor debug-only để `console.log(...)` trạng thái mạng và sự kiện `online/offline`. Block này không tham gia vào bất kỳ logic render hoặc offline detection nào.

## Fix
- Gỡ toàn bộ debug `console.log` khỏi `OfflineIndicatorComponent`
- Giữ nguyên logic banner offline / syncing / slow-network
- Không động tới offline detection, retry policy hay route handling

## Verified
- [x] `npm run build`
- [x] `git diff --check`
- [x] Search source không còn các chuỗi:
  - `[PWA] Network Status`
  - `[PWA] Network: online event fired`
  - `[PWA] Network: offline event fired`

## Notes
- `Unchecked runtime.lastError` trong ảnh chụp không thấy xuất phát từ source app, nhiều khả năng là noise từ extension/browser context.
- Lỗi `504` riêng lẻ ở `profile:1` không thuộc scope PR này.
