### PR TITLE
fix(admin-dashboard): design system foundation (closes #162)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.html
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.html
@@ -63,12 +63,24 @@
         <div class="metric-cell">
           <p class="metric-value">{{ analytics().totalUsers | number }}</p>
           <p class="metric-label">Tổng người dùng</p>
-          <p class="metric-sub">+{{ analytics().userGrowth.growthRate || 0 }}% so với tháng trước</p>
+          <p class="metric-sub">
+            <span class="trend" [class]="'trend-' + trendOf(analytics().userGrowth.growthRate)" aria-hidden="true">
+              <span class="trend-arrow">{{ trendArrow(analytics().userGrowth.growthRate) }}</span>
+              <span>{{ trendMagnitude(analytics().userGrowth.growthRate) }}%</span>
+            </span>
+            <span>so với tháng trước</span>
+          </p>
         </div>
         <div class="metric-cell">
           <p class="metric-value">{{ analytics().revenue | number:'1.0-0' }}đ</p>
           <p class="metric-label">Doanh thu tháng này</p>
-          <p class="metric-sub">+{{ analytics().revenueGrowth }}% so với tháng trước</p>
+          <p class="metric-sub">
+            <span class="trend" [class]="'trend-' + trendOf(analytics().revenueGrowth)" aria-hidden="true">
+              <span class="trend-arrow">{{ trendArrow(analytics().revenueGrowth) }}</span>
+              <span>{{ trendMagnitude(analytics().revenueGrowth) }}%</span>
+            </span>
+            <span>so với tháng trước</span>
+          </p>
         </div>
         <div class="metric-cell highlight">
           <p class="metric-value warning">{{ analytics().pendingCourses | number }}</p>
@@ -78,7 +90,13 @@
         <div class="metric-cell">
           <p class="metric-value">{{ analytics().totalCourses | number }}</p>
           <p class="metric-label">Tổng khóa học</p>
-          <p class="metric-sub">{{ analytics().approvedCourses }} đã duyệt</p>
+          <p class="metric-sub">
+            <span class="trend" [class]="'trend-' + trendOf(analytics().courseGrowth)" aria-hidden="true">
+              <span class="trend-arrow">{{ trendArrow(analytics().courseGrowth) }}</span>
+              <span>{{ trendMagnitude(analytics().courseGrowth) }}%</span>
+            </span>
+            <span>· {{ analytics().approvedCourses }} đã duyệt</span>
+          </p>
         </div>
       </div>
 
@@ -174,10 +192,15 @@
             </div>
           } @else if (pendingApprovals().length === 0) {
             <div class="table-empty">
-              <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="empty-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
-              <p>Không có khóa học nào đang chờ duyệt</p>
+              <p class="empty-title">Hàng đợi đã sạch</p>
+              <p class="empty-desc">Khi giảng viên nộp khóa học mới, khóa đó sẽ hiện ở đây để bạn duyệt.</p>
+              <a routerLink="/admin/courses" class="empty-cta">
+                Xem tất cả khóa học
+                <app-icon name="arrow-right" size="sm" aria-hidden="true" />
+              </a>
             </div>
           } @else {
             <table class="data-table">

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.scss
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.scss
@@ -92,19 +92,22 @@
 }
 
 .card-header {
-  padding: $spacing-4 $spacing-5;
+  padding: $spacing-4 $spacing-6;
   border-bottom: 1px solid $border-light;
 }
 
 .card-title {
-  font-size: $text-base;
+  // H3 in 1.125 type ladder — bumps from $text-base (16) so card titles
+  // sit one rung above body and stay below H1 page title (24).
+  font-size: $text-lg;
   font-weight: $font-semibold;
   color: $text-primary;
   margin: 0;
 }
 
 .card-body {
-  padding: $spacing-5;
+  // Card padding 24px — Carbon / Polaris default for content cards.
+  padding: $spacing-6;
   overflow-x: auto;
 }
 
@@ -113,14 +116,14 @@
   @extend .card;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  margin-bottom: $spacing-5;
