### PR TITLE
feat(admin-analytics): windowed endpoint /analytics/window?days={7|30|90} (closes #164)

### DIFF
--- a/backend/src/main/java/com/example/lms/config/PasswordConfig.java
+++ b/backend/src/main/java/com/example/lms/config/PasswordConfig.java
@@ -5,11 +5,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.Clock;
+
 @Configuration
 public class PasswordConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
     }
 }

--- a/backend/src/main/java/com/example/lms/course_authoring/admin/application/dto/GrowthMetric.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/admin/application/dto/GrowthMetric.java
@@ -1,0 +1,28 @@
+package com.example.lms.course_authoring.admin.application.dto;
+
+/**
+ * Growth metric comparing the current window to the immediately preceding window
+ * of the same length.
+ *
+ * <p>{@code growthRate} is the percentage change ((this - last) / last) * 100.
+ * It is {@code null} when {@code lastWindow == 0 && thisWindow > 0} so the FE can
+ * render an explicit "—" / "+∞" indicator instead of a misleading percentage.
+ */
+public record GrowthMetric(
+        long thisWindow,
+        long lastWindow,
+        Double growthRate
+) {
+
+    public static GrowthMetric of(long thisWindow, long lastWindow) {
+        return new GrowthMetric(thisWindow, lastWindow, computeGrowthRate(thisWindow, lastWindow));
+    }
+
+    private static Double computeGrowthRate(long thisWindow, long lastWindow) {
+        if (lastWindow == 0L) {
+            return thisWindow == 0L ? 0.0 : null;
+        }
+        double rate = ((double) (thisWindow - lastWindow) / (double) lastWindow) * 100.0;
+        return Math.round(rate * 10.0) / 10.0;
+    }
+}

--- a/backend/src/main/java/com/example/lms/course_authoring/admin/application/dto/WindowedAnalyticsResponse.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/admin/application/dto/WindowedAnalyticsResponse.java
@@ -1,0 +1,25 @@
+package com.example.lms.course_authoring.admin.application.dto;
+
+import java.time.Instant;
+
+/**
+ * Windowed analytics payload for the admin dashboard date-range toggle (F-08).
+ *
+ * <p>The {@code total*} fields are cumulative counts at {@link #windowEnd}; the
+ * {@link GrowthMetric} fields compare new entities created within
+ * {@code [windowStart, windowEnd)} against the immediately preceding window of
+ * the same length. {@code revenue} is the revenue earned within the current
+ * window, {@code revenueGrowth} is the percentage change vs. the prior window.
+ */
+public record WindowedAnalyticsResponse(
+        int windowDays,
+        long totalUsers,
+        long totalCourses,
+        long totalEnrollments,
+        double revenue,
+        GrowthMetric userGrowth,
+        Double revenueGrowth,
+        GrowthMetric courseGrowth,
+        Instant windowStart,
+        Instant windowEnd
+) {}

--- a/backend/src/main/java/com/example/lms/course_authoring/admin/application/port/AdminAnalyticsPort.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/admin/application/port/AdminAnalyticsPort.java
@@ -1,0 +1,56 @@
+package com.example.lms.course_authoring.admin.application.port;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Aggregation port for admin analytics queries.
+ *
+ * <p>All "Between" methods use a half-open interval {@code [from, to)} so two
+ * adjacent windows do not double-count the boundary instant.
+ */
+public interface AdminAnalyticsPort {
+
+    // === System-wide totals (cumulative) ===
+
+    long countAllUsers();
+
+    long countAllCourses();
+
+    long countAllEnrollments();
+
+    // === System-wide windowed counts ===
+
+    long countUsersCreatedBetween(Instant from, Instant to);
+
+    long countCoursesCreatedBetween(Instant from, Instant to);
+
+    BigDecimal sumRevenueBetween(Instant from, Instant to);
+
+    // === Org-scoped totals (cumulative) ===
+
+    long countUsersByOrganization(UUID organizationId);
+
+    long countCoursesByTeacherIds(Set<UUID> teacherIds);
+
+    long countEnrollmentsByCourseIds(List<UUID> courseIds);
+
+    // === Org-scoped windowed counts ===
+
+    long countUsersCreatedBetweenInOrganization(UUID organizationId, Instant from, Instant to);
+
+    long countCoursesCreatedBetweenByTeacherIds(Set<UUID> teacherIds, Instant from, Instant to);
+
+    BigDecimal sumRevenueBetweenByCourseIds(List<UUID> courseIds, Instant from, Instant to);
+
+    // === Org helpers ===
+
+    /** Resolve teacher IDs that belong to the given organization. */
+    Set<UUID> findTeacherIdsByOrganization(UUID organizationId);
+
+    /** Resolve course IDs owned by any teacher in the given set. */
+    List<UUID> findCourseIdsByTeacherIds(Set<UUID> teacherIds);
+}

