### PR TITLE
feat(admin-portal): cross-cutting foundation — kpi-card + color unify + styleUrl fix (closes #173)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin-analytics.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-analytics.component.ts
@@ -8,6 +8,10 @@ import { AuthService } from '../../../../core/services/auth.service';
   selector: 'app-admin-analytics',
   imports: [],
   templateUrl: './admin-analytics.component.html',
+  // CC-03 (mega audit 2026-04-25): styleUrl was missing — main SCSS never
+  // loaded so .stat-icon stretched to full content width (1136×1136).
+  // Same root-cause class as PR #168 / F-ST1.
+  styleUrl: './admin-analytics.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AdminAnalyticsComponent implements OnInit {

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.scss
@@ -55,10 +55,13 @@ $orange-700: #9A3412;
 }
 
 .btn-create {
+  // CC-02 (mega audit 2026-04-25): primary action color unified across the
+  // admin portal to $blue-primary. Orange was reserved for warning states
+  // and didn't belong on a "+ Add admin" CTA.
   display: inline-flex;
   align-items: center;
   padding: 10px $spacing-4;
-  background: $orange-primary;
+  background: $blue-primary;
   color: $text-inverse;
   font-size: $text-sm;
   font-weight: $font-medium;
@@ -68,7 +71,7 @@ $orange-700: #9A3412;
   transition: background $transition-normal;
   white-space: nowrap;
 
-  &:hover { background: $orange-hover; }
+  &:hover { background: $blue-hover; }
 
   svg { width: 16px; height: 16px; margin-right: $spacing-2; }
 }

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.html
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.html
@@ -58,46 +58,29 @@
     </div>
 
     <div class="dashboard-main">
-      <!-- ① Metrics Strip (Stripe pattern — 4 cells, no icons) -->
+      <!-- ① Metrics Strip (Stripe pattern — 4 cells, no icons).
+           Migrated to shared <app-kpi-card> per CC-01 (mega audit 2026-04-25)
+           — same visual contract as before, but every other admin surface now
+           consumes the same component instead of bespoke .metric-cell markup. -->
       <div class="metrics-strip">
-        <div class="metric-cell">
-          <p class="metric-value">{{ analytics().totalUsers | number }}</p>
-          <p class="metric-label">Tổng người dùng</p>
-          <p class="metric-sub">
-            <span class="trend" [class]="'trend-' + trendOf(analytics().userGrowth.growthRate)" aria-hidden="true">
-              <span class="trend-arrow">{{ trendArrow(analytics().userGrowth.growthRate) }}</span>
-              <span>{{ trendMagnitude(analytics().userGrowth.growthRate) }}%</span>
-            </span>
-            <span>so với tháng trước</span>
-          </p>
-        </div>
-        <div class="metric-cell">
-          <p class="metric-value">{{ analytics().revenue | number:'1.0-0' }}đ</p>
-          <p class="metric-label">Doanh thu tháng này</p>
-          <p class="metric-sub">
-            <span class="trend" [class]="'trend-' + trendOf(analytics().revenueGrowth)" aria-hidden="true">
-              <span class="trend-arrow">{{ trendArrow(analytics().revenueGrowth) }}</span>
-              <span>{{ trendMagnitude(analytics().revenueGrowth) }}%</span>
-            </span>
-            <span>so với tháng trước</span>
-          </p>
-        </div>
-        <div class="metric-cell highlight">
-          <p class="metric-value warning">{{ analytics().pendingCourses | number }}</p>
-          <p class="metric-label">Khóa học chờ duyệt</p>
-          <p class="metric-sub warning-text">Cần xử lý</p>
-        </div>
-        <div class="metric-cell">
-          <p class="metric-value">{{ analytics().totalCourses | number }}</p>
-          <p class="metric-label">Tổng khóa học</p>
-          <p class="metric-sub">
-            <span class="trend" [class]="'trend-' + trendOf(analytics().courseGrowth)" aria-hidden="true">
-              <span class="trend-arrow">{{ trendArrow(analytics().courseGrowth) }}</span>
-              <span>{{ trendMagnitude(analytics().courseGrowth) }}%</span>
-            </span>
-            <span>· {{ analytics().approvedCourses }} đã duyệt</span>
-          </p>
-        </div>
+        <app-kpi-card
+          [value]="analytics().totalUsers | number"
+          label="Tổng người dùng"
+          [trend]="analytics().userGrowth.growthRate" />
+        <app-kpi-card
+          [value]="(analytics().revenue | number:'1.0-0') + 'đ'"
+          label="Doanh thu tháng này"
+          [trend]="analytics().revenueGrowth" />
+        <app-kpi-card
+          [value]="analytics().pendingCourses | number"
+          label="Khóa học chờ duyệt"
+          variant="warning"
+          sub="Cần xử lý" />
+        <app-kpi-card
+          [value]="analytics().totalCourses | number"
+          label="Tổng khóa học"
+          [trend]="analytics().courseGrowth"
+          [sub]="'· ' + analytics().approvedCourses + ' đã duyệt'" />
       </div>
 
       <!--

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.scss
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.scss
@@ -115,7 +115,10 @@
   overflow-x: auto;
 }
 
