### PR TITLE
chore(scripts): add dev/reset-local-data.sh for repeatable cleanup

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,7 @@ This folder contains operational helpers that are useful locally but are not par
 - If you add manual verification helpers again, keep them current with the live API version and place them under a dedicated subfolder.
 - Generated artifacts from these scripts should stay out of the repository root.
 - `dev/coord-watch.ps1` is a local coordination utility for watcher-style mailbox workflows under `coord/`.
+- `dev/reset-local-data.sh` wipes local dev uploads + FE ephemeral junk (does NOT touch git, node_modules, build caches, or DB). Useful between milestones or before a fresh demo dataset.
 - `prod-video-smoke.ps1` exercises the production upload -> asset -> manifest path with a real file.
 - `run-distributed-scenario.ps1` is the current helper for two-origin playback bursts (`local + worker VM`) against a ready URL.
 - `debug/pwa-repair-smoke.py` captures the production PWA repair flow into `.tmp-playwright-storage-smoke/`.

--- a/scripts/dev/reset-local-data.sh
+++ b/scripts/dev/reset-local-data.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Reset local dev data — wipe uploaded files and build caches without touching git.
+#
+# Use between milestones or when starting a fresh demo dataset.
+# Safe to run while containers are stopped. DB is NOT touched — use pg_dump/pg_restore for that.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+echo "== reset-local-data.sh =="
+echo "Root: $ROOT"
+echo
+
+echo "1/3  Clearing backend/uploads/* (keeps directory structure for Docker volume)"
+if [ -d "backend/uploads" ]; then
+  for d in backend/uploads/*/; do
+    [ -d "$d" ] && rm -rf "$d"*
+  done
+  echo "     done — $(du -sh backend/uploads | cut -f1) remaining"
+else
+  echo "     skip (folder missing)"
+fi
+
+echo
+echo "2/3  Removing FE ephemeral junk (fe/fe, fe/screenshots, fe/.tmp, fe/out-tsc)"
+rm -rf fe/fe fe/screenshots fe/.tmp fe/out-tsc
+echo "     done"
+
+echo
+echo "3/3  Removing Claude Code temp settings"
+rm -f .claude/settings.local.json.tmp.*
+echo "     done"
+
+echo
+echo "Summary (not touched):"
+echo "  - .git/                (repo history)"
+echo "  - fe/node_modules/     (reinstall with 'npm ci' if needed)"
+echo "  - fe/.angular/         (Angular cache — keep for fast rebuild)"
+echo "  - backend/target/      (Maven cache — keep for fast rebuild)"
+echo "  - backups/             (production DB dumps)"
+echo "  - DB                   (use 'docker compose down -v' + migrate to reset)"


### PR DESCRIPTION
## Summary

Adds \`scripts/dev/reset-local-data.sh\` that wipes local-only junk (uploads, FE ephemera, Claude temp files) between milestones. Script intentionally preserves build caches, node_modules, backups, and the DB so it is safe to run anytime.

After running: \`backend/uploads\` = 60 KB (only empty subdirs for Docker volume mount), all FE debug folders removed.

## Linked issues

Closes #111

## Change type

- [x] Infra / CI

## What changed

- \`scripts/dev/reset-local-data.sh\` (new, executable)
- \`scripts/README.md\` — added one line describing it

## Why

Between the faculty and school milestones, \`backend/uploads/\` had silently grown to **6.7 GB** of test video uploads + transcoded renditions + packages, plus ~10 MB of FE debug folders. None of this is in git, but there was no documented procedure to clear it. The script codifies the procedure so future sessions can clean with one command.

## Testing

- [x] Script runs cleanly on a populated tree (used it to free 6.7 GB in this session)
- [x] Idempotent (running twice is a no-op)
- [x] Preserves \`backend/uploads/\` subdirectory structure for Docker volume mount
- [x] Does not touch \`.git\`, \`fe/node_modules\`, \`fe/.angular\`, \`backend/target\`, \`backups/\`

## Risk & rollback

- **Risk**: none if you run it. The only caveat is that local test uploads are destroyed — but that is the whole point.
- **Rollback**: \`git revert <this-commit>\` removes the script. Already-deleted data cannot be recovered (not meant to be).

## Checklist

- [x] Conventional commit
- [x] No secrets
- [x] Self-reviewed diff
- [x] Docs updated (\`scripts/README.md\`)
- [ ] CI green (auto-run)