--- a/backend/src/main/java/com/example/lms/course_authoring/admin/application/usecase/GetWindowedAnalyticsUseCase.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/admin/application/usecase/GetWindowedAnalyticsUseCase.java
@@ -1,0 +1,144 @@
+package com.example.lms.course_authoring.admin.application.usecase;
+
+import com.example.lms.course_authoring.admin.application.dto.GrowthMetric;
+import com.example.lms.course_authoring.admin.application.dto.WindowedAnalyticsResponse;
+import com.example.lms.course_authoring.admin.application.port.AdminAnalyticsPort;
+import com.example.lms.shared.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Computes admin dashboard analytics for a sliding window of {@code days} days,
+ * compared against the immediately preceding window of the same length. Backs
+ * the F-08 date-range toggle (epic #157).
+ *
+ * <p>Window semantics: {@code [now - days, now)} for the current window,
+ * {@code [now - 2*days, now - days)} for the prior window. Half-open intervals
+ * mean adjacent windows do not double-count the boundary instant.
+ *
+ * <p>When {@code organizationId} is non-null the use case scopes every count to
+ * users in that organization and courses owned by teachers in that
+ * organization. When it is null the counts are system-wide.
+ */
+@Component
+@RequiredArgsConstructor
+public class GetWindowedAnalyticsUseCase {
+
+    private static final Set<Integer> ALLOWED_DAYS = Set.of(7, 30, 90);
+
+    private final AdminAnalyticsPort analyticsPort;
+    private final Clock clock;
+
+    public WindowedAnalyticsResponse execute(int days, UUID organizationId) {
+        validateDays(days);
+
+        Instant windowEnd = Instant.now(clock);
+        Instant windowStart = windowEnd.minus(days, ChronoUnit.DAYS);
+        Instant prevWindowStart = windowStart.minus(days, ChronoUnit.DAYS);
+
+        return organizationId != null
+                ? buildOrgScoped(days, organizationId, windowStart, windowEnd, prevWindowStart)
+                : buildSystemWide(days, windowStart, windowEnd, prevWindowStart);
+    }
+
+    private void validateDays(int days) {
+        if (!ALLOWED_DAYS.contains(days)) {
+            throw new ValidationException(
+                    "days",
+                    "Tham số 'days' chỉ chấp nhận 7, 30 hoặc 90 (đã nhận: " + days + ")"
+            );
+        }
+    }
+
+    private WindowedAnalyticsResponse buildSystemWide(
+            int days, Instant windowStart, Instant windowEnd, Instant prevWindowStart
+    ) {
+        long totalUsers = analyticsPort.countAllUsers();
+        long totalCourses = analyticsPort.countAllCourses();
+        long totalEnrollments = analyticsPort.countAllEnrollments();
+
+        long usersThis = analyticsPort.countUsersCreatedBetween(windowStart, windowEnd);
+        long usersLast = analyticsPort.countUsersCreatedBetween(prevWindowStart, windowStart);
+        long coursesThis = analyticsPort.countCoursesCreatedBetween(windowStart, windowEnd);
+        long coursesLast = analyticsPort.countCoursesCreatedBetween(prevWindowStart, windowStart);
+
+        BigDecimal revenueThis = analyticsPort.sumRevenueBetween(windowStart, windowEnd);
+        BigDecimal revenueLast = analyticsPort.sumRevenueBetween(prevWindowStart, windowStart);
+
+        return assemble(
+                days, windowStart, windowEnd,
+                totalUsers, totalCourses, totalEnrollments,
+                usersThis, usersLast,
+                coursesThis, coursesLast,
+                revenueThis, revenueLast
+        );
+    }
+
+    private WindowedAnalyticsResponse buildOrgScoped(
+            int days, UUID organizationId, Instant windowStart, Instant windowEnd, Instant prevWindowStart
+    ) {
+        Set<UUID> teacherIds = analyticsPort.findTeacherIdsByOrganization(organizationId);
+        List<UUID> courseIds = analyticsPort.findCourseIdsByTeacherIds(teacherIds);
+
+        long totalUsers = analyticsPort.countUsersByOrganization(organizationId);
+        long totalCourses = analyticsPort.countCoursesByTeacherIds(teacherIds);
+        long totalEnrollments = analyticsPort.countEnrollmentsByCourseIds(courseIds);
+
+        long usersThis = analyticsPort.countUsersCreatedBetweenInOrganization(organizationId, windowStart, windowEnd);
+        long usersLast = analyticsPort.countUsersCreatedBetweenInOrganization(organizationId, prevWindowStart, windowStart);
+        long coursesThis = analyticsPort.countCoursesCreatedBetweenByTeacherIds(teacherIds, windowStart, windowEnd);
+        long coursesLast = analyticsPort.countCoursesCreatedBetweenByTeacherIds(teacherIds, prevWindowStart, windowStart);
+
+        BigDecimal revenueThis = analyticsPort.sumRevenueBetweenByCourseIds(courseIds, windowStart, windowEnd);
+        BigDecimal revenueLast = analyticsPort.sumRevenueBetweenByCourseIds(courseIds, prevWindowStart, windowStart);
+
+        return assemble(
+                days, windowStart, windowEnd,
+                totalUsers, totalCourses, totalEnrollments,
+                usersThis, usersLast,
+                coursesThis, coursesLast,
+                revenueThis, revenueLast
+        );
+    }
+
+    private WindowedAnalyticsResponse assemble(
+            int days, Instant windowStart, Instant windowEnd,
+            long totalUsers, long totalCourses, long totalEnrollments,
+            long usersThis, long usersLast,
+            long coursesThis, long coursesLast,
+            BigDecimal revenueThis, BigDecimal revenueLast
+    ) {
+        double revenue = revenueThis.setScale(2, RoundingMode.HALF_UP).doubleValue();
+        return new WindowedAnalyticsResponse(
+                days,
+                totalUsers,
+                totalCourses,
+                totalEnrollments,
+                revenue,
+                GrowthMetric.of(usersThis, usersLast),
+                computeRevenueGrowth(revenueThis, revenueLast),
+                GrowthMetric.of(coursesThis, coursesLast),
+                windowStart,
+                windowEnd
+        );
+    }
+
+    private Double computeRevenueGrowth(BigDecimal revenueThis, BigDecimal revenueLast) {
+        if (revenueLast == null || revenueLast.signum() == 0) {
+            return revenueThis != null && revenueThis.signum() > 0 ? null : 0.0;
+        }
+        BigDecimal delta = revenueThis.subtract(revenueLast);
+        BigDecimal rate = delta.divide(revenueLast, 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100));
+        return rate.setScale(1, RoundingMode.HALF_UP).doubleValue();
+    }
+}

