### PR TITLE
feat(admin-users): migrate 4 surface KPI strips to shared kpi-card (closes #175)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
@@ -14,64 +14,28 @@
       </div>
     </div>
 
-    <!-- Stats Cards -->
+    <!-- Stats Cards — migrated to shared <app-kpi-card> per CC-01. -->
     <div class="stats-strip">
-      <div class="stat-card">
-        <div class="stat-card-inner">
-          <div>
-            <p class="stat-label">Tổng Admin</p>
-            <p class="stat-value">{{ totalAdmins() }}</p>
-            <p class="stat-sub">{{ activeAdmins() }} đang hoạt động</p>
-          </div>
-          <div class="stat-icon icon-orange">
-            <svg fill="currentColor" viewBox="0 0 20 20">
-              <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"></path>
-            </svg>
-          </div>
-        </div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-card-inner">
-          <div>
-            <p class="stat-label">Super Admin</p>
-            <p class="stat-value">{{ superAdmins() }}</p>
-            <p class="stat-sub">Quyền cao nhất</p>
-          </div>
-          <div class="stat-icon icon-error">
-            <svg fill="currentColor" viewBox="0 0 20 20">
-              <path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-            </svg>
-          </div>
-        </div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-card-inner">
-          <div>
-            <p class="stat-label">Bị khóa</p>
-            <p class="stat-value">{{ blockedAdmins() }}</p>
-            <p class="stat-sub">Tài khoản bị khóa</p>
-          </div>
-          <div class="stat-icon icon-muted">
-            <svg fill="currentColor" viewBox="0 0 20 20">
-              <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2z" clip-rule="evenodd"></path>
-            </svg>
-          </div>
-        </div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-card-inner">
-          <div>
-            <p class="stat-label">Hoạt động gần đây</p>
-            <p class="stat-value">{{ recentlyActive() }}</p>
-            <p class="stat-sub">Trong 7 ngày qua</p>
-          </div>
-          <div class="stat-icon icon-primary">
-            <svg fill="currentColor" viewBox="0 0 20 20">
-              <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"></path>
-            </svg>
-          </div>
-        </div>
-      </div>
+      <app-kpi-card
+        [value]="totalAdmins()"
+        label="Tổng Admin"
+        [sub]="activeAdmins() + ' đang hoạt động'" />
+
+      <app-kpi-card
+        [value]="superAdmins()"
+        label="Super Admin"
+        sub="Quyền cao nhất" />
+
+      <app-kpi-card
+        [value]="blockedAdmins()"
+        label="Bị khóa"
+        sub="Tài khoản bị khóa"
+        variant="error" />
+
+      <app-kpi-card
+        [value]="recentlyActive()"
+        label="Hoạt động gần đây"
+        sub="Trong 7 ngày qua" />
     </div>
 
     <!-- Search & Filter -->

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { AdminService, AdminUser, UserAccountStatus, UpdateUserStatusRequest } from '../../infrastructure/services/admin.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
+import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 /**
  * Admin User Management Component
  * SOTA Design: Coursera-inspired with role change, status actions
@@ -12,7 +13,7 @@ import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.s
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-admin-user-management',
-  imports: [RouterModule, FormsModule],
+  imports: [RouterModule, FormsModule, KpiCardComponent],
   templateUrl: './admin-user-management.component.html',
   styleUrl: './admin-user-management.component.scss'
 })

--- a/fe/src/app/features/admin/presentation/components/student-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.html
@@ -14,65 +14,28 @@
       </div>
     </div>
 
-    <!-- Stats Cards -->
+    <!-- Stats Cards — migrated to shared <app-kpi-card> per CC-01. -->
     <div class="stats-strip">
-      <div class="stat-card">
-        <div class="stat-card-inner">
-          <div>
-            <p class="stat-label">Tổng Học viên</p>
-            <p class="stat-value">{{ totalStudents() }}</p>
-            <p class="stat-sub">{{ activeStudents() }} đang hoạt động</p>
-          </div>
-          <div class="stat-icon icon-primary">
-            <svg fill="currentColor" viewBox="0 0 20 20">
-              <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3z"></path>
-            </svg>
-          </div>
-        </div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-card-inner">
-          <div>
-            <p class="stat-label">Đã đăng ký</p>
-            <p class="stat-value">{{ totalEnrollments() }}</p>
-            <p class="stat-sub">Lượt đăng ký khóa học</p>
-          </div>
-          <div class="stat-icon icon-success">
-            <svg fill="currentColor" viewBox="0 0 20 20">
-              <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"></path>
-              <path fill-rule="evenodd" d="M4 5a2 2 0 012-2v1a1 1 0 001 1h6a1 1 0 001-1V3a2 2 0 012 2v6a2 2 0 01-2 2H6a2 2 0 01-2-2V5z" clip-rule="evenodd"></path>
-            </svg>
-          </div>
-        </div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-card-inner">
-          <div>
-            <p class="stat-label">Bị khóa</p>
-            <p class="stat-value">{{ blockedStudents() }}</p>
-            <p class="stat-sub">Tài khoản bị khóa</p>
-          </div>
-          <div class="stat-icon icon-error">
-            <svg fill="currentColor" viewBox="0 0 20 20">
-              <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2z" clip-rule="evenodd"></path>
-            </svg>
-          </div>
-        </div>
-      </div>
-      <div class="stat-card">
-        <div class="stat-card-inner">
-          <div>
-            <p class="stat-label">Mới trong tuần</p>
-            <p class="stat-value">{{ newThisWeek() }}</p>
-            <p class="stat-sub">Đăng ký mới</p>
-          </div>
-          <div class="stat-icon icon-primary">
-            <svg fill="currentColor" viewBox="0 0 20 20">
-              <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"></path>
-            </svg>
-          </div>
-        </div>
-      </div>
+      <app-kpi-card
+        [value]="totalStudents()"
+        label="Tổng Học viên"
+        [sub]="activeStudents() + ' đang hoạt động'" />
+
+      <app-kpi-card
+        [value]="totalEnrollments()"
+        label="Đã đăng ký"
+        sub="Lượt đăng ký khóa học" />
+
+      <app-kpi-card
+        [value]="blockedStudents()"
+        label="Bị khóa"
+        sub="Tài khoản bị khóa"
+        variant="error" />
+
+      <app-kpi-card
+        [value]="newThisWeek()"
+        label="Mới trong tuần"
+        sub="Đăng ký mới" />
     </div>
 
     <!-- Search & Filter -->

--- a/fe/src/app/features/admin/presentation/components/student-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.ts
@@ -7,6 +7,7 @@ import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
+import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 
 /**
  * Student Management Component
@@ -15,7 +16,7 @@ import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-student-management',
-  imports: [RouterModule, FormsModule],
+  imports: [RouterModule, FormsModule, KpiCardComponent],
   // F-ST1 hotfix: was missing — main SCSS file never loaded so .stat-icon
   // had no width/height constraint and stretched to 1136×1136, making the
   // page unusable. Mirrors teacher-management.component.ts:20.

--- a/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
@@ -8,6 +8,7 @@ import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
+import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 
 /**
  * Teacher Management Component
@@ -16,7 +17,7 @@ import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-teacher-management',
-  imports: [RouterModule, FormsModule],
+  imports: [RouterModule, FormsModule, KpiCardComponent],
   styleUrl: './teacher-management.component.scss',
   templateUrl: './teacher-management.html'
 })

--- a/fe/src/app/features/admin/presentation/components/teacher-management.html
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.html
@@ -13,65 +13,28 @@
           </button>
         </div>
 
-        <!-- Stats Cards -->
+        <!-- Stats Cards — migrated to shared <app-kpi-card> per CC-01. -->
         <div class="stats-strip">
-          <div class="stat-card">
-            <div class="stat-inner">
-              <div>
-                <p class="stat-label">Tổng Giảng viên</p>
-                <p class="stat-value">{{ totalTeachers() }}</p>
-                <p class="stat-sub">{{ activeTeachers() }} đang hoạt động</p>
-              </div>
-              <div class="stat-icon icon-purple">
-                <svg fill="currentColor" viewBox="0 0 20 20">
-                  <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"></path>
-                  <path fill-rule="evenodd" d="M4 5a2 2 0 012-2v1a1 1 0 001 1h6a1 1 0 001-1V3a2 2 0 012 2v6a2 2 0 01-2 2H6a2 2 0 01-2-2V5z" clip-rule="evenodd"></path>
-                </svg>
-              </div>
-            </div>
-          </div>
-          <div class="stat-card">
-            <div class="stat-inner">
-              <div>
-                <p class="stat-label">Khóa học</p>
-                <p class="stat-value">{{ totalCourses() }}</p>
-                <p class="stat-sub">Đang giảng dạy</p>
-              </div>
-              <div class="stat-icon icon-green">
-                <svg fill="currentColor" viewBox="0 0 20 20">
-                  <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3z"></path>
-                </svg>
-              </div>
-            </div>
-          </div>
-          <div class="stat-card">
-            <div class="stat-inner">
-              <div>
-                <p class="stat-label">Bị khóa</p>
-                <p class="stat-value">{{ blockedTeachers() }}</p>
-                <p class="stat-sub">Tài khoản bị khóa</p>
-              </div>
-              <div class="stat-icon icon-red">
-                <svg fill="currentColor" viewBox="0 0 20 20">
-                  <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2z" clip-rule="evenodd"></path>
-                </svg>
-              </div>
-            </div>
-          </div>
-          <div class="stat-card">
-            <div class="stat-inner">
-              <div>
-                <p class="stat-label">Hoạt động gần đây</p>
-                <p class="stat-value">{{ recentlyActive() }}</p>
-                <p class="stat-sub">Trong 7 ngày qua</p>
-              </div>
-              <div class="stat-icon icon-blue">
-                <svg fill="currentColor" viewBox="0 0 20 20">
-                  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"></path>
-                </svg>
-              </div>
-            </div>
-          </div>
+          <app-kpi-card
+            [value]="totalTeachers()"
+            label="Tổng Giảng viên"
+            [sub]="activeTeachers() + ' đang hoạt động'" />
+
+          <app-kpi-card
+            [value]="totalCourses()"
+            label="Khóa học"
+            sub="Đang giảng dạy" />
+
+          <app-kpi-card
+            [value]="blockedTeachers()"
+            label="Bị khóa"
+            sub="Tài khoản bị khóa"
+            variant="error" />
+
+          <app-kpi-card
+            [value]="recentlyActive()"
+            label="Hoạt động gần đây"
+            sub="Trong 7 ngày qua" />
         </div>
 
         <!-- Search & Filter -->

--- a/fe/src/app/features/admin/presentation/components/user-management/components/stats-cards/stats-cards.component.html
+++ b/fe/src/app/features/admin/presentation/components/user-management/components/stats-cards/stats-cards.component.html
@@ -1,66 +1,21 @@
 <div class="stats-grid">
-  <!-- Total Users Card -->
-  <div class="stat-card">
-    <div class="stat-card__row">
-      <div class="stat-card__content">
-        <p class="stat-card__label">Tổng người dùng</p>
-        <p class="stat-card__value">{{ state.totalUsers() }}</p>
-        <p class="stat-card__sub">{{ state.activeUsers() }} đang hoạt động</p>
-      </div>
-      <div class="stat-card__icon stat-card__icon--primary">
-        <svg class="icon" fill="currentColor" viewBox="0 0 20 20">
-          <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 8v1h1.5a.5.5 0 01.5.5v9a.5.5 0 01-.5.5h-13a.5.5 0 01-.5-.5v-9a.5.5 0 01.5-.5H8v-1a5 5 0 00-5 5v1h9.93z"></path>
-        </svg>
-      </div>
-    </div>
-  </div>
+  <app-kpi-card
+    [value]="state.totalUsers()"
+    label="Tổng người dùng"
+    [sub]="state.activeUsers() + ' đang hoạt động'" />
 
-  <!-- Teachers Card -->
-  <div class="stat-card">
-    <div class="stat-card__row">
-      <div class="stat-card__content">
-        <p class="stat-card__label">Giảng viên</p>
-        <p class="stat-card__value">{{ state.totalTeachers() }}</p>
-        <p class="stat-card__sub">Đang giảng dạy</p>
-      </div>
-      <div class="stat-card__icon stat-card__icon--purple">
-        <svg class="icon" fill="currentColor" viewBox="0 0 20 20">
-          <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"></path>
-          <path fill-rule="evenodd" d="M4 5a2 2 0 012-2v1a1 1 0 001 1h6a1 1 0 001-1V3a2 2 0 012 2v6a2 2 0 01-2 2H6a2 2 0 01-2-2V5zm3 4a1 1 0 000 2h.01a1 1 0 100-2H7zm3 0a1 1 0 000 2h3a1 1 0 100-2h-3z" clip-rule="evenodd"></path>
-        </svg>
-      </div>
-    </div>
-  </div>
+  <app-kpi-card
+    [value]="state.totalTeachers()"
+    label="Giảng viên"
+    sub="Đang giảng dạy" />
 
-  <!-- Students Card -->
-  <div class="stat-card">
-    <div class="stat-card__row">
-      <div class="stat-card__content">
-        <p class="stat-card__label">Học viên</p>
-        <p class="stat-card__value">{{ state.totalStudents() }}</p>
-        <p class="stat-card__sub">Đang học tập</p>
-      </div>
-      <div class="stat-card__icon stat-card__icon--green">
-        <svg class="icon" fill="currentColor" viewBox="0 0 20 20">
-          <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0zM6 18a1 1 0 001-1v-2.065a8.935 8.935 0 00-2-.712V17a1 1 0 001 1z"></path>
-        </svg>
-      </div>
-    </div>
-  </div>
+  <app-kpi-card
+    [value]="state.totalStudents()"
+    label="Học viên"
+    sub="Đang học tập" />
 
-  <!-- Admins Card -->
-  <div class="stat-card">
-    <div class="stat-card__row">
-      <div class="stat-card__content">
-        <p class="stat-card__label">Quản trị viên</p>
-        <p class="stat-card__value">{{ state.totalAdmins() }}</p>
-        <p class="stat-card__sub">Quản lý hệ thống</p>
-      </div>
-      <div class="stat-card__icon stat-card__icon--orange">
-        <svg class="icon" fill="currentColor" viewBox="0 0 20 20">
-          <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"></path>
-        </svg>
-      </div>
-    </div>
-  </div>
+  <app-kpi-card
+    [value]="state.totalAdmins()"
+    label="Quản trị viên"
+    sub="Quản lý hệ thống" />
 </div>

--- a/fe/src/app/features/admin/presentation/components/user-management/components/stats-cards/stats-cards.component.scss
+++ b/fe/src/app/features/admin/presentation/components/user-management/components/stats-cards/stats-cards.component.scss
@@ -1,11 +1,13 @@
 @use '../../../../../../../../styles/variables' as *;
 
-// ===== HOST =====
+/* Migrated to <app-kpi-card> per CC-01 (mega audit 2026-04-25). The card
+   visuals (value / label / sub / variant) live in the shared component;
+   this file only owns the grid layout. */
+
 :host {
   display: block;
 }
 
-// ===== STATS GRID =====
 .stats-grid {
   display: grid;
   grid-template-columns: 1fr;
@@ -21,12 +23,10 @@
   }
 }
 
