### PR TITLE
fix(fe): dev-mode SSR perf + probe reliability (fixes #147)

### DIFF
--- a/fe/angular.json
+++ b/fe/angular.json
@@ -43,8 +43,7 @@
             "server": "src/main.server.ts",
             "ssr": {
               "entry": "src/server.ts"
-            },
-            "outputMode": "server"
+            }
           },
           "configurations": {
             "production": {
@@ -80,14 +79,14 @@
                 }
               ],
               "outputHashing": "all",
-              "serviceWorker": "ngsw-config.json"
+              "serviceWorker": "ngsw-config.json",
+              "outputMode": "server"
             },
             "development": {
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true,
-              "ssr": false,
-              "outputMode": "static"
+              "ssr": false
             }
           },
           "defaultConfiguration": "production"

--- a/fe/proxy.conf.json
+++ b/fe/proxy.conf.json
@@ -3,13 +3,19 @@
     "target": "http://localhost:8088",
     "secure": false,
     "changeOrigin": true,
-    "logLevel": "debug"
+    "logLevel": "info"
+  },
+  "/actuator": {
+    "target": "http://localhost:8088",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "info"
   },
   "/ws": {
     "target": "http://localhost:8088",
     "secure": false,
     "changeOrigin": true,
     "ws": true,
-    "logLevel": "debug"
+    "logLevel": "info"
   }
 }

--- a/fe/src/app/core/services/network-status.service.ts
+++ b/fe/src/app/core/services/network-status.service.ts
@@ -3,6 +3,11 @@ import { Injectable, signal, computed, OnDestroy } from '@angular/core';
 export type ConnectionTier = 'none' | 'slow' | 'fast';
 export type ConnectionTransport = 'wifi' | 'ethernet' | 'cellular' | 'unknown';
 
+const OFFLINE_GRACE_MS = 1_500;
+const RECENT_OFFLINE_WINDOW_MS = 5_000;
+const PROBE_INTERVAL_MS = 120_000;
+const PROBE_TIMEOUT_MS = 4_000;
+
 @Injectable({ providedIn: 'root' })
 export class NetworkStatusService implements OnDestroy {
   readonly online = signal(this.getBrowserOnlineHint());
@@ -41,16 +46,32 @@ export class NetworkStatusService implements OnDestroy {
     this.getBrowserOnlineHint() ? null : Date.now(),
   );
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private offlineGraceTimer: ReturnType<typeof setTimeout> | null = null;
   private probeInterval: ReturnType<typeof setInterval> | null = null;
+
   private readonly onlineHandler = () => {
+    if (this.offlineGraceTimer) {
+      clearTimeout(this.offlineGraceTimer);
+      this.offlineGraceTimer = null;
+    }
     this.recentOfflineSignalAt.set(null);
     this.updateStatus();
     this.probeLatency();
   };
+
+  // Browser 'offline' events are often spurious (Wi-Fi transitions, OS sleep,
+  // VPN toggles). Wait a grace period and verify with a probe before flipping
+  // the UI to the offline state.
   private readonly offlineHandler = () => {
-    this.markOfflineState();
-    this.updateStatus();
+    if (this.offlineGraceTimer) clearTimeout(this.offlineGraceTimer);
+    this.offlineGraceTimer = setTimeout(() => {
+      this.offlineGraceTimer = null;
+      if (!this.getBrowserOnlineHint()) {
+        this.probeLatency();
+      }
+    }, OFFLINE_GRACE_MS);
   };
+
   private readonly connectionChangeHandler = () => this.debouncedUpdate();
   private connectionRef: { removeEventListener?: (type: string, listener: EventListenerOrEventListenerObject) => void } | null = null;
 
@@ -76,7 +97,7 @@ export class NetworkStatusService implements OnDestroy {
       if (this.getBrowserOnlineHint()) {
         this.probeLatency();
       }
-    }, 120_000);
+    }, PROBE_INTERVAL_MS);
   }
 
   ngOnDestroy(): void {
@@ -92,14 +113,17 @@ export class NetworkStatusService implements OnDestroy {
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
     }
+    if (this.offlineGraceTimer) {
+      clearTimeout(this.offlineGraceTimer);
+    }
   }
 