--- a/backend/src/main/java/com/example/lms/course_authoring/admin/infrastructure/persistence/AdminAnalyticsAdapter.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/admin/infrastructure/persistence/AdminAnalyticsAdapter.java
@@ -1,0 +1,116 @@
+package com.example.lms.course_authoring.admin.infrastructure.persistence;
+
+import com.example.lms.course_authoring.admin.application.port.AdminAnalyticsPort;
+import com.example.lms.course_authoring.infrastructure.persistence.JpaCourseRepository;
+import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
+import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
+import com.example.lms.learning_delivery.infrastructure.persistence.JpaEnrollmentRepository;
+import com.example.lms.shared.infrastructure.persistence.repository.PaymentTransactionJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Infrastructure adapter wiring {@link AdminAnalyticsPort} to existing JPA
+ * repositories. Aggregates spans modules (identity / course_authoring /
+ * learning_delivery / payments) which is acceptable here because the admin
+ * dashboard is intentionally a cross-cutting view.
+ */
+@Component
+@RequiredArgsConstructor
+public class AdminAnalyticsAdapter implements AdminAnalyticsPort {
+
+    private final UserJpaRepository userRepository;
+    private final JpaCourseRepository courseRepository;
+    private final JpaEnrollmentRepository enrollmentRepository;
+    private final PaymentTransactionJpaRepository paymentRepository;
+
+    @Override
+    public long countAllUsers() {
+        return userRepository.count();
+    }
+
+    @Override
+    public long countAllCourses() {
+        return courseRepository.count();
+    }
+
+    @Override
+    public long countAllEnrollments() {
+        return enrollmentRepository.count();
+    }
+
+    @Override
+    public long countUsersCreatedBetween(Instant from, Instant to) {
+        return userRepository.countByCreatedAtBetween(from, to);
+    }
+
+    @Override
+    public long countCoursesCreatedBetween(Instant from, Instant to) {
+        return courseRepository.countByCreatedAtBetween(from, to);
+    }
+
+    @Override
+    public BigDecimal sumRevenueBetween(Instant from, Instant to) {
+        BigDecimal sum = paymentRepository.sumRevenueByDateRange(from, to);
+        return sum != null ? sum : BigDecimal.ZERO;
+    }
+
+    @Override
+    public long countUsersByOrganization(UUID organizationId) {
+        if (organizationId == null) return 0L;
+        return userRepository.countByOrganizationId(organizationId);
+    }
+
+    @Override
+    public long countCoursesByTeacherIds(Set<UUID> teacherIds) {
+        if (teacherIds == null || teacherIds.isEmpty()) return 0L;
+        return courseRepository.countByTeacherIdIn(teacherIds);
+    }
+
+    @Override
+    public long countEnrollmentsByCourseIds(List<UUID> courseIds) {
+        if (courseIds == null || courseIds.isEmpty()) return 0L;
+        return enrollmentRepository.countTotalByCourseIds(courseIds);
+    }
+
+    @Override
+    public long countUsersCreatedBetweenInOrganization(UUID organizationId, Instant from, Instant to) {
+        if (organizationId == null) return 0L;
+        return userRepository.countByOrganizationIdAndCreatedAtBetween(organizationId, from, to);
+    }
+
+    @Override
+    public long countCoursesCreatedBetweenByTeacherIds(Set<UUID> teacherIds, Instant from, Instant to) {
+        if (teacherIds == null || teacherIds.isEmpty()) return 0L;
+        return courseRepository.countByTeacherIdInAndCreatedAtBetween(teacherIds, from, to);
+    }
+
+    @Override
+    public BigDecimal sumRevenueBetweenByCourseIds(List<UUID> courseIds, Instant from, Instant to) {
+        if (courseIds == null || courseIds.isEmpty()) return BigDecimal.ZERO;
+        BigDecimal sum = paymentRepository.sumRevenueByCourseIdsAndDateRange(courseIds, from, to);
+        return sum != null ? sum : BigDecimal.ZERO;
+    }
+
+    @Override
+    public Set<UUID> findTeacherIdsByOrganization(UUID organizationId) {
+        if (organizationId == null) return Set.of();
+        return userRepository.findByOrganizationId(organizationId).stream()
+                .filter(u -> u.getRole() == UserJpaEntity.UserRole.TEACHER)
+                .map(UserJpaEntity::getId)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public List<UUID> findCourseIdsByTeacherIds(Set<UUID> teacherIds) {
+        if (teacherIds == null || teacherIds.isEmpty()) return List.of();
+        return courseRepository.findCourseIdsByTeacherIdIn(teacherIds);
+    }
+}

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/JpaCourseRepository.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/JpaCourseRepository.java
@@ -214,4 +214,19 @@ public interface JpaCourseRepository extends JpaRepository<CourseJpaEntity, UUID
 
     @Query("SELECT c.id FROM CourseJpaEntity c WHERE c.teacherId IN :teacherIds")
     List<UUID> findCourseIdsByTeacherIdIn(@Param("teacherIds") Collection<UUID> teacherIds);
+
+    // === Windowed analytics queries (half-open [from, to)) ===
+
+    @Query("SELECT COUNT(c) FROM CourseJpaEntity c WHERE c.createdAt >= :from AND c.createdAt < :to")
+    long countByCreatedAtBetween(
+            @Param("from") java.time.Instant from,
+            @Param("to") java.time.Instant to
+    );
+
+    @Query("SELECT COUNT(c) FROM CourseJpaEntity c WHERE c.teacherId IN :teacherIds AND c.createdAt >= :from AND c.createdAt < :to")
+    long countByTeacherIdInAndCreatedAtBetween(
+            @Param("teacherIds") Collection<UUID> teacherIds,
+            @Param("from") java.time.Instant from,
+            @Param("to") java.time.Instant to
+    );
 }

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3.java
@@ -1,5 +1,7 @@
 package com.example.lms.course_authoring.infrastructure.web;
 
