### PR TITLE
fix(admin): system dashboard real-data + accessible reject (closes #151)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin.component.ts
@@ -1,5 +1,5 @@
 import { Component, signal, inject, OnInit, computed, ChangeDetectionStrategy } from '@angular/core';
-import { AdminService, SystemAnalytics } from '../../infrastructure/services/admin.service';
+import { AdminService, SystemAnalytics, PendingCourseSummary } from '../../infrastructure/services/admin.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { PendingApproval } from './dashboard/dashboard.types';
@@ -119,20 +119,20 @@ export class AdminComponent implements OnInit {
   private loadPendingApprovals(): void {
     this.isLoadingPending.set(true);
     this.adminService.getPendingCourses().subscribe({
-      next: (response) => {
-        this.pendingApprovals.set(
-          response.data.map(course => ({
-            id: course.id,
-            name: course.title,
-            type: 'course' as const,
-            submittedDate: course.submittedAt || course.createdAt
-          }))
-        );
+      next: (response: { data: PendingCourseSummary[] }) => {
+        const items: PendingApproval[] = response.data.map((course) => ({
+          id: course.id,
+          name: course.title,
+          type: 'course',
+          submittedDate: course.submittedAt || course.createdAt
+        }));
+        this.pendingApprovals.set(items);
         this.isLoadingPending.set(false);
       },
       error: () => {
         this.pendingApprovals.set([]);
         this.isLoadingPending.set(false);
+        this.toast.error('Không thể tải danh sách chờ duyệt. Vui lòng thử lại.');
       }
     });
   }

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.html
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.html
@@ -16,35 +16,14 @@
           </div>
         }
       </div>
-      <!-- Chart + feed skeleton -->
-      <div class="content-grid grid-2-1">
-        <div class="skeleton-card animate-pulse" style="min-height:440px">
-          <div class="sk" style="height:16px;width:240px;margin-bottom:16px"></div>
-          <div class="sk-light" style="height:360px;width:100%"></div>
-        </div>
-        <div class="skeleton-card animate-pulse" style="min-height:440px">
-          <div class="sk" style="height:16px;width:160px;margin-bottom:16px"></div>
-          @for (_ of [1,2,3,4,5]; track $index) {
-            <div style="display:flex;gap:12px;padding:12px 0;border-bottom:1px solid #f3f4f6">
-              <div class="sk" style="height:8px;width:8px;border-radius:50%;margin-top:4px;flex-shrink:0"></div>
-              <div style="flex:1">
-                <div class="sk-light" style="height:14px;width:90%;margin-bottom:4px"></div>
-                <div class="sk-light" style="height:10px;width:60%"></div>
-              </div>
-            </div>
-          }
-        </div>
-      </div>
-      <!-- Table + health skeleton -->
+      <!-- Summary + table skeleton -->
       <div class="content-grid grid-2-1">
         <div class="skeleton-card animate-pulse" style="min-height:280px">
-          <div class="sk" style="height:16px;width:180px;margin-bottom:16px"></div>
-          @for (_ of [1,2,3]; track $index) {
-            <div style="display:flex;gap:16px;padding:12px 0;border-bottom:1px solid #f3f4f6">
-              <div class="sk-light" style="height:14px;flex:2"></div>
-              <div class="sk-light" style="height:14px;flex:1"></div>
-              <div class="sk-light" style="height:14px;flex:1"></div>
-              <div class="sk-light" style="height:14px;flex:1"></div>
+          <div class="sk" style="height:16px;width:160px;margin-bottom:16px"></div>
+          @for (_ of [1,2,3,4]; track $index) {
+            <div style="display:flex;gap:12px;padding:12px 0;border-bottom:1px solid #f3f4f6">
+              <div class="sk" style="height:8px;width:8px;border-radius:50%;margin-top:4px;flex-shrink:0"></div>
+              <div class="sk-light" style="height:14px;width:90%"></div>
             </div>
           }
         </div>
@@ -96,87 +75,29 @@
         </div>
       </div>
 
-      <!-- ② Revenue Chart + Activity Feed -->
-      <div class="content-grid grid-2-1">
-        <div class="card chart-card">
-          <div class="card-header">
-            <h2 class="card-title">Tổng quan doanh thu (30 ngày)</h2>
-          </div>
-          <div class="chart-area">
-            <app-revenue-chart [revenueData]="revenueChartData()" />
-          </div>
-        </div>
+      <!--
+        Biểu đồ doanh thu 30 ngày trước đây dựng từ dailyAvg + Math.sin(...)
+        → dữ liệu synthetic hiển thị như số liệu thật. Sẽ khôi phục khi
+        backend expose endpoint daily revenue (cùng pattern với org-admin
+        dashboard sau PR #145 / issue #75).
+      -->
 
-        <div class="card activity-card">
-          <div class="card-header">
-            <h2 class="card-title">Hoạt động gần đây</h2>
-          </div>
-          <div class="activity-list">
-            @for (activity of recentActivities(); track activity.id) {
-              <div class="activity-item">
-                <div class="activity-dot"></div>
-                <div class="activity-content">
-                  <p class="activity-message">{{ activity.message }}</p>
-                  <p class="activity-time">{{ activity.timestamp | date:'short' }}</p>
-                </div>
-              </div>
-            }
-          </div>
-        </div>
-      </div>
-
-      <!-- ③ Pending Approvals + System Health -->
+      <!-- ② Quick summary + System Health -->
       <div class="content-grid grid-2-1">
-        <!-- Pending Approvals Table -->
-        <div class="card">
+        <div class="card summary-card">
           <div class="card-header">
-            <h2 class="card-title">Danh sách chờ duyệt</h2>
+            <h2 class="card-title">Tổng quan nhanh</h2>
           </div>
-          <div class="card-body">
-            @if (isLoadingPending()) {
-              <div class="table-loading">
-                <div class="spinner"></div>
-                <span>Đang tải...</span>
-              </div>
-            } @else if (pendingApprovals().length === 0) {
-              <div class="table-empty">
-                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                <p>Không có khóa học nào đang chờ duyệt</p>
-              </div>
+          <div class="summary-list">
+            @if (quickSummary().length === 0) {
+              <p class="summary-empty">Chưa có dữ liệu để tổng hợp.</p>
             } @else {
-              <table class="data-table">
-                <thead>
-                  <tr>
-                    <th>Tên</th>
-                    <th>Loại</th>
-                    <th>Ngày gửi</th>
-                    <th>Hành động</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  @for (approval of pendingApprovals(); track approval.id) {
-                    <tr>
-                      <td>{{ approval.name }}</td>
-                      <td>
-                        @if (approval.type === 'course') {
-                          <span class="badge badge-primary">Khóa học</span>
-                        } @else {
-                          <span class="badge badge-purple">Giảng viên</span>
-                        }
-                      </td>
-                      <td class="date-text">{{ formatDate(approval.submittedDate) }}</td>
-                      <td>
-                        <div class="action-btns">
-                          <button class="btn-approve" (click)="approveCourse(approval.id)">Duyệt</button>
-                          <button class="btn-reject" (click)="rejectCourse(approval.id)">Từ chối</button>
-                        </div>
-                      </td>
-                    </tr>
-                  }
-                </tbody>
-              </table>
+              @for (item of quickSummary(); track item.id) {
+                <div class="summary-item">
+                  <div class="summary-dot"></div>
+                  <p class="summary-message">{{ item.message }}</p>
+                </div>
+              }
             }
           </div>
         </div>
@@ -230,6 +151,102 @@
           </div>
         </div>
       </div>
+
+      <!-- ③ Pending Approvals (full-width) -->
+      <div class="card">
+        <div class="card-header">
+          <h2 class="card-title">Danh sách chờ duyệt</h2>
+        </div>
+        <div class="card-body">
+          @if (isLoadingPending()) {
+            <div class="table-loading">
+              <div class="spinner"></div>
+              <span>Đang tải...</span>
+            </div>
+          } @else if (pendingApprovals().length === 0) {
+            <div class="table-empty">
+              <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <p>Không có khóa học nào đang chờ duyệt</p>
+            </div>
+          } @else {
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>Tên</th>
+                  <th>Loại</th>
+                  <th>Ngày gửi</th>
+                  <th>Hành động</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (approval of pendingApprovals(); track approval.id) {
+                  <tr>
+                    <td>{{ approval.name }}</td>
+                    <td>
+                      @if (approval.type === 'course') {
+                        <span class="badge badge-primary">Khóa học</span>
+                      } @else {
+                        <span class="badge badge-purple">Giảng viên</span>
+                      }
+                    </td>
+                    <td class="date-text">{{ formatDate(approval.submittedDate) }}</td>
+                    <td>
+                      <div class="action-btns">
+                        <button class="btn-approve" (click)="approveCourse(approval.id)">Duyệt</button>
+                        <button class="btn-reject" (click)="openRejectModal(approval.id, approval.name)">Từ chối</button>
+                      </div>
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          }
+        </div>
+      </div>
     </div>
   </div>
 }
+
+<!-- Reject course modal -->
+<app-dialog
+  [open]="rejectModalOpen()"
+  title="Từ chối khóa học"
+  [subtitle]="pendingRejectName()"
+  size="md"
+  variant="danger"
+  role="alertdialog"
+  [busy]="rejecting()"
+  (close)="closeRejectModal()">
+
+  <div class="reject-form">
+    <label class="reject-label" for="reject-reason-system">
+      Lý do từ chối <span class="required">*</span>
+    </label>
+    <textarea
+      id="reject-reason-system"
+      class="reject-textarea"
+      rows="4"
+      placeholder="Mô tả chi tiết lý do từ chối khóa học này (tối thiểu 10 ký tự)..."
+      [value]="rejectReason()"
+      (input)="rejectReason.set($any($event.target).value)"
+    ></textarea>
+    @if (rejectReason().trim().length > 0 && !rejectReasonValid()) {
+      <p class="reject-hint error">Lý do cần ít nhất 10 ký tự.</p>
+    } @else {
+      <p class="reject-hint">{{ rejectReason().trim().length }}/10 ký tự tối thiểu</p>
+    }
+  </div>
+
+  <div dialogFooter>
+    <button type="button" class="btn-cancel" [disabled]="rejecting()" (click)="closeRejectModal()">Hủy</button>
+    <button
+      type="button"
+      class="btn-confirm-reject"
+      [disabled]="!rejectReasonValid() || rejecting()"
+      (click)="confirmReject()">
+      Từ chối khóa học
+    </button>
+  </div>
+</app-dialog>

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.scss
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.scss
@@ -124,18 +124,15 @@
   }
 }
 
-/* ===== CHART CARD ===== */
-.chart-card { overflow: hidden; }
+/* ===== SUMMARY CARD =====
+   Replaces the old "Activity feed" card whose timestamps were synthetic
+   (`new Date()`) and the revenue chart whose 30-day series came from
+   `dailyAvg + Math.sin(...)`. Both are restored when the backend exposes
+   real time-series endpoints.
+*/
+.summary-card { overflow: hidden; }
 
-.chart-area {
-  padding: $spacing-5;
-  min-height: 400px;
-}
-
-/* ===== ACTIVITY CARD ===== */
-.activity-card { overflow: hidden; }
-
-.activity-list {
+.summary-list {
   padding: $spacing-4 $spacing-5;
   max-height: 400px;
   overflow-y: auto;
@@ -147,7 +144,7 @@
   scrollbar-color: $gray-300 transparent;
 }
 
-.activity-item {
+.summary-item {
   display: flex;
   gap: $spacing-3;
   padding: $spacing-3 0;
@@ -156,7 +153,7 @@
   &:last-child { border-bottom: none; }
 }
 
-.activity-dot {
+.summary-dot {
   width: 8px;
   height: 8px;
   background: $blue-primary;
@@ -165,18 +162,18 @@
   flex-shrink: 0;
 }
 
-.activity-content { flex: 1; min-width: 0; }
-
-.activity-message {
+.summary-message {
+  flex: 1;
   font-size: $text-sm;
   color: $gray-700;
-  margin: 0 0 2px;
+  margin: 0;
 }
 
-.activity-time {
-  font-size: $text-xs;
-  color: $gray-400;
+.summary-empty {
+  font-size: $text-sm;
+  color: $text-muted;
   margin: 0;
+  padding: $spacing-3 0;
 }
 
 /* ===== DATA TABLE ===== */
@@ -404,8 +401,7 @@
   .card-body { padding: $spacing-3 $spacing-4; }
   .card-title { font-size: $text-sm; }
 
-  .chart-area { padding: $spacing-3; min-height: 300px; }
-  .activity-list { padding: $spacing-3; max-height: 300px; }
+  .summary-list { padding: $spacing-3; max-height: 300px; }
 
   .data-table th { padding: 8px $spacing-3; font-size: 10px; }
   .data-table td { padding: 8px $spacing-3; font-size: 13px; }
@@ -483,13 +479,12 @@
     margin-bottom: 10px !important;
   }
 
-  // Hide: chart (complex for print), actions, skeleton
-  .chart-card { display: none !important; }
+  // Hide: actions, skeleton
   .action-btns { display: none !important; }
   .skeleton-strip, .skeleton-card { display: none !important; }
 
-  // Activity: expand all
-  .activity-list {
+  // Summary: expand all
+  .summary-list {
     max-height: none !important;
     overflow: visible !important;
     padding: 8px 12px !important;
@@ -511,5 +506,105 @@
   .badge, .health-dot, .health-status, .metric-value {
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
+  }
+}
+
+/* ===== REJECT MODAL =====
+   Mirrors org-admin dashboard reject form (PR #145) so both portals
+   present an identical confirm UX backed by shared <app-dialog>.
+*/
+.reject-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.reject-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #0f172a;
+
+  .required {
+    color: #dc2626;
+    margin-left: 2px;
+  }
+}
+
+.reject-textarea {
+  width: 100%;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #0f172a;
+  background: #f8fafc;
+  resize: vertical;
+  transition: border-color 0.15s;
+  font-family: inherit;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: #0056D2;
+    background: #fff;
+    box-shadow: 0 0 0 3px rgba(0, 86, 210, 0.08);
+  }
+
+  &::placeholder {
+    color: #94a3b8;
+  }
+}
+
+.reject-hint {
+  font-size: 12px;
+  color: #64748b;
+  margin: 0;
+
+  &.error {
+    color: #dc2626;
+  }
+}
+
+.btn-cancel {
+  padding: 8px 16px;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 8px;
+  background: #fff;
+  color: #475569;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+
+  &:hover:not(:disabled) {
+    background: #f1f5f9;
+    border-color: #cbd5e1;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.btn-confirm-reject {
+  padding: 8px 20px;
+  border: none;
+  border-radius: 8px;
+  background: #dc2626;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+
+  &:hover:not(:disabled) {
+    background: #b91c1c;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 }

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.ts
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.ts
@@ -1,12 +1,17 @@
-import { Component, input, output, computed, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, output, computed, signal, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SystemAnalytics } from '../../../infrastructure/services/admin.service';
-import { RevenueChartComponent, RevenueData } from './components/revenue-chart.component';
 import { PendingApproval } from './dashboard.types';
+import { DialogComponent } from '../../../../../shared/components/dialog/dialog.component';
+
+interface QuickSummaryItem {
+  id: string;
+  message: string;
+}
 
 @Component({
   selector: 'app-admin-system-dashboard',
-  imports: [CommonModule, RevenueChartComponent],
+  imports: [CommonModule, DialogComponent],
   templateUrl: './admin-system-dashboard.component.html',
   styleUrl: './admin-system-dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -22,44 +27,51 @@ export class AdminSystemDashboardComponent {
   courseApproved = output<string>();
   courseRejected = output<{ id: string; reason: string }>();
 
-  // --- Derived state (ADMIN only) ---
-  revenueChartData = computed<RevenueData>(() => {
-    const dailyAvg = (this.analytics().monthlyRevenue || 0) / 30;
-    const labels: string[] = [];
-    const data: number[] = [];
-    const today = new Date();
-
-    for (let i = 29; i >= 0; i--) {
-      const d = new Date(today);
-      d.setDate(d.getDate() - i);
-      labels.push(`${String(d.getDate()).padStart(2, '0')}/${String(d.getMonth() + 1).padStart(2, '0')}`);
-      data.push(Math.max(0, Math.floor(dailyAvg + Math.sin(i * 0.7) * dailyAvg * 0.3)));
-    }
-    return { labels, data };
-  });
-
-  recentActivities = computed(() => {
+  // Snapshot summary derived from analytics counts. Replaces the previous
+  // "Hoạt động gần đây" feed which faked timestamps via `new Date()` —
+  // misleading because none of these items represent a real activity log.
+  quickSummary = computed<QuickSummaryItem[]>(() => {
     const a = this.analytics();
-    const items: { id: number; message: string; timestamp: Date }[] = [];
-    let seq = 1;
-    if (a.pendingCourses > 0) items.push({ id: seq++, message: `${a.pendingCourses} khóa học đang chờ duyệt`, timestamp: new Date() });
-    if (a.totalEnrollments > 0) items.push({ id: seq++, message: `${a.totalEnrollments} lượt đăng ký khóa học`, timestamp: new Date() });
-    if (a.totalStudents > 0) items.push({ id: seq++, message: `${a.totalStudents} học viên trong hệ thống`, timestamp: new Date() });
-    if (a.totalCourses > 0) items.push({ id: seq++, message: `${a.totalCourses} khóa học đã tạo`, timestamp: new Date() });
-    if (items.length === 0) items.push({ id: 1, message: 'Chưa có hoạt động nào', timestamp: new Date() });
+    const items: QuickSummaryItem[] = [];
+    if (a.pendingCourses > 0) items.push({ id: 'pending', message: `${a.pendingCourses} khóa học đang chờ duyệt` });
+    if (a.totalEnrollments > 0) items.push({ id: 'enrollments', message: `${a.totalEnrollments} lượt đăng ký khóa học` });
+    if (a.totalStudents > 0) items.push({ id: 'students', message: `${a.totalStudents} học viên trong hệ thống` });
+    if (a.totalCourses > 0) items.push({ id: 'courses', message: `${a.totalCourses} khóa học đã tạo` });
     return items;
   });
+
+  // --- Reject modal state (mirrors org-admin pattern from PR #145) ---
+  rejectModalOpen = signal(false);
+  private pendingRejectId = signal<string | null>(null);
+  pendingRejectName = signal('');
+  rejectReason = signal('');
+  rejecting = signal(false);
+  rejectReasonValid = computed(() => this.rejectReason().trim().length >= 10);
 
   // --- Actions ---
   approveCourse(courseId: string): void {
     this.courseApproved.emit(courseId);
   }
 
-  rejectCourse(courseId: string): void {
-    const reason = prompt('Nhập lý do từ chối khóa học:');
-    if (reason?.trim()) {
-      this.courseRejected.emit({ id: courseId, reason: reason.trim() });
-    }
+  openRejectModal(courseId: string, courseName: string): void {
+    this.pendingRejectId.set(courseId);
+    this.pendingRejectName.set(courseName);
+    this.rejectReason.set('');
+    this.rejectModalOpen.set(true);
+  }
+
+  closeRejectModal(): void {
+    this.rejectModalOpen.set(false);
+    this.pendingRejectId.set(null);
+    this.pendingRejectName.set('');
+    this.rejectReason.set('');
+  }
+
+  confirmReject(): void {
+    const id = this.pendingRejectId();
+    if (!id || !this.rejectReasonValid() || this.rejecting()) return;
+    this.courseRejected.emit({ id, reason: this.rejectReason().trim() });
+    this.closeRejectModal();
   }
 
   formatDate(dateString: string): string {


### PR DESCRIPTION
Closes #151.

## Summary

Three honesty / a11y issues on the SYSTEM admin dashboard, all surfaced during the same audit that produced #75 / PR #145 for ORG_ADMIN. This PR brings the system dashboard up to the same quality bar that org-admin already reached.

## Changes

| File | Change |
|---|---|
| \`fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.ts\` | Drop \`revenueChartData\` (Math.sin synthetic). Drop \`recentActivities\` (fake \`new Date()\` timestamps). Add \`quickSummary\` (snapshot, no time field). Add reject-modal signal state mirroring org-admin (open/name/reason/busy/valid). Replace \`prompt()\` with \`openRejectModal()\` flow. Import \`DialogComponent\`. |
| \`.../admin-system-dashboard.component.html\` | Remove revenue-chart card and activity-feed card. Add Tổng quan nhanh card with empty state. Add \`<app-dialog variant=\"danger\">\` reject modal at the bottom (textarea + 10-char hint + cancel/confirm). |
| \`.../admin-system-dashboard.component.scss\` | Replace \`.chart-*\` and \`.activity-*\` blocks with \`.summary-*\` (same scrolling/dot pattern). Update mobile + print rules to match new selectors. Append reject-modal styles ported from org-admin SCSS for visual parity. |
| \`fe/src/app/features/admin/presentation/components/admin.component.ts\` | Import \`PendingCourseSummary\` for typed \`response.data.map\`. \`loadPendingApprovals\` error handler now calls \`toast.error(...)\` so admins see API failures instead of an empty table that pretends \"all clear\". |

Diff: 294 +, 170 −, 4 files.

## Why

1. **Synthetic chart**: \`Math.sin(i * 0.7) * dailyAvg * 0.3\` is not a revenue series — it just animates around an average. Users were looking at fiction. PR #145 already removed this from org-admin under the same reasoning (#75); system admin was the last consumer.
2. **Synthetic activity feed**: each item came with \`timestamp: new Date()\` and rendered as a clock-time, which makes them look like an event log. They were always just analytics snapshots. Renamed and the time row removed so the UI matches the data.
3. **\`prompt()\` for reject reason**: zero a11y, no validation, can't enforce minimum length, doesn't match the design system. The shared \`<app-dialog>\` (focus trap, ESC, alertdialog role, animated bottom sheet on mobile) is already used by org-admin — same component, identical UX now.
4. **Silent error**: the previous error handler set \`pendingApprovals\` to \`[]\` quietly. An empty table is indistinguishable from \"queue is empty\" — admins didn't know the API was broken. Now they get a toast.
5. **Type cast → real type**: \`PendingCourseSummary\` was defined in \`admin.service.ts:60-75\` all along; \`response.data.map(course => ...)\` was just untyped.

## Out of scope

- \`RevenueChartComponent\` source file is now orphaned (no consumers). Left in place — same precedent as PR #145, which removed the import without deleting the file. A dedicated cleanup PR can decide whether to delete or repurpose it when backend exposes a daily-revenue endpoint.
- Adding the \`COURSE_REJECTION_CATEGORIES\` dropdown alongside the free-text reason. The service supports it (\`RejectCoursePayload.category\`) but org-admin doesn't use it yet either — keeping the two portals in lockstep is more important than adding a new field unilaterally.

## Verification

- \`npx tsc --noEmit -p fe/tsconfig.json\` passes
- \`npx ng build --configuration=production\` succeeds (warnings are pre-existing Sass \`@import\` deprecations and CommonJS bailouts from \`mammoth\`, unchanged by this PR)
- \`grep -nE \"Math\.(sin|cos|random)\" fe/src/app/features/admin/\` → only matches inside docs/comments
- \`grep -n \"prompt(\" fe/src/app/features/admin/\` → 0 matches
- Login \`admin@maritime.edu\` / \`admin123\` and walk \`/admin/dashboard\` (see test plan)

## Test plan

- [ ] Login as admin → \`/admin/dashboard\` renders without revenue chart, with \"Tổng quan nhanh\" card
- [ ] Quick-summary card shows item rows derived from analytics counts; **no clock timestamps**
- [ ] When pending list has rows, click \"Từ chối\" → dialog opens (focus on textarea, ESC closes, backdrop click closes)
- [ ] Type < 10 chars → confirm button disabled, hint shows \"X/10 ký tự tối thiểu\"; ≥ 10 chars → enabled
- [ ] Confirm → toast \"Đã từ chối khóa học\", row disappears
- [ ] Block backend (\`docker compose stop backend\`) → reload dashboard → toast \"Không thể tải danh sách chờ duyệt...\"
- [ ] Mobile: dialog renders as bottom-sheet with drag-handle (≤640 px)

## Risk & rollback

- Risk: low. Pattern is a direct port of PR #145; same shared \`DialogComponent\`.
- Rollback: revert this single commit. Old \`prompt()\` and chart code can be restored from git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)