### PR TITLE
fix(admin): add lg:w-72 to desktop sidebar wrapper (fixes #154)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
@@ -17,7 +17,7 @@ import { AiAvailabilityService } from '../../../ai-chat/application/services/ai-
     <div class="min-h-screen flex">
       <!-- Desktop Sidebar -->
       @if (!shouldHideSidebar()) {
-        <div class="hidden lg:flex lg:flex-col lg:fixed lg:inset-y-0 lg:z-50">
+        <div class="hidden lg:flex lg:flex-col lg:fixed lg:inset-y-0 lg:z-50 lg:w-72">
           <app-sidebar [config]="adminSidebarConfig" [collapsed]="false"></app-sidebar>
         </div>
       }


### PR DESCRIPTION
Closes #154. Follow-up to PR #152.

## Browser-verified bug

Sử dụng `agent-browser` skill để đo trực tiếp DOM trên `localhost:4200/admin/dashboard`:

| Metric | Before | After |
|---|---:|---:|
| Sidebar bounding width | **225px** | **288px** |
| Has `lg:w-72` class | false | true |
| Content inner left | 288px | 288px |
| Visual gap (sidebar→content) | **63px** | **0px** |

## Root cause

`admin-layout-simple.component.ts:20` desktop sidebar wrapper:
```html
<!-- BEFORE -->
<div class="hidden lg:flex lg:flex-col lg:fixed lg:inset-y-0 lg:z-50">
```
Không có width class. Wrapper `position: fixed` → browser compute intrinsic content width = 225px. Khi đó `lg:pl-72` (288px) trên main content tạo gap 63px.

## Fix

```diff
-<div class="hidden lg:flex lg:flex-col lg:fixed lg:inset-y-0 lg:z-50">
+<div class="hidden lg:flex lg:flex-col lg:fixed lg:inset-y-0 lg:z-50 lg:w-72">
```

Khớp với pattern teacher (`teacher-layout-simple.component.ts:21-22` `md:w-72`) và student.

## Verification

```bash
# Browser inspection (agent-browser skill)
agent-browser open http://localhost:4200/admin/dashboard
agent-browser eval 'document.querySelector("div.hidden.lg\:flex").getBoundingClientRect().width'
# Returns: 288 ✓
```

## Why PR #152 missed this

Audit prompt enumerated `admin-layout-simple.component.ts:30` (mobile drawer) và `:37` (content padding) nhưng không call out line 20 (desktop wrapper). Sub-agent fix đúng những gì được specified. Process improvement noted in issue #154.

## Test plan

- [x] `agent-browser` đo width = 288px desktop
- [x] Visual: không còn gap giữa sidebar và content
- [ ] Hard refresh `/admin/dashboard` browser người dùng → confirm khớp `/teacher` và `/student`
- [ ] CI 4/4 xanh

🤖 Generated with [Claude Code](https://claude.com/claude-code)