### PR TITLE
fix(org-admin): bind role-aware pageTitle/pageSubtitle in teacher + student (fixes #76)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/student-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.html
@@ -4,8 +4,8 @@
     <div class="header-section">
       <div class="header-row">
         <div>
-          <h1 class="page-title">Quản lý Học viên</h1>
-          <p class="page-subtitle">Quản lý các tài khoản học viên trong hệ thống</p>
+          <h1 class="page-title">{{ pageTitle() }}</h1>
+          <p class="page-subtitle">{{ pageSubtitle() }}</p>
         </div>
         <button (click)="openCreateModal()" class="btn-primary">
           <svg fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd"/></svg>

--- a/fe/src/app/features/admin/presentation/components/student-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.ts
@@ -35,6 +35,12 @@ export class StudentManagementComponent implements OnInit {
 
   isSystemAdmin = computed(() => this.authService.userRole() === 'admin');
   courseSearchRoute = computed(() => `${getAdminPortalBase(this.authService.userRole())}/courses`);
+  pageTitle = computed(() => this.isSystemAdmin() ? 'Quản lý Học viên' : 'Học viên của tổ chức');
+  pageSubtitle = computed(() =>
+    this.isSystemAdmin()
+      ? 'Quản lý các tài khoản học viên trong hệ thống'
+      : 'Quản lý các tài khoản học viên thuộc tổ chức của bạn'
+  );
 
   // State
   allUsers = signal<AdminUser[]>([]);

--- a/fe/src/app/features/admin/presentation/components/teacher-management.html
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.html
@@ -4,8 +4,8 @@
         <!-- Header -->
         <div class="page-header">
           <div>
-            <h1 class="page-title">Quản lý Giảng viên</h1>
-            <p class="page-subtitle">Quản lý các tài khoản giảng viên trong hệ thống</p>
+            <h1 class="page-title">{{ pageTitle() }}</h1>
+            <p class="page-subtitle">{{ pageSubtitle() }}</p>
           </div>
           <button (click)="openCreateModal()" class="btn-create">
             <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd"/></svg>


### PR DESCRIPTION
## Summary

Issue #76 flagged that the ORG_ADMIN portal leaked system-admin voice through hard-coded headings on \`/org-admin/users/teachers\` and \`/org-admin/users/students\`. The components already exposed role-aware \`pageTitle()\` / \`pageSubtitle()\` signals for teachers (and \`isSystemAdmin()\` for students) — the templates just weren't binding them. Minimal fix: wire the bindings, add the missing signals on student-management, done.

## Change type

- [x] Enhancement (presentation copy)

## Closes

Closes #76.

## What changed

3 files, +10/−4:

- **\`fe/src/app/features/admin/presentation/components/teacher-management.html\`**
  - Bind \`{{ pageTitle() }}\` / \`{{ pageSubtitle() }}\` (component already had them)
- **\`fe/src/app/features/admin/presentation/components/student-management.component.ts\`**
  - Add \`pageTitle\` and \`pageSubtitle\` computed signals mirroring the teacher pattern
- **\`fe/src/app/features/admin/presentation/components/student-management.component.html\`**
  - Bind the new signals

## Why not split components?

Issue #76 suggests creating separate top-level components per portal. I chose the smaller-blast-radius path: the existing components are already role-aware via \`authService.userRole()\` for business logic (e.g. the toast warnings about who can disable accounts, the analytics branches in course-management). Duplicating 3 components worth of templates just to fork 2 strings is premature — we'd double the regression surface without gaining clarity. If/when the portals' affordance sets actually diverge (different columns, different bulk actions, different filter chips), that's the right moment to split.

## What was inspected but intentionally left alone

| Location | Reason to keep |
|---|---|
| Toast \`'Chỉ quản trị hệ thống mới có thể vô hiệu hóa...'\` | Factually correct — only system admin can disable these accounts. System voice is accurate here. |
| \`course-review.html\` dialog subtitle \`'Giảng viên sẽ nhận thông báo trong hệ thống và email...'\` | Refers to the notification **delivery** surface (in-app + email), not the admin context. |
| \`course-management.*\` | Already uses the signal pattern. |

## Testing

- [x] \`npm run build\` (production) → SUCCESS
- [x] Route verify local:
  - \`/admin/users/teachers\` → \"Quản lý Giảng viên\" + \"... trong hệ thống\"
  - \`/org-admin/users/teachers\` → \"Giảng viên của tổ chức\" + \"... thuộc tổ chức của bạn\"
  - \`/admin/users/students\` → \"Quản lý Học viên\" + \"... trong hệ thống\"
  - \`/org-admin/users/students\` → \"Học viên của tổ chức\" + \"... thuộc tổ chức của bạn\"
- [ ] E2E regression when VM resumes

## Risk & rollback

- **Risk**: none. Pure template binding change + 2 signals; no behavior change.
- **Rollback**: \`git revert\`

## Checklist

- [x] Conventional commit
- [x] No secrets
- [x] Build verified
- [x] Self-reviewed diff