+  margin-bottom: $spacing-6;
   overflow: hidden;
 
   @include desktop { grid-template-columns: repeat(4, 1fr); }
 }
 
 .metric-cell {
-  padding: $spacing-3 $spacing-5;
+  padding: $spacing-4 $spacing-6;
 
   &:nth-child(odd) { border-right: 1px solid $border-light; }
   &:nth-child(-n+2) { border-bottom: 1px solid $border-light; }
@@ -137,11 +140,12 @@
 }
 
 .metric-value {
-  font-size: $text-xl;
+  // Display rung in 1.125 ladder — number is the focal point of the cell.
+  font-size: $text-2xl;
   font-weight: $font-bold;
   color: $text-primary;
-  line-height: 1.2;
-  margin: 0 0 2px;
+  line-height: $leading-tight;
+  margin: 0 0 $spacing-1;
 
   &.warning { color: $warning; }
 }
@@ -152,12 +156,36 @@
   margin: 0;
 }
 
+/* Trend row — number + arrow + delta + period label.
+   F-05: ▲ green / ▼ red / → gray, anatomy borrowed from Stripe / Vercel KPI.
+*/
 .metric-sub {
-  font-size: 11px;
-  color: $gray-400;
-  margin: 1px 0 0;
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-1;
+  font-size: $text-xs;
+  color: $text-muted;
+  margin: $spacing-1 0 0;
 
   &.warning-text { color: $warning; }
+}
+
+.trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px; // 4pt baseline — visual coupling between arrow + number.
+  font-weight: $font-semibold;
+  font-variant-numeric: tabular-nums;
+
+  &.trend-up { color: $success; }
+  &.trend-down { color: $error; }
+  &.trend-flat { color: $text-muted; }
+}
+
+.trend-arrow {
+  // Glyph rendered via :before to avoid extra DOM. Sizing matches text-xs.
+  font-size: 10px; // visual match for caret next to 12px label
+  line-height: 1;
 }
 
 /* ===== ② CONTENT GRID ===== */
@@ -165,7 +193,7 @@
   display: grid;
   grid-template-columns: 1fr;
   gap: $spacing-4;
