### PR TITLE
fix(admin): unify sidebar width 256→288px (closes #150)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
@@ -27,14 +27,14 @@ import { AiAvailabilityService } from '../../../ai-chat/application/services/ai-
         <div class="fixed inset-0 z-50 lg:hidden"
           (click)="toggleMobileSidebar()">
           <div class="fixed inset-0 bg-black bg-opacity-50"></div>
-          <div class="fixed inset-y-0 left-0 w-64 bg-white shadow-lg">
+          <div class="fixed inset-y-0 left-0 w-72 bg-white shadow-lg">
             <app-sidebar [config]="adminSidebarConfig" [collapsed]="false"></app-sidebar>
           </div>
         </div>
       }
 
       <!-- Main content + AI Sidebar wrapper -->
-      <div [class]="shouldHideSidebar() ? 'flex flex-1 min-w-0 min-h-screen' : 'lg:pl-64 flex flex-1 min-w-0 min-h-screen'">
+      <div [class]="shouldHideSidebar() ? 'flex flex-1 min-w-0 min-h-screen' : 'lg:pl-72 flex flex-1 min-w-0 min-h-screen'">
 
         <!-- Main content column -->
         <div class="flex flex-col flex-1 min-w-0">
@@ -146,7 +146,7 @@ import { AiAvailabilityService } from '../../../ai-chat/application/services/ai-
       width: 100%;
     }
 
-    .lg\\:pl-64 {
+    .lg\\:pl-72 {
       transition: padding-left 0.3s ease;
     }
 


### PR DESCRIPTION
Closes #150.

## Summary

Admin layout was rendering its sidebar at 256px (`w-64` / `lg:pl-64`) while teacher and student layouts use 288px (`md:w-72` / `md:pl-72`). This swaps the Tailwind classes in the admin layout wrapper so all three portals match. Shared \`SidebarComponent\` is unchanged — the width is decided by the wrapper.

## Changes

| File | Change |
|---|---|
| \`fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts\` | Mobile drawer panel \`w-64\` → \`w-72\` (line 30); main content wrapper \`lg:pl-64\` → \`lg:pl-72\` (line 37); CSS transition selector \`.lg\\:pl-64\` → \`.lg\\:pl-72\` (line 149) |

Diff is 3 lines (3 +, 3 −). No business logic touched.

## Why

Spec from session prompt: \"Unify sidebar widths giữa admin / teacher / student → 288px (w-72)\". Visual rhythm was inconsistent when the user switched between portals or viewed two windows side-by-side.

## Out of scope

- Breakpoint difference: admin uses \`lg:\` (1024px+), teacher/student use \`md:\` (768px+). Tablet UX is genuinely different and worth a separate discussion before changing — not a width fix.
- Adding a collapse toggle to admin sidebar (teacher/student have one) — structural refactor; out of scope here.

## Verification

- \`npx tsc --noEmit -p fe/tsconfig.json\` → passes (TypeScript compilation completed)
- Diff < 10 lines, single file
- Shared \`SidebarComponent\` and its CSS untouched (only wrapper width changes)

## Test plan

- [ ] Login \`admin@maritime.edu\` / \`admin123\`, open \`/admin/dashboard\`
- [ ] DevTools: confirm desktop sidebar = 288px (\`<div class=\"hidden lg:flex...\">\`)
- [ ] Resize to <1024px, open mobile drawer (☰), confirm panel = 288px
- [ ] Open teacher portal in another tab, confirm widths visually identical
- [ ] Toggle AI sidebar (Wiii icon, right side), confirm it animates in over the main column without stomping on the wider sidebar
- [ ] Verify nothing in main content overflows or wraps strangely at the wider padding

## Risk & rollback

Cosmetic-only. Rollback = revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)