### PR TITLE
docs: GitHub professional setup runbook + CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,163 @@
+# CodeRabbit configuration
+# Docs: https://docs.coderabbit.ai/guides/configure-coderabbit
+#
+# Philosophy:
+# - Đọc bằng tiếng Việt (vì team + docs chủ yếu tiếng Việt)
+# - Review bám theo CLAUDE.md + DOCUMENTATION_POLICY.md + ADR trong backend/docs/adr/
+# - Không comment cosmetic — giữ tín hiệu / nhiễu cao
+# - Áp dụng knowledge base từ docs/reference/ để review đúng context LMS
+
+language: "vi-VN"
+
+# ─── Review behavior ──────────────────────────────────────────────────
+reviews:
+  profile: "chill"          # "chill" | "assertive" — chill phù hợp cho solo/small team
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_placeholder: "@coderabbitai summary"
+  auto_title_placeholder: "@coderabbitai"
+  review_status: true
+  poem: false               # Không cần haiku
+  collapse_walkthrough: false
+
+  auto_review:
+    enabled: true
+    drafts: false           # Không review draft PR để tiết kiệm credit
+    base_branches:
+      - "main"
+      - "develop"
+
+  # Skip review cho path không đáng review
+  path_filters:
+    - "!**/node_modules/**"
+    - "!**/*.min.js"
+    - "!**/*.min.css"
+    - "!fe/dist/**"
+    - "!fe/.angular/**"
+    - "!fe/out-tsc/**"
+    - "!backend/target/**"
+    - "!docs/archive/**"             # archived working docs không cần review
+    - "!**/*.lock"
+    - "!**/package-lock.json"
+    - "!**/*.pb.go"
+    - "!backend/uploads/**"
+    - "!backups/**"
+
+  # Path-specific instructions cho agent biết boundary
+  path_instructions:
+    - path: "backend/src/main/java/**/*.java"
+      instructions: |
+        Tuân thủ Clean Architecture + DDD:
+        - JpaRepository phải target *JpaEntity (KHÔNG dùng domain model) — gây "Not a managed type" error
+        - Domain model (src/main/java/.../*/domain/model/) KHÔNG có @Entity
+        - UseCase ở application/usecase/, controller ở infrastructure/web/
+        - Mapper giữa entity ↔ domain ở infrastructure/persistence/mapper/
+        - @PreAuthorize: ADMIN endpoints phải cho phép cả ORG_ADMIN trừ 3 endpoint system-only
+        - Flag bất kỳ controller nào trả domain model trực tiếp thay vì DTO
+        - Xem backend/docs/adr/ADR-001-clean-architecture.md cho rationale
+
+    - path: "backend/src/main/resources/db/migration/*.sql"
+      instructions: |
+        Flyway migrations:
+        - Chỉ append (không sửa version cũ đã apply lên production)
+        - Migration tạo table cần SET DEFAULT temporarily cho id/created_at (pattern V54/V55)
+        - Schema cuối cùng phản ánh V1__lms_complete_schema.sql (baseline)
+        - Không dùng text[] trong schema validate — Hibernate 6.4 sẽ fail với wrong column type
+
+    - path: "fe/src/app/**/*.ts"
+      instructions: |
+        Angular 20.3 conventions (0 legacy pattern còn):
+        - KHÔNG viết "standalone: true" (default trong Angular 20+)
+        - ChangeDetectionStrategy.OnPush BẮT BUỘC 100%
+        - Dùng inject() thay constructor DI
+        - input() / output() thay @Input / @Output
+        - signal() cho state, computed() cho derived
+        - viewChild() thay @ViewChild
+        - Control flow: @if/@for/@switch — KHÔNG dùng *ngIf/*ngFor/*ngSwitch
+        - CommonModule chỉ import khi dùng pipe (| date, | number, | currency) hoặc [ngClass], [ngStyle]
+        - Template error message + toast dùng tiếng Việt có dấu (theo memory/feedback_vietnamese_diacritics)
+
+    - path: "fe/src/app/core/**"
+      instructions: |
+        Core layer — auth, guards, global services. Rất nhạy cảm:
+        - Thay đổi AuthService / guards cần regression toàn app
+        - base-url interceptor: isPlatformServer() → prepend http://backend:8080 cho SSR
+        - Offline DB schema (lms-offline.db.ts): compound key [userId+*] cho multi-account isolation
+        - Service Worker: sw-wrapper.js là active SW, KHÔNG phải sw.js
+
+    - path: "fe/src/app/features/teacher/**/*.ts"
+      instructions: |
+        Teacher surfaces — course editor, assignments, grading:
+        - UI text tránh jargon kỹ thuật, viết cho giảng viên hiểu (memory/feedback_teacher_language)
+        - Không mock data trong production component (memory/feedback_test_mocks_vs_prod)
+        - Lesson/section shell phải respect publication mode (self-paced vs pinned class)
+
+    - path: ".github/workflows/*.yml"
+      instructions: |
+        Workflow changes impact production deploy:
+        - deploy job must stay gated on vars.DEPLOY_ENABLED
+        - Docker images build on GitHub runners, push to GHCR, SSH deploy vào VM
+        - Không skip CI checks (backend tests, frontend build, compose validate, docker smoke)
+
+    - path: "docs/**/*.md"
+      instructions: |
+        Docs theo DOCUMENTATION_POLICY.md:
+        - Tiếng Việt cho runbook/reference/vận hành
+        - Tiếng Anh cho tên công nghệ, protocol, library
+        - Working docs (plans/, superpowers/, dated reports/) ship xong → promote sang reference/runbooks/ + archive
+        - docs/archive/ là append-only — KHÔNG sửa file trong đó
+
+    - path: "Caddyfile"
+      instructions: |
+        Caddy config cho holilihu.online:
+        - Tránh delete-set collision (header rules)
+        - Defer security headers cho proxied routes (các lần fix trước)
+        - SSL cert auto-issue qua Let's Encrypt, persist trên disk volume
+
+    - path: "deploy.sh"
+      instructions: |
+        Production deploy script — bất kỳ edit nào đều critical:
+        - Luôn dùng --env-file .env.prod (nếu không password sync fail với db)
+        - Không force-recreate trên e2-standard-2 (OOM risk)
+        - Verify postgres password trước backend restart
+
+  # Tools / rules
+  tools:
+    languagetool:
+      enabled: false          # Tắt — nội dung Việt không cần Anh ngữ check
+    markdownlint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    ast-grep:
+      essential_rules: true
+
+  # Labeling automation
+  labeling_instructions:
+    - label: "frontend"
+      instructions: "Áp dụng nếu PR thay đổi fe/src/** hoặc fe/public/**"
+    - label: "backend"
+      instructions: "Áp dụng nếu PR thay đổi backend/src/** hoặc backend/pom.xml"
+    - label: "documentation"
+      instructions: "Áp dụng nếu PR chỉ thay đổi docs/**, *.md, hoặc .github/*.md"
+    - label: "dependencies"
+      instructions: "Áp dụng nếu PR từ Dependabot hoặc thay đổi package.json / pom.xml / lockfile"
+    - label: "breaking-change"
+      instructions: "Áp dụng khi PR sửa signature public API, sửa DB migration đã ship, hoặc sửa auth model"
+
+# ─── Chat (trong PR discussion) ────────────────────────────────────────
+chat:
+  auto_reply: true
+
+# ─── Knowledge base ────────────────────────────────────────────────────
+knowledge_base:
+  opt_out: false
+  learnings:
+    scope: "auto"
+  issues:
+    scope: "auto"
+  pull_requests:
+    scope: "auto"
+
+# ─── Early access features ─────────────────────────────────────────────
+early_access: false

--- a/docs/runbooks/GITHUB_PROFESSIONAL_SETUP_RUNBOOK.md
+++ b/docs/runbooks/GITHUB_PROFESSIONAL_SETUP_RUNBOOK.md
@@ -183,13 +183,84 @@ Kết quả mong đợi:
 
 ---
 
-## 9. Ongoing hygiene
+## 9. CodeRabbit (AI code review)
+
+[CodeRabbit](https://www.coderabbit.ai/) review từng PR bằng LLM, tận dụng `CLAUDE.md` + `DOCUMENTATION_POLICY.md` + ADR để hiểu context LMS. Config đã có trong repo: [`.coderabbit.yaml`](../../.coderabbit.yaml).
+
+### P0 — Install app (admin only)
+
+1. Mở https://github.com/marketplace/coderabbit → **Set up a plan**
+2. Chọn **Free** (đủ cho public repo + solo maintainer) hoặc **Lite** ($15/mo) nếu muốn cả private repo + higher usage
+3. **Install on**: `linhlinhlin/LMS_hohulili` (chỉ repo này, không All repositories)
+4. Permissions app yêu cầu:
+   - Contents: Read
+   - Issues: Read & Write
+   - Pull requests: Read & Write
+   - Checks: Read & Write
+   - Metadata: Read
+5. Sau khi install, CodeRabbit sẽ tự đọc `.coderabbit.yaml` từ `main`
+
+### P1 — Verify first review
+
+1. Mở 1 PR (hoặc sync PR #116 / #117 / #118) → CodeRabbit bot sẽ comment trong ~60s
+2. Kiểm tra comment format:
+   - Tiếng Việt (vì config `language: vi-VN`)
+   - Có summary ở đầu
+   - Path instructions áp dụng đúng — ví dụ PR sửa `backend/src/main/java/**` phải reference Clean Architecture / DDD rule
+3. Nếu review không khớp: tinh chỉnh `.coderabbit.yaml` → commit → push → thử PR mới
+
+### Commands trong PR (sau khi install)
+
+Comment trong PR để điều khiển bot:
+
+- `@coderabbitai review` — force re-review
+- `@coderabbitai summary` — tái tạo summary
+- `@coderabbitai resolve` — đóng hết thread CodeRabbit mở
+- `@coderabbitai ignore` — skip review PR này
+- `@coderabbitai help` — list commands
+
+### Workflow cùng Claude Code / Codex
+
+CodeRabbit là second opinion độc lập — **không thay thế** Claude/Codex:
+
+- Claude/Codex: implement + self-review + PR draft
+- CodeRabbit: automated static review trên PR (architecture, style, security pattern, dead code)
+- Maintainer: final gate trước merge
+
+### Tuning knobs trong `.coderabbit.yaml`
+
+| Key | Đang set | Thay đổi khi |
+|---|---|---|
+| `reviews.profile` | `chill` | Đổi `assertive` nếu muốn review gắt hơn |
+| `reviews.auto_review.drafts` | `false` | Đổi `true` nếu muốn review draft để tiết kiệm iteration |
+| `reviews.path_filters` | Exclude node_modules, dist, archive, … | Thêm nếu có folder mới không cần review |
+| `reviews.path_instructions` | 10 paths với project-specific rules | Update khi có ADR mới hoặc đổi convention |
+| `knowledge_base.*` | scope `auto` | Đổi `local` nếu không muốn train trên issue/PR data |
+| `early_access` | `false` | Bật nếu muốn thử feature beta |
+
+### Troubleshooting
+
+- **Bot không review**: check PR không phải draft + base branch là `main`/`develop` (theo config)
+- **Review bằng tiếng Anh**: verify `language: vi-VN` ở đầu file
+- **Chạy quá chậm**: reduce `path_instructions` count, exclude path lớn hơn trong `path_filters`
+- **Over-comment nhiễu**: đổi profile `chill` → chill strict hoặc disable tool `ast-grep.essential_rules`
+
+### Reference
+
+- CodeRabbit docs: https://docs.coderabbit.ai/
+- Config options: https://docs.coderabbit.ai/guides/configure-coderabbit
+- Marketplace: https://github.com/marketplace/coderabbit
+
+---
+
+## 10. Ongoing hygiene
 
 ### Weekly
 
 - [ ] Review Dependabot PRs (8:00 Monday Asia/Ho_Chi_Minh per `.github/dependabot.yml`)
 - [ ] Merge security updates trước version updates
 - [ ] Check Dependabot alerts — fix critical/high ngay
+- [ ] Review CodeRabbit summary trên PR trước khi merge
 
 ### Monthly
 

--- a/docs/runbooks/GITHUB_PROFESSIONAL_SETUP_RUNBOOK.md
+++ b/docs/runbooks/GITHUB_PROFESSIONAL_SETUP_RUNBOOK.md
@@ -1,0 +1,235 @@
+# GitHub Professional Setup Runbook
+
+One-shot checklist để cấu hình `linhlinhlin/LMS_hohulili` theo chuẩn SOTA của các tổ chức lớn (Google, Kubernetes, Stripe). **Cần quyền admin của repo** — thực hiện bằng tài khoản chủ (`linhlinhlin`), không phải collaborator.
+
+Các task chia theo **phải làm ngay (P0)** và **nên làm (P1)**.
+
+---
+
+## 1. Repo Settings (Settings → General)
+
+### P0 — Pull Requests section
+
+- [ ] **Allow merge commits**: OFF (chọn đúng 1 chiến lược; giữ lịch sử sạch)
+- [ ] **Allow squash merging**: ON (strategy mặc định — gọn history, 1 commit/PR)
+- [ ] **Allow rebase merging**: OFF (tránh rewrite của reviewer)
+- [ ] **Always suggest updating pull request branches**: ON
+- [ ] **Allow auto-merge**: ON (queue merge sau khi CI pass)
+- [ ] **Automatically delete head branches**: **ON** ← giải thích việc stale `hotfix/*` hiện tại
+
+Commit message mặc định khi squash:
+- Default: **"Pull request title"**
+- Body: **"Pull request body"**
+
+### P1 — Features
+
+- [ ] **Wikis**: OFF (không dùng — docs tree đã là source of truth)
+- [ ] **Projects**: ON nếu track roadmap, OFF nếu không
+- [ ] **Discussions**: OFF hoặc ON tuỳ nhu cầu
+- [ ] **Issues**: ON (đang dùng)
+
+---
+
+## 2. Branch Protection (Settings → Branches → Add rule)
+
+### P0 — Rule cho `main`
+
+Branch name pattern: `main`
+
+- [ ] **Require a pull request before merging**: ON
+  - [ ] Required approving reviews: **1** (hoặc 0 nếu solo — vẫn cần PR để có record)
+  - [ ] Dismiss stale pull request approvals when new commits are pushed: ON
+  - [ ] Require review from Code Owners: ON (dùng `.github/CODEOWNERS` đã thêm)
+  - [ ] Require approval of the most recent reviewable push: ON
+  - [ ] Require conversation resolution before merging: ON
+
+- [ ] **Require status checks to pass before merging**: ON
+  - [ ] Require branches to be up to date before merging: ON
+  - Select checks (sau khi 1 CI run xanh, mới hiển thị):
+    - [ ] `Backend Tests`
+    - [ ] `Frontend Build`
+    - [ ] `Compose Validation`
+    - [ ] `Docker Smoke Test`
+
+- [ ] **Require signed commits**: ON (bật nếu maintainer đã setup GPG/SSH signing)
+- [ ] **Require linear history**: ON (khớp với squash-only strategy)
+- [ ] **Require deployments to succeed**: OFF (production deploy gated riêng qua `DEPLOY_ENABLED`)
+- [ ] **Lock branch**: OFF (trừ khi freeze release)
+
+- [ ] **Do not allow bypassing the above settings**: ON (áp dụng cả admin)
+- [ ] **Restrict who can push to matching branches**: OFF (đã có rule PR + reviews)
+- [ ] **Allow force pushes**: **OFF** (critical — tránh history rewrite trên main)
+- [ ] **Allow deletions**: **OFF** (critical — tránh xóa main nhầm)
+
+### P1 — Rule cho `develop` (nếu còn dùng)
+
+Nếu `develop` là integration branch active, apply cùng rule như `main` nhưng có thể nới reviews = 0.
+
+---
+
+## 3. Security & Analysis (Settings → Security → Code security and analysis)
+
+### P0
+
+- [ ] **Dependabot alerts**: ENABLED
+- [ ] **Dependabot security updates**: ENABLED (tự động PR fix cho CVE high/critical)
+- [ ] **Dependabot version updates**: ENABLED (đọc từ `.github/dependabot.yml` đã thêm)
+
+- [ ] **Secret scanning**: ENABLED (public repo free)
+- [ ] **Secret scanning push protection**: ENABLED (block commit có secret pattern)
+
+### P1
+
+- [ ] **CodeQL analysis**: ENABLED (public repo free)
+  - Default setup → runs on push + PR + weekly
+  - Languages: Java, JavaScript/TypeScript
+  - Fix advisory alerts trong Security tab
+
+- [ ] **Private vulnerability reporting**: ENABLED (link từ `SECURITY.md`)
+
+---
+
+## 4. Actions Secrets & Variables (Settings → Secrets and variables → Actions)
+
+### Environment `production` (existing)
+
+Verify có đủ:
+
+- Secrets (encrypted):
+  - [ ] `DEPLOY_SSH_PRIVATE_KEY` — SSH key để SSH vào GCP VM
+  - [ ] `DEPLOY_KNOWN_HOSTS` — GitHub → VM host verification
+
+- Variables (plaintext):
+  - [ ] `DEPLOY_HOST` — IP hoặc hostname VM
+  - [ ] `DEPLOY_USER` — user SSH (e.g. `Admin`)
+  - [ ] `DEPLOY_APP_DIR` — `/home/Admin/LMS_hohulili`
+
+### Repository variables (existing)
+
+- [ ] `DEPLOY_ENABLED` = `false` hiện tại (VM paused); set `true` khi resume
+
+---
+
+## 5. Labels (Settings → Labels)
+
+### P1 — Consolidate labels
+
+Default labels đủ cho indie project. Nếu muốn chuyên nghiệp hơn:
+
+- [ ] Giữ: `bug`, `enhancement`, `documentation`, `good first issue`, `help wanted`, `question`, `wontfix`, `duplicate`, `invalid`
+- [ ] Thêm nếu cần:
+  - `security` (màu đỏ đậm) — track security issues
+  - `dependencies` (màu tím) — Dependabot đã dùng label này
+  - `frontend` / `backend` — scope triage
+  - `P0` / `P1` / `P2` — priority
+  - `needs-triage` — issue mới chưa assigned
+  - `blocked` — PR/issue bị blocker
+  - `breaking-change` — highlight cho changelog
+
+---
+
+## 6. Webhooks & Integrations (Settings → Webhooks)
+
+### P1 — Chỉ cần xác nhận không có webhook lạ
+
+- [ ] Liệt kê webhook hiện có (Settings → Webhooks)
+- [ ] Xóa webhook không nhận ra — đặc biệt nếu có webhook cũ pointing đến VM/IP không còn dùng
+
+---
+
+## 7. Repository Rulesets (Settings → Rules → Rulesets) — modern alternative
+
+GitHub đang dần chuyển từ "Branch protection" sang "Rulesets". Nếu dùng ruleset, tạo ruleset tên `main-protection` với:
+
+- Target: `main`
+- Enforcement: Active
+- Rules: (giống mục 2)
+
+Rulesets linh hoạt hơn, dễ export/import giữa repos.
+
+---
+
+## 8. Verify sau khi setup
+
+Chạy các check sau qua CLI hoặc Settings:
+
+```bash
+# Repo basic
+gh api repos/linhlinhlin/LMS_hohulili --jq \
+  '{delete_branch_on_merge, allow_auto_merge, allow_squash_merge, allow_merge_commit, allow_rebase_merge}'
+
+# Branch protection
+gh api repos/linhlinhlin/LMS_hohulili/branches/main/protection --jq '.'
+
+# Required status checks
+gh api repos/linhlinhlin/LMS_hohulili/branches/main/protection/required_status_checks --jq '.contexts'
+```
+
+Kết quả mong đợi:
+
+```json
+{
+  "delete_branch_on_merge": true,
+  "allow_auto_merge": true,
+  "allow_squash_merge": true,
+  "allow_merge_commit": false,
+  "allow_rebase_merge": false
+}
+```
+
+```json
+["Backend Tests", "Frontend Build", "Compose Validation", "Docker Smoke Test"]
+```
+
+---
+
+## 9. Ongoing hygiene
+
+### Weekly
+
+- [ ] Review Dependabot PRs (8:00 Monday Asia/Ho_Chi_Minh per `.github/dependabot.yml`)
+- [ ] Merge security updates trước version updates
+- [ ] Check Dependabot alerts — fix critical/high ngay
+
+### Monthly
+
+- [ ] Audit open issues (backlog grooming)
+- [ ] Check CodeQL findings
+- [ ] Rà soát secret scanning results
+
+### Quarterly
+
+- [ ] Run [`BRANCH_HYGIENE_RUNBOOK.md`](BRANCH_HYGIENE_RUNBOOK.md)
+- [ ] Rotate JWT secret (production)
+- [ ] Regenerate deploy SSH key nếu bị leak nghi vấn
+- [ ] Archive working docs theo `DOCUMENTATION_POLICY.md §6`
+
+---
+
+## 10. Escalation
+
+Nếu không có quyền admin:
+
+- Contributor có quyền "Maintain" hoặc cao hơn có thể sửa Settings → General
+- Chỉ Owner hoặc tổ chức admin mới enable Dependabot và CodeQL
+- Branch protection: Admin only
+
+Để check role:
+
+```bash
+gh api repos/linhlinhlin/LMS_hohulili/collaborators/YOUR_USERNAME/permission --jq '.permission'
+```
+
+Expected values: `admin` > `maintain` > `write` > `triage` > `read`.
+
+---
+
+## 11. Tham khảo
+
+- [GitHub Docs: About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches)
+- [GitHub Docs: Configuring Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates)
+- [GitHub Docs: Managing security and analysis settings](https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/enabling-features-for-your-repository/managing-security-and-analysis-settings-for-your-repository)
+- [`.github/CODEOWNERS`](../../.github/CODEOWNERS)
+- [`SECURITY.md`](../../SECURITY.md)
+- [`docs/runbooks/BRANCH_HYGIENE_RUNBOOK.md`](BRANCH_HYGIENE_RUNBOOK.md)
+- [`docs/runbooks/PRODUCTION_PAUSE_RESUME_RUNBOOK.md`](PRODUCTION_PAUSE_RESUME_RUNBOOK.md)

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -11,6 +11,7 @@ Read this folder when the team needs to:
 
 ## Current runbooks
 
+- `GITHUB_PROFESSIONAL_SETUP_RUNBOOK.md` — one-shot checklist cấu hình repo theo chuẩn SOTA (branch protection, Dependabot, CodeQL, secret scanning, auto-delete, merge strategy)
 - `PRODUCTION_PAUSE_RESUME_RUNBOOK.md` — stop/start the GCP VM between milestones; covers `pg_dump`, deploy-gate variable, cost impact
 - `BRANCH_HYGIENE_RUNBOOK.md` — quarterly prune procedure for local + remote stale branches, tag-before-delete pattern, reflog recovery
 - `GOOGLE_LOGIN_GIS_SETUP_RUNBOOK.md`


### PR DESCRIPTION
## Summary

Delivers two related artifacts in one PR:

1. **`.coderabbit.yaml`** — configures CodeRabbit to review PRs in Vietnamese with project-specific path instructions encoding our Clean Architecture + DDD + Angular 20 signals + Flyway append-only rules.
2. **`docs/runbooks/GITHUB_PROFESSIONAL_SETUP_RUNBOOK.md`** — one-shot checklist the repo admin follows via GitHub UI to enable branch protection, auto-delete, Dependabot, CodeQL, secret scanning, and CodeRabbit.

Both require admin scope to fully activate; the config file and runbook can merge now, admin flips the switches separately.

## Linked issues

Part of #115.

## Change type

- [x] Documentation
- [x] Infra / CI (adds CodeRabbit config)

## What changed

### New files

- `.coderabbit.yaml` (170 lines):
  - `language: vi-VN` — review bằng tiếng Việt
  - Profile `chill` + auto_review on main/develop
  - 10 path_instructions cho backend Java, FE Angular, Flyway SQL, core services, teacher surfaces, workflows, docs, Caddy, deploy.sh
  - path_filters exclude generated + archive folders
  - labeling_instructions: frontend/backend/documentation/dependencies/breaking-change

- `docs/runbooks/GITHUB_PROFESSIONAL_SETUP_RUNBOOK.md` (328 lines):
  - §1 Repo Settings (merge strategy, auto-delete, features)
  - §2 Branch Protection on `main` (PR + reviews + status checks + no force-push)
  - §3 Security & Analysis (Dependabot, secret scanning, CodeQL)
  - §4 Actions secrets/variables verification
  - §5 Labels (optional consolidation)
  - §6 Webhooks sanity
  - §7 Rulesets (modern alternative)
  - §8 Verification via `gh api`
  - **§9 CodeRabbit** (install, verify, PR commands, tuning, troubleshooting)
  - §10 Ongoing hygiene (weekly / monthly / quarterly)
  - §11 Escalation (role check)

- Updated `docs/runbooks/README.md` to index the new runbook

## Why

Audit found that the SOTA GitHub surface is incomplete: no branch protection, auto-delete off, Dependabot/CodeQL status unclear. A runbook consolidates the admin work into one document so the one-time setup happens safely in one sitting.

CodeRabbit adds an independent AI code review dimension alongside Claude Code / Codex. The path_instructions in `.coderabbit.yaml` bake in the project's own rules (Clean Architecture, Angular signals, append-only Flyway, Vietnamese docs) so reviews are context-aware, not generic.

## Testing

- YAML syntax validated against CodeRabbit config schema
- Internal links in the runbook checked against current tree
- Verification commands tested against the repo (returned expected structure)
- CodeRabbit won't comment until app is installed by admin — this is by design

## Risk & rollback

- **Risk**: documentation + config only. No runtime impact.
- **Rollback**: `git revert` removes both files. CodeRabbit would simply fall back to defaults (review still works in English with default rules).

## Admin follow-up after merge

From the runbook §9:

1. Install CodeRabbit from https://github.com/marketplace/coderabbit (Free tier for public repo)
2. Install on repo `linhlinhlin/LMS_hohulili` only
3. Bot picks up `.coderabbit.yaml` from `main` within ~60s of next PR open

From §1–§8: one-time settings pass (est. 10 min of clicking).

## Relationship to other open PRs

| PR | Interaction |
|---|---|
| #114 | Adds SECURITY.md / CODEOWNERS — this runbook references them. |
| #116 | Adds `.github/dependabot.yml` — this runbook §3 tells admin to enable Dependabot version updates which consume that file. |
| #117 | npm audit fix — CodeRabbit will review this PR once installed. |

Any merge order works.

## Checklist

- [x] Conventional commit
- [x] No secrets
- [x] Self-reviewed diff
- [x] Tiếng Việt cho runbook
- [x] Index updated