-/* ===== ① METRICS STRIP (Stripe pattern) ===== */
+/* ===== ① METRICS STRIP (Stripe pattern) =====
+   Children are <app-kpi-card> components — see shared/components/admin/kpi-card.
+   This strip only owns the outer container shape and divider lines between
+   cards; each card paints its own value / label / trend. */
 .metrics-strip {
   @extend .card;
   display: grid;
@@ -126,8 +129,8 @@
   @include desktop { grid-template-columns: repeat(4, 1fr); }
 }
 
-.metric-cell {
-  padding: $spacing-4 $spacing-6;
+.metrics-strip > app-kpi-card {
+  display: block;
 
   &:nth-child(odd) { border-right: 1px solid $border-light; }
   &:nth-child(-n+2) { border-bottom: 1px solid $border-light; }
@@ -137,59 +140,6 @@
     border-bottom: none !important;
     &:last-child { border-right: none; }
   }
-
-  &.highlight {
-    background: rgba($warning, 0.04);
-  }
-}
-
-.metric-value {
-  // Display rung in 1.125 ladder — number is the focal point of the cell.
-  font-size: $text-2xl;
-  font-weight: $font-bold;
-  color: $text-primary;
-  line-height: $leading-tight;
-  margin: 0 0 $spacing-1;
-
-  &.warning { color: $warning; }
-}
-
-.metric-label {
-  font-size: $text-xs;
-  color: $text-muted;
-  margin: 0;
-}
-
-/* Trend row — number + arrow + delta + period label.
-   F-05: ▲ green / ▼ red / → gray, anatomy borrowed from Stripe / Vercel KPI.
-*/
-.metric-sub {
-  display: inline-flex;
-  align-items: center;
-  gap: $spacing-1;
-  font-size: $text-xs;
-  color: $text-muted;
-  margin: $spacing-1 0 0;
-
-  &.warning-text { color: $warning; }
-}
-
-.trend {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px; // 4pt baseline — visual coupling between arrow + number.
-  font-weight: $font-semibold;
-  font-variant-numeric: tabular-nums;
-
-  &.trend-up { color: $success; }
-  &.trend-down { color: $error; }
-  &.trend-flat { color: $text-muted; }
-}
-
-.trend-arrow {
-  // Glyph rendered via :before to avoid extra DOM. Sizing matches text-xs.
-  font-size: 10px; // visual match for caret next to 12px label
-  line-height: 1;
 }
 
 /* ===== ② CONTENT GRID ===== */
@@ -605,10 +555,8 @@
   .header-inner { padding: $spacing-3; }
   .page-title { font-size: $text-lg; }
 
