### PR TITLE
feat(admin): sidebar collapse parity (CC-04, epic #161)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
@@ -17,8 +17,12 @@ import { AiAvailabilityService } from '../../../ai-chat/application/services/ai-
     <div class="min-h-screen flex">
       <!-- Desktop Sidebar -->
       @if (!shouldHideSidebar()) {
-        <div class="hidden lg:flex lg:flex-col lg:fixed lg:inset-y-0 lg:z-50 lg:w-72">
-          <app-sidebar [config]="adminSidebarConfig" [collapsed]="false"></app-sidebar>
+        <div class="hidden lg:flex lg:flex-col lg:fixed lg:inset-y-0 lg:z-50"
+             [class.lg:w-16]="isSidebarCollapsed()"
+             [class.lg:w-72]="!isSidebarCollapsed()">
+          <app-sidebar [config]="adminSidebarConfig"
+                       [collapsed]="isSidebarCollapsed()"
+                       (toggleCollapse)="toggleSidebarCollapse()"></app-sidebar>
         </div>
       }
 
@@ -34,7 +38,9 @@ import { AiAvailabilityService } from '../../../ai-chat/application/services/ai-
       }
 
       <!-- Main content + AI Sidebar wrapper -->
-      <div [class]="shouldHideSidebar() ? 'flex flex-1 min-w-0 min-h-screen' : 'lg:pl-72 flex flex-1 min-w-0 min-h-screen'">
+      <div class="flex flex-1 min-w-0 min-h-screen"
+           [class.lg:pl-16]="!shouldHideSidebar() && isSidebarCollapsed()"
+           [class.lg:pl-72]="!shouldHideSidebar() && !isSidebarCollapsed()">
 
         <!-- Main content column -->
         <div class="flex flex-col flex-1 min-w-0">
@@ -277,6 +283,12 @@ export class AdminLayoutSimpleComponent implements OnInit, OnDestroy {
   private router = inject(Router);
   protected isMobileSidebarOpen = signal(false);
 
+  // CC-04 — sidebar collapse parity với teacher / student. Persisted in
+  // localStorage under `admin_sidebar_collapsed` (separate key per portal
+  // so an admin's preference doesn't leak into other portals nếu cùng
+  // user role-switch).
+  protected isSidebarCollapsed = signal(false);
+
   // Sidebar config — use shared config based on user role
   protected get adminSidebarConfig() {
     const role = this.authService.userRole() || 'admin';
@@ -314,6 +326,7 @@ export class AdminLayoutSimpleComponent implements OnInit, OnDestroy {
   });
 
   ngOnInit(): void {
+    this.loadSidebarCollapsed();
     this.loadAiSidebarState();
     this.loadAiSidebarWidth();
 
@@ -340,6 +353,26 @@ export class AdminLayoutSimpleComponent implements OnInit, OnDestroy {
 
   toggleMobileSidebar(): void {
     this.isMobileSidebarOpen.update(open => !open);
+  }
+
+  toggleSidebarCollapse(): void {
+    this.isSidebarCollapsed.update(v => !v);
+    try {
+      localStorage?.setItem('admin_sidebar_collapsed', this.isSidebarCollapsed().toString());
+    } catch {
+      // Storage may be disabled in private mode — silently ignore.
+    }
+  }
+
+  private loadSidebarCollapsed(): void {
+    try {
+      const saved = localStorage?.getItem('admin_sidebar_collapsed');
+      if (saved !== null && saved !== undefined) {
+        this.isSidebarCollapsed.set(saved === 'true');
+      }
+    } catch {
+      // ignore
+    }
   }
 
   // --- AI Sidebar ---


### PR DESCRIPTION
Part of epic #161 — final polish PR.

Adds sidebar collapse parity to admin layout (teacher / student đã có từ trước; admin missing).

## Findings addressed

- **CC-04** Sidebar collapse toggle cho admin layout — pattern parity với teacher / student

## Findings deferred (defer rationale below)

- **CC-06** Bulk action bar → cần shared `<app-bulk-action-bar>` + state machine. Heavy, separate PR.
- **CC-10** Per-row kebab menu → cần shared dropdown component. Heavy.
- **CC-11 / CC-12** Cross-surface spacing/heading re-audit → re-run audit sau khi tất cả PR-A..E merged để measure new state, không speculative.
- **F-17** FAB/AI sidebar toggle overlap — manual review confirm AI sidebar toggle ở viewport edge (right: 0), không overlap card content. Audit had visual misread.
- **F-CAT2** Course count badge per category — `CategoryDTO` (BE) không expose `courseCount`. BE issue riêng.
- **F-15** Dark mode — separate scope.

## Changes

| File | Change |
|---|---|
| `admin-layout-simple.component.ts` | Thêm `isSidebarCollapsed` signal. `[collapsed]` + `(toggleCollapse)` binding lên shared `<app-sidebar>`. `toggleSidebarCollapse()` + `loadSidebarCollapsed()` với localStorage `admin_sidebar_collapsed` key. Try/catch quanh localStorage cho private mode. Conditional `[class.lg:w-16]/[class.lg:w-72]` cho wrapper + `[class.lg:pl-16]/[class.lg:pl-72]` cho main gutter. |

1 file, +36 / −3 LOC.

## Browser verification (agent-browser admin@maritime.edu, 1440×900)

| Test | Result |
|---|---|
| `window.ng.getComponent(el)` exposes `isSidebarCollapsed` signal | ✓ |
| `window.ng.getComponent(el)` exposes `toggleSidebarCollapse()` method | ✓ |
| Direct call `cmp.toggleSidebarCollapse()` flips signal + writes "true" to localStorage | ✓ |
| Manual emit `sidebar.toggleCollapse.emit()` → output binding fires layout handler | ✓ |
| Programmatic `btn.click()` on `.collapse-toggle` → full flow (DOM → output → handler → state) | ✓ |
| Wrapper class swaps `lg:w-72` ↔ removed when collapsed | ✓ |

Note: agent-browser ref-click không trigger because button có `position: absolute; right: -12px` (sticking out past sidebar edge) → `elementFromPoint` ở visual center of bounding rect returns parent. Real user mouse click hits inner icon area which dispatches correctly. JS `btn.click()` test confirms.

## Convention compliance

- [x] OnPush
- [x] signal-based, no constructor DI
- [x] localStorage key namespaced (`admin_sidebar_collapsed`) — không leak cross-portal
- [x] Try/catch quanh storage access (private mode safe)
- [x] WCAG: button đã có `aria-label="Thu gọn sidebar"` từ shared sidebar component

## Test plan

- [ ] Login admin → click "Thu gọn sidebar" button (icon trái-phải on sidebar right edge) → sidebar shrinks 288 → 64px
- [ ] localStorage `admin_sidebar_collapsed` = "true" sau click
- [ ] Reload page → sidebar giữ collapsed state
- [ ] Click again → expand back
- [ ] Mobile (375): collapse toggle ẩn (CSS `display: none` < 768px)
- [ ] Private mode browser (no localStorage) → vẫn toggle được, không crash

## Risk & rollback

- Risk: thấp. Pure layout state addition, không đụng routing / API / business logic.
- Rollback: `git revert`. Sidebar trở về luôn 288px width.

## Out of scope (recap)

CC-06, CC-10, CC-11/12, F-15, F-17, F-CAT2 — đã liệt kê trong defer rationale ở trên.

🤖 Generated with [Claude Code](https://claude.com/claude-code)