### PR TITLE
fix(admin-dashboard): real /actuator/health + defer date range to BE (closes #165)

### DIFF
--- a/fe/src/app/features/admin/infrastructure/services/system-health.service.ts
+++ b/fe/src/app/features/admin/infrastructure/services/system-health.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, signal } from '@angular/core';
+
+/**
+ * Real backend health probe via Spring Boot Actuator.
+ *
+ * Replaces the previous fictional 4-row breakdown (database / api / email /
+ * storage = 'healthy') in the admin dashboard. The course-analytics API never
+ * carried those fields — the FE was filling them with `??` defaults, so the
+ * card always showed green even when the backend was down.
+ *
+ * Backend exposes `/actuator/health` (public, no auth — see
+ * config/PublicApiEndpointMatcher.java:42). Default Spring Boot response is
+ * `{"status":"UP"}` or `{"status":"DOWN"}`. Anything else (network error,
+ * non-200, AbortError) is classified DOWN.
+ */
+export type HealthStatus = 'up' | 'down' | 'unknown';
+
+const PROBE_TIMEOUT_MS = 5_000;
+
+@Injectable({ providedIn: 'root' })
+export class SystemHealthService {
+  readonly status = signal<HealthStatus>('unknown');
+  readonly lastChecked = signal<Date | null>(null);
+  readonly loading = signal(false);
+
+  async refresh(): Promise<void> {
+    if (this.loading()) return;
+    this.loading.set(true);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+
+    try {
+      const res = await fetch('/actuator/health', {
+        method: 'GET',
+        signal: controller.signal,
+        cache: 'no-store',
+      });
+      if (!res.ok) {
+        this.status.set('down');
+      } else {
+        const body = await res.json().catch(() => null);
+        const raw = (body?.status ?? '').toString().toUpperCase();
+        this.status.set(raw === 'UP' ? 'up' : 'down');
+      }
+    } catch {
+      // AbortError, network failure, JSON parse error — all map to DOWN.
+      this.status.set('down');
+    } finally {
+      clearTimeout(timeoutId);
+      this.lastChecked.set(new Date());
+      this.loading.set(false);
+    }
+  }
+}

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.html
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.html
@@ -129,52 +129,57 @@
           </nav>
         </div>
 
-        <!-- System Health -->
+        <!-- System Health — single real status from /actuator/health (F-06).
+             Previous 4-row breakdown (api/db/email/storage) was synthetic —
+             the analytics API never returned those fields. -->
         <div class="card health-card">
           <div class="card-header">
             <h2 class="card-title">Trạng thái hệ thống</h2>
+            <button
+              type="button"
+              class="health-refresh"
+              (click)="refreshHealth()"
+              [disabled]="health.loading()"
+              [attr.aria-label]="'Làm mới trạng thái hệ thống'">
+              <app-icon name="refresh" size="sm" aria-hidden="true" />
+              <span class="sr-only">Làm mới</span>
+            </button>
           </div>