-  hasRecentOfflineSignal(windowMs = 15_000): boolean {
+  hasRecentOfflineSignal(windowMs = RECENT_OFFLINE_WINDOW_MS): boolean {
     const lastOfflineSignalAt = this.recentOfflineSignalAt();
     return lastOfflineSignalAt != null && Date.now() - lastOfflineSignalAt <= windowMs;
   }
 
-  isEffectivelyOffline(windowMs = 15_000): boolean {
+  isEffectivelyOffline(windowMs = RECENT_OFFLINE_WINDOW_MS): boolean {
     return !this.getBrowserOnlineHint()
       || !this.online()
       || this.hasRecentOfflineSignal(windowMs);
@@ -135,50 +159,34 @@ export class NetworkStatusService implements OnDestroy {
     }
   }
 
+  // Single-probe health check against /actuator/health. Previously used a
+  // two-step icon-HEAD + actuator-GET sequence which had a race condition where
+  // the icon succeeded but actuator timed out, showing false-offline state.
+  // In dev, /actuator is proxied to the Spring Boot backend at :8088.
   private probeLatency(): void {
-    if (!this.getBrowserOnlineHint()) return;
+    if (!this.getBrowserOnlineHint()) {
+      this.markOfflineState();
+      return;
+    }
 
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    const timeoutId = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
     const start = performance.now();
 
-    fetch('/icons/icon-192x192.png', {
-      method: 'HEAD',
+    fetch('/actuator/health', {
+      method: 'GET',
       signal: controller.signal,
       cache: 'no-store',
+      redirect: 'error',
     })
-      .then(async (iconResponse) => {
-        this.ensureSuccessfulProbeResponse(iconResponse);
+      .then((response) => {
         clearTimeout(timeoutId);
-
+        this.ensureSuccessfulProbeResponse(response);
         const rtt = performance.now() - start;
-        const apiController = new AbortController();
-        const apiTimeoutId = setTimeout(() => apiController.abort(), 3000);
-
-        try {
-          const apiResponse = await fetch('/actuator/health', {
-            method: 'GET',
-            signal: apiController.signal,
-            cache: 'no-store',
-          });
-          this.ensureSuccessfulProbeResponse(apiResponse);
-          this.markMeasuredOnlineState(rtt);
-        } catch {
-          this.markOfflineState();
-        } finally {
-          clearTimeout(apiTimeoutId);
-        }
+        this.markMeasuredOnlineState(rtt);
       })
-      .catch((error) => {
+      .catch(() => {
         clearTimeout(timeoutId);
-
-        if (error?.name === 'AbortError') {
-          this.online.set(true);
-          this.recentOfflineSignalAt.set(null);
-          this.effectiveBandwidthMbps.set(0.3);
-          return;
-        }
-
         this.markOfflineState();
       });
   }


### PR DESCRIPTION
Closes #147.

## Summary

Three linked bugs found during a PWA + online-offline audit:

1. **Dev-mode SSR leak** → every HTML request took ~7.3s TTFB.
2. **Health probe false-positive in dev** → `/actuator/health` resolved against dev server and returned HTML.
3. **Offline banner flicker** → spurious browser `offline` events flipped UI state instantly; 15s "recent offline" window kept app in offline state long after recovery.

## Changes

| File | Change |
|---|---|
| `fe/angular.json` | Move `outputMode: "server"` from root `options` → `production` config only. Dev now truly runs CSR. |
| `fe/proxy.conf.json` | Add `/actuator` proxy to `:8088`. Downgrade `logLevel` debug→info. |
| `fe/src/app/core/services/network-status.service.ts` | Single-probe `/actuator/health` with `redirect: 'error'`; 1.5s grace on browser offline event; recent-offline window 15s→5s. |

## Measurements

| Endpoint | Before | After |
|---|---:|---:|
| `/` TTFB | ~7.3s | ~6–10ms |
| `/actuator/health` via :4200 | 302 → HTML | 200 JSON |
| `/api/v3/courses?page=0&size=3` | ~60ms | ~40ms |

## Verification

- `npx ng test --include=src/app/core/services/network-status.service.spec.ts --watch=false` → **14/14 PASS**
- `npx ng build --configuration=production` → `dist/lms-angular/server/` (SSR) + `dist/lms-angular/browser/ngsw.json` both emitted; no regressions.
- Manual curl benchmarks (see measurements table).

## Why it matters

- **Dev productivity**: every page navigation / hard reload was 7.3s slower than necessary. Compounded across a day of work, this is significant.
- **Offline-logic reliability**: in dev the probe never caught real backend failures because it always "succeeded" against the dev server's HTML fallback. Developers could not exercise offline-fallback paths.
- **User-perceived stability**: the red "Ngoại tuyến" banner no longer flickers on benign Wi-Fi transitions.

## Test plan

- [ ] BE + FE up → navigate through login → admin dashboard → student/teacher views; no perf regressions, no offline banner flicker during normal use.
- [ ] Open DevTools → Network → throttle to Offline; banner should appear within ~1.5–2s after the first failed request (not instantly — intentional, to absorb spurious events). Restore network → banner clears immediately.
- [ ] Stop backend container → FE still renders (shell loads from proxy), but API calls fail; `/actuator/health` probe returns error and marks offline.
- [ ] Re-start backend → next probe (≤120s interval) or next `online` event clears banner.
- [ ] Prod build + deploy dry-run (optional): verify SSR + PWA still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)