### PR TITLE
fix(admin-telemetry): convert offline-storage findFiltered to native SQL (fixes #77)

### DIFF
--- a/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/OfflineStorageTelemetryJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/OfflineStorageTelemetryJpaRepository.java
@@ -27,15 +27,36 @@ public interface OfflineStorageTelemetryJpaRepository extends JpaRepository<Offl
         Long getRecreateFailedCount();
     }
 
-    @Query("""
-        SELECT e FROM OfflineStorageTelemetryJpaEntity e
-        JOIN UserJpaEntity u ON u.id = e.userId
-        WHERE (:eventType IS NULL OR e.eventType = :eventType)
-          AND (:userId IS NULL OR e.userId = :userId)
-          AND (:search IS NULL OR LOWER(u.email) LIKE LOWER(CONCAT('%', :search, '%'))
-               OR LOWER(u.fullName) LIKE LOWER(CONCAT('%', :search, '%')))
-        ORDER BY e.createdAt DESC
-        """)
+    // Native SQL instead of JPQL: Hibernate 6 JPQL parser trips over
+    // LOWER(CONCAT('%', :search, '%')) when :search is bound to NULL, raising
+    // "operator does not exist: text like text" at runtime. Native SQL tolerates
+    // NULL in CONCAT (PostgreSQL concat treats NULL as ''), which is the same
+    // pattern every other query in this repository already uses.
+    // See issue #77 for the production 500 this caused.
+    @Query(
+        value = """
+            SELECT e.*
+            FROM client_offline_storage_telemetry e
+            JOIN users u ON u.id = e.user_id
+            WHERE (:eventType IS NULL OR e.event_type = :eventType)
+              AND (CAST(:userId AS uuid) IS NULL OR e.user_id = CAST(:userId AS uuid))
+              AND (:search IS NULL
+                   OR LOWER(u.email) LIKE LOWER(CONCAT('%', :search, '%'))
+                   OR LOWER(u.full_name) LIKE LOWER(CONCAT('%', :search, '%')))
+            ORDER BY e.created_at DESC
+            """,
+        countQuery = """
+            SELECT COUNT(*)
+            FROM client_offline_storage_telemetry e
+            JOIN users u ON u.id = e.user_id
+            WHERE (:eventType IS NULL OR e.event_type = :eventType)
+              AND (CAST(:userId AS uuid) IS NULL OR e.user_id = CAST(:userId AS uuid))
+              AND (:search IS NULL
+                   OR LOWER(u.email) LIKE LOWER(CONCAT('%', :search, '%'))
+                   OR LOWER(u.full_name) LIKE LOWER(CONCAT('%', :search, '%')))
+            """,
+        nativeQuery = true
+    )
     Page<OfflineStorageTelemetryJpaEntity> findFiltered(String eventType, UUID userId, String search, Pageable pageable);
 
     @Query(value = """


### PR DESCRIPTION
## Summary

Fixes the production 500 on \`/admin/offline-storage\` default load by rewriting the JPQL \`findFiltered(…)\` as native SQL. Hibernate 6 JPQL raises \"operator does not exist: text like text\" when \`:search\` is NULL; PostgreSQL's native \`CONCAT\` tolerates NULL as empty string. The fix matches the pattern already used by every other query in the same repository file.

Closes #77.

## Change type

- [x] Bug fix

## What changed

\`backend/src/main/java/com/example/lms/shared/infrastructure/persistence/OfflineStorageTelemetryJpaRepository.java\` — convert \`findFiltered\` from JPQL to native SQL:

- Query body mirrors the existing \`countSince\` / \`aggregateEventTypesSince\` queries (same JOIN, same nullable-filter pattern)
- Explicit \`countQuery\` so Spring Data's Page machinery still works
- Explicit \`CAST(:userId AS uuid)\` for safe NULL binding on PostgreSQL
- Added a comment explaining why we picked native SQL over JPQL (links to #77 root cause)

Net: +30 / −9 lines, one file.

## Why

Per the issue:

- Admins opening \`/admin/offline-storage\` see the shell + analytic cards render correctly, then the logs table collapses to \"Chưa có bản ghi phù hợp\" regardless of whether the DB has rows
- Actual endpoint behavior: \`500 Internal Server Error\` with \"operator does not exist\" at JDBC layer
- Workaround was to type any search term to dodge the bad JPQL path — not discoverable

Every other query in the same repository file (\`countSince\`, \`countDistinctUsersSince\`, \`countRequiresRedownloadSince\`, \`aggregateEventTypesSince\`, \`topRoutesSince\`, \`aggregatePlatformsSince\`, \`dailyTrendSince\`) already uses native SQL and doesn't fail. This fix makes \`findFiltered\` consistent.

## Testing

- [x] \`mvn compile -DskipTests\` — SUCCESS
- [x] \`mvn test -Dtest=*Telemetry*\` — 5/5 pass (existing tests still green)
- [x] \`grep\` confirms all queries in the file now use the same native SQL pattern
- [ ] Production smoke when VM resumes — verify \`GET /api/v3/admin/client-telemetry/offline-storage?page=0&size=20\` returns 200 with empty content instead of 500

## Risk & rollback

- **Risk**: very low. Native SQL is semantically identical to the JPQL (same join, same filter predicates), and other queries in the file prove PostgreSQL accepts the NULL-in-CONCAT pattern.
- **Rollback**: \`git revert\`. Restores the broken JPQL.

## Out of scope (tracked as follow-up)

- Frontend \`offline-storage-telemetry.component.ts\` should distinguish \"API failure\" from \"empty result\" per issue #77 Scope §3. That's a FE change in \`fe/src/app/features/admin/presentation/components/offline-storage-telemetry.component.*\` — file a separate FE issue/PR once this BE fix merges and we confirm the endpoint is healthy.
- Automated regression test: add when we decide on a Testcontainers pattern for this module (currently the other queries also lack integration tests).

## Checklist

- [x] Conventional commit
- [x] No secrets
- [x] Tests pass locally
- [x] Self-reviewed diff
- [x] Root cause + fix rationale documented in the code comment