### PR TITLE
fix(org-admin): pathMatch full + review/organization sidebar entries (fixes #74, #72)

### DIFF
--- a/fe/src/app/features/admin/admin.routes.ts
+++ b/fe/src/app/features/admin/admin.routes.ts
@@ -74,7 +74,11 @@ export const adminRoutes: Routes = [
         path: 'courses',
         children: [
           {
+            // pathMatch 'full' required — see org-admin.routes.ts for context.
+            // Prevents the empty-path child from swallowing '/courses/review'
+            // and '/courses/:id/preview'. Issue #74.
             path: '',
+            pathMatch: 'full',
             loadComponent: () => import('./presentation/components/course-management.component').then(m => m.CourseManagementComponent),
             title: 'Quản lý khóa học'
           },

--- a/fe/src/app/features/org-admin/org-admin.routes.ts
+++ b/fe/src/app/features/org-admin/org-admin.routes.ts
@@ -41,7 +41,12 @@ export const orgAdminRoutes: Routes = [
         path: 'courses',
         children: [
           {
+            // pathMatch 'full' required — without it, this empty-path child
+            // captures any URL under /courses/* via prefix match, silently
+            // shadowing the sibling 'review' and ':courseId/preview' routes.
+            // Issue #74.
             path: '',
+            pathMatch: 'full',
             loadComponent: () => import('../admin/presentation/components/course-management.component').then(m => m.CourseManagementComponent),
             title: 'Khóa học của tổ chức'
           },

--- a/fe/src/app/shared/components/navigation/sidebar.config.ts
+++ b/fe/src/app/shared/components/navigation/sidebar.config.ts
@@ -273,13 +273,25 @@ const orgAdminMenuItems: SidebarMenuItem[] = [
     label: 'Khóa học',
     route: '/org-admin/courses',
     icon: 'courses',
-    group: 'Quản lý',
-    alsoActiveFor: ['/org-admin/courses/review']
+    exact: true,
+    group: 'Quản lý'
+  },
+  {
+    label: 'Duyệt khóa học',
+    route: '/org-admin/courses/review',
+    icon: 'file-check',
+    group: 'Quản lý'
   },
   {
     label: 'Phân tích',
     route: '/org-admin/analytics',
     icon: 'bar-chart',
+    group: 'Báo cáo'
+  },
+  {
+    label: 'Tổ chức',
+    route: '/org-admin/organization',
+    icon: 'shield',
     group: 'Báo cáo'
   }
 ];


### PR DESCRIPTION
## Summary

Unblocks the ORG_ADMIN portal foundation (issues #74 and #72 together) by fixing a router config bug and adding the missing sidebar entries so \`/org-admin/courses/review\` and \`/org-admin/organization\` are reachable both directly and via menu.

## Change type

- [x] Bug fix
- [x] Enhancement (sidebar navigation)

## Closes

- Closes #74 (foundation: portal shell + review deep-link)
- Closes #72 (organization route orphaned)

## What changed

3 files, +23/-2:

- **\`fe/src/app/features/org-admin/org-admin.routes.ts\`**
  - Added \`pathMatch: 'full'\` to the empty-path child under \`path: 'courses'\`
  - Comment explains the router behavior so future reviewers don't revert
- **\`fe/src/app/features/admin/admin.routes.ts\`**
  - Same fix for \`/admin/courses\` — the bug pattern was in both portals
- **\`fe/src/app/shared/components/navigation/sidebar.config.ts\`** — \`orgAdminMenuItems\`:
  - \"Khóa học\" now \`exact: true\` (drops legacy \`alsoActiveFor\`)
  - + \"Duyệt khóa học\" → \`/org-admin/courses/review\` (icon \`file-check\`)
  - + \"Tổ chức\" → \`/org-admin/organization\` (icon \`shield\`)

## Why

**Router bug (#74)**: Angular router child route \`{ path: '' }\` defaults to \`pathMatch: 'prefix'\`, which matches any URL starting with empty — including \`/review\` and \`/:id/preview\`. So \`/org-admin/courses/review\` was silently captured by the course-list child, never reaching the review queue component. \`pathMatch: 'full'\` restricts matching to exactly empty segments, letting siblings handle their own paths.

**Orphan route (#72)**: \`/org-admin/organization\` existed in the route config but the sidebar had no entry, so org admins couldn't navigate there. Also the \"Khóa học\" entry was marking itself active for \`/courses/review\` via \`alsoActiveFor\`, hiding the need for a dedicated entry.

Both fixes are minimal and together satisfy the acceptance criteria of #74:

- ✅ \`/org-admin/courses/review\` renders the review queue
- ✅ Sidebar has entries for dashboard, teachers, students, courses, review, analytics, organization
- ✅ Shell still role-aware via existing \`authService.userRole()\` branching (no shell split needed)
- ✅ \`/admin/*\` unchanged for system admin

## Testing

- [x] \`npm run build\` (production) → SUCCESS
- [x] Local router verify:
  - \`/org-admin/courses\` → CourseManagementComponent
  - \`/org-admin/courses/review\` → CourseReviewComponent  ✓ (was broken, now works)
  - \`/org-admin/organization\` → OrganizationDetailComponent  ✓
- [x] Sidebar renders 7 entries for ORG_ADMIN in correct groups (Tổng quan / Quản lý / Báo cáo)
- [ ] E2E regression when VM resumes

## Risk & rollback

- **Risk**: very low.
  - Router change is purely additive (makes previously-shadowed routes reachable)
  - No TypeScript API change
  - Icons chosen from existing set, no new SVG
- **Rollback**: \`git revert\` restores pre-PR routes.

## Out of scope (separate issues)

- \`#76\` — split teacher/student/course copy between admin and org-admin surfaces
- \`#75\` — redesign dashboard/analytics around org-truthful signals
- Dedicated \`OrgAdminLayoutComponent\` — current shell is already role-aware via \`authService.userRole()\`; further separation is cosmetic

## Checklist

- [x] Conventional commit
- [x] No secrets
- [x] Build verified locally
- [x] Self-reviewed diff
- [x] Icons from existing icon set (no new assets)