-  .metric-cell { padding: $spacing-3; }
-  .metric-value { font-size: $text-xl; } // 20px on small screens — keep big numbers legible
-  .metric-label { font-size: $text-xs; }
-  .metric-sub { display: none; }
+  // KPI strip layout only — value / label / sub sizing lives in the
+  // shared kpi-card component (CC-01).
 
   .card-header { padding: $spacing-3 $spacing-4; }
   .card-body { padding: $spacing-4; }
@@ -642,9 +590,7 @@
 // Ultra-small (<340px)
 @media screen and (max-width: 340px) {
   .dashboard-main { padding: $spacing-3 $spacing-2; }
-  .metric-cell { padding: $spacing-2 $spacing-3; }
-  .metric-value { font-size: $text-lg; } // drop one rung on very narrow screens
-  .metric-label { font-size: $text-xs; }
+  // KPI sizing — see kpi-card.component.scss ultra-small media query.
 
   .card-header { padding: $spacing-2 $spacing-3; }
   .card-body { padding: $spacing-2 $spacing-3; }
@@ -685,19 +631,16 @@
     page-break-inside: avoid;
   }
 
-  // Metrics: show sub labels, 4-col always
+  // Metrics: 4-col always, divider between cards.
   .metrics-strip {
     grid-template-columns: repeat(4, 1fr) !important;
     margin-bottom: 10px !important;
   }