-// ===== STAT CARD =====
-.stat-card {
+.stats-grid > app-kpi-card {
   background: $bg-surface;
   border-radius: $radius-lg;
   border: 1px solid $border-default;
-  padding: $spacing-6;
   transition: box-shadow $transition-normal;
 
   &:hover {
@@ -34,129 +34,23 @@
   }
 }
 
-.stat-card__row {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-}
-
-.stat-card__content {
-  flex: 1;
-}
-
-.stat-card__label {
-  font-size: $text-xs;
-  font-weight: $font-medium;
-  color: $text-muted;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: $spacing-2;
-}
-
-.stat-card__value {
-  font-size: $text-2xl;
-  font-weight: $font-bold;
-  color: $text-primary;
-}
-
-.stat-card__sub {
-  font-size: $text-xs;
-  color: $text-secondary;
-  margin-top: $spacing-2;
-}
-
-// ===== ICON CONTAINER =====
-.stat-card__icon {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: $radius-lg;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-
-  &--primary {
-    background: rgba($blue-primary, 0.05);
-    color: $blue-primary;
-  }
-
-  &--purple {
-    background: #FAF5FF; // purple-50
-    color: #9333EA; // purple-600
-  }
-
-  &--green {
-    background: #F0FDF4; // green-50
-    color: #16A34A; // green-600
-  }
-
-  &--orange {
-    background: #FFF7ED; // orange-50
-    color: #EA580C; // orange-600
-  }
-}
-
-.icon {
-  width: 1.25rem;
-  height: 1.25rem;
-}
-
-// ===== SKELETON =====
-.skeleton {
-  background: linear-gradient(90deg, $gray-200 25%, $gray-100 50%, $gray-200 75%);
-  background-size: 200% 100%;
-  animation: skeleton-pulse 1.5s ease-in-out infinite;
-  border-radius: $radius-sm;
-}
-
-.skeleton-card {
-  height: 5.5rem;
-  border-radius: $radius-lg;
-}
-
-@keyframes skeleton-pulse {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
-}
-
-// ===== RESPONSIVE =====
 @media (max-width: 340px) {
   .stats-grid {
     grid-template-columns: 1fr;
     gap: $spacing-3;
     margin-bottom: $spacing-6;
   }
-
-  .stat-card {
-    padding: $spacing-4;
-  }
-
-  .stat-card__value {
-    font-size: $text-xl;
-  }
-
-  .stat-card__icon {
-    width: 2rem;
-    height: 2rem;
-  }
-
-  .icon {
-    width: 1rem;
-    height: 1rem;
-  }
 }
 
-// ===== PRINT =====
 @media print {
   .stats-grid {
     grid-template-columns: repeat(4, 1fr);
     gap: $spacing-2;
   }
 
-  .stat-card {
+  .stats-grid > app-kpi-card {
     box-shadow: none;
     border: 1px solid #ddd;
-    padding: $spacing-3;
 
     &:hover {
       box-shadow: none;

--- a/fe/src/app/features/admin/presentation/components/user-management/components/stats-cards/stats-cards.component.ts
+++ b/fe/src/app/features/admin/presentation/components/user-management/components/stats-cards/stats-cards.component.ts
@@ -1,10 +1,11 @@
 import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
 
 import { UserManagementState } from '../../state/user-management.state';
+import { KpiCardComponent } from '../../../../../../../shared/components/admin/kpi-card/kpi-card.component';
 
 @Component({
   selector: 'app-user-stats-cards',
-  imports: [],
+  imports: [KpiCardComponent],
   templateUrl: './stats-cards.component.html',
   styleUrl: './stats-cards.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
Closes #175. Part of epic #161. Builds on #174 (PR-A merged).

## Findings addressed

- **CC-01 application**: Migrate 4 surface trong `/admin/users/*` family sang `<app-kpi-card>` từ PR #174

## Findings re-verified (audit stale)

agent-browser test trên main hiện tại:

- **F-U1** "Vai trò chính" — `hasVaiTroChinh: false`. KPI labels đã clear: "Tổng người dùng / Giảng viên / Học viên / Quản trị viên".
- **F-U2** "Audit Edit" button — `hasAuditEdit: false`. Header buttons hiện tại là "Thêm người dùng / Import Excel"; table top-right có "Xuất CSV". Không có "Audit Edit".

## Findings deferred

- **F-U3 / F-AD2** inline-edit role/status dropdown — STILL PRESENT. Needs confirmation modal + edge case handling (cannot suspend self, super admin demote, reauth flow). Doesn't fit ≤ 800 LOC budget. Track riêng PR-B-followup.

## Changes

| File | Change |
|---|---|
| `.../user-management/components/stats-cards/stats-cards.component.{ts,html,scss}` | 4 KPI inline markup → 4 `<app-kpi-card>`. SCSS shrinks ~80 lines (visual rules now in shared component). |
| `.../admin-user-management.component.{ts,html}` | 4 stat-card divs → 4 `<app-kpi-card>`. "Bị khóa" uses `variant="error"`. |
| `.../teacher-management.{component.ts,html}` | Same migration. |
| `.../student-management.component.{ts,html}` | Same migration. |

9 files, +93 / −350 LOC (net -257 LOC).

## Browser verification (agent-browser, admin@maritime.edu, 1440×900)

| Surface | `<app-kpi-card>` | `.stat-card` (cũ) | H1 |
|---|---:|---:|---|
| `/admin/users/all` | **4** | 0 | Quản lý người dùng |
| `/admin/users/admins` | **4** | 0 | Quản lý Quản trị viên |
| `/admin/users/teachers` | **4** | 0 | Quản lý Giảng viên |
| `/admin/users/students` | **4** | 0 | Quản lý Học viên |

Visual contract: number + label + sub. "Bị khóa" cards có `kpi-error` variant background tint. Mobile (375): KPI 1-col stack, type rung drops.

## Convention compliance

- [x] OnPush mọi component (giữ nguyên từ trước)
- [x] inject() / signal — không constructor DI
- [x] @if / @for — không `*ngIf`
- [x] Không `standalone: true` explicit
- [x] Tokens-based shared SCSS through kpi-card
- [x] No decorative brand icons inside KPI cells (per CC-01 guideline)
- [x] Vietnamese diacritics, terminology không thay đổi (giữ "Tổng Học viên" vs "Tất cả Học viên")

## Acceptance criteria (issue #175)

- [x] 4 surface trong `/admin/users/*` đều render qua `<app-kpi-card>`
- [x] Visual contract: number + label + sub + variant
- [x] Bỏ decorative brand icons inside cells
- [x] CI 4/4 expect xanh
- [x] agent-browser before/after measurement cho 4 surface

## Test plan

- [ ] Login admin → mỗi surface render — 4 KPI cards consistent visual
- [ ] DevTools: `$$('app-kpi-card').length === 4` cho mỗi page
- [ ] Click "Thêm Học viên" / "Thêm Giảng viên" / "Thêm Quản trị viên" → modal mở (regression test)
- [ ] Mobile (375×812): KPI 1-col stack
- [ ] Print preview: 4-col grid via shared SCSS

## Risk & rollback

- Risk: thấp. Pure migration, không đụng state / API / business logic.
- Rollback: `git revert`. UX trở về 4 markup style khác nhau (CC-01 violation).

## Out of scope (defer)

- **F-U3 / F-AD2** inline-edit dropdown (modal confirm + reauth) → PR-B-followup
- **F-T1** KPI "Đang dạy 0/0" sanity check → BE issue
- Bulk action bar (CC-06), sidebar nav consistency (CC-05) → PR-Z
- Per-surface SCSS dead `.stat-*` rule cleanup → PR-Z polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)