+import com.example.lms.course_authoring.admin.application.dto.WindowedAnalyticsResponse;
+import com.example.lms.course_authoring.admin.application.usecase.GetWindowedAnalyticsUseCase;
 import com.example.lms.course_authoring.application.usecase.ApproveCourseUseCase;
 import com.example.lms.course_authoring.application.usecase.RejectCourseUseCase;
 import com.example.lms.course_authoring.domain.model.Course;
@@ -56,6 +58,7 @@ public class AdminCoursesControllerV3 {
     private final ApproveCourseUseCase approveCourseUseCase;
     private final RejectCourseUseCase rejectCourseUseCase;
     private final CourseReviewEventJpaRepository reviewEventRepository;
+    private final GetWindowedAnalyticsUseCase getWindowedAnalyticsUseCase;
 
     @Operation(summary = "Get all courses with pagination and filtering")
     @GetMapping("/all")
@@ -254,6 +257,18 @@ public class AdminCoursesControllerV3 {
                 .totalRevenue(totalRevenue)
                 .monthlyRevenue(monthlyRevenue)
                 .build();
+    }
+
+    @Operation(summary = "Get windowed analytics (7/30/90 days) for the admin dashboard date-range toggle")
+    @GetMapping("/analytics/window")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORG_ADMIN')")
+    public ResponseEntity<ApiResponse<WindowedAnalyticsResponse>> getWindowedAnalytics(
+            @RequestParam int days,
+            @AuthenticationPrincipal UserJpaEntity currentUser
+    ) {
+        UUID organizationId = isOrgAdmin(currentUser) ? currentUser.getOrganizationId() : null;
+        WindowedAnalyticsResponse analytics = getWindowedAnalyticsUseCase.execute(days, organizationId);
+        return ResponseEntity.ok(ApiResponse.success(analytics, "Dữ liệu phân tích theo khung thời gian"));
     }
 
     @Operation(summary = "Approve a course")

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/repository/UserJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/repository/UserJpaRepository.java
@@ -115,5 +115,20 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, UUID> {
             @Param("search") String search,
             Pageable pageable
     );
+
+    // === Windowed analytics queries (half-open [from, to)) ===
+
+    @Query("SELECT COUNT(u) FROM UserJpaEntity u WHERE u.createdAt >= :from AND u.createdAt < :to")
+    long countByCreatedAtBetween(@Param("from") java.time.Instant from, @Param("to") java.time.Instant to);
+
+    @Query("SELECT COUNT(u) FROM UserJpaEntity u WHERE u.organizationId = :orgId")
+    long countByOrganizationId(@Param("orgId") UUID orgId);
+
+    @Query("SELECT COUNT(u) FROM UserJpaEntity u WHERE u.organizationId = :orgId AND u.createdAt >= :from AND u.createdAt < :to")
+    long countByOrganizationIdAndCreatedAtBetween(
+            @Param("orgId") UUID orgId,
+            @Param("from") java.time.Instant from,
+            @Param("to") java.time.Instant to
+    );
 }
 