-          <div class="health-list">
-            <div class="health-item">
-              <div class="health-dot" [class.healthy]="analytics().systemHealth.api === 'healthy'"
-                [class.error]="analytics().systemHealth.api !== 'healthy'"></div>
-              <span class="health-name">API Service</span>
-              <span class="health-status"
-                [class.status-ok]="analytics().systemHealth.api === 'healthy'"
-                [class.status-err]="analytics().systemHealth.api !== 'healthy'">
-                {{ analytics().systemHealth.api === 'healthy' ? 'Hoạt động' : 'Lỗi' }}
-              </span>
-            </div>
-            <div class="health-item">
-              <div class="health-dot" [class.healthy]="analytics().systemHealth.database === 'healthy'"
-                [class.error]="analytics().systemHealth.database !== 'healthy'"></div>
-              <span class="health-name">Database</span>
-              <span class="health-status"
-                [class.status-ok]="analytics().systemHealth.database === 'healthy'"
-                [class.status-err]="analytics().systemHealth.database !== 'healthy'">
-                {{ analytics().systemHealth.database === 'healthy' ? 'Hoạt động' : 'Lỗi' }}
-              </span>
-            </div>
-            <div class="health-item">
-              <div class="health-dot" [class.healthy]="analytics().systemHealth.email === 'healthy'"
-                [class.error]="analytics().systemHealth.email !== 'healthy'"></div>
-              <span class="health-name">Email Service</span>
-              <span class="health-status"
-                [class.status-ok]="analytics().systemHealth.email === 'healthy'"
-                [class.status-err]="analytics().systemHealth.email !== 'healthy'">
-                {{ analytics().systemHealth.email === 'healthy' ? 'Hoạt động' : 'Lỗi' }}
-              </span>
-            </div>
-            <div class="health-item">
-              <div class="health-dot" [class.healthy]="analytics().systemHealth.storage === 'healthy'"
-                [class.warn]="analytics().systemHealth.storage !== 'healthy'"></div>
-              <span class="health-name">Bộ nhớ</span>
-              <span class="health-status"
-                [class.status-ok]="analytics().systemHealth.storage === 'healthy'"
-                [class.status-warn]="analytics().systemHealth.storage !== 'healthy'">
-                {{ analytics().systemHealth.storage === 'healthy' ? 'Hoạt động' : 'Cần kiểm tra' }}
-              </span>
-            </div>
+          <div class="health-summary">
+            @if (health.status() === 'unknown') {
+              <div class="health-row health-row-unknown">
+                <div class="health-dot warn"></div>
+                <div class="health-text">
+                  <p class="health-name">Đang kiểm tra...</p>
+                  <p class="health-meta">Đang gọi /actuator/health</p>
+                </div>
+              </div>
+            } @else if (health.status() === 'up') {
+              <div class="health-row health-row-up">
+                <div class="health-dot healthy"></div>
+                <div class="health-text">
+                  <p class="health-name">Hệ thống đang hoạt động</p>
+                  <p class="health-meta">
+                    Cập nhật lúc {{ health.lastChecked() | date:'HH:mm:ss' }}
+                  </p>
+                </div>
+                <span class="health-badge status-ok">UP</span>
+              </div>
+            } @else {
+              <div class="health-row health-row-down">
+                <div class="health-dot error"></div>
+                <div class="health-text">
+                  <p class="health-name">Hệ thống gặp sự cố</p>
+                  <p class="health-meta">
+                    Lần kiểm tra cuối: {{ health.lastChecked() | date:'HH:mm:ss' }}
+                  </p>
+                </div>
+                <span class="health-badge status-err">DOWN</span>
+              </div>
+            }
+            <p class="health-source">
+              Nguồn dữ liệu: <code>GET /actuator/health</code>
+            </p>
           </div>
         </div>
       </div>

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.scss
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.scss
@@ -92,6 +92,10 @@
 }
 
 .card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-3;
   padding: $spacing-4 $spacing-6;
   border-bottom: 1px solid $border-light;
 }
@@ -432,19 +436,28 @@
   }
 }
 
