### PR TITLE
feat(admin-courses): split price column + empty state CTA + SLA badge (closes #179)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/course-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/course-management.component.html
@@ -165,7 +165,8 @@
                   <th>Khóa học</th>
                   <th>Giảng viên</th>
                   <th>Trạng thái</th>
-                  <th>Giá / Học viên</th>
+                  <th>Giá</th>
+                  <th>Học viên</th>
                   <th class="col-actions">Thao tác</th>
                 </tr>
               </thead>
@@ -221,7 +222,9 @@
                     </td>
                     <td>
                       <div class="price-text">{{ course.price ? formatCurrency(course.price) : 'Miễn phí' }}</div>
-                      <div class="students-text">{{ course.enrolledCount || 0 }} học viên</div>
+                    </td>
+                    <td>
+                      <div class="students-text">{{ course.enrolledCount || 0 }}</div>
                     </td>
                     <td>
                       <div class="action-btns">

--- a/fe/src/app/features/admin/presentation/components/course-review.component.html
+++ b/fe/src/app/features/admin/presentation/components/course-review.component.html
@@ -142,6 +142,14 @@
                       <span [class]="getCourseStatusClass(course)">
                         {{ getCourseStatusText(course) }}
                       </span>
+                      @if (canReviewCourse(course) && course.submittedAt) {
+                        <div
+                          class="sla-badge"
+                          [class]="'sla-' + getSlaUrgency(course)"
+                          [title]="'Đã chờ ' + getSlaDays(course) + ' ngày kể từ ngày nộp'">
+                          ⏱ Chờ {{ getSlaDays(course) }} ngày
+                        </div>
+                      }
                     </td>
                     <td class="col-center">
                       <div class="action-btns">
@@ -195,8 +203,10 @@
           </div>
         } @else {
           <app-empty-state
-            title="Không tìm thấy khóa học nào"
-            description="Thử điều chỉnh từ khóa tìm kiếm hoặc chọn bộ lọc khác."
+            [title]="emptyStateTitle()"
+            [description]="emptyStateDescription()"
+            [actionLabel]="hasActiveFilter() ? 'Xóa bộ lọc' : ''"
+            (actionClick)="clearFilters()"
             variant="compact">
             <svg icon fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"

--- a/fe/src/app/features/admin/presentation/components/course-review.component.scss
+++ b/fe/src/app/features/admin/presentation/components/course-review.component.scss
@@ -1204,3 +1204,33 @@
 @keyframes spin {
   to { transform: rotate(360deg); }
 }
+
+/* ===== SLA BADGE (F-CR3) =====
+   Sits below the status pill on PENDING rows so reviewers see urgency
+   without opening detail. Color encodes time-since-submission band. */
+.sla-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-top: $spacing-1;
+  font-size: $text-xs;
+  font-weight: $font-medium;
+  padding: 2px $spacing-2;
+  border-radius: $radius-sm;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+
+  &.sla-ok {
+    background: $gray-100;
+    color: $gray-600;
+  }
+  &.sla-watch {
+    background: $warning-light;
+    color: $warning;
+  }
+  &.sla-overdue {
+    background: $error-light;
+    color: $error;
+    font-weight: $font-semibold;
+  }
+}

