### PR TITLE
fix(org-admin): remove synthetic chart + hide system-health for ORG_ADMIN (fixes #75)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin-analytics.component.html
+++ b/fe/src/app/features/admin/presentation/components/admin-analytics.component.html
@@ -241,7 +241,8 @@
 
         <!-- Right Column -->
         <div class="right-column">
-          <!-- System Health -->
+          <!-- System Health — platform ops (admin only); hidden for ORG_ADMIN per #75 -->
+          @if (isSystemAdmin()) {
           <div class="card">
             <div class="card-header">
               <h3 class="card-title title-primary">
@@ -306,6 +307,7 @@
               </div>
             </div>
           </div>
+          }
 
           <!-- User Growth -->
           <div class="card">

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.html
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.html
@@ -71,14 +71,12 @@
       </div>
 
       <div class="content-grid">
-        <div class="card chart-card">
-          <div class="card-header">
-            <h2 class="card-title">Xu hướng đăng ký (30 ngày)</h2>
-          </div>
-          <div class="chart-area">
-            <app-revenue-chart [revenueData]="enrollmentTrendData()" chartLabel="Lượt đăng ký" />
-          </div>
-        </div>
+        <!--
+          Xu hướng đăng ký 30 ngày chart removed (issue #75): trước đây dựng
+          từ dailyAvg + Math.sin(...) → dữ liệu synthetic hiển thị như số liệu
+          thật. Sẽ khôi phục khi có backend time-series endpoint cho org-scoped
+          enrollments.
+        -->
 
         <div class="card">
           <div class="card-header">

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.ts
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.ts
@@ -2,7 +2,7 @@ import { Component, input, output, computed, ChangeDetectionStrategy, inject, si
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { SystemAnalytics } from '../../../infrastructure/services/admin.service';
-import { RevenueChartComponent, RevenueData } from './components/revenue-chart.component';
+// RevenueChartComponent + RevenueData removed with the synthetic trend chart (#75).
 import { PendingApproval } from './dashboard.types';
 import { AuthService } from '../../../../../core/services/auth.service';
 import { getAdminPortalBase } from '../../../../../core/utils/portal-route.util';
@@ -10,7 +10,7 @@ import { DialogComponent } from '../../../../../shared/components/dialog/dialog.
 
 @Component({
   selector: 'app-admin-org-dashboard',
-  imports: [CommonModule, RouterModule, RevenueChartComponent, DialogComponent],
+  imports: [CommonModule, RouterModule, DialogComponent],
   templateUrl: './admin-org-dashboard.component.html',
   styleUrl: './admin-org-dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -34,20 +34,8 @@ export class AdminOrgDashboardComponent {
   activeCourseCount = computed(() => this.analytics().approvedCourses);
   portalBase = computed(() => getAdminPortalBase(this.authService.userRole()));
 
-  enrollmentTrendData = computed<RevenueData>(() => {
-    const dailyAvg = (this.analytics().totalEnrollments || 0) / 30;
-    const labels: string[] = [];
-    const data: number[] = [];
-    const today = new Date();
-
-    for (let i = 29; i >= 0; i--) {
-      const d = new Date(today);
-      d.setDate(d.getDate() - i);
-      labels.push(`${String(d.getDate()).padStart(2, '0')}/${String(d.getMonth() + 1).padStart(2, '0')}`);
-      data.push(Math.max(0, Math.floor(dailyAvg + Math.sin(i * 0.7) * dailyAvg * 0.3)));
-    }
-    return { labels, data };
-  });
+  // enrollmentTrendData removed (issue #75): was synthetic (dailyAvg + sin wave).
+  // Restore when backend exposes a true org-scoped time-series endpoint.
 
   // --- Reject modal state ---
   rejectModalOpen = signal(false);


### PR DESCRIPTION
## Summary

Issue #75 flagged two truthfulness gaps in the ORG_ADMIN portal:

1. **Dashboard** showed a \"Xu hướng đăng ký (30 ngày)\" chart built from \`dailyAvg + Math.sin(...)\` — synthetic wave presented as real data.
2. **Analytics** exposed a \"Trạng thái hệ thống\" card (Database / API / Storage / Email health) that belongs only to the system admin surface.

This PR removes the fake chart and gates the system-health card behind \`isSystemAdmin()\`.

## Change type

- [x] Enhancement (presentation honesty)
- [x] Bug fix (misleading data)

Closes #75.

## What changed

3 files, +13/-25:

- **\`dashboard/admin-org-dashboard.component.html\`** — drop the chart \`<div class=\"card chart-card\">\` block; leave a comment pointing to #75
- **\`dashboard/admin-org-dashboard.component.ts\`** — drop \`enrollmentTrendData\` computed, drop \`RevenueChartComponent\` + \`RevenueData\` imports, drop component from \`imports\` array
- **\`admin-analytics.component.html\`** — wrap the System Health card in \`@if (isSystemAdmin())\`

## Why

- A dashboard that invents numbers destroys trust the first time a savvy operator cross-checks. Better to show fewer cards than fake cards.
- System-health is platform ops, not org ops. The backend already has \`buildOrgScopedAnalytics\` for real org-scoped metrics; UI just needed to respect the role boundary.

## Testing

- [x] \`npm run build\` (production) → SUCCESS
- [x] Route verify local:
  - \`/org-admin/dashboard\` → chart card gone, pending approvals card occupies the grid
  - \`/org-admin/analytics\` → System Health card not rendered; page flows User Growth → Active Users
  - \`/admin/analytics\` → System Health card **still rendered** (admin preserved)
- [x] No TypeScript or template lint errors
- [ ] E2E when VM resumes

## Risk & rollback

- **Risk**: very low. Pure subtractive change — no API, no service, no data. If a user misses the chart we can restore behind a feature flag while we build the real endpoint.
- **Rollback**: \`git revert\`. Note: reverting restores the synthetic data display, which reintroduces the honesty issue.

## Follow-up (separate issue or future PR)

- Build a real backend time-series endpoint for org-scoped enrollments (e.g. \`GET /api/v3/admin/analytics/enrollment-trend?days=30\` with ORG_ADMIN org-scope filter), then reintroduce the chart bound to it.
- Consider a generic \"platform ops\" guard directive so future cards can opt into admin-only rendering with \`*appIfAdmin\` instead of inline \`@if\`.

## Checklist

- [x] Conventional commit
- [x] No secrets
- [x] Build verified
- [x] Self-reviewed diff
- [x] Comments in code explain WHY code was removed