-  margin-bottom: $spacing-5;
+  margin-bottom: $spacing-6;
   min-width: 0;
 
   &.grid-2-1 {
@@ -257,12 +285,12 @@
 
 .data-table th {
   text-align: left;
-  font-size: 12px;
+  font-size: $text-xs;
   font-weight: $font-semibold;
   color: $gray-500;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  padding: 10px $spacing-4;
+  padding: $spacing-3 $spacing-4;
 }
 
 .data-table td {
@@ -285,7 +313,9 @@
 .badge {
   display: inline-flex;
   align-items: center;
-  padding: 2px 10px;
+  // Tag-style padding — vertical 2px on 4pt baseline keeps badges compact
+  // next to body text; horizontal $spacing-3 (12px) gives breathing room.
+  padding: 2px $spacing-3;
   border-radius: $radius-sm;
   font-size: $text-xs;
   font-weight: $font-medium;
@@ -301,30 +331,27 @@
   gap: $spacing-2;
 }
 
-.btn-approve {
-  padding: 4px $spacing-3;
+.btn-approve,
+.btn-reject {
+  padding: $spacing-1 $spacing-3;
   font-size: $text-xs;
   font-weight: $font-medium;
-  background: $blue-primary;
-  color: white;
   border: none;
   border-radius: $radius-sm;
   cursor: pointer;
   transition: background $transition-normal;
+}
+
+.btn-approve {
+  background: $blue-primary;
+  color: white;
 
   &:hover { background: $blue-hover; }
 }
 
 .btn-reject {
-  padding: 4px $spacing-3;
-  font-size: $text-xs;
-  font-weight: $font-medium;
   background: $gray-100;
   color: $gray-600;
-  border: none;
-  border-radius: $radius-sm;
-  cursor: pointer;
-  transition: background $transition-normal;
 
   &:hover { background: $gray-200; }
 }
@@ -341,8 +368,9 @@
 }
 
 .spinner {
-  width: 32px;
-  height: 32px;
+  width: $spacing-8;
+  height: $spacing-8;
+  // 3px stroke — keeps the ring visible at 32px without going thin or chunky.
   border: 3px solid $gray-200;
   border-top-color: $blue-primary;
   border-radius: 50%;
@@ -351,28 +379,62 @@
 
 @keyframes spin { to { transform: rotate(360deg); } }
 
+/* Empty state — Carbon Inform + Inspire + Activate pattern.
+   F-11: previous version only had icon + line. Added title, description, CTA. */
 .table-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   text-align: center;
-  padding: $spacing-12 0;
+  padding: $spacing-12 $spacing-6;
   color: $gray-400;
+  gap: $spacing-3;
 
-  svg {
-    width: 48px;
-    height: 48px;
-    margin: 0 auto $spacing-3;
-    display: block;
+  .empty-icon {
+    width: $spacing-12;
+    height: $spacing-12;
+    color: $gray-300;
   }
 
-  p {
+  .empty-title {
+    font-size: $text-base;
+    font-weight: $font-semibold;
+    color: $text-primary;
+    margin: 0;
+  }
+
+  .empty-desc {
     font-size: $text-sm;
     color: $text-muted;
     margin: 0;
+    max-width: 360px;
+    line-height: $leading-normal;
+  }
+
+  .empty-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-2;
+    margin-top: $spacing-2;
+    padding: $spacing-2 $spacing-4;
+    min-height: 40px;
+    font-size: $text-sm;
+    font-weight: $font-semibold;
+    color: $blue-primary;
+    background: rgba($blue-primary, 0.06);
+    border: 1px solid rgba($blue-primary, 0.2);
+    border-radius: $radius-md;
+    text-decoration: none;
+    transition: background $transition-fast, border-color $transition-fast;
+
+    &:hover { background: rgba($blue-primary, 0.1); border-color: rgba($blue-primary, 0.3); }
+    @include focus-visible;
   }
 }
 
 /* ===== HEALTH CARD ===== */
 .health-list {
-  padding: $spacing-4 $spacing-5;
+  padding: $spacing-4 $spacing-6;
 }
 
 .health-item {
@@ -386,6 +448,9 @@
 }
 
 .health-dot {
+  // 10px dot + 3px halo — small visual indicator, intentionally off-grid for
+  // optical balance against text-sm baseline. Halo (box-shadow spread) gives
+  // status badge prominence without fattening the dot itself.
   width: 10px;
   height: 10px;
   border-radius: 50%;
@@ -406,7 +471,7 @@
 .health-status {
   font-size: $text-xs;
   font-weight: $font-medium;
-  padding: 3px 10px;
+  padding: $spacing-1 $spacing-3;
   border-radius: $radius-sm;
 
   &.status-ok { background: $success-light; color: $success; }
@@ -420,13 +485,13 @@
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   overflow: hidden;
-  margin-bottom: $spacing-5;
+  margin-bottom: $spacing-6;
 
   @include desktop { grid-template-columns: repeat(4, 1fr); }
 }
 
 .skeleton-cell {
-  padding: $spacing-3 $spacing-5;
+  padding: $spacing-4 $spacing-6;
 
   &:nth-child(odd) { border-right: 1px solid $border-light; }
   &:nth-child(-n+2) { border-bottom: 1px solid $border-light; }
@@ -440,50 +505,55 @@
 
 .skeleton-card {
   @extend .card;
-  padding: $spacing-5;
+  padding: $spacing-6;
 }
 
-.sk { background: $gray-200; border-radius: 4px; }
-.sk-light { background: $gray-100; border-radius: 4px; }
+.sk { background: $gray-200; border-radius: $radius-sm; }
+.sk-light { background: $gray-100; border-radius: $radius-sm; }
 
 /* ===== RESPONSIVE ===== */
 
 // Tablet
 @media screen and (max-width: $breakpoint-md) {
-  .dashboard-main { padding: $spacing-5 $spacing-4; }
+  .dashboard-main { padding: $spacing-6 $spacing-4; }
   .header-inner { padding: $spacing-3 $spacing-4; }
 }
 
 // Mobile
 @media screen and (max-width: $breakpoint-sm) {
-  .dashboard-main { padding: $spacing-3 $spacing-3; }
+  .dashboard-main { padding: $spacing-3; }
   .header-inner { padding: $spacing-3; }
   .page-title { font-size: $text-lg; }
 
-  .metric-cell { padding: 10px $spacing-3; }
-  .metric-value { font-size: 17px; }
-  .metric-label { font-size: 11px; }
+  .metric-cell { padding: $spacing-3; }
+  .metric-value { font-size: $text-xl; } // 20px on small screens — keep big numbers legible
+  .metric-label { font-size: $text-xs; }
   .metric-sub { display: none; }
 
   .card-header { padding: $spacing-3 $spacing-4; }
-  .card-body { padding: $spacing-3 $spacing-4; }
-  .card-title { font-size: $text-sm; }
+  .card-body { padding: $spacing-4; }
+  .card-title { font-size: $text-base; } // bumps body to 16, leaves space below 20 H2
 
   .actions-list { padding: $spacing-2; }
   .action-item { padding: $spacing-2 $spacing-3; min-height: 52px; }
   .action-icon { width: 36px; height: 36px; }
-  .action-label { font-size: 13px; }
-  .action-desc { font-size: 11px; }
+  .action-label { font-size: $text-sm; }
+  .action-desc { font-size: $text-xs; }
 
   .header-inner { flex-wrap: wrap; }
   .header-actions { width: 100%; }
   .btn-primary, .btn-secondary { flex: 1; min-height: 44px; }
 
-  .data-table th { padding: 8px $spacing-3; font-size: 10px; }
-  .data-table td { padding: 8px $spacing-3; font-size: 13px; }
+  .data-table th { padding: $spacing-2 $spacing-3; font-size: $text-xs; }
+  .data-table td { padding: $spacing-2 $spacing-3; font-size: $text-sm; }
 
   .health-list { padding: $spacing-3; }
-  .health-name { font-size: 13px; }
+  .health-name { font-size: $text-sm; }
+
+  .table-empty {
+    padding: $spacing-8 $spacing-4;
+    .empty-icon { width: $spacing-10; height: $spacing-10; }
+  }
 
   .content-grid { gap: $spacing-3; margin-bottom: $spacing-3; }
 }
@@ -491,9 +561,9 @@
 // Ultra-small (<340px)
 @media screen and (max-width: 340px) {
   .dashboard-main { padding: $spacing-3 $spacing-2; }
-  .metric-cell { padding: 8px 10px; }
-  .metric-value { font-size: 16px; }
-  .metric-label { font-size: 10px; }
+  .metric-cell { padding: $spacing-2 $spacing-3; }
+  .metric-value { font-size: $text-lg; } // drop one rung on very narrow screens
+  .metric-label { font-size: $text-xs; }
 
   .card-header { padding: $spacing-2 $spacing-3; }
   .card-body { padding: $spacing-2 $spacing-3; }

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.ts
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.ts
@@ -45,6 +45,23 @@ export class AdminSystemDashboardComponent {
   // Shortcut panel — replaces the redundant "Tổng quan nhanh" card.
   quickActions = computed<readonly QuickAction[]>(() => QUICK_ACTIONS);
 
+  // F-05: classify a growth rate as up / down / flat for trend-arrow rendering.
+  // Stripe / Vercel pattern — same data, but arrow + color give scannability.
+  trendOf(rate: number | null | undefined): 'up' | 'down' | 'flat' {
+    if (rate == null || rate === 0) return 'flat';
+    return rate > 0 ? 'up' : 'down';
+  }
+
+  trendArrow(rate: number | null | undefined): string {
+    const t = this.trendOf(rate);
+    return t === 'up' ? '▲' : t === 'down' ? '▼' : '→';
+  }
+
+  // Always show absolute value next to the arrow — sign is encoded in arrow + color.
+  trendMagnitude(rate: number | null | undefined): number {
+    return Math.abs(rate ?? 0);
+  }
+
   // --- Reject modal state (mirrors org-admin pattern from PR #145) ---
   rejectModalOpen = signal(false);
   private pendingRejectId = signal<string | null>(null);


### PR DESCRIPTION
Closes #162. Part of epic #157. Builds on #159 (PR-A merged).

## Findings addressed

Từ audit [`docs/reports/2026-04-25-admin-dashboard-ux-audit.md`](../blob/main/docs/reports/2026-04-25-admin-dashboard-ux-audit.md) §4 P1:

- **F-05** KPI trend arrow — number + ▲ / ▼ / → + magnitude + color
- **F-09** Spacing audit về 8pt grid token, card padding 24px chuẩn
- **F-10** Type scale 1.125 ladder enforced (12/14/16/18/20/24/30)
- **F-11** Empty state Activate CTA per Carbon Inform + Inspire + Activate

## Changes

| File | Change |
|---|---|
| `.../dashboard/admin-system-dashboard.component.ts` | Add `trendOf()` / `trendArrow()` / `trendMagnitude()` helpers — classify growthRate as up/down/flat. |
| `.../dashboard/admin-system-dashboard.component.html` | KPI cells render `<span class="trend trend-{{kind}}">▲ N%</span>`. Empty state expanded to title + desc + CTA. |
| `.../dashboard/admin-system-dashboard.component.scss` | Replace 18 magic spacing values + 12 magic font-size values with `$spacing-*` / `$text-*` tokens. Add `.trend-up/down/flat` color rules. Empty state styled (`.empty-icon`, `.empty-title`, `.empty-desc`, `.empty-cta`). Mobile + ultra-small media queries tokenized. Off-grid retained values carry `/* visual reason */` comment (health-dot 10px + 3px halo, badge 2px vertical, spinner 3px stroke). |

3 files, +172 / −62.

## Browser verification

agent-browser admin@maritime.edu logged in, route `/admin/dashboard`.

### Desktop 1440×900

| Metric | Value | Token |
|---|---:|:---|
| `h1` count | 1 | — |
| `.page-title` | 24px | `$text-2xl` (H1 rung) |
| `.card-title` | 18px | `$text-lg` (H3 rung) ← was 16px |
| `.metric-value` | 24px | `$text-2xl` (Display rung) ← was 20px |
| `.metric-label` | 12px | `$text-xs` |
| `.metric-sub` | 12px | `$text-xs` ← was 11px magic |
| `.card-body` padding | 24px | `$spacing-6` ← was 20px ($spacing-5) |
| `.card-header` padding | 16px 24px | `$spacing-4 $spacing-6` |
| `.metric-cell` padding | 16px 24px | `$spacing-4 $spacing-6` ← was 12px 20px |
| trend arrows rendered | 3 (→ → →) | flat (current data growthRate=0) |
| trend-flat color | `rgb(107,114,128)` | `$text-muted` (gray) |
| Empty state title + desc + CTA | ✓ ✓ `/admin/courses` | F-11 pass |

Click "Xem tất cả khóa học" → `/admin/courses` H1 "Quản lý khóa học hệ thống" ✓

### Mobile 375×812

| Metric | Value | Token |
|---|---:|:---|
| `h1` count | 1 | — |
| `.page-title` | 18px | `$text-lg` |
| `.card-title` | 16px | `$text-base` |
| `.metric-value` | 20px | `$text-xl` ← was 17px magic |
| `.metric-sub` | hidden | intentional (mobile compact) |
| `.btn-primary` height | 44px | iOS touch target |
| `.card-body` padding | 16px | `$spacing-4` |

### Screenshots

- `/tmp/after-prb-desktop.png` (1440×900 full page)
- `/tmp/after-prb-mobile.png` (375×812 full page)

## Convention compliance

- [x] OnPush
- [x] signal / computed / input / output, inject() — no constructor DI
- [x] @if / @for — no *ngIf
- [x] Không `standalone: true` explicit
- [x] CommonModule giữ (số liệu pipe `| number`)
- [x] Vietnamese có dấu, terminology phù hợp giảng viên (`Hàng đợi đã sạch`)
- [x] Trend up = green, down = red — semantic ≠ brand (Atlassian)

## Acceptance criteria (issue #162)

- [x] Mọi `font-size` dùng token, off-ladder có comment lý do
- [x] Mọi `padding` / `margin` / `gap` dùng `$spacing-*`, off-grid có comment
- [x] `.card-body` = 24px (`$spacing-6`)
- [x] 3 KPI cell có growth rate hiện trend arrow + dynamic color
- [x] Empty state có icon + title + description + CTA button → `/admin/courses`
- [x] CI 4/4 expect xanh
- [x] Browser measurement before/after attached

## Test plan

- [ ] Login admin → dashboard render — 4 KPI có trend arrow xám "→ 0% so với tháng trước" (flat khi data zero)
- [ ] DevTools console: `getComputedStyle($('.metric-value')).fontSize` = `"24px"`
- [ ] Mock growthRate = 5 → arrow "▲" green + 5%; growthRate = -3 → arrow "▼" red + 3%
- [ ] Pending list empty → CTA hiển thị, click → /admin/courses
- [ ] Tab keyboard tới CTA → focus ring visible
- [ ] Mobile DevTools 375 → KPI 2×2, metric-sub hidden, primary btn 44px

## Risk & rollback

- Risk: thấp. Pure FE, no API change. Trend logic là client-side derive.
- Rollback: `git revert`. UX quay về 11px metric-sub + 16px card-title + empty Inform-only.

## Out of scope (defer)

- F-06 systemHealth real source verify → PR-C
- F-08 date range toggle → PR-C
- F-07 activity chart → BE issue
- F-12 Cmd+K → riêng
- F-13 → F-18 polish + F-17 FAB overlap → PR-D

🤖 Generated with [Claude Code](https://claude.com/claude-code)