--- a/fe/src/app/features/admin/presentation/components/course-review.component.ts
+++ b/fe/src/app/features/admin/presentation/components/course-review.component.ts
@@ -78,6 +78,55 @@ export class CourseReviewComponent implements OnInit {
   previewContent$ = signal<any[]>([]);
   loadingPreview = signal(false);
 
+  // F-CR1 — empty state CTA. Helper to detect whether the current view is
+  // empty because of an applied filter (so we offer to clear it) versus
+  // genuinely no data (no CTA — there's nothing to clear).
+  hasActiveFilter = computed(() => {
+    return this.statusFilter !== '' || this.searchKeyword.trim() !== '';
+  });
+
+  emptyStateTitle = computed(() => {
+    if (this.statusFilter === 'PENDING') return 'Không có khóa học chờ duyệt';
+    if (this.statusFilter === 'APPROVED') return 'Chưa có khóa học nào được duyệt';
+    if (this.statusFilter === 'REJECTED') return 'Chưa có khóa học bị từ chối';
+    if (this.statusFilter === 'DRAFT') return 'Chưa có khóa học nháp';
+    return 'Không tìm thấy khóa học nào';
+  });
+
+  emptyStateDescription = computed(() => {
+    if (this.hasActiveFilter()) {
+      return 'Thử điều chỉnh từ khóa tìm kiếm hoặc chọn bộ lọc khác.';
+    }
+    return 'Khi giảng viên gửi khóa học mới, danh sách sẽ hiển thị ở đây.';
+  });
+
+  clearFilters(): void {
+    this.searchKeyword = '';
+    this.statusFilter = '';
+    this.currentPage = 1;
+    this.loadCourses();
+  }
+
+  // F-CR3 — SLA badge.
+  // Days since the teacher submitted for review. Reviewer sees urgency at a
+  // glance instead of clicking into each row.
+  getSlaDays(course: CourseListItem): number {
+    if (!course.submittedAt) return 0;
+    const submitted = new Date(course.submittedAt).getTime();
+    if (Number.isNaN(submitted)) return 0;
+    const diffMs = Date.now() - submitted;
+    return Math.max(0, Math.floor(diffMs / (1000 * 60 * 60 * 24)));
+  }
+
+  // < 3 days = ok (gray), 3-7 = watch (amber), > 7 = overdue (red).
+  // Thresholds picked from internal SLA discussion — easy to tune later.
+  getSlaUrgency(course: CourseListItem): 'ok' | 'watch' | 'overdue' {
+    const days = this.getSlaDays(course);
+    if (days >= 7) return 'overdue';
+    if (days >= 3) return 'watch';
+    return 'ok';
+  }
+
   ngOnInit() {
     this.loadCourses();
   }


### PR DESCRIPTION
Closes #179. Part of epic #161 (admin portal mega refresh).

## Findings addressed

Mega audit `docs/reports/2026-04-25-admin-portal-mega-audit.md`:

- **F-C2** Split "Giá / Học viên" thành 2 cột riêng
- **F-CR1** Empty state Activate CTA "Xóa bộ lọc"
- **F-CR3** SLA badge "⏱ Chờ N ngày" cho PENDING courses

## Findings deferred

- **F-C1** KPI count mismatch → BE data verify, separate issue
- **F-C3** per-row 5-7 icons → kebab menu (cần shared dropdown component, PR-Z)
- **F-CR2** Coursera-style side-by-side review pane → riêng (heavy redesign)

## Changes

| File | Change |
|---|---|
| `course-management.component.html` | Tách header `<th>Giá / Học viên</th>` → 2 `<th>`. Tách cell từ 1 td (price + students stack) → 2 td (price | students count). |
| `course-review.component.html` | Empty state thêm `[actionLabel]` + `(actionClick)`. SLA badge `<div class="sla-badge sla-{{ urgency }}">` dưới status pill cho PENDING + có submittedAt. |
| `course-review.component.ts` | Thêm `hasActiveFilter` / `emptyStateTitle` / `emptyStateDescription` computeds. Thêm `clearFilters()` action. Thêm `getSlaDays()` / `getSlaUrgency()` helpers — 3-band classification (ok/watch/overdue). |
| `course-review.component.scss` | Thêm `.sla-badge` với `.sla-ok` / `.sla-watch` / `.sla-overdue` rules dùng semantic tokens (`$gray-100`, `$warning-light`, `$error-light`). |

4 files, +96 / −4 LOC.

## Browser verification (agent-browser admin@maritime.edu, 1440×900)

### `/admin/courses`

| Metric | Before | After |
|---|---|---|
| Column count | 6 | **7** (split Price + Students) |
| Headers | "Giá / Học viên" gộp | **"Giá" + "Học viên"** riêng |

### `/admin/courses/review`

| Metric | Before | After |
|---|---|---|
| Empty state | Inform-only ("Không tìm thấy / Thử điều chỉnh") | **Title context-aware + Activate CTA "Xóa bộ lọc"** |
| Empty title | static "Không tìm thấy khóa học nào" | **"Không có khóa học chờ duyệt" / "Chưa có khóa học bị từ chối"...** theo filter |
| SLA badge | — | `getSlaDays(course)` + 3-band color (gray/amber/red) |

Screenshot: empty state hiện "Xóa bộ lọc" button khi filter PENDING.

SLA badge implementation type-checked + production build pass; live test cần PENDING data (test DB hiện tại không có).

## Convention compliance

- [x] OnPush
- [x] Signal-based: `signal()` cho state, `computed()` cho derived
- [x] @if / @for
- [x] Tokens-based SCSS (`$warning-light`, `$error-light`, `$spacing-*`)
- [x] WCAG: SLA badge có `title` attribute + label đầy đủ "Chờ N ngày"
- [x] Vietnamese diacritics

## Acceptance criteria (issue #179)

- [x] `/admin/courses` 7 cột với Giá + Học viên riêng
- [x] `/admin/courses/review` empty state có CTA khi filter active
- [x] PENDING courses có SLA pill
- [x] CI 4/4 expect xanh
- [x] agent-browser before/after measurement

## Test plan

- [ ] Login admin → `/admin/courses` → table có 7 cột riêng biệt
- [ ] DevTools: `$$('thead th').length === 7`
- [ ] `/admin/courses/review` PENDING tab empty → CTA "Xóa bộ lọc" hiện
- [ ] Click "Xóa bộ lọc" → reload với statusFilter=''  
- [ ] Có 1 PENDING course với submittedAt 5 ngày trước → SLA pill amber "Chờ 5 ngày"
- [ ] PENDING với submittedAt 10 ngày → SLA pill red bold "Chờ 10 ngày"

## Risk & rollback

- Risk: thấp. Pure FE markup + helper logic, không đụng API/state.
- Rollback: `git revert`. Mất column split + CTA + SLA badge.

## Out of scope

- F-C1 BE data sanity → BE issue
- F-C3 kebab menu → PR-Z polish
- F-CR2 side-by-side review → riêng PR sau

🤖 Generated with [Claude Code](https://claude.com/claude-code)