### PR TITLE
fix(test): align ClassControllerSecurity assertion with Vietnamese diacritics

### DIFF
--- a/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/ClassControllerSecurityTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/ClassControllerSecurityTest.java
@@ -105,7 +105,7 @@ class ClassControllerSecurityTest {
 
         assertThatThrownBy(() -> controller.createClass(request, owner))
                 .isInstanceOf(com.example.lms.shared.exception.BusinessRuleException.class)
-                .hasMessageContaining("Quan ly lop");
+                .hasMessageContaining("Quản lý lớp");
     }
 
     @Test
@@ -201,7 +201,7 @@ class ClassControllerSecurityTest {
 
         assertThatThrownBy(() -> controller.getClassesByCourse(courseId, owner))
                 .isInstanceOf(com.example.lms.shared.exception.BusinessRuleException.class)
-                .hasMessageContaining("Quan ly lop");
+                .hasMessageContaining("Quản lý lớp");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Main CI has been red since the Vietnamese message in \`ClassControllerV3.throwSelfPacedRejection()\` was updated with proper diacritics (\`Quản lý lớp\`) but the test still asserts \`hasMessageContaining(\"Quan ly lop\")\`. Every Dependabot PR inherits this failure.

1-line fix: update test assertion to match production message exactly. 13/13 tests pass locally.

## Change type

- [x] Bug fix

## What changed

\`backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/ClassControllerSecurityTest.java\`:

- Line 108: \`"Quan ly lop"\` → \`"Quản lý lớp"\`
- Line 204: \`"Quan ly lop"\` → \`"Quản lý lớp"\`

## Why

Production code emits Vietnamese with proper diacritics per \`docs/reference/DOCUMENTATION_POLICY.md §1\`. The test was written before the message was localized and has been stale since.

Effect: main CI xanh trở lại → mọi Dependabot PR (hiện 16 cái) inherit CI xanh.

## Testing

Local verify:

\`\`\`bash
cd backend
mvn test -B -Dtest=ClassControllerSecurityTest
# [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
# [INFO] BUILD SUCCESS
\`\`\`

## Risk & rollback

- **Risk**: none — test-only change, production code unchanged
- **Rollback**: \`git revert\`

## Checklist

- [x] Conventional commit
- [x] No secrets
- [x] Tests pass locally
- [x] Self-reviewed diff