-/* ===== HEALTH CARD ===== */
-.health-list {
+/* ===== HEALTH CARD =====
+   F-06: replaced 4-row fictional breakdown with single real /actuator/health
+   summary + lastChecked timestamp + manual refresh. */
+.health-summary {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-3;
   padding: $spacing-4 $spacing-6;
 }
 
-.health-item {
+.health-row {
   display: flex;
   align-items: center;
   gap: $spacing-3;
-  padding: $spacing-3 0;
-  border-bottom: 1px solid $border-light;
+  padding: $spacing-3;
+  border-radius: $radius-md;
+  background: $gray-50;
+  transition: background $transition-fast;
 
-  &:last-child { border-bottom: none; }
+  &.health-row-up { background: rgba($success, 0.06); }
+  &.health-row-down { background: rgba($error, 0.06); }
+  &.health-row-unknown { background: rgba($warning, 0.06); }
 }
 
 .health-dot {
@@ -461,22 +474,89 @@
   &.warn { background: $warning; box-shadow: 0 0 0 3px rgba($warning, 0.15); }
 }
 
-.health-name {
+.health-text {
   flex: 1;
-  font-size: $text-sm;
-  font-weight: $font-medium;
-  color: $gray-700;
+  min-width: 0;
 }
 
-.health-status {
+.health-name {
+  font-size: $text-sm;
+  font-weight: $font-semibold;
+  color: $text-primary;
+  margin: 0;
+}
+
+.health-meta {
   font-size: $text-xs;
-  font-weight: $font-medium;
-  padding: $spacing-1 $spacing-3;
+  color: $text-muted;
+  margin: 2px 0 0; // 4pt baseline — tight pairing with name above
+  font-variant-numeric: tabular-nums;
+}
+
+.health-badge {
+  font-size: $text-xs;
+  font-weight: $font-bold;
+  padding: $spacing-1 $spacing-2;
   border-radius: $radius-sm;
+  letter-spacing: 0.5px;
 
   &.status-ok { background: $success-light; color: $success; }
   &.status-err { background: $error-light; color: $error; }
-  &.status-warn { background: $warning-light; color: $warning; }
+}
+
+.health-source {
+  font-size: $text-xs;
+  color: $text-muted;
+  margin: 0;
+
+  code {
+    font-family: $font-family-mono;
+    font-size: 11px; // mono fonts run visually larger; nudge down a step
+    background: $gray-100;
+    padding: 2px $spacing-1;
+    border-radius: $radius-sm;
+    color: $gray-700;
+  }
+}
+
+.health-refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: $spacing-8;
+  height: $spacing-8;
+  padding: 0;
+  border: 1px solid $border-default;
+  border-radius: $radius-md;
+  background: white;
+  color: $text-muted;
+  cursor: pointer;
+  transition: background $transition-fast, color $transition-fast, border-color $transition-fast;
+
+  &:hover:not(:disabled) {
+    background: $gray-50;
+    color: $blue-primary;
+    border-color: $blue-primary;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @include focus-visible;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* ===== SKELETON ===== */
@@ -547,8 +627,9 @@
   .data-table th { padding: $spacing-2 $spacing-3; font-size: $text-xs; }
   .data-table td { padding: $spacing-2 $spacing-3; font-size: $text-sm; }
 
-  .health-list { padding: $spacing-3; }
-  .health-name { font-size: $text-sm; }
+  .health-summary { padding: $spacing-3; }
+  .health-row { padding: $spacing-2 $spacing-3; }
+  .health-source { display: none; }
 
   .table-empty {
     padding: $spacing-8 $spacing-4;
@@ -649,11 +730,13 @@
   }
 
   // Health: compact
-  .health-list { padding: 8px 12px !important; }
-  .health-item { padding: 6px 0 !important; }
+  .health-summary { padding: 8px 12px !important; gap: 6px !important; }
+  .health-row { padding: 4px 8px !important; }
+  .health-refresh { display: none !important; }
+  .health-source { display: none !important; }
 
   // Print colors
-  .badge, .health-dot, .health-status, .metric-value {
+  .badge, .health-dot, .health-badge, .metric-value {
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
   }

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.ts
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.ts
@@ -1,7 +1,8 @@
-import { Component, input, output, signal, computed, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, output, signal, computed, inject, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { SystemAnalytics } from '../../../infrastructure/services/admin.service';
+import { SystemHealthService } from '../../../infrastructure/services/system-health.service';
 import { PendingApproval } from './dashboard.types';
 import { DialogComponent } from '../../../../../shared/components/dialog/dialog.component';
 import { IconComponent, IconName } from '../../../../../shared/components/icon/icon.component';
@@ -31,12 +32,25 @@ const QUICK_ACTIONS: readonly QuickAction[] = [
   styleUrl: './admin-system-dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class AdminSystemDashboardComponent {
+export class AdminSystemDashboardComponent implements OnInit {
+  // F-06: backend health is read from /actuator/health (real ping), not from
+  // the synthetic systemHealth object the analytics API used to imply.
+  protected health = inject(SystemHealthService);
+
   // --- Inputs from parent ---
   analytics = input.required<SystemAnalytics>();
   pendingApprovals = input.required<PendingApproval[]>();
   isLoading = input.required<boolean>();
   isLoadingPending = input.required<boolean>();
+
+  ngOnInit(): void {
+    // Fire and forget — service flips its own loading signal during the probe.
+    this.health.refresh();
+  }
+
+  refreshHealth(): void {
+    this.health.refresh();
+  }
 
   // --- Outputs to parent ---
   courseApproved = output<string>();


### PR DESCRIPTION
Closes #165. Part of epic #157. Builds on #163 (PR-B merged).
Refs #164 (BE windowed analytics endpoint for F-08).

## Findings addressed

Từ audit `docs/reports/2026-04-25-admin-dashboard-ux-audit.md` §4 P1:

- **F-06** Replace fictional 4-row systemHealth với real `/actuator/health` summary + timestamp + manual refresh
- **F-08** Date range toggle — **defer** to BE issue #164 (cần windowed analytics endpoint trước; adding FE toggle bây giờ = synthetic UI)

## Why F-06 matters

Truy ngược source: `AdminCoursesControllerV3.CourseAnalyticsResponse:811` không có field `systemHealth`. FE service dùng `??` fallback `{ database: 'healthy', api: 'healthy', storage: 'healthy', email: 'healthy' }` — luôn xanh kể cả backend down. Đúng anti-pattern PR #145 đã fix cho ORG_ADMIN dashboard.

## Changes

| File | Change |
|---|---|
| `fe/.../admin/infrastructure/services/system-health.service.ts` *(new)* | Ping `/actuator/health` (5s timeout, AbortController). Classify response → `up` / `down` / `unknown`. Network/parse error → `down` (fail-loud). |
| `.../dashboard/admin-system-dashboard.component.ts` | Inject `SystemHealthService`. `ngOnInit` calls `refresh()`. Add `refreshHealth()` for manual button. |
| `.../dashboard/admin-system-dashboard.component.html` | Drop 4 health-item rows. Render single `.health-row` với 3 state (up/down/unknown), timestamp `Cập nhật lúc HH:mm:ss`, refresh button trong card-header, source label `Nguồn dữ liệu: GET /actuator/health`. |
| `.../dashboard/admin-system-dashboard.component.scss` | Drop `.health-list/.health-item/.health-status`. Add `.health-summary`, `.health-row` (state-tinted bg), `.health-refresh` (32×32 icon button + focus-visible), `.health-source`, `.health-badge`, `.sr-only`. card-header → flex space-between để chứa title + refresh button. Mobile: source code line ẩn. Print: refresh + source ẩn. |

4 files, +219 / −62.

## Browser verification (agent-browser)

### Desktop 1440×900

| | Before | After |
|---|---|---|
| `.health-list` (4-row breakdown) | tồn tại với synthetic data | **không còn trong DOM** |
| Health source | hard-coded `'healthy'` từ FE fallback | **`fetch('/actuator/health')`** thật |
| Status display | 4 row "API Service" / "Database" / "Email" / "Bộ nhớ" giả | **1 row "Hệ thống đang hoạt động"** |
| Timestamp | — | **"Cập nhật lúc 13:57:22"** |
| Refresh button | — | **icon button trong card-header** |
| Source label | — | **`Nguồn dữ liệu: GET /actuator/health`** |
| Refresh click → timestamp update | — | **13:57:22 → 13:57:40 ✓** |

### Mobile 375×812

- Single row layout compact, badge "UP" giữ position phải
- Source code line ẩn (mobile rule)
- Refresh button vẫn visible

## Why defer F-08

BE `GET /api/v3/admin/courses/analytics` trả snapshot tháng hiện tại
(`monthlyRevenue`, `totalEnrollments`, ...). Không có `?days={7|30|90}` param.

Tracked tại issue #164 với spec endpoint mới. Khi BE ship endpoint, mở
PR riêng cho FE date-range toggle reusable component (dashboard + ORG_ADMIN
dashboard cùng dùng).

Pattern này nhất quán với PR #145 / #153: **không add UI control mà BE
chưa support** — gây synthetic data illusion.

## Convention compliance

- [x] OnPush
- [x] signal / inject — không constructor DI
- [x] @if / @for
- [x] Không `standalone: true` explicit
- [x] CommonModule (cho `| date` pipe trên timestamp)
- [x] Vietnamese có dấu, terminology rõ ("Hệ thống đang hoạt động" thay vì "API Service hoạt động" jargon)
- [x] WCAG 2.2 SC 2.5.8: refresh button 32×32, focus-visible 2px outline

## Acceptance criteria (issue #165)

- [x] Card không còn render 4 service giả
- [x] Hiển thị 1 status từ `/actuator/health` thật
- [x] Timestamp `Cập nhật lúc HH:mm:ss`
- [x] Manual refresh button
- [x] AbortError / non-200 / parse error → DOWN status
- [x] CI 4/4 expect xanh
- [x] Browser verify desktop + mobile

## Test plan

- [ ] Login admin → dashboard render — health card hiển thị "Hệ thống đang hoạt động" + timestamp
- [ ] Click refresh button → timestamp update, dot vẫn xanh
- [ ] Stop backend (`docker compose stop backend`) → reload dashboard → health card "Hệ thống gặp sự cố" + UP→DOWN
- [ ] Mobile DevTools 375 → row compact, source code ẩn
- [ ] Tab keyboard tới refresh button → focus ring visible 2px
- [ ] Screen reader: focus refresh button → "Làm mới trạng thái hệ thống"

## Risk & rollback

- Risk: thấp. Service mới isolated, dashboard component thay 1 card.
- Rollback: `git revert`. Card sẽ trở về 4-row synthetic — re-introduce
  honesty bug.

## Out of scope (defer)

- F-07 activity chart — BE issue riêng (cần daily series endpoint)
- F-08 date range — BE issue #164
- F-12 Cmd+K — task riêng
- F-13 → F-18 polish (incl F-17 FAB overlap với health card) — PR-D optional

🤖 Generated with [Claude Code](https://claude.com/claude-code)