### PR TITLE
fix(admin-users-students): icon rendering full-width bug P0 BLOCKING (closes #167)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/student-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.ts
@@ -16,6 +16,10 @@ import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-student-management',
   imports: [RouterModule, FormsModule],
+  // F-ST1 hotfix: was missing — main SCSS file never loaded so .stat-icon
+  // had no width/height constraint and stretched to 1136×1136, making the
+  // page unusable. Mirrors teacher-management.component.ts:20.
+  styleUrl: './student-management.component.scss',
   styles: [`
     select.role-select {
       cursor: pointer;


### PR DESCRIPTION
Closes #167. Part of epic #161 (admin portal mega refresh).

**P0 BLOCKING** — `/admin/users/students` was rendering giant 1136×1136 black blocks instead of KPI icons. Page completely unusable.

## Root cause

`student-management.component.ts` was missing `styleUrl: './student-management.component.scss'` in its `@Component` decorator. The SCSS file existed with `.stat-icon { width: 40px; height: 40px; svg { width: 20px; height: 20px } }` but Angular never loaded it → no size constraint → element stretched to full parent content area (1136px).

`teacher-management.component.ts:20` had `styleUrl` correctly. Just a typo / missed line in students.

## Fix

1-line addition to the decorator (4 LOC including comment).

## Browser verification (agent-browser, admin@maritime.edu)

| Metric | Before | After |
|---|---:|---:|
| `.stat-icon` size | 1136 × 1136 px | **40 × 40 px** |
| Page H1 | rendered but page broken | **"Quản lý Học viên"** |
| KPI strip | 4 giant black blocks | **4 cards** (Tổng / Đã đăng ký / Bị khóa / Hoạt động gần đây) |
| Table | hidden under broken icons | **28 students** với avatar + role pill |
| Search bar / filter | hidden | **visible** |

Screenshot after fix: `/tmp/after-hotfix-students.png` — full students page renders correctly.

## Convention compliance

- [x] OnPush giữ nguyên
- [x] inject() / signal / computed
- [x] No template/HTML changes
- [x] Comment giải thích WHY (có precedent từ teacher-management.component.ts:20)

## Acceptance criteria (issue #167)

- [x] `.stat-icon` = 40 × 40 px
- [x] H1 "Quản lý Học viên" hiển thị
- [x] Table students render đúng layout
- [x] CI 4/4 expect xanh
- [x] agent-browser measurement before/after

## Test plan

- [ ] Login `admin@maritime.edu` → `/admin/users/students` render đúng (DevTools: `getComputedStyle($('.stat-icon')).width === "40px"`)
- [ ] Mobile (375×812) — KPI 1-col stack, icon vẫn 40×40
- [ ] Click status dropdown / search bar → component hoạt động bình thường

## Risk & rollback

- Risk: cực thấp. 1 dòng decorator. SCSS đã được test trên `/admin/users/teachers` (cùng pattern).
- Rollback: `git revert`. Page sẽ trở lại trạng thái broken — không khuyến nghị.

## Out of scope (defer)

Các finding khác cho students từ mega audit:
- CC-01 (KPI card unify across portal) → Portal PR-A
- CC-02 (primary action color) → Portal PR-A  
- CC-10 (status pill read-only thay inline-edit dropdown) → Portal PR-B

Đây là **hotfix tối thiểu** chỉ để unblock page. Redesign sẽ trong PR-B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)