### PR TITLE
fix(admin-users): require confirm modal on status change F-U3 + F-AD2 (closes #177)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
@@ -132,9 +132,26 @@ export class AdminUserManagementComponent implements OnInit {
     });
   }
 
-  // Status action handler
-  onStatusActionChange(user: AdminUser, newStatus: string) {
+  // Status action handler — F-AD2 security fix: require confirm modal before
+  // suspending or activating an admin account. Admins suspending other admins
+  // is the highest-blast-radius action in the portal; the modal makes the
+  // intent explicit and the cancel path re-fetches to revert dropdown UI.
+  async onStatusActionChange(user: AdminUser, newStatus: string) {
     if (!newStatus) return;
+
+    const isBlock = newStatus === 'BLOCKED';
+    const confirmed = await this.confirmDialog.confirm({
+      title: isBlock ? 'Khóa tài khoản Quản trị viên' : 'Kích hoạt tài khoản',
+      message: isBlock
+        ? `Bạn có chắc muốn khóa tài khoản Quản trị viên ${user.name}? Họ sẽ mất quyền truy cập hệ thống cho đến khi được mở khóa.`
+        : `Bạn có chắc muốn kích hoạt lại tài khoản của ${user.name}?`,
+      confirmText: isBlock ? 'Khóa tài khoản' : 'Kích hoạt',
+      variant: isBlock ? 'danger' : 'warning'
+    });
+    if (!confirmed) {
+      this.loadUsers();
+      return;
+    }
 
     this.adminService.updateUserStatus(user.id, {
       status: newStatus as UserAccountStatus,

--- a/fe/src/app/features/admin/presentation/components/student-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.ts
@@ -163,9 +163,25 @@ export class StudentManagementComponent implements OnInit {
     });
   }
 
-  // Status action handler
-  onStatusActionChange(user: AdminUser, newStatus: string) {
+  // Status action handler — F-U3 security fix: require confirm modal before
+  // suspending or activating an account. Cancel → loadUsers() re-fetch reverts
+  // the inline-edit dropdown UI.
+  async onStatusActionChange(user: AdminUser, newStatus: string) {
     if (!newStatus) return;
+
+    const isBlock = newStatus === 'BLOCKED';
+    const confirmed = await this.confirmDialog.confirm({
+      title: isBlock ? 'Khóa tài khoản' : 'Kích hoạt tài khoản',
+      message: isBlock
+        ? `Bạn có chắc muốn khóa tài khoản của ${user.name}? Họ sẽ không đăng nhập được cho đến khi mở khóa.`
+        : `Bạn có chắc muốn kích hoạt lại tài khoản của ${user.name}?`,
+      confirmText: isBlock ? 'Khóa tài khoản' : 'Kích hoạt',
+      variant: isBlock ? 'danger' : 'warning'
+    });
+    if (!confirmed) {
+      this.loadUsers();
+      return;
+    }
 
     this.adminService.updateUserStatus(user.id, {
       status: newStatus as UserAccountStatus,

--- a/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
@@ -152,9 +152,25 @@ export class TeacherManagementComponent implements OnInit {
     });
   }
 
-  // Status action handler
-  onStatusActionChange(user: AdminUser, newStatus: string) {
+  // Status action handler — F-U3/F-AD2 security fix: require confirm modal
+  // before suspending or activating an account. Cancel → loadUsers() re-fetch
+  // reverts the inline-edit dropdown UI to the previous value.
+  async onStatusActionChange(user: AdminUser, newStatus: string) {
     if (!newStatus) return;
+
+    const isBlock = newStatus === 'BLOCKED';
+    const confirmed = await this.confirmDialog.confirm({
+      title: isBlock ? 'Khóa tài khoản' : 'Kích hoạt tài khoản',
+      message: isBlock
+        ? `Bạn có chắc muốn khóa tài khoản của ${user.name}? Họ sẽ không đăng nhập được cho đến khi mở khóa.`
+        : `Bạn có chắc muốn kích hoạt lại tài khoản của ${user.name}?`,
+      confirmText: isBlock ? 'Khóa tài khoản' : 'Kích hoạt',
+      variant: isBlock ? 'danger' : 'warning'
+    });
+    if (!confirmed) {
+      this.loadUsers();
+      return;
+    }
 
     this.adminService.updateUserStatus(user.id, {
       status: newStatus as UserAccountStatus,


### PR DESCRIPTION
Closes #177. Part of epic #161 (admin portal mega refresh).

Security gate cho inline-edit status dropdown trong users family.

## Vấn đề

Mega audit đánh dấu **F-U3** (users/all) + **F-AD2** (users/admins) là security risk: admin click nhầm dropdown trong table row → user bị suspend ngay không xác nhận.

Trước fix:
- `onStatusActionChange()` gọi `updateUserStatus()` **ngay** khi dropdown change
- Không có confirm gate
- Inconsistent với `onRoleChange()` ở cùng 3 component (đã có confirmDialog từ trước)

Đáng kể nhất là `/admin/users/admins`: admin A click nhầm dropdown row admin B → admin B mất quyền truy cập hệ thống.

## Fix

Thêm `confirmDialog.confirm({...})` vào `onStatusActionChange()` ở 3 component:
- `admin-user-management.component.ts` (admins surface — wording mạnh nhất)
- `teacher-management.component.ts`
- `student-management.component.ts`

Anatomy:
| `newStatus` | `variant` | Title | Message |
|---|---|---|---|
| BLOCKED | danger | Khóa tài khoản | nêu rõ user sẽ mất quyền đăng nhập |
| ACTIVE | warning | Kích hoạt tài khoản | xác nhận mở khóa |

Cancel → `loadUsers()` re-fetch để dropdown sync về giá trị cũ (vì `<select (change)>` template đã reset value về placeholder; re-fetch đồng bộ data).

## Browser verification (agent-browser, admin@maritime.edu, /admin/users/teachers)

1. Open status dropdown row 1 → select "Khóa"
2. **Modal xuất hiện**: heading "Khóa tài khoản" + Hủy + Khóa tài khoản
3. Click "Hủy" → modal đóng, **không gọi API**, dropdown reset

## Convention compliance

- [x] OnPush giữ nguyên
- [x] async/await cho confirm modal (idiomatic)
- [x] `inject(ConfirmDialogService)` đã có sẵn — không cần thêm DI
- [x] Vietnamese diacritics, terminology phù hợp role
- [x] Variant 'danger' cho BLOCKED (Atlassian semantic color)

## Why not full pill+kebab redesign?

Audit recommend status pill (read-only) + kebab menu `⋮` → modal confirm. Đó là full UX redesign cần:
- Shared kebab-menu component
- Cancel-suspend-self edge case
- Super-admin-demote logic
- Test 3 surface với regression suite

Vượt budget ≤ 800 LOC. Track riêng PR-Z polish.

**Confirm modal là minimum security gate** — chặn click nhầm, đủ để gỡ status quo "click → suspend ngay".

## Acceptance criteria (issue #177)

- [x] `onStatusActionChange()` ở 3 surface gọi `confirmDialog.confirm()` trước API
- [x] BLOCKED → variant 'danger' với message nêu rõ
- [x] Cancel → dropdown revert về cũ (qua loadUsers re-fetch)
- [x] Không break flow positive (confirm → API → toast)
- [x] CI 4/4 expect xanh
- [x] agent-browser test pass: cancel BLOCK confirmed via DOM check

## Test plan

- [ ] Login admin → `/admin/users/teachers` → mở status dropdown row 1 → select "Khóa" → modal hiện → Hủy → status không đổi
- [ ] Same flow + click "Khóa tài khoản" → API call → user blocked, table refreshes
- [ ] `/admin/users/admins` — modal title có chữ "Quản trị viên" emphasis
- [ ] `/admin/users/students` — modal hiện đầy đủ
- [ ] Mobile (375): modal layout OK

## Risk & rollback

- Risk: thấp. Chỉ thêm confirm gate, không đụng API/state.
- Rollback: `git revert`. Hồi sinh security risk — không khuyến nghị.

## Out of scope (defer)

- Full pill+kebab redesign → PR-Z polish
- Re-auth on role escalation → security audit issue riêng
- F-T1 KPI 0/0 sanity → BE issue

3 files, +55 / −6 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)