--- a/backend/src/test/java/com/example/lms/course_authoring/admin/application/usecase/GetWindowedAnalyticsUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/admin/application/usecase/GetWindowedAnalyticsUseCaseTest.java
@@ -1,0 +1,298 @@
+package com.example.lms.course_authoring.admin.application.usecase;
+
+import com.example.lms.course_authoring.admin.application.dto.WindowedAnalyticsResponse;
+import com.example.lms.course_authoring.admin.application.port.AdminAnalyticsPort;
+import com.example.lms.shared.exception.ValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetWindowedAnalyticsUseCase Tests")
+class GetWindowedAnalyticsUseCaseTest {
+
+    private static final Instant NOW = Instant.parse("2026-04-25T00:00:00Z");
+
+    @Mock private AdminAnalyticsPort port;
+
+    private GetWindowedAnalyticsUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        Clock fixed = Clock.fixed(NOW, ZoneOffset.UTC);
+        useCase = new GetWindowedAnalyticsUseCase(port, fixed);
+    }
+
+    @Nested
+    @DisplayName("Days validation")
+    class DaysValidationTests {
+
+        @ParameterizedTest
+        @ValueSource(ints = {7, 30, 90})
+        @DisplayName("Should accept days = 7, 30, 90")
+        void shouldAcceptValidWindow(int days) {
+            stubSystemWideZeros();
+
+            WindowedAnalyticsResponse response = useCase.execute(days, null);
+
+            assertThat(response.windowDays()).isEqualTo(days);
+            assertThat(response.windowEnd()).isEqualTo(NOW);
+            assertThat(response.windowStart()).isEqualTo(NOW.minus(days, ChronoUnit.DAYS));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {0, 1, 6, 8, 15, 29, 31, 60, 89, 91, 365})
+        @DisplayName("Should throw ValidationException for invalid days values (→ 400)")
+        void shouldRejectInvalidWindow(int days) {
+            assertThatThrownBy(() -> useCase.execute(days, null))
+                    .isInstanceOf(ValidationException.class)
+                    .hasMessageContaining("days")
+                    .hasMessageContaining(String.valueOf(days));
+        }
+
+        @Test
+        @DisplayName("Should reject negative days")
+        void shouldRejectNegativeDays() {
+            assertThatThrownBy(() -> useCase.execute(-7, null))
+                    .isInstanceOf(ValidationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("SYSTEM_ADMIN — system-wide aggregation")
+    class SystemWideTests {
+
+        @Test
+        @DisplayName("Should aggregate system-wide totals + windowed growth for days=7")
+        void shouldAggregateSystemWide() {
+            Instant windowStart = NOW.minus(7, ChronoUnit.DAYS);
+            Instant prevStart = NOW.minus(14, ChronoUnit.DAYS);
+
+            when(port.countAllUsers()).thenReturn(43L);
+            when(port.countAllCourses()).thenReturn(10L);
+            when(port.countAllEnrollments()).thenReturn(67L);
+            when(port.countUsersCreatedBetween(windowStart, NOW)).thenReturn(4L);
+            when(port.countUsersCreatedBetween(prevStart, windowStart)).thenReturn(2L);
+            when(port.countCoursesCreatedBetween(windowStart, NOW)).thenReturn(3L);
+            when(port.countCoursesCreatedBetween(prevStart, windowStart)).thenReturn(2L);
+            when(port.sumRevenueBetween(windowStart, NOW)).thenReturn(new BigDecimal("1500.00"));
+            when(port.sumRevenueBetween(prevStart, windowStart)).thenReturn(new BigDecimal("1000.00"));
+
+            WindowedAnalyticsResponse r = useCase.execute(7, null);
+
+            assertThat(r.windowDays()).isEqualTo(7);
+            assertThat(r.totalUsers()).isEqualTo(43L);
+            assertThat(r.totalCourses()).isEqualTo(10L);
+            assertThat(r.totalEnrollments()).isEqualTo(67L);
+            assertThat(r.revenue()).isEqualTo(1500.0);
+
+            assertThat(r.userGrowth().thisWindow()).isEqualTo(4L);
+            assertThat(r.userGrowth().lastWindow()).isEqualTo(2L);
+            assertThat(r.userGrowth().growthRate()).isEqualTo(100.0);
+
+            assertThat(r.courseGrowth().thisWindow()).isEqualTo(3L);
+            assertThat(r.courseGrowth().lastWindow()).isEqualTo(2L);
+            assertThat(r.courseGrowth().growthRate()).isEqualTo(50.0);
+
+            assertThat(r.revenueGrowth()).isEqualTo(50.0);
+            assertThat(r.windowEnd()).isEqualTo(NOW);
+            assertThat(r.windowStart()).isEqualTo(windowStart);
+
+            // Verify no org-scoped queries were called
+            verify(port, never()).findTeacherIdsByOrganization(any());
+            verify(port, never()).countUsersByOrganization(any());
+            verify(port, never()).countCoursesByTeacherIds(any());
+        }
+
+        @Test
+        @DisplayName("Window arithmetic: days=30 produces 30-day windows")
+        void daysThirtyProducesThirtyDayWindow() {
+            stubSystemWideZeros();
+
+            WindowedAnalyticsResponse r = useCase.execute(30, null);
+
+            assertThat(r.windowEnd()).isEqualTo(NOW);
+            assertThat(r.windowStart()).isEqualTo(NOW.minus(30, ChronoUnit.DAYS));
+            verify(port).countUsersCreatedBetween(NOW.minus(30, ChronoUnit.DAYS), NOW);
+            verify(port).countUsersCreatedBetween(NOW.minus(60, ChronoUnit.DAYS), NOW.minus(30, ChronoUnit.DAYS));
+        }
+
+        @Test
+        @DisplayName("Window arithmetic: days=90 produces 90-day windows")
+        void daysNinetyProducesNinetyDayWindow() {
+            stubSystemWideZeros();
+
+            WindowedAnalyticsResponse r = useCase.execute(90, null);
+
+            assertThat(r.windowStart()).isEqualTo(NOW.minus(90, ChronoUnit.DAYS));
+            verify(port).countCoursesCreatedBetween(NOW.minus(90, ChronoUnit.DAYS), NOW);
+            verify(port).countCoursesCreatedBetween(NOW.minus(180, ChronoUnit.DAYS), NOW.minus(90, ChronoUnit.DAYS));
+        }
+    }
+
+    @Nested
+    @DisplayName("ORG_ADMIN — org-scoped aggregation")
+    class OrgScopedTests {
+
+        @Test
+        @DisplayName("Should scope every count to the organization when orgId is provided")
+        void shouldScopeAllCountsToOrganization() {
+            UUID orgId = UUID.randomUUID();
+            UUID teacherId = UUID.randomUUID();
+            Set<UUID> teacherIds = Set.of(teacherId);
+            UUID courseId = UUID.randomUUID();
+            List<UUID> courseIds = List.of(courseId);
+
+            Instant windowStart = NOW.minus(7, ChronoUnit.DAYS);
+            Instant prevStart = NOW.minus(14, ChronoUnit.DAYS);
+
+            when(port.findTeacherIdsByOrganization(orgId)).thenReturn(teacherIds);
+            when(port.findCourseIdsByTeacherIds(teacherIds)).thenReturn(courseIds);
+            when(port.countUsersByOrganization(orgId)).thenReturn(12L);
+            when(port.countCoursesByTeacherIds(teacherIds)).thenReturn(4L);
+            when(port.countEnrollmentsByCourseIds(courseIds)).thenReturn(20L);
+            when(port.countUsersCreatedBetweenInOrganization(orgId, windowStart, NOW)).thenReturn(2L);
+            when(port.countUsersCreatedBetweenInOrganization(orgId, prevStart, windowStart)).thenReturn(1L);
+            when(port.countCoursesCreatedBetweenByTeacherIds(teacherIds, windowStart, NOW)).thenReturn(1L);
+            when(port.countCoursesCreatedBetweenByTeacherIds(teacherIds, prevStart, windowStart)).thenReturn(0L);
+            when(port.sumRevenueBetweenByCourseIds(courseIds, windowStart, NOW)).thenReturn(new BigDecimal("250.00"));
+            when(port.sumRevenueBetweenByCourseIds(courseIds, prevStart, windowStart)).thenReturn(new BigDecimal("100.00"));
+
+            WindowedAnalyticsResponse r = useCase.execute(7, orgId);
+
+            assertThat(r.totalUsers()).isEqualTo(12L);
+            assertThat(r.totalCourses()).isEqualTo(4L);
+            assertThat(r.totalEnrollments()).isEqualTo(20L);
+            assertThat(r.revenue()).isEqualTo(250.0);
+
+            assertThat(r.userGrowth().thisWindow()).isEqualTo(2L);
+            assertThat(r.userGrowth().lastWindow()).isEqualTo(1L);
+            assertThat(r.userGrowth().growthRate()).isEqualTo(100.0);
+
+            // courseGrowth: lastWindow=0, thisWindow>0 → growthRate null
+            assertThat(r.courseGrowth().thisWindow()).isEqualTo(1L);
+            assertThat(r.courseGrowth().lastWindow()).isEqualTo(0L);
+            assertThat(r.courseGrowth().growthRate()).isNull();
+
+            assertThat(r.revenueGrowth()).isEqualTo(150.0);
+
+            // System-wide queries must NOT be called
+            verify(port, never()).countAllUsers();
+            verify(port, never()).countAllCourses();
+            verify(port, never()).countAllEnrollments();
+            verify(port, never()).countUsersCreatedBetween(any(), any());
+            verify(port, never()).countCoursesCreatedBetween(any(), any());
+            verify(port, never()).sumRevenueBetween(any(), any());
+        }
+
+        @Test
+        @DisplayName("ORG_ADMIN with no teachers in org should return zeros for course/revenue")
+        void orgAdminEmptyTeachersReturnsZeros() {
+            UUID orgId = UUID.randomUUID();
+
+            when(port.findTeacherIdsByOrganization(orgId)).thenReturn(Set.of());
+            when(port.findCourseIdsByTeacherIds(Set.of())).thenReturn(List.of());
+            when(port.countUsersByOrganization(orgId)).thenReturn(1L);
+            when(port.countCoursesByTeacherIds(Set.of())).thenReturn(0L);
+            when(port.countEnrollmentsByCourseIds(List.of())).thenReturn(0L);
+            when(port.countUsersCreatedBetweenInOrganization(eq(orgId), any(), any())).thenReturn(0L);
+            when(port.countCoursesCreatedBetweenByTeacherIds(eq(Set.of()), any(), any())).thenReturn(0L);
+            when(port.sumRevenueBetweenByCourseIds(eq(List.of()), any(), any())).thenReturn(BigDecimal.ZERO);
+
+            WindowedAnalyticsResponse r = useCase.execute(7, orgId);
+
+            assertThat(r.totalUsers()).isEqualTo(1L);
+            assertThat(r.totalCourses()).isZero();
+            assertThat(r.totalEnrollments()).isZero();
+            assertThat(r.revenue()).isZero();
+            assertThat(r.userGrowth().thisWindow()).isZero();
+            assertThat(r.userGrowth().growthRate()).isEqualTo(0.0);
+            assertThat(r.courseGrowth().growthRate()).isEqualTo(0.0);
+            assertThat(r.revenueGrowth()).isEqualTo(0.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("Growth rate edge cases")
+    class GrowthRateEdgeCases {
+
+        @Test
+        @DisplayName("Both windows zero → growthRate 0.0 (no change)")
+        void bothZeroIsZeroGrowth() {
+            stubSystemWideZeros();
+            WindowedAnalyticsResponse r = useCase.execute(7, null);
+            assertThat(r.userGrowth().growthRate()).isEqualTo(0.0);
+            assertThat(r.courseGrowth().growthRate()).isEqualTo(0.0);
+            assertThat(r.revenueGrowth()).isEqualTo(0.0);
+        }
+
+        @Test
+        @DisplayName("lastWindow = 0 with positive thisWindow → growthRate null (FE renders +∞)")
+        void lastZeroPositiveThisIsNull() {
+            when(port.countAllUsers()).thenReturn(0L);
+            when(port.countAllCourses()).thenReturn(0L);
+            when(port.countAllEnrollments()).thenReturn(0L);
+            when(port.countUsersCreatedBetween(any(), any()))
+                    .thenReturn(5L)   // thisWindow
+                    .thenReturn(0L);  // lastWindow
+            when(port.countCoursesCreatedBetween(any(), any())).thenReturn(0L);
+            when(port.sumRevenueBetween(any(), any()))
+                    .thenReturn(new BigDecimal("123.45"))
+                    .thenReturn(BigDecimal.ZERO);
+
+            WindowedAnalyticsResponse r = useCase.execute(7, null);
+
+            assertThat(r.userGrowth().growthRate()).isNull();
+            assertThat(r.revenueGrowth()).isNull();
+        }
+
+        @Test
+        @DisplayName("Decline (50 → 25) → growthRate -50.0")
+        void declineProducesNegativeGrowth() {
+            when(port.countAllUsers()).thenReturn(100L);
+            when(port.countAllCourses()).thenReturn(10L);
+            when(port.countAllEnrollments()).thenReturn(50L);
+            when(port.countUsersCreatedBetween(any(), any()))
+                    .thenReturn(25L)   // thisWindow
+                    .thenReturn(50L);  // lastWindow
+            when(port.countCoursesCreatedBetween(any(), any())).thenReturn(0L);
+            when(port.sumRevenueBetween(any(), any())).thenReturn(BigDecimal.ZERO);
+
+            WindowedAnalyticsResponse r = useCase.execute(7, null);
+
+            assertThat(r.userGrowth().growthRate()).isEqualTo(-50.0);
+        }
+    }
+
+    private void stubSystemWideZeros() {
+        when(port.countAllUsers()).thenReturn(0L);
+        when(port.countAllCourses()).thenReturn(0L);
+        when(port.countAllEnrollments()).thenReturn(0L);
+        when(port.countUsersCreatedBetween(any(), any())).thenReturn(0L);
+        when(port.countCoursesCreatedBetween(any(), any())).thenReturn(0L);
+        when(port.sumRevenueBetween(any(), any())).thenReturn(BigDecimal.ZERO);
+    }
+}

--- a/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3Test.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3Test.java
@@ -1,9 +1,10 @@
 package com.example.lms.course_authoring.infrastructure.web;
 
+import com.example.lms.course_authoring.admin.application.usecase.GetWindowedAnalyticsUseCase;
 import com.example.lms.course_authoring.domain.model.Course;
 import com.example.lms.course_authoring.domain.repository.CourseRepository;
-import com.example.lms.course_authoring.infrastructure.persistence.entity.CategoryJpaEntity;
-import com.example.lms.course_authoring.infrastructure.persistence.repository.CategoryJpaRepository;
+import com.example.lms.course_authoring.infrastructure.persistence.repository.CourseCategoryJpaRepository;
+import com.example.lms.course_authoring.infrastructure.persistence.repository.CourseReviewEventJpaRepository;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
 import com.example.lms.learning_delivery.infrastructure.persistence.JpaEnrollmentRepository;
@@ -40,11 +41,13 @@ class AdminCoursesControllerV3Test {
 
     @Mock private CourseRepository courseRepository;
     @Mock private UserJpaRepository userRepository;
-    @Mock private CategoryJpaRepository categoryRepository;
+    @Mock private CourseCategoryJpaRepository categoryRepository;
     @Mock private JpaEnrollmentRepository enrollmentRepository;
     @Mock private PaymentTransactionJpaRepository paymentTransactionRepository;
     @Mock private com.example.lms.course_authoring.application.usecase.ApproveCourseUseCase approveCourseUseCase;
     @Mock private com.example.lms.course_authoring.application.usecase.RejectCourseUseCase rejectCourseUseCase;
+    @Mock private CourseReviewEventJpaRepository reviewEventRepository;
+    @Mock private GetWindowedAnalyticsUseCase getWindowedAnalyticsUseCase;
 
     @InjectMocks private AdminCoursesControllerV3 controller;
 


### PR DESCRIPTION
## Summary

- Adds `GET /api/v3/admin/courses/analytics/window?days={7|30|90}` backing the **F-08** date-range toggle on `/admin/dashboard` (epic #157).
- Returns cumulative totals (users / courses / enrollments) plus windowed growth metrics comparing **this window vs. an equal-length prior window** for users, courses, and revenue.
- ORG_ADMIN scope mirrors `buildOrgScopedAnalytics` precedent from PR #145.

Closes #164.

## Endpoint

```
GET /api/v3/admin/courses/analytics/window?days={7|30|90}
Authorization: Bearer <jwt>
Roles: ADMIN, ORG_ADMIN
```

Sample response (system-wide, days=7, live curl):

```json
{
  "windowDays": 7,
  "totalUsers": 43,
  "totalCourses": 10,
  "totalEnrollments": 67,
  "revenue": 0.0,
  "userGrowth": { "thisWindow": 6, "lastWindow": 0, "growthRate": null },
  "revenueGrowth": 0.0,
  "courseGrowth": { "thisWindow": 0, "lastWindow": 0, "growthRate": 0.0 },
  "windowStart": "2026-04-18T07:52:42.071694468Z",
  "windowEnd": "2026-04-25T07:52:42.071694468Z"
}
```

`days=15` → HTTP 400 with `VALIDATION_ERROR` and field-level message in Vietnamese.

## Design notes

- **Half-open windows `[from, to)`** so adjacent ranges do not double-count the boundary instant.
- **Growth rate**: `((this − last) / last) × 100`, rounded to 1 dp. When `last = 0` and `this > 0` it returns `null` so the FE can render `+∞` / `—` rather than a misleading `0%`.
- **Clean Architecture**: new `AdminAnalyticsPort` (application port) + `AdminAnalyticsAdapter` (infrastructure) keep `GetWindowedAnalyticsUseCase` free of JPA leaks per CLAUDE.md rules.
- **Clock injection** (`Clock.systemUTC()` bean) so the use case is unit-testable without `Thread.sleep`.
- **Repository additions** are pure additions — no existing query was changed.

## Files

- New: `course_authoring/admin/{application/{dto,port,usecase},infrastructure/persistence}` (5 main files + 1 test).
- Modified: `AdminCoursesControllerV3` (+1 endpoint, +1 dependency), `UserJpaRepository` / `JpaCourseRepository` (+5 count queries), `PasswordConfig` (Clock bean).
- Repaired: `AdminCoursesControllerV3Test` had stale `CategoryJpaRepository` import + missing mocks for already-required constructor args.

## Test plan

- [x] `mvn test -Dtest='AdminCourses*,GetWindowedAnalytics*' -B` — 31/31 green
- [x] Full `mvn test` — **1021/1021** green, 0 failures
- [x] Live `curl` with ADMIN JWT for `days=7,30,90` → response shape matches spec
- [x] Live `curl` with ORG_ADMIN JWT — totals are org-scoped
- [x] Live `curl` `days=15` → HTTP 400 with structured `ValidationException` payload
- [x] **Org isolation**: inserted a STUDENT in a second organization → ADMIN saw `totalUsers=44`, ORG_ADMIN of org1 saw `totalUsers=43` (test fixture cleaned up post-verification)
- [ ] CI: pending push (verify after this PR opens)

## New unit-test coverage (`GetWindowedAnalyticsUseCaseTest` — 23 tests)

- Days validation: `7/30/90` accepted; `0/1/6/8/15/29/31/60/89/91/365/-7` rejected with `ValidationException` (→ 400)
- System-wide: full aggregation for `days=7`, plus window-arithmetic checks for `days=30/90`
- Org-scoped: full aggregation when `organizationId` provided; empty-teacher org returns zeros for course/revenue
- Growth-rate edges: both windows zero → `0.0`; `last=0,this>0` → `null`; decline (50→25) → `-50.0`

## Out of scope

Does **not** add the FE date-range toggle component — that lives in a follow-up FE PR per epic #157.

## Hard rules respected

- No self-merge — leaving for parent review.
- No `@PreAuthorize` bypass — endpoint enforces `ADMIN`/`ORG_ADMIN`.
- No synthetic data — all counts come from the real DB. Live verification used real seed accounts.
- GCP not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)