### PR TITLE
fix(deps): pin springdoc-openapi to 2.5.0 — unbreak Docker Smoke + prod boot

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -16,7 +16,15 @@
   </parent>
   <properties>
     <java.version>21</java.version>
-    <springdoc.version>3.0.3</springdoc.version>
+    <!-- Pin to 2.5.0 (last version tested with Spring Boot 3.2.6 / Spring 6.1).
+         - springdoc 3.x targets Spring Boot 4 and pulls in spring-boot-servlet/
+           webmvc/jackson/validation 4.0.5 transitives that conflict with
+           actuator-autoconfigure 3.2.6 → startup crash "EndpointCondition must
+           be used on @Bean methods".
+         - springdoc 2.8.x needs Spring Framework 6.2 (for
+           LiteWebJarsResourceResolver) which Spring Boot 3.2 doesn't ship.
+         Bump only after upgrading Spring Boot (PR #131 hold). -->
+    <springdoc.version>2.5.0</springdoc.version>
     <jjwt.version>0.13.0</jjwt.version>
     <lombok.version>1.18.46</lombok.version>
   </properties>


### PR DESCRIPTION
## Summary

Reverts the springdoc-openapi bump from PR #128 (\`2.5.0 → 3.0.3\`). Springdoc 3.x targets Spring Boot 4 and poisons the classpath with \`spring-boot-servlet/webmvc/jackson/validation 4.0.5\` transitives whose META-INF imports reference classes missing from the Spring Boot 3.2.6 actuator we actually load. The full backend cannot bootstrap; CI Docker Smoke fails and production would crash at startup.

Pinning back to 2.5.0 restores a clean boot (verified locally, \`actuator/health\` → \`{\"status\":\"UP\"}\`).

## Change type

- [x] Bug fix (P0 — main CI red)
- [x] Dependency downgrade (tracked constraint)

## Priority

**P0** — this unblocks every downstream PR (including #141 user-status persistence) and restores green Docker Smoke on main. Should merge first.

## What changed

\`backend/pom.xml\`:
- \`<springdoc.version>3.0.3</springdoc.version>\` → \`<springdoc.version>2.5.0</springdoc.version>\`
- Added a 5-line comment explaining the version constraint so Dependabot / future contributors don't re-bump blindly

## Diagnosis

Error observed during \`docker compose up\`:

\`\`\`
org.springframework.beans.factory.BeanDefinitionStoreException: Failed to process import candidates
Caused by: java.lang.IllegalStateException: Error processing condition on
  org.springframework.boot.servlet.autoconfigure.actuate.web.mappings.ServletMappingsAutoConfiguration
Caused by: java.lang.IllegalStateException: EndpointCondition must be used on @Bean methods
  when the endpoint is not specified
\`\`\`

- That class path (\`org.springframework.boot.servlet.autoconfigure.actuate.web.mappings\`) exists in Spring Boot **4.0.5**, not 3.2.6.
- \`mvn dependency:tree\` shows \`spring-boot-servlet:jar:4.0.5\`, \`spring-boot-webmvc:jar:4.0.5\`, \`spring-boot-jackson:jar:4.0.5\`, \`spring-boot-validation:jar:4.0.5\`, \`spring-boot-web-server:jar:4.0.5\`, \`spring-boot-http-converter:jar:4.0.5\` — **pulled transitively via \`springdoc-openapi-starter-webmvc-ui:3.0.3\`**.
- \`OnAvailableEndpointCondition.getTarget()\` in actuator-autoconfigure 3.2.6 can't reconcile the 4.0.5 imports → bean graph refresh cancelled.

## Why unit tests missed this

\`mvn test\` bootstraps test-slice contexts that only touch the MVC/JPA subset needed by the test. The full actuator imports graph is only resolved on real boot. That's why CI \`Backend Tests: SUCCESS\` while \`Docker Smoke Test: FAILURE\`.

## Other Dependabot bumps ruled out

- \`hypersistence-utils-hibernate-63\` 3.7.0 → 3.15.2 → no Spring deps
- \`software.amazon.awssdk:s3\` 2.25.0 → 2.42.40 → own classpath
- \`jjwt\` 0.12 → 0.13 → no Spring
- \`lombok\` 1.18.42 → 1.18.46 → compile-time only
- \`com.resend:resend-java\` 3 → 4 → already merged & green

Confirmed via \`mvn dependency:tree | grep ':4\.'\` returning 0 matches after the pin.

## Why not springdoc 2.8.x?

Also tried 2.8.13 — still fails with:

\`\`\`
ClassNotFoundException: org.springframework.web.servlet.resource.LiteWebJarsResourceResolver
\`\`\`

That class is Spring 6.2+; Spring Boot 3.2.6 ships Spring 6.1. 2.5.0 is the ceiling for Spring Boot 3.2.x.

## Testing

- [x] \`mvn dependency:tree | grep ':4\.'\` → 0 matches (no Spring Boot 4 transitive)
- [x] \`mvn compile -DskipTests\` → SUCCESS
- [x] \`docker compose down -v && build --no-cache backend && up -d db backend\`
  - Backend started in 24s (vs. infinite restart loop before)
  - \`curl http://localhost:8088/actuator/health\` → \`{\"status\":\"UP\"}\`
- [ ] CI Docker Smoke should go from FAILURE → SUCCESS after this merges (verify on main)

## Risk & rollback

- **Risk**: very low. This is the same version that was green for months before PR #128 merged. We keep Swagger UI functionality (2.5.0 supports OpenAPI 3.1, Bearer auth, all our tag annotations).
- **Rollback**: \`git revert\` — but main would break again. Real forward-path is a Spring Boot 3.5+ / Spring Boot 4 upgrade PR, then re-bump springdoc.

## Follow-up after merge

1. Close the Dependabot-opened PR that would re-bump springdoc to 3.x until we're on Spring Boot 4 (or add springdoc to Dependabot \`ignore\` in \`.github/dependabot.yml\` for major bumps)
2. Re-run Docker Smoke on all other open/recently-merged PRs that inherited this break
3. Coordinated Spring Boot 4 upgrade is tracked as #131 hold per \`docs/runbooks/GITHUB_PROFESSIONAL_SETUP_RUNBOOK.md\`

## Checklist

- [x] Conventional commit
- [x] No secrets
- [x] Local boot verified
- [x] Self-reviewed diff
- [x] Comment in pom.xml documents the version constraint