### PR TITLE
feat(admin-logs): Vietnamese labels + CSV export (closes #183)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/audit-logs.component.html
+++ b/fe/src/app/features/admin/presentation/components/audit-logs.component.html
@@ -1,6 +1,14 @@
 <div class="audit-page">
   <div class="audit-inner">
-    <h1 class="page-title">Nhật ký kiểm toán</h1>
+    <div class="page-header">
+      <h1 class="page-title">Nhật ký kiểm toán</h1>
+      <button (click)="exportCsvCurrentPage()" class="btn-export" [disabled]="logs().length === 0" title="Xuất các dòng đang hiển thị ra CSV">
+        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" width="16" height="16">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+        </svg>
+        Xuất CSV
+      </button>
+    </div>
 
     <!-- Filters -->
     <div class="filter-bar">
@@ -9,19 +17,19 @@
           <label class="filter-label">Bảng</label>
           <select [(ngModel)]="tableFilter" (ngModelChange)="onFilterChange()" class="filter-select">
             <option value="">Tất cả</option>
-            <option value="courses">courses</option>
-            <option value="users">users</option>
-            <option value="enrollments">enrollments</option>
-            <option value="submissions">submissions</option>
+            <option value="courses">Khóa học</option>
+            <option value="users">Người dùng</option>
+            <option value="enrollments">Đăng ký học</option>
+            <option value="submissions">Bài nộp</option>
           </select>
         </div>
         <div class="filter-group">
           <label class="filter-label">Hành động</label>
           <select [(ngModel)]="actionFilter" (ngModelChange)="onFilterChange()" class="filter-select">
             <option value="">Tất cả</option>
-            <option value="INSERT">INSERT</option>
-            <option value="UPDATE">UPDATE</option>
-            <option value="DELETE">DELETE</option>
+            <option value="INSERT">Thêm mới</option>
+            <option value="UPDATE">Cập nhật</option>
+            <option value="DELETE">Xoá</option>
           </select>
         </div>
       </div>
@@ -44,10 +52,10 @@
           @for (log of logs(); track log.id) {
             <tr>
               <td class="cell-id">{{ log.id }}</td>
-              <td class="cell-table-name">{{ log.tableName }}</td>
+              <td class="cell-table-name" [title]="log.tableName">{{ getTableLabel(log.tableName) }}</td>
               <td>
-                <span class="badge" [class]="getActionClass(log.action)">
-                  {{ log.action }}
+                <span class="badge" [class]="getActionClass(log.action)" [title]="log.action">
+                  {{ getActionLabel(log.action) }}
                 </span>
               </td>
               <td class="cell-record-id">{{ log.recordId | slice:0:8 }}...</td>

--- a/fe/src/app/features/admin/presentation/components/audit-logs.component.scss
+++ b/fe/src/app/features/admin/presentation/components/audit-logs.component.scss
@@ -13,12 +13,51 @@
 }
 
 /* ===== HEADER ===== */
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-3;
+  margin-bottom: $spacing-6;
+  flex-wrap: wrap;
+}
+
 .page-title {
   font-size: $text-2xl;
   font-weight: $font-bold;
   color: $text-primary;
-  margin: 0 0 $spacing-6;
+  margin: 0;
   line-height: $leading-tight;
+}
+
+/* F-L4 — CSV export button. Audit-only consumers expect a quick "current
+   page" download to drop into a SOC2 / ISO 27001 evidence folder. */
+.btn-export {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-2;
+  padding: $spacing-2 $spacing-4;
+  min-height: 40px;
+  font-size: $text-sm;
+  font-weight: $font-semibold;
+  color: white;
+  background: $blue-primary;
+  border: 1px solid $blue-primary;
+  border-radius: $radius-md;
+  cursor: pointer;
+  transition: background $transition-fast, border-color $transition-fast;
+
+  &:hover:not(:disabled) {
+    background: $blue-hover;
+    border-color: $blue-hover;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @include focus-visible;
 }
 
 /* ===== FILTER BAR ===== */

--- a/fe/src/app/features/admin/presentation/components/audit-logs.component.ts
+++ b/fe/src/app/features/admin/presentation/components/audit-logs.component.ts
@@ -2,6 +2,24 @@ import { Component, signal, inject, OnInit, ChangeDetectionStrategy } from '@ang
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { AuditApi, AuditLogEntry } from '../../../../api/endpoints/audit.api';
+import { ToastService } from '../../../../core/services/toast.service';
+
+// F-L1 — map raw DB-level operation names to Vietnamese label.
+// "Auth0 Logs" precedent: surface human-readable verb, keep machine
+// name accessible (we render Vietnamese in the badge, raw still in JSON
+// detail panel).
+const ACTION_LABELS: Readonly<Record<string, string>> = {
+  INSERT: 'Thêm mới',
+  UPDATE: 'Cập nhật',
+  DELETE: 'Xoá',
+};
+
+const TABLE_LABELS: Readonly<Record<string, string>> = {
+  courses:     'Khóa học',
+  users:       'Người dùng',
+  enrollments: 'Đăng ký học',
+  submissions: 'Bài nộp',
+};
 
 @Component({
   selector: 'app-audit-logs',
@@ -12,6 +30,7 @@ import { AuditApi, AuditLogEntry } from '../../../../api/endpoints/audit.api';
 })
 export class AuditLogsComponent implements OnInit {
   private auditApi = inject(AuditApi);
+  private toast = inject(ToastService);
 
   logs = signal<AuditLogEntry[]>([]);
   currentPage = signal(0);
@@ -55,6 +74,15 @@ export class AuditLogsComponent implements OnInit {
     this.expandedId.set(this.expandedId() === id ? null : id);
   }
 
+  // F-L1 helpers.
+  getActionLabel(action: string): string {
+    return ACTION_LABELS[action] ?? action;
+  }
+
+  getTableLabel(tableName: string): string {
+    return TABLE_LABELS[tableName] ?? tableName;
+  }
+
   getActionClass(action: string): string {
     switch (action) {
       case 'INSERT': return 'badge badge-insert';
@@ -67,5 +95,48 @@ export class AuditLogsComponent implements OnInit {
   formatJson(data: Record<string, unknown> | null): string {
     if (!data) return '{}';
     return JSON.stringify(data, null, 2);
+  }
+
+  // F-L4 — CSV export of the rows currently rendered (audit page-by-page).
+  // Full-history export needs a BE endpoint streaming the whole table
+  // (compliance asks SOC2 / ISO27001) — tracked separately.
+  exportCsvCurrentPage(): void {
+    const rows = this.logs();
+    if (rows.length === 0) {
+      this.toast.warning('Không có nhật ký để xuất.');
+      return;
+    }
+
+    const header = ['ID', 'Bảng', 'Hành động', 'Record ID', 'Người thực hiện', 'Thời gian'];
+    const escape = (v: unknown) => {
+      const s = v == null ? '' : String(v);
+      // RFC 4180: quote when content has comma/quote/newline; escape inner quotes.
+      return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+    };
+
+    const lines = [
+      header.join(','),
+      ...rows.map(r => [
+        r.id,
+        this.getTableLabel(r.tableName),
+        this.getActionLabel(r.action),
+        r.recordId,
+        r.changedBy ?? '',
+        r.changedAt
+      ].map(escape).join(','))
+    ];
+
+    // BOM for Excel UTF-8 friendliness.
+    const blob = new Blob(['﻿' + lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `audit-logs-page-${this.currentPage() + 1}-${new Date().toISOString().slice(0, 10)}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+
+    this.toast.success(`Đã xuất ${rows.length} dòng CSV.`);
   }
 }


### PR DESCRIPTION
Closes #183. Part of epic #161 (admin portal mega refresh).

## Findings addressed

- **F-L1** Action badges raw "INSERT/UPDATE/DELETE" → Vietnamese "Thêm mới / Cập nhật / Xoá" (Auth0 / GitHub audit log pattern: human-readable surface, machine name accessible via `title`)
- **F-L4** Thêm "Xuất CSV" button cho compliance evidence (SOC2/ISO27001 audit ask)

## Findings deferred

- **F-L2** Date range filter → BE issue (`/audit-logs` không có `?from=&to=` param)
- **F-L3** Search by actor email/name → BE issue (cần BE search param)

## Changes

| File | Change |
|---|---|
| `audit-logs.component.ts` | `ACTION_LABELS` + `TABLE_LABELS` const maps. `getActionLabel()` + `getTableLabel()` helpers (fallback to raw value khi key unknown). `exportCsvCurrentPage()` method với RFC 4180 escaping + UTF-8 BOM + ISO-date filename. |
| `audit-logs.component.html` | Page-header với "Xuất CSV" button. Filter dropdown options Vietnamese. Action badge `{{ getActionLabel(log.action) }}` với `title="raw"`. Cell `{{ getTableLabel(log.tableName) }}`. |
| `audit-logs.component.scss` | `.page-header` flex layout. `.btn-export` button (40px touch target, focus-visible). |

3 files, +130 / −12 LOC.

## Browser verification (agent-browser admin@maritime.edu, 1440×900)

| | Before | After |
|---|---|---|
| Filter "Hành động" options | "INSERT / UPDATE / DELETE" | **"Thêm mới / Cập nhật / Xoá"** |
| Filter "Bảng" options | "courses / users / enrollments / submissions" | **"Khóa học / Người dùng / Đăng ký học / Bài nộp"** |
| Action badges in table | "DELETE", "INSERT" | **"Xoá", "Thêm mới"** |
| Raw machine name | hidden | **`title=""` attribute (compliance audit)** |
| CSV export | — | **"Xuất CSV" button + 40px target** |

CSV format:
- Header tiếng Việt: ID, Bảng, Hành động, Record ID, Người thực hiện, Thời gian
- RFC 4180 quote escaping
- UTF-8 BOM cho Excel
- Filename `audit-logs-page-N-YYYY-MM-DD.csv`

## Convention compliance

- [x] OnPush
- [x] inject(), signal-based state
- [x] @if/@for, không *ngIf
- [x] Tokens-based SCSS
- [x] Vietnamese diacritics, terminology rõ
- [x] WCAG: aria via title attribute, button 40px touch target

## Test plan

- [ ] `/admin/logs` render với new labels
- [ ] Filter "Cập nhật" → call API với `action=UPDATE` (machine name vẫn gửi BE)
- [ ] Click "Xuất CSV" → download file `audit-logs-page-1-YYYY-MM-DD.csv`
- [ ] Open CSV trong Excel → tiếng Việt hiển thị đúng (BOM)
- [ ] No data → button disabled

## Risk & rollback

- Risk: thấp. Pure FE labeling + client-side CSV. BE API không thay đổi.
- Rollback: `git revert`. Quay về raw machine name + không CSV.

## Out of scope

- F-L2 date range → BE issue
- F-L3 actor search → BE issue
- Full-history CSV export streaming → BE issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)