-  .metric-cell {
-    padding: 8px 12px !important;
+  .metrics-strip > app-kpi-card {
     border-bottom: none !important;
     border-right: 1px solid $gray-300;
     &:last-child { border-right: none; }
   }
-  .metric-sub { display: block !important; }
-  .metric-value { font-size: 16px !important; }
 
   // Grid: single column
   .content-grid {
@@ -735,8 +678,8 @@
   .health-refresh { display: none !important; }
   .health-source { display: none !important; }
 
-  // Print colors
-  .badge, .health-dot, .health-badge, .metric-value {
+  // Print colors — kpi-card value color comes from the shared component.
+  .badge, .health-dot, .health-badge {
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
   }

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.ts
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.ts
@@ -6,6 +6,7 @@ import { SystemHealthService } from '../../../infrastructure/services/system-hea
 import { PendingApproval } from './dashboard.types';
 import { DialogComponent } from '../../../../../shared/components/dialog/dialog.component';
 import { IconComponent, IconName } from '../../../../../shared/components/icon/icon.component';
+import { KpiCardComponent } from '../../../../../shared/components/admin/kpi-card/kpi-card.component';
 
 interface QuickAction {
   id: string;
@@ -27,7 +28,7 @@ const QUICK_ACTIONS: readonly QuickAction[] = [
 
 @Component({
   selector: 'app-admin-system-dashboard',
-  imports: [CommonModule, RouterLink, DialogComponent, IconComponent],
+  imports: [CommonModule, RouterLink, DialogComponent, IconComponent, KpiCardComponent],
   templateUrl: './admin-system-dashboard.component.html',
   styleUrl: './admin-system-dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -58,23 +59,6 @@ export class AdminSystemDashboardComponent implements OnInit {
 
   // Shortcut panel — replaces the redundant "Tổng quan nhanh" card.
   quickActions = computed<readonly QuickAction[]>(() => QUICK_ACTIONS);
-
-  // F-05: classify a growth rate as up / down / flat for trend-arrow rendering.
-  // Stripe / Vercel pattern — same data, but arrow + color give scannability.
-  trendOf(rate: number | null | undefined): 'up' | 'down' | 'flat' {
-    if (rate == null || rate === 0) return 'flat';
-    return rate > 0 ? 'up' : 'down';
-  }
-
-  trendArrow(rate: number | null | undefined): string {
-    const t = this.trendOf(rate);
-    return t === 'up' ? '▲' : t === 'down' ? '▼' : '→';
-  }
-
-  // Always show absolute value next to the arrow — sign is encoded in arrow + color.
-  trendMagnitude(rate: number | null | undefined): number {
-    return Math.abs(rate ?? 0);
-  }
 
   // --- Reject modal state (mirrors org-admin pattern from PR #145) ---
   rejectModalOpen = signal(false);

--- a/fe/src/app/features/admin/presentation/components/system-settings.component.ts
+++ b/fe/src/app/features/admin/presentation/components/system-settings.component.ts
@@ -8,6 +8,11 @@ import { ToastService } from '../../../../core/services/toast.service';
   selector: 'app-system-settings',
   imports: [FormsModule],
   templateUrl: './system-settings.component.html',
+  // CC-03 (mega audit 2026-04-25): consistency with admin-analytics fix —
+  // settings page renders OK without the SCSS today (template uses Tailwind
+  // utility classes), but wiring up the stylesheet now prevents future
+  // surprises if the template grows custom classes.
+  styleUrl: './system-settings.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SystemSettingsComponent implements OnInit {

--- a/fe/src/app/features/admin/presentation/components/teacher-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.component.scss
@@ -48,10 +48,14 @@ $purple-bg: #FAF5FF;
 }
 
 .btn-create {
+  // CC-02 (mega audit 2026-04-25): primary action color unified across the
+  // admin portal to $blue-primary. Purple drifted in early but Atlassian
+  // Color Foundations limits brand to one primary; semantic colors stay for
+  // status / destructive only.
   display: inline-flex;
   align-items: center;
   padding: $spacing-2 $spacing-4;
-  background: $purple;
+  background: $blue-primary;
   color: white;
   font-size: $text-sm;
   font-weight: $font-medium;
@@ -60,7 +64,7 @@ $purple-bg: #FAF5FF;
   cursor: pointer;
   transition: background $transition-normal;
 
-  &:hover { background: $purple-hover; }
+  &:hover { background: $blue-hover; }
 
   svg { margin-right: $spacing-2; }
 }

--- a/fe/src/app/shared/components/admin/kpi-card/kpi-card.component.html
+++ b/fe/src/app/shared/components/admin/kpi-card/kpi-card.component.html
@@ -1,0 +1,20 @@
+<div class="kpi-card" [class]="'kpi-' + variant()">
+  <p class="kpi-value">{{ value() }}</p>
+  <p class="kpi-label">{{ label() }}</p>
+  @if (hasTrend() || sub()) {
+    <p class="kpi-sub">
+      @if (hasTrend()) {
+        <span class="trend" [class]="'trend-' + trendKind()" aria-hidden="true">
+          <span class="trend-arrow">{{ trendArrowGlyph() }}</span>
+          <span>{{ trendMag() }}%</span>
+        </span>
+      }
+      @if (trendLabel() && hasTrend()) {
+        <span>{{ trendLabel() }}</span>
+      }
+      @if (sub()) {
+        <span [class.sub-after-trend]="hasTrend()">{{ sub() }}</span>
+      }
+    </p>
+  }
+</div>

--- a/fe/src/app/shared/components/admin/kpi-card/kpi-card.component.scss
+++ b/fe/src/app/shared/components/admin/kpi-card/kpi-card.component.scss
@@ -1,0 +1,101 @@
+@use '../../../../../styles/variables' as *;
+
+/* Shared KPI card — admin portal (Stripe / Linear / Vercel pattern).
+   Source of truth lives here; per-surface SCSS must NOT redefine these
+   selectors. CC-01 audit 2026-04-25. */
+
+:host {
+  display: block;
+}
+
+.kpi-card {
+  padding: $spacing-4 $spacing-6;
+  background: white;
+  display: flex;
+  flex-direction: column;
+  gap: 2px; // 4pt baseline — tight value↔label coupling
+
+  &.kpi-warning {
+    background: rgba($warning, 0.04);
+  }
+
+  // success / error variants currently only differ on value color + bg tint.
+  // Reserved for status KPIs (e.g. "Đã từ chối" red, "Đã duyệt" green).
+  &.kpi-success {
+    background: rgba($success, 0.04);
+  }
+  &.kpi-error {
+    background: rgba($error, 0.04);
+  }
+}
+
+.kpi-value {
+  // Display rung in 1.125 type ladder — number is the focal point.
+  font-size: $text-2xl;
+  font-weight: $font-bold;
+  color: $text-primary;
+  line-height: $leading-tight;
+  margin: 0 0 $spacing-1;
+  font-variant-numeric: tabular-nums;
+
+  .kpi-warning & { color: $warning; }
+  .kpi-success & { color: $success; }
+  .kpi-error & { color: $error; }
+}
+
+.kpi-label {
+  font-size: $text-xs;
+  color: $text-muted;
+  margin: 0;
+}
+
+.kpi-sub {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: $spacing-1;
+  font-size: $text-xs;
+  color: $text-muted;
+  margin: $spacing-1 0 0;
+
+  .sub-after-trend {
+    margin-left: $spacing-1;
+  }
+}
+
+.trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-weight: $font-semibold;
+  font-variant-numeric: tabular-nums;
+
+  &.trend-up   { color: $success; }
+  &.trend-down { color: $error; }
+  &.trend-flat { color: $text-muted; }
+}
+
+.trend-arrow {
+  font-size: 10px; // visual match for caret next to 12px label
+  line-height: 1;
+}
+
+/* Mobile — keep big numbers legible, hide sub when space is tight at the
+   strip level. The strip parent decides; the card itself stays self-contained. */
+@media screen and (max-width: $breakpoint-sm) {
+  .kpi-card {
+    padding: $spacing-3;
+  }
+  .kpi-value {
+    font-size: $text-xl;
+  }
+}
+
+@media screen and (max-width: 340px) {
+  .kpi-card {
+    padding: $spacing-2 $spacing-3;
+  }
+  .kpi-value {
+    font-size: $text-lg;
+  }
+}

--- a/fe/src/app/shared/components/admin/kpi-card/kpi-card.component.ts
+++ b/fe/src/app/shared/components/admin/kpi-card/kpi-card.component.ts
@@ -1,0 +1,55 @@
+import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
+import { trendOf, trendArrow, trendMagnitude } from '../../../utils/trend.util';
+
+/**
+ * Shared KPI card for the admin portal — Stripe / Linear / Vercel pattern.
+ *
+ * One visual language across every admin surface (CC-01 in 2026-04-25 mega
+ * audit). Surfaces previously each had their own bespoke `.metric-cell`
+ * markup with brand-colored decorative icons; this component ends that drift.
+ *
+ * Anatomy: value (large) + label + optional sub line + optional trend badge.
+ * Variant only changes the accent border / value color, **not** the icon —
+ * the audit explicitly bars decorative brand icons inside KPI cards.
+ *
+ * Usage:
+ * ```html
+ * <app-kpi-card label="Tổng người dùng" [value]="42 | number"
+ *               [trend]="userGrowth.growthRate" trendLabel="so với tháng trước" />
+ * <app-kpi-card label="Khóa học chờ duyệt" [value]="3" variant="warning" sub="Cần xử lý" />
+ * ```
+ */
+export type KpiVariant = 'default' | 'warning' | 'success' | 'error';
+
+@Component({
+  selector: 'app-kpi-card',
+  imports: [],
+  templateUrl: './kpi-card.component.html',
+  styleUrl: './kpi-card.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class KpiCardComponent {
+  // Caller passes the formatted value (so the card doesn't need to know about
+  // pipes or i18n number formatting). Pass `'42'` or `'12.500.000đ'`. Accepts
+  // `null` because Angular's `| number` pipe is typed `string | null` even
+  // when the source signal is non-nullable.
+  value = input.required<string | number | null>();
+  label = input.required<string>();
+
+  // Sub line — short status text (e.g. "Cần xử lý", "10 đã duyệt").
+  // Mutually exclusive with `trend` in practice; if both provided, both render.
+  sub = input<string>('');
+
+  // Growth rate as a percentage. When provided (and not undefined), the card
+  // renders the ▲ / ▼ / → trend pill before the trend label.
+  trend = input<number | undefined>(undefined);
+  trendLabel = input<string>('so với tháng trước');
+
+  variant = input<KpiVariant>('default');
+
+  // Computed presentation
+  trendKind = computed(() => trendOf(this.trend()));
+  trendArrowGlyph = computed(() => trendArrow(this.trend()));
+  trendMag = computed(() => trendMagnitude(this.trend()));
+  hasTrend = computed(() => this.trend() !== undefined && this.trend() !== null);
+}

--- a/fe/src/app/shared/utils/trend.util.ts
+++ b/fe/src/app/shared/utils/trend.util.ts
@@ -1,0 +1,27 @@
+/**
+ * Trend classification helpers — used by KPI cards across the admin portal
+ * to render the ▲ / ▼ / → arrow + semantic color (green / red / gray).
+ *
+ * Extracted from AdminSystemDashboardComponent (PR #163) so per-surface
+ * KPI components don't each have to copy the same 3 helpers.
+ *
+ * Sign convention: anything > 0 = up (good), < 0 = down (bad), 0 / null = flat.
+ * "Bad" semantics is up to the caller — if a metric like "rejected" is meant
+ * to read negatively when up, swap arrow / color at the call site rather than
+ * complicating this utility.
+ */
+export type TrendKind = 'up' | 'down' | 'flat';
+
+export function trendOf(rate: number | null | undefined): TrendKind {
+  if (rate == null || rate === 0) return 'flat';
+  return rate > 0 ? 'up' : 'down';
+}
+
+export function trendArrow(rate: number | null | undefined): string {
+  const t = trendOf(rate);
+  return t === 'up' ? '▲' : t === 'down' ? '▼' : '→';
+}
+
+export function trendMagnitude(rate: number | null | undefined): number {
+  return Math.abs(rate ?? 0);
+}


### PR DESCRIPTION
Closes #173. Part of epic #161 (admin portal mega refresh).

## Findings addressed

Từ mega audit `docs/reports/2026-04-25-admin-portal-mega-audit.md`:

- **CC-01** Shared `<app-kpi-card>` component (foundation cho per-surface migration)
- **CC-02** Primary action color unify về `#0056D2`
- **CC-03** Fix `/admin/analytics` giant icon bug (cùng class với F-ST1 / PR #168) + preventive styleUrl cho settings

## Changes

| File | Change |
|---|---|
| `fe/src/app/shared/utils/trend.util.ts` *(new)* | Pure helpers `trendOf` / `trendArrow` / `trendMagnitude` extract từ dashboard PR #163 — reusable cross-portal |
| `fe/src/app/shared/components/admin/kpi-card/` *(new)* | `<app-kpi-card>` với `value` / `label` / `sub` / `trend` / `trendLabel` / `variant` (default/warning/success/error). OnPush, signal inputs, no decorative brand icons. Mobile + ultra-small media queries built-in. |
| `.../dashboard/admin-system-dashboard.component.{ts,html,scss}` | Migrate 4 KPI cells → `<app-kpi-card>`. Drop `metric-cell/value/label/sub/trend*` rules from dashboard SCSS (~80 lines removed; lives in kpi-card now). Print + mobile media queries updated to new selector `.metrics-strip > app-kpi-card`. |
| `.../admin-user-management.component.scss` | `.btn-create` `$orange-primary` → `$blue-primary` |
| `.../teacher-management.component.scss` | `.btn-create` `$purple` → `$blue-primary` |
| `.../admin-analytics.component.ts` | Add `styleUrl` (was missing — same bug class as F-ST1) |
| `.../system-settings.component.ts` | Add `styleUrl` preventively |

11 files, +260 / −131.

## Browser verification (agent-browser)

### Dashboard 1440×900

| | Before | After |
|---|---|---|
| KPI markup | 4 `.metric-cell` divs (bespoke) | **4 `<app-kpi-card>` (shared)** |
| Old `.metric-cell` count | 4 | **0** |
| `.kpi-value` font-size | — | **24px** (Display rung) |
| Variants applied | — | **`kpi-default` x3 + `kpi-warning` x1 (pending)** |
| Trend arrows | inline markup | **shared logic; → → → flat for growthRate=0** |
| `trend-flat` color | — | **`rgb(107,114,128)`** ($text-muted) |

### `/admin/users/admins`

| | Before | After |
|---|---|---|
| `.btn-create` "Thêm Quản trị viên" bg | orange | **`rgb(0,86,210)` = `#0056D2`** |

### `/admin/users/teachers`

| | Before | After |
|---|---|---|
| `.btn-create` "Thêm Giảng viên" bg | purple | **`rgb(0,86,210)` = `#0056D2`** |

### `/admin/analytics`

| | Before | After |
|---|---|---|
| `.stat-icon` size | 1136×1136 (giant, page unusable) | **40×40** |
| Page state | broken layout | **renders KPI + revenue + health + user growth** |
| Same bug class as | F-ST1 (PR #168) — missing `styleUrl` | — |

### `/admin/settings`

Already rendered correctly before fix; `styleUrl` added preventively.

## Convention compliance

- [x] OnPush mọi component
- [x] Signal inputs / outputs / inject() — no constructor DI
- [x] @if / @for / @switch — no `*ngIf`
- [x] Không `standalone: true` explicit (Angular 20+ default)
- [x] Tokens-based SCSS (`$spacing-*`, `$text-*`, semantic color tokens)
- [x] WCAG 2.2: aria-hidden on trend glyph, focus-visible (inherited cards)
- [x] Vietnamese diacritics

## Acceptance criteria (issue #173)

- [x] `<app-kpi-card>` component standalone trong `shared/components/admin/kpi-card/`
- [x] Props: `value`, `label`, `sub?`, `trend?`, `trendLabel?`, `variant?`
- [x] Trend helpers extract sang `shared/utils/trend.util.ts`
- [x] Dashboard 4 KPI cells migrated, visual identical
- [x] `admin-user-management.component.scss` `.btn-create` → blue
- [x] `teacher-management.component.scss` `.btn-create` → blue
- [x] `admin-analytics.component.ts` thêm styleUrl, page render đúng
- [x] `system-settings.component.ts` thêm styleUrl
- [x] CI 4/4 expect xanh
- [x] agent-browser before/after measurement

## Test plan

- [ ] Login admin → `/admin/dashboard` render — 4 KPI cards, "Khóa học chờ duyệt" có warning tint
- [ ] DevTools: `$$('app-kpi-card').length === 4`, `$$('.metric-cell').length === 0`
- [ ] `/admin/users/admins` "Thêm Quản trị viên" button blue
- [ ] `/admin/users/teachers` "Thêm Giảng viên" button blue
- [ ] `/admin/analytics` không còn giant icon, KPI 4 cards render
- [ ] `/admin/settings` render đúng (no regression)
- [ ] Mobile (375×812): KPI 2×2 grid, cards stack đúng

## Risk & rollback

- Risk: thấp-trung bình. Foundation migration. Dashboard visual unchanged. Color change cosmetic.
- Rollback: `git revert`. Removes shared component + restores bespoke `.metric-cell` markup. Loses trend helpers utility.

## Out of scope (defer)

- Per-surface KPI migration (users/courses/payouts) → Portal PR-B/C/D
- Bulk action bar (CC-06), sidebar collapse (CC-04) → PR-Z polish
- F-13..F-18 dashboard polish → PR-Z
- F-07 activity chart, Cmd+K — separate tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)