### PR TITLE
chore(ci): add Dependabot config for weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,120 @@
+# Dependabot auto-updates
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Strategy:
+# - Security updates: allowed via Dependabot Security alerts (auto-PR high/critical)
+# - Version updates: weekly, grouped by ecosystem to reduce PR noise
+# - Patch bumps grouped together; major bumps separate for review
+# - Schedule on Monday morning Asia/Ho_Chi_Minh to land in the dev week
+
+version: 2
+
+updates:
+  # ─── Frontend (Angular + related) ───────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/fe"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Ho_Chi_Minh"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "frontend"
+    groups:
+      angular:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+      testing:
+        patterns:
+          - "@playwright/*"
+          - "@types/jasmine"
+          - "karma*"
+          - "jasmine*"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ─── Backend (Maven) ────────────────────────────────────────────────
+  - package-ecosystem: "maven"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Ho_Chi_Minh"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "backend"
+    groups:
+      spring:
+        patterns:
+          - "org.springframework*"
+      testing:
+        patterns:
+          - "org.junit*"
+          - "org.mockito*"
+          - "org.assertj*"
+          - "com.tngtech.archunit*"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ─── GitHub Actions ─────────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Ho_Chi_Minh"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "ci"
+
+  # ─── Docker base images ─────────────────────────────────────────────
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Ho_Chi_Minh"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/fe"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Ho_Chi_Minh"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"


### PR DESCRIPTION
## Summary

Adds \`.github/dependabot.yml\` enabling weekly automated version updates for npm (fe/), maven (backend/), github-actions, and docker. Updates are grouped by ecosystem to keep PR count low while catching security patches quickly.

## Linked issues

Part of #115.

## Change type

- [x] Infra / CI

## What changed

- \`.github/dependabot.yml\` (120 lines) — 5 ecosystems:
  - npm in \`/fe\` (Angular + testing + minor/patch groups, 5 PRs max)
  - maven in \`/backend\` (Spring + testing + minor/patch groups, 5 PRs max)
  - github-actions in \`/\` (3 PRs max)
  - docker in \`/backend\` (2 PRs max)
  - docker in \`/fe\` (2 PRs max)
- Schedule: every Monday 08:00 Asia/Ho_Chi_Minh
- Commit message prefix: \`chore(deps)\` / \`chore(ci)\` / \`chore(docker)\` per conventional commits
- Labels: \`dependencies\` + ecosystem (\`frontend\`/\`backend\`/\`ci\`/\`docker\`)

## Why

Without \`dependabot.yml\`, version updates don't happen automatically — only security updates (if enabled by admin separately). The grouped strategy keeps the "noise to value" ratio sane: minor/patch bumps in a single PR per ecosystem, major bumps separated for review.

## Testing

- YAML syntax valid per [Dependabot config reference](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
- Dependabot will start scheduling on Monday 08:00 after admin enables "Dependabot version updates" in Settings → Code security

## Risk & rollback

- **Risk**: may create up to ~17 grouped PRs per week initially (ecosystem limits). Can tune \`open-pull-requests-limit\` lower if overwhelming.
- **Rollback**: \`git revert\` removes the file; Dependabot immediately stops version updates.

## Follow-up needed (admin-only)

Repo admin (\`linhlinhlin\`) must enable in Settings → Code security:

- Dependabot alerts
- Dependabot security updates
- Dependabot version updates (reads this file)

See [\`docs/runbooks/GITHUB_PROFESSIONAL_SETUP_RUNBOOK.md\`](docs/runbooks/GITHUB_PROFESSIONAL_SETUP_RUNBOOK.md) (from the sibling PR in #115) for the full checklist.

## Checklist

- [x] Conventional commit
- [x] No secrets
- [x] Self-reviewed diff