### PR TITLE
fix(admin-dashboard): P0 a11y + primary action (closes #158)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
@@ -51,7 +51,7 @@ import { AiAvailabilityService } from '../../../ai-chat/application/services/ai-
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
                       </svg>
                     </button>
-                    <h1 class="ml-3 text-lg font-semibold text-gray-900">{{ mobileTitle() }}</h1>
+                    <p class="ml-3 text-lg font-semibold text-gray-900 mb-0">{{ mobileTitle() }}</p>
                   </div>
                   <div class="flex items-center space-x-3">
                     <span class="text-sm text-gray-600 hidden sm:inline">{{ authService.currentUser()?.fullName }}</span>

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.html
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.html
@@ -21,9 +21,12 @@
         <div class="skeleton-card animate-pulse" style="min-height:280px">
           <div class="sk" style="height:16px;width:160px;margin-bottom:16px"></div>
           @for (_ of [1,2,3,4]; track $index) {
-            <div style="display:flex;gap:12px;padding:12px 0;border-bottom:1px solid #f3f4f6">
-              <div class="sk" style="height:8px;width:8px;border-radius:50%;margin-top:4px;flex-shrink:0"></div>
-              <div class="sk-light" style="height:14px;width:90%"></div>
+            <div style="display:flex;align-items:center;gap:12px;padding:10px 0">
+              <div class="sk" style="height:40px;width:40px;border-radius:8px;flex-shrink:0"></div>
+              <div style="flex:1;display:flex;flex-direction:column;gap:6px">
+                <div class="sk" style="height:12px;width:60%"></div>
+                <div class="sk-light" style="height:10px;width:85%"></div>
+              </div>
             </div>
           }
         </div>
@@ -47,6 +50,10 @@
     <div class="header-bar">
       <div class="header-inner">
         <h1 class="page-title">Bảng điều khiển hệ thống</h1>
+        <div class="header-actions">
+          <a routerLink="/admin/analytics" class="btn-secondary">Xem báo cáo</a>
+          <a routerLink="/admin/users/all" class="btn-primary">Thêm người dùng</a>
+        </div>
       </div>
     </div>
 
@@ -82,24 +89,26 @@
         dashboard sau PR #145 / issue #75).
       -->
 
-      <!-- ② Quick summary + System Health -->
+      <!-- ② Quick actions + System Health -->
       <div class="content-grid grid-2-1">
-        <div class="card summary-card">
+        <div class="card actions-card">
           <div class="card-header">
-            <h2 class="card-title">Tổng quan nhanh</h2>
+            <h2 class="card-title">Hành động nhanh</h2>
           </div>
-          <div class="summary-list">
-            @if (quickSummary().length === 0) {
-              <p class="summary-empty">Chưa có dữ liệu để tổng hợp.</p>
-            } @else {
-              @for (item of quickSummary(); track item.id) {
-                <div class="summary-item">
-                  <div class="summary-dot"></div>
-                  <p class="summary-message">{{ item.message }}</p>
+          <nav class="actions-list" aria-label="Lối tắt quản trị">
+            @for (action of quickActions(); track action.id) {
+              <a [routerLink]="action.route" class="action-item">
+                <div class="action-icon">
+                  <app-icon [name]="action.icon" size="md" aria-hidden="true" />
                 </div>
-              }
+                <div class="action-text">
+                  <span class="action-label">{{ action.label }}</span>
+                  <span class="action-desc">{{ action.description }}</span>
+                </div>
+                <app-icon name="chevron-right" size="sm" class="action-chevron" aria-hidden="true" />
+              </a>
             }
-          </div>
+          </nav>
         </div>
 
         <!-- System Health -->

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.scss
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.scss
@@ -17,6 +17,11 @@
   max-width: 1400px;
   margin: 0 auto;
   padding: $spacing-4 $spacing-6;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-4;
+  flex-wrap: wrap;
 }
 
 .page-title {
@@ -25,6 +30,50 @@
   color: $text-primary;
   margin: 0;
   line-height: $leading-tight;
+}
+
+.header-actions {
+  display: flex;
+  gap: $spacing-2;
+  flex-shrink: 0;
+}
+
+/* Header action buttons — primary "Thêm người dùng" + secondary "Xem báo cáo".
+   Stripe/Linear/Vercel pattern: 1 prominent primary action top-right. */
+.btn-primary,
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: $spacing-2 $spacing-4;
+  min-height: 40px; // WCAG 2.2 SC 2.5.8 touch target
+  font-size: $text-sm;
+  font-weight: $font-semibold;
+  border-radius: $radius-md;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background $transition-fast, border-color $transition-fast, color $transition-fast;
+  white-space: nowrap;
+
+  @include focus-visible;
+}
+
+.btn-primary {
+  background: $blue-primary;
+  color: white;
+  border: 1px solid $blue-primary;
+
+  &:hover { background: $blue-hover; border-color: $blue-hover; }
+  &:active { background: $blue-pressed; border-color: $blue-pressed; }
+}
+
+.btn-secondary {
+  background: white;
+  color: $text-primary;
+  border: 1px solid $border-default;
+
+  &:hover { background: $gray-50; border-color: $border-dark; }
+  &:active { background: $gray-100; }
 }
 
 /* ===== MAIN ===== */
@@ -124,56 +173,75 @@
   }
 }
 
-/* ===== SUMMARY CARD =====
-   Replaces the old "Activity feed" card whose timestamps were synthetic
-   (`new Date()`) and the revenue chart whose 30-day series came from
-   `dailyAvg + Math.sin(...)`. Both are restored when the backend exposes
-   real time-series endpoints.
-*/
-.summary-card { overflow: hidden; }
+/* ===== QUICK ACTIONS CARD =====
+   Replaces the old "Tổng quan nhanh" card that duplicated KPI strip counts
+   (F-02 in audit 2026-04-25). Shortcut panel pattern from Stripe / Linear /
+   Vercel — gives admins an obvious next action on page load. */
+.actions-card { overflow: hidden; }
 
-.summary-list {
-  padding: $spacing-4 $spacing-5;
-  max-height: 400px;
-  overflow-y: auto;
-
-  &::-webkit-scrollbar { width: 4px; }
-  &::-webkit-scrollbar-track { background: transparent; }
-  &::-webkit-scrollbar-thumb { background: $gray-300; border-radius: 2px; }
-  scrollbar-width: thin;
-  scrollbar-color: $gray-300 transparent;
-}
-
-.summary-item {
+.actions-list {
   display: flex;
-  gap: $spacing-3;
-  padding: $spacing-3 0;
-  border-bottom: 1px solid $border-light;
-
-  &:last-child { border-bottom: none; }
+  flex-direction: column;
+  padding: $spacing-2;
 }
 
-.summary-dot {
-  width: 8px;
-  height: 8px;
-  background: $blue-primary;
-  border-radius: 50%;
-  margin-top: 5px;
+.action-item {
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+  padding: $spacing-3;
+  border-radius: $radius-md;
+  color: $text-primary;
+  text-decoration: none;
+  transition: background $transition-fast;
+  min-height: 56px; // WCAG 2.2 SC 2.5.8 — comfortable touch target
+
+  &:hover { background: $gray-50; }
+  &:focus-visible {
+    outline: 2px solid $blue-primary;
+    outline-offset: -2px;
+  }
+
+  &:hover .action-chevron { color: $blue-primary; transform: translateX(2px); }
+}
+
+.action-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: $radius-md;
+  background: rgba($blue-primary, 0.08);
+  color: $blue-primary;
   flex-shrink: 0;
 }
 
-.summary-message {
+.action-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   flex: 1;
-  font-size: $text-sm;
-  color: $gray-700;
-  margin: 0;
+  min-width: 0;
 }
 
-.summary-empty {
+.action-label {
   font-size: $text-sm;
+  font-weight: $font-semibold;
+  color: $text-primary;
+  line-height: $leading-tight;
+}
+
+.action-desc {
+  font-size: $text-xs;
   color: $text-muted;
-  margin: 0;
-  padding: $spacing-3 0;
+  line-height: $leading-normal;
+}
+
+.action-chevron {
+  color: $gray-400;
+  flex-shrink: 0;
+  transition: transform $transition-fast, color $transition-fast;
 }
 
 /* ===== DATA TABLE ===== */
@@ -401,7 +469,15 @@
   .card-body { padding: $spacing-3 $spacing-4; }
   .card-title { font-size: $text-sm; }
 
-  .summary-list { padding: $spacing-3; max-height: 300px; }
+  .actions-list { padding: $spacing-2; }
+  .action-item { padding: $spacing-2 $spacing-3; min-height: 52px; }
+  .action-icon { width: 36px; height: 36px; }
+  .action-label { font-size: 13px; }
+  .action-desc { font-size: 11px; }
+
+  .header-inner { flex-wrap: wrap; }
+  .header-actions { width: 100%; }
+  .btn-primary, .btn-secondary { flex: 1; min-height: 44px; }
 
   .data-table th { padding: 8px $spacing-3; font-size: 10px; }
   .data-table td { padding: 8px $spacing-3; font-size: 13px; }
@@ -479,16 +555,20 @@
     margin-bottom: 10px !important;
   }
 
-  // Hide: actions, skeleton
+  // Hide: actions, skeleton, header buttons
   .action-btns { display: none !important; }
+  .header-actions { display: none !important; }
   .skeleton-strip, .skeleton-card { display: none !important; }
 
-  // Summary: expand all
-  .summary-list {
-    max-height: none !important;
-    overflow: visible !important;
+  // Quick actions: expand all
+  .actions-list {
     padding: 8px 12px !important;
   }
+  .action-item {
+    padding: 6px 8px !important;
+    min-height: auto !important;
+  }
+  .action-chevron { display: none !important; }
 
   // Table: condensed
   .data-table th { padding: 6px 8px !important; font-size: 10px !important; }

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.ts
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.ts
@@ -1,17 +1,32 @@
-import { Component, input, output, computed, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, output, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
 import { SystemAnalytics } from '../../../infrastructure/services/admin.service';
 import { PendingApproval } from './dashboard.types';
 import { DialogComponent } from '../../../../../shared/components/dialog/dialog.component';
+import { IconComponent, IconName } from '../../../../../shared/components/icon/icon.component';
 
-interface QuickSummaryItem {
+interface QuickAction {
   id: string;
-  message: string;
+  label: string;
+  description: string;
+  route: string;
+  icon: IconName;
 }
+
+// Static list — routes verified against fe/src/app/features/admin/admin.routes.ts.
+// Replaces the old "Tổng quan nhanh" card which duplicated KPI strip counts
+// (F-02 in audit 2026-04-25). Pattern follows Stripe/Linear shortcut panels.
+const QUICK_ACTIONS: readonly QuickAction[] = [
+  { id: 'add-user',    label: 'Thêm người dùng',  description: 'Tạo tài khoản giảng viên hoặc học viên',      route: '/admin/users/all',   icon: 'users' },
+  { id: 'categories',  label: 'Quản lý danh mục', description: 'Thêm, sửa, xóa danh mục khóa học',             route: '/admin/categories',  icon: 'tag' },
+  { id: 'analytics',   label: 'Xem báo cáo',      description: 'Phân tích học viên, doanh thu, tăng trưởng',   route: '/admin/analytics',   icon: 'bar-chart' },
+  { id: 'settings',    label: 'Cấu hình hệ thống', description: 'Thiết lập thanh toán, bảo mật, thông báo',    route: '/admin/settings',    icon: 'settings' },
+];
 
 @Component({
   selector: 'app-admin-system-dashboard',
-  imports: [CommonModule, DialogComponent],
+  imports: [CommonModule, RouterLink, DialogComponent, IconComponent],
   templateUrl: './admin-system-dashboard.component.html',
   styleUrl: './admin-system-dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -27,18 +42,8 @@ export class AdminSystemDashboardComponent {
   courseApproved = output<string>();
   courseRejected = output<{ id: string; reason: string }>();
 
-  // Snapshot summary derived from analytics counts. Replaces the previous
-  // "Hoạt động gần đây" feed which faked timestamps via `new Date()` —
-  // misleading because none of these items represent a real activity log.
-  quickSummary = computed<QuickSummaryItem[]>(() => {
-    const a = this.analytics();
-    const items: QuickSummaryItem[] = [];
-    if (a.pendingCourses > 0) items.push({ id: 'pending', message: `${a.pendingCourses} khóa học đang chờ duyệt` });
-    if (a.totalEnrollments > 0) items.push({ id: 'enrollments', message: `${a.totalEnrollments} lượt đăng ký khóa học` });
-    if (a.totalStudents > 0) items.push({ id: 'students', message: `${a.totalStudents} học viên trong hệ thống` });
-    if (a.totalCourses > 0) items.push({ id: 'courses', message: `${a.totalCourses} khóa học đã tạo` });
-    return items;
-  });
+  // Shortcut panel — replaces the redundant "Tổng quan nhanh" card.
+  quickActions = computed<readonly QuickAction[]>(() => QUICK_ACTIONS);
 
   // --- Reject modal state (mirrors org-admin pattern from PR #145) ---
   rejectModalOpen = signal(false);

--- a/fe/src/app/shared/components/navigation/sidebar.component.html
+++ b/fe/src/app/shared/components/navigation/sidebar.component.html
@@ -38,7 +38,7 @@
                 @if (item.badge) {
                 <span class="nav-badge">{{ item.badge }}</span>
                 }
-                <span class="nav-tooltip">{{ item.label }}</span>
+                <span class="nav-tooltip" aria-hidden="true">{{ item.label }}</span>
             </a>
 
             <!-- Sub-menu items -->


### PR DESCRIPTION
Closes #158. Part of epic #157.

## Findings addressed

Từ audit [`docs/reports/2026-04-25-admin-dashboard-ux-audit.md`](../blob/main/docs/reports/2026-04-25-admin-dashboard-ux-audit.md):

- **F-01** Heading hierarchy: mobile top-bar đang dùng `<h1>` song song với page H1 → 2 H1/trang. Đổi sang `<p>` giữ nguyên visual. Desktop vốn đúng (sidebar dùng h2).
- **F-02** Replace redundant `Tổng quan nhanh` card bằng `Hành động nhanh` — 4 shortcut link (Thêm người dùng / Quản lý danh mục / Xem báo cáo / Cấu hình hệ thống). Pattern Stripe/Linear.
- **F-03** Thêm header primary action: `Thêm người dùng` (blue primary) + `Xem báo cáo` (secondary). Top-right `.header-bar`.
- **F-04** `.nav-tooltip` render cùng text với `.nav-label` → SR đọc 2 lần. Thêm `aria-hidden="true"`.

## Changes

| File | Change |
|---|---|
| `fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts` | Mobile top-bar `<h1>` → `<p class="... mb-0">` (F-01 mobile fix) |
| `.../dashboard/admin-system-dashboard.component.ts` | Drop `quickSummary` computed, drop `QuickSummaryItem` interface. Add `QUICK_ACTIONS` readonly array + `quickActions` computed. Import `RouterLink` + `IconComponent`. |
| `.../dashboard/admin-system-dashboard.component.html` | `.header-inner` có `.header-actions` với primary/secondary anchor. `.summary-card` → `.actions-card` với 4 `<a.action-item>` (icon + label + desc + chevron). Skeleton cập nhật để match layout mới. |
| `.../dashboard/admin-system-dashboard.component.scss` | Thêm `.header-actions`, `.btn-primary`, `.btn-secondary` (40px desktop / 44px mobile touch target). Thay `.summary-*` rules bằng `.actions-*` (icon 40×40, hover translateX chevron). Print + mobile + ultra-small media queries update selector. |
| `fe/src/app/shared/components/navigation/sidebar.component.html` | `.nav-tooltip` → `aria-hidden="true"` |

5 files, +168 / −74 LOC.

## Browser verification

`agent-browser` — admin@maritime.edu đăng nhập, đo tại `/admin/dashboard`.

### Desktop 1440×900

| Metric | Before (audit) | After |
|---|---:|---:|
| `<h1>` count | 2 (claim audit; thực tế 1) | **1** (`Bảng điều khiển hệ thống`) |
| `page-title` font-size | 18px (audit claim) | **24px** |
| Primary btn ở header | 0 | **1** (`Thêm người dùng`, 40px height) |
| `summary-card` duplicate KPI | tồn tại | **không còn trong DOM** |
| Quick actions | — | **4 shortcut link** verified routes |
| `.nav-tooltip aria-hidden` | không | **true cho 10/10 nav items** |

### Mobile 375×812

| Metric | Before | After |
|---|---:|---:|
| `<h1>` count | 2 (mobile top-bar + page title) | **1** |
| Mobile top-bar element | `<h1>` | **`<p class="... mb-0">`** |
| Primary btn height | — | **44px** (iOS 44pt target) |

### Click-through

- `Thêm người dùng` → `/admin/users/all` (H1: `Quản lý người dùng`) ✓

### Screenshots

- `/tmp/after-pra-desktop.png` (1440×900 full page)
- `/tmp/after-pra-mobile.png` (375×812 full page)

![Desktop after PR-A](https://user-images.githubusercontent.com/placeholder/desktop.png)
![Mobile after PR-A](https://user-images.githubusercontent.com/placeholder/mobile.png)

(Screenshot files local; CodeRabbit + maintainer review sẽ re-verify bằng agent-browser nếu cần.)

## Convention compliance

- [x] `ChangeDetectionStrategy.OnPush` giữ nguyên
- [x] `signal()` / `computed()` / `input()` / `output()` — không dùng constructor DI
- [x] `@if` / `@for` — không dùng `*ngIf` / `*ngFor`
- [x] Không `standalone: true` explicit
- [x] `CommonModule` giữ (dùng `| number` pipe trong KPI strip)
- [x] Vietnamese text có dấu, terminology match existing UX (`Thêm người dùng`)

## Acceptance criteria (từ issue #158)

- [x] Chỉ 1 `<h1>` trên `/admin/dashboard` ở cả desktop + mobile
- [x] `Tổng quan nhanh` thay bằng `Hành động nhanh` với 4 route verified
- [x] Header có primary `Thêm người dùng` + secondary `Xem báo cáo`
- [x] `.nav-tooltip` có `aria-hidden="true"`
- [x] Convention compliance
- [x] Visual verification desktop + mobile

## Test plan

- [ ] Login `admin@maritime.edu` / `admin123` → `/admin/dashboard` render
  - [ ] 1 H1 duy nhất (DevTools: `$$('h1').length === 1`)
  - [ ] Header có 2 button bên phải
  - [ ] `Hành động nhanh` card có 4 item, hover → chevron translateX
  - [ ] Click mỗi item điều hướng đúng
- [ ] Mobile (DevTools 375×812) → top-bar `<p>` không phải `<h1>`
- [ ] Keyboard Tab qua 4 action item → focus ring visible 2px `#0056D2`
- [ ] Screen reader: focus nav item → nghe label 1 lần, không echo 2 lần
- [ ] `/admin/dashboard` → click `Thêm người dùng` → `/admin/users/all` load OK

## Risk & rollback

- Risk: thấp. Pure FE change, không đụng BE, không đụng state.
- Rollback: `git revert`. UX sẽ quay về bản có 2 H1 + card redundant.

## Out of scope (defer)

- F-05 KPI trend arrow → PR-B
- F-06 systemHealth real source verify → PR-C
- F-07 activity chart → issue BE riêng
- F-08 date range toggle → PR-C
- F-09 / F-10 spacing + type scale tokens → PR-B
- F-11 empty state Activate CTA → PR-B
- F-13 → F-18 polish → PR-D (optional)
- F-17 FAB overlap với health card → P2 polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)