### PR TITLE
feat(admin-be): wave 1 batch — audit log, category count, teacher KPI, pending alignment (#187, #188, #189, #190, #191)

### DIFF
--- a/backend/src/main/java/com/example/lms/course_authoring/application/usecase/ManageCourseCategoryUseCase.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/application/usecase/ManageCourseCategoryUseCase.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -23,6 +24,15 @@ public class ManageCourseCategoryUseCase {
 
     public List<CourseCategory> getActiveTree() {
         return categoryRepo.findAllActiveTree();
+    }
+
+    /**
+     * Returns a map of {@code categoryId → number of APPROVED courses} for
+     * populating the {@code courseCount} field on category DTOs (issue #189).
+     * Categories absent from the map have zero published courses.
+     */
+    public Map<UUID, Long> getApprovedCourseCountsByCategory() {
+        return categoryRepo.countApprovedCoursesByCategory();
     }
 
     @Transactional

--- a/backend/src/main/java/com/example/lms/course_authoring/domain/repository/CourseCategoryRepository.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/domain/repository/CourseCategoryRepository.java
@@ -3,6 +3,7 @@ package com.example.lms.course_authoring.domain.repository;
 import com.example.lms.course_authoring.domain.model.CourseCategory;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -17,4 +18,14 @@ public interface CourseCategoryRepository {
     boolean existsByCode(String code);
     boolean existsBySlug(String slug);
     boolean existsByPrefix(String prefix);
+
+    /**
+     * Counts APPROVED courses for every category that has at least one. Returns
+     * a map keyed by category id; absent categories default to 0 at the call
+     * site.
+     *
+     * <p>Used by the admin categories listing (issue #189, F-CAT2) so the UI
+     * can show a "(47)" badge next to each category name without N+1 queries.
+     */
+    Map<UUID, Long> countApprovedCoursesByCategory();
 }

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/CourseCategoryRepositoryAdapter.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/CourseCategoryRepositoryAdapter.java
@@ -3,6 +3,7 @@ package com.example.lms.course_authoring.infrastructure.persistence;
 import com.example.lms.course_authoring.domain.model.CourseCategory;
 import com.example.lms.course_authoring.domain.repository.CourseCategoryRepository;
 import com.example.lms.course_authoring.infrastructure.persistence.entity.CourseCategoryJpaEntity;
+import com.example.lms.course_authoring.infrastructure.persistence.entity.CourseJpaEntity.CourseStatus;
 import com.example.lms.course_authoring.infrastructure.persistence.repository.CourseCategoryJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -68,7 +69,7 @@ public class CourseCategoryRepositoryAdapter implements CourseCategoryRepository
     @Override
     public Map<UUID, Long> countApprovedCoursesByCategory() {
         Map<UUID, Long> result = new HashMap<>();
-        for (Object[] row : jpaRepo.countApprovedCoursesByCategory()) {
+        for (Object[] row : jpaRepo.countCoursesByCategoryGroupedByStatus(CourseStatus.APPROVED)) {
             if (row == null || row.length < 2 || row[0] == null || row[1] == null) continue;
             result.put((UUID) row[0], ((Number) row[1]).longValue());
         }

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/CourseCategoryRepositoryAdapter.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/CourseCategoryRepositoryAdapter.java
@@ -65,6 +65,16 @@ public class CourseCategoryRepositoryAdapter implements CourseCategoryRepository
     @Override
     public boolean existsByPrefix(String prefix) { return jpaRepo.existsByPrefix(prefix); }
 
+    @Override
+    public Map<UUID, Long> countApprovedCoursesByCategory() {
+        Map<UUID, Long> result = new HashMap<>();
+        for (Object[] row : jpaRepo.countApprovedCoursesByCategory()) {
+            if (row == null || row.length < 2 || row[0] == null || row[1] == null) continue;
+            result.put((UUID) row[0], ((Number) row[1]).longValue());
+        }
+        return result;
+    }
+
     // --- Mapping ---
 
     private CourseCategory toDomain(CourseCategoryJpaEntity e) {

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/JpaCourseRepository.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/JpaCourseRepository.java
@@ -165,6 +165,21 @@ public interface JpaCourseRepository extends JpaRepository<CourseJpaEntity, UUID
 
     long countByTeacherId(UUID teacherId);
 
+    /**
+     * Batch counterpart to {@link #countByTeacherId(UUID)} — returns rows of
+     * {@code [teacherId, count]} for every teacher referenced in the input
+     * set. Used by the admin teacher list to populate the per-teacher
+     * "Khóa học" KPI without N+1 queries (issue #190, F-T1).
+     *
+     * <p>Teachers with zero courses do NOT appear in the result; the caller
+     * must default them to 0.
+     */
+    @Query("SELECT c.teacherId, COUNT(c) " +
+            "FROM CourseJpaEntity c " +
+            "WHERE c.teacherId IN :teacherIds " +
+            "GROUP BY c.teacherId")
+    java.util.List<Object[]> countCoursesByTeacherIds(@Param("teacherIds") Collection<UUID> teacherIds);
+
     long countByStatus(CourseJpaEntity.CourseStatus status);
 
     @Query(value = "SELECT * FROM courses c WHERE unaccent(LOWER(c.title)) LIKE unaccent(LOWER(CONCAT('%', :search, '%')))", nativeQuery = true)

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/repository/CourseCategoryJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/repository/CourseCategoryJpaRepository.java
@@ -1,8 +1,10 @@
 package com.example.lms.course_authoring.infrastructure.persistence.repository;
 
 import com.example.lms.course_authoring.infrastructure.persistence.entity.CourseCategoryJpaEntity;
+import com.example.lms.course_authoring.infrastructure.persistence.entity.CourseJpaEntity.CourseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -44,9 +46,9 @@ public interface CourseCategoryJpaRepository extends JpaRepository<CourseCategor
      * not visible to learners and would inflate the number misleadingly.
      */
     @Query("SELECT c.categoryId, COUNT(c) " +
-            "FROM com.example.lms.course_authoring.infrastructure.persistence.entity.CourseJpaEntity c " +
+            "FROM CourseJpaEntity c " +
             "WHERE c.categoryId IS NOT NULL " +
-            "  AND c.status = com.example.lms.course_authoring.infrastructure.persistence.entity.CourseJpaEntity.CourseStatus.APPROVED " +
+            "  AND c.status = :status " +
             "GROUP BY c.categoryId")
-    List<Object[]> countApprovedCoursesByCategory();
+    List<Object[]> countCoursesByCategoryGroupedByStatus(@Param("status") CourseStatus status);
 }

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/repository/CourseCategoryJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/repository/CourseCategoryJpaRepository.java
@@ -30,4 +30,23 @@ public interface CourseCategoryJpaRepository extends JpaRepository<CourseCategor
     Optional<CourseCategoryJpaEntity> findByCode(String code);
 
     Optional<CourseCategoryJpaEntity> findBySlug(String slug);
+
+    /**
+     * Count APPROVED courses per category (issue #189, F-CAT2).
+     *
+     * <p>Returns rows of {@code [categoryId, count]} so the application layer
+     * can populate a {@code Map<UUID, Long>} in O(1) lookup. Categories with
+     * zero published courses are simply absent from the result and default to
+     * 0 in the map.
+     *
+     * <p>Domain rule: only {@code APPROVED} courses count toward the
+     * category's public-facing badge — DRAFT / PENDING / REJECTED courses are
+     * not visible to learners and would inflate the number misleadingly.
+     */
+    @Query("SELECT c.categoryId, COUNT(c) " +
+            "FROM com.example.lms.course_authoring.infrastructure.persistence.entity.CourseJpaEntity c " +
+            "WHERE c.categoryId IS NOT NULL " +
+            "  AND c.status = com.example.lms.course_authoring.infrastructure.persistence.entity.CourseJpaEntity.CourseStatus.APPROVED " +
+            "GROUP BY c.categoryId")
+    List<Object[]> countApprovedCoursesByCategory();
 }

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3.java
@@ -569,6 +569,18 @@ public class AdminCoursesControllerV3 {
     }
 
     private Page<Course> queryCourses(String status, String search, PageRequest pageable) {
+        // Issue #191 (F-C1): the "Chờ duyệt" KPI on /admin/courses is sourced
+        // from `pendingCourses = countReviewQueue()` which includes BOTH
+        // strictly-PENDING courses AND APPROVED courses with a
+        // PENDING_REVIEW draft change. Routing `status=PENDING` filters
+        // through `findReviewQueue` keeps the table count and the KPI in
+        // lock-step — clicking "Chờ duyệt" can no longer return an empty
+        // page when the strip says "10".
+        if (isPendingReviewFilter(status)) {
+            return search != null && !search.isBlank()
+                    ? filterByTitle(courseRepository.findReviewQueue(pageable), search)
+                    : courseRepository.findReviewQueue(pageable);
+        }
         if (status != null && !status.isBlank() && search != null && !search.isBlank()) {
             try {
                 Course.CourseStatus courseStatus = Course.CourseStatus.valueOf(status.toUpperCase(Locale.ROOT));
@@ -595,6 +607,14 @@ public class AdminCoursesControllerV3 {
         if (teacherIds == null || teacherIds.isEmpty()) {
             return Page.empty(pageable);
         }
+        // Issue #191 (F-C1): see queryCourses — same alignment for the
+        // ORG_ADMIN path so org-scoped KPI and table stay consistent.
+        if (isPendingReviewFilter(status)) {
+            Page<Course> reviewQueue = courseRepository.findReviewQueueByTeacherIds(teacherIds, pageable);
+            return search != null && !search.isBlank()
+                    ? filterByTitle(reviewQueue, search)
+                    : reviewQueue;
+        }
         if (status != null && !status.isBlank() && search != null && !search.isBlank()) {
             try {
                 Course.CourseStatus courseStatus = Course.CourseStatus.valueOf(status.toUpperCase(Locale.ROOT));
@@ -615,6 +635,32 @@ public class AdminCoursesControllerV3 {
             return courseRepository.findByTeacherIdsAndTitleContaining(teacherIds, search, pageable);
         }
         return courseRepository.findByTeacherIds(teacherIds, pageable);
+    }
+
+    /**
+     * "Chờ duyệt" is a *review queue* concept, not a strict status. It covers
+     * courses with {@code status = PENDING} as well as previously-APPROVED
+     * courses whose draft has been resubmitted ({@code draft_change_status =
+     * PENDING_REVIEW}). Both surfaces (KPI strip + table filter) must agree
+     * on this definition (issue #191).
+     */
+    private boolean isPendingReviewFilter(String status) {
+        return status != null && "PENDING".equalsIgnoreCase(status.trim());
+    }
+
+    /**
+     * Title-substring filter applied client-side to a review-queue page. The
+     * review queue is a native query that already aggregates two predicates;
+     * adding a third LIKE branch in SQL would duplicate the count query and
+     * is not worth the complexity for an admin filter against ≤ 100 rows.
+     */
+    private Page<Course> filterByTitle(Page<Course> page, String search) {
+        String needle = search.toLowerCase(Locale.ROOT);
+        List<Course> filtered = page.getContent().stream()
+                .filter(c -> c.getTitle() != null
+                        && c.getTitle().toLowerCase(Locale.ROOT).contains(needle))
+                .collect(Collectors.toList());
+        return new PageImpl<>(filtered, page.getPageable(), filtered.size());
     }
 
     private Page<Course> loadAndFilterOrgScopedCourses(

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseCategoryControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseCategoryControllerV3.java
@@ -16,6 +16,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Tag(name = "Course Categories V3")
@@ -33,7 +34,12 @@ public class CourseCategoryControllerV3 {
     @Cacheable("courseCategories")
     public ResponseEntity<ApiResponse<List<CourseCategoryDTO>>> getActiveTree() {
         var tree = useCase.getActiveTree();
-        return ResponseEntity.ok(ApiResponse.success(tree.stream().map(this::toDTO).toList(), "Danh muc khoa hoc"));
+        // Public listing surfaces the courseCount badge — same source of truth
+        // as the admin tree (issue #189, F-CAT2).
+        Map<UUID, Long> counts = useCase.getApprovedCourseCountsByCategory();
+        return ResponseEntity.ok(ApiResponse.success(
+                tree.stream().map(c -> toDTO(c, counts)).toList(),
+                "Danh muc khoa hoc"));
     }
 
     // --- Admin CRUD ---
@@ -43,7 +49,10 @@ public class CourseCategoryControllerV3 {
     @PreAuthorize("hasAnyRole('ADMIN', 'ORG_ADMIN')")
     public ResponseEntity<ApiResponse<List<CourseCategoryDTO>>> getFullTree() {
         var tree = useCase.getAllTree();
-        return ResponseEntity.ok(ApiResponse.success(tree.stream().map(this::toDTO).toList(), "Tat ca danh muc"));
+        Map<UUID, Long> counts = useCase.getApprovedCourseCountsByCategory();
+        return ResponseEntity.ok(ApiResponse.success(
+                tree.stream().map(c -> toDTO(c, counts)).toList(),
+                "Tat ca danh muc"));
     }
 
     @Operation(summary = "Create category")
@@ -57,7 +66,8 @@ public class CourseCategoryControllerV3 {
         } else {
             created = useCase.createRoot(req.code(), req.name(), req.slug(), req.prefix(), req.description(), req.icon());
         }
-        return ResponseEntity.ok(ApiResponse.success(toDTO(created), "Da tao danh muc"));
+        // Newly-created category has no APPROVED courses yet → 0 by default.
+        return ResponseEntity.ok(ApiResponse.success(toDTO(created, Map.of()), "Da tao danh muc"));
     }
 
     @Operation(summary = "Update category")
@@ -66,7 +76,8 @@ public class CourseCategoryControllerV3 {
     @CacheEvict(value = "courseCategories", allEntries = true)
     public ResponseEntity<ApiResponse<CourseCategoryDTO>> update(@PathVariable UUID id, @Valid @RequestBody UpdateCategoryRequest req) {
         var updated = useCase.update(id, req.name(), req.slug(), req.description(), req.icon(), req.prefix());
-        return ResponseEntity.ok(ApiResponse.success(toDTO(updated), "Da cap nhat danh muc"));
+        Map<UUID, Long> counts = useCase.getApprovedCourseCountsByCategory();
+        return ResponseEntity.ok(ApiResponse.success(toDTO(updated, counts), "Da cap nhat danh muc"));
     }
 
     @Operation(summary = "Deactivate category (soft delete)")
@@ -89,10 +100,19 @@ public class CourseCategoryControllerV3 {
 
     // --- DTOs ---
 
+    /**
+     * Category projection returned to the admin UI.
+     *
+     * <p>{@code courseCount} (issue #189, F-CAT2) is the number of APPROVED
+     * courses directly assigned to this category. Subcategory counts are NOT
+     * rolled up into the parent — each level reports its own count, mirroring
+     * Notion / Strapi behavior. The FE can sum the children itself if a
+     * "total under this branch" badge is needed.
+     */
     public record CourseCategoryDTO(
             String id, String parentId, String code, String name, String slug,
             String prefix, String description, String icon, int sortOrder,
-            boolean active, List<CourseCategoryDTO> children
+            boolean active, long courseCount, List<CourseCategoryDTO> children
     ) {}
 
     public record CreateCategoryRequest(
@@ -113,14 +133,15 @@ public class CourseCategoryControllerV3 {
             @Size(max = 10) String prefix
     ) {}
 
-    private CourseCategoryDTO toDTO(CourseCategory c) {
+    private CourseCategoryDTO toDTO(CourseCategory c, Map<UUID, Long> counts) {
+        long count = c.getId() != null ? counts.getOrDefault(c.getId(), 0L) : 0L;
         return new CourseCategoryDTO(
                 c.getId().toString(),
                 c.getParentId() != null ? c.getParentId().toString() : null,
                 c.getCode(), c.getName(), c.getSlug(),
                 c.getPrefix(), c.getDescription(), c.getIcon(),
-                c.getSortOrder(), c.isActive(),
-                c.getChildren().stream().map(this::toDTO).toList()
+                c.getSortOrder(), c.isActive(), count,
+                c.getChildren().stream().map(child -> toDTO(child, counts)).toList()
         );
     }
 }

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/web/UserControllerV3.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/web/UserControllerV3.java
@@ -115,6 +115,10 @@ public class UserControllerV3 {
         }
 
         Page<UserResponse> response = users.map(this::toResponse);
+        // Issue #190 (F-T1): hydrate coursesCreated for TEACHER rows so the
+        // teacher-management KPI strip ("Đang dạy", "Khóa học") shows real
+        // numbers instead of zeros. Batched to a single SQL aggregate.
+        enrichTeacherCourseCounts(response.getContent());
         return ResponseEntity.ok(ApiResponse.success(response, "Danh sách người dùng"));
     }
 
@@ -135,6 +139,7 @@ public class UserControllerV3 {
             page = userRepository.findAll(PageRequest.of(0, 1000));
         }
         List<UserResponse> response = page.getContent().stream().map(this::toResponse).toList();
+        enrichTeacherCourseCounts(response);
         return ResponseEntity.ok(ApiResponse.success(response, "Danh sách tất cả người dùng"));
     }
 
@@ -210,6 +215,7 @@ public class UserControllerV3 {
             }
             return r;
         });
+        enrichTeacherCourseCounts(response.getContent());
         return ResponseEntity.ok(ApiResponse.success(response, "Tìm thấy người dùng"));
     }
 
@@ -250,6 +256,7 @@ public class UserControllerV3 {
                     return r;
                 })
                 .toList();
+        enrichTeacherCourseCounts(response);
         return ResponseEntity.ok(ApiResponse.success(response, "Danh sách giảng viên"));
     }
 
@@ -696,6 +703,50 @@ public class UserControllerV3 {
                 .createdAt(user.getCreatedAt() != null ? user.getCreatedAt().toString() : null)
                 .updatedAt(user.getUpdatedAt() != null ? user.getUpdatedAt().toString() : null)
                 .build();
+    }
+
+    // === Enrichment Helpers ===
+
+    /**
+     * Hydrate {@code coursesCreated} on every TEACHER row in the page using a
+     * single batched aggregate. Other roles are ignored (they get the default
+     * 0). Mutates the responses in place — the page wrapper is left untouched.
+     *
+     * <p>Implements the data side of issue #190 (F-T1) so the teacher
+     * management KPI strip ("Đang dạy", "Khóa học") shows real numbers
+     * instead of the static zeros the FE was previously summing.
+     */
+    private void enrichTeacherCourseCounts(java.util.Collection<UserResponse> rows) {
+        if (rows == null || rows.isEmpty()) return;
+
+        java.util.Set<UUID> teacherIds = rows.stream()
+                .filter(r -> "teacher".equalsIgnoreCase(r.getRole()))
+                .map(r -> {
+                    try {
+                        return UUID.fromString(r.getId());
+                    } catch (IllegalArgumentException ex) {
+                        return null;
+                    }
+                })
+                .filter(java.util.Objects::nonNull)
+                .collect(java.util.stream.Collectors.toCollection(java.util.HashSet::new));
+        if (teacherIds.isEmpty()) return;
+
+        java.util.Map<UUID, Long> counts = new java.util.HashMap<>(teacherIds.size());
+        for (Object[] row : courseRepository.countCoursesByTeacherIds(teacherIds)) {
+            if (row == null || row.length < 2 || row[0] == null || row[1] == null) continue;
+            counts.put((UUID) row[0], ((Number) row[1]).longValue());
+        }
+
+        for (UserResponse r : rows) {
+            if (!"teacher".equalsIgnoreCase(r.getRole())) continue;
+            try {
+                UUID id = UUID.fromString(r.getId());
+                r.setCoursesCreated(counts.getOrDefault(id, 0L).intValue());
+            } catch (IllegalArgumentException ex) {
+                // Leave default 0 if id is somehow malformed.
+            }
+        }
     }
 
     // === Business Guard Helpers ===

--- a/backend/src/main/java/com/example/lms/shared/application/dto/AuditLogEntryDto.java
+++ b/backend/src/main/java/com/example/lms/shared/application/dto/AuditLogEntryDto.java
@@ -1,0 +1,23 @@
+package com.example.lms.shared.application.dto;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Application-layer projection of an audit log entry. Includes the actor's
+ * email and name resolved from the users table so the admin UI does not need
+ * to issue a follow-up lookup per row.
+ */
+public record AuditLogEntryDto(
+        Long id,
+        String tableName,
+        UUID recordId,
+        String action,
+        Map<String, Object> oldData,
+        Map<String, Object> newData,
+        UUID changedBy,
+        String actorEmail,
+        String actorName,
+        Instant changedAt
+) { }

--- a/backend/src/main/java/com/example/lms/shared/application/dto/AuditLogQuery.java
+++ b/backend/src/main/java/com/example/lms/shared/application/dto/AuditLogQuery.java
@@ -1,0 +1,47 @@
+package com.example.lms.shared.application.dto;
+
+import java.time.Instant;
+
+/**
+ * Query parameters for filtering audit log entries.
+ *
+ * <p>Window semantics: {@code [from, to)} half-open interval so adjacent ranges
+ * do not double-count the boundary instant (matches the convention used by
+ * {@code GetWindowedAnalyticsUseCase}).
+ *
+ * <p>Empty / null filters are treated as "any value", letting the application
+ * layer compose them with existing filters without branching at every call
+ * site.
+ */
+public record AuditLogQuery(
+        String tableName,
+        String action,
+        Instant from,
+        Instant to,
+        String actorEmail,
+        String actorName,
+        int page,
+        int size
+) {
+    /**
+     * Returns a new query with normalised paging bounds (page >= 0, 1 <= size <= 100).
+     */
+    public AuditLogQuery normalise() {
+        int safePage = Math.max(0, page);
+        int safeSize = Math.min(Math.max(1, size), 100);
+        return new AuditLogQuery(
+                blankToNull(tableName),
+                blankToNull(action),
+                from,
+                to,
+                blankToNull(actorEmail),
+                blankToNull(actorName),
+                safePage,
+                safeSize
+        );
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+}

--- a/backend/src/main/java/com/example/lms/shared/application/port/AuditLogQueryPort.java
+++ b/backend/src/main/java/com/example/lms/shared/application/port/AuditLogQueryPort.java
@@ -1,0 +1,17 @@
+package com.example.lms.shared.application.port;
+
+import com.example.lms.shared.application.dto.AuditLogEntryDto;
+import com.example.lms.shared.application.dto.AuditLogQuery;
+import org.springframework.data.domain.Page;
+
+/**
+ * Port (application-layer interface) exposing read-only access to the audit
+ * log. The use case relies on this so it never touches JPA types directly,
+ * keeping the layer compliant with CLAUDE.md Clean Architecture rules.
+ */
+public interface AuditLogQueryPort {
+
+    Page<AuditLogEntryDto> search(AuditLogQuery query);
+
+    AuditLogEntryDto findById(Long id);
+}

--- a/backend/src/main/java/com/example/lms/shared/application/usecase/SearchAuditLogUseCase.java
+++ b/backend/src/main/java/com/example/lms/shared/application/usecase/SearchAuditLogUseCase.java
@@ -1,0 +1,98 @@
+package com.example.lms.shared.application.usecase;
+
+import com.example.lms.shared.application.dto.AuditLogEntryDto;
+import com.example.lms.shared.application.dto.AuditLogQuery;
+import com.example.lms.shared.application.port.AuditLogQueryPort;
+import com.example.lms.shared.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Use case backing {@code GET /api/v3/admin/audit-logs}. Centralises the
+ * date-range and paging validation so the controller stays thin and the
+ * business invariants are unit-testable without booting Spring.
+ *
+ * <p>Validation rules (see issues #187, #188):
+ * <ul>
+ *   <li>{@code from} must be on or before {@code to}</li>
+ *   <li>Window may not exceed 365 days (SOC2 / ISO27001 evidence period)</li>
+ *   <li>Window default is the most recent 7 days when neither {@code from}
+ *       nor {@code to} is provided</li>
+ * </ul>
+ *
+ * <p>Window semantics are half-open {@code [from, to)} for the same reason as
+ * {@link com.example.lms.course_authoring.admin.application.usecase.GetWindowedAnalyticsUseCase}
+ * — adjacent ranges must not double-count the boundary instant.
+ */
+@Component
+@RequiredArgsConstructor
+public class SearchAuditLogUseCase {
+
+    private static final long MAX_WINDOW_DAYS = 365L;
+    private static final long DEFAULT_WINDOW_DAYS = 7L;
+
+    private final AuditLogQueryPort port;
+    private final Clock clock;
+
+    public Page<AuditLogEntryDto> execute(AuditLogQuery rawQuery) {
+        AuditLogQuery query = rawQuery.normalise();
+        AuditLogQuery resolved = applyDefaultWindow(query);
+        validateWindow(resolved.from(), resolved.to());
+        return port.search(resolved);
+    }
+
+    public AuditLogEntryDto getById(Long id) {
+        if (id == null || id <= 0) {
+            throw new ValidationException("id", "ID nhật ký kiểm toán không hợp lệ");
+        }
+        return port.findById(id);
+    }
+
+    /**
+     * Default the window to the most recent 7 days when both bounds are absent.
+     * If only one bound is provided we leave it alone — partial filters are
+     * still legitimate (e.g. "everything after this date").
+     */
+    private AuditLogQuery applyDefaultWindow(AuditLogQuery query) {
+        if (query.from() != null || query.to() != null) {
+            return query;
+        }
+        Instant now = Instant.now(clock);
+        Instant windowStart = now.minus(DEFAULT_WINDOW_DAYS, ChronoUnit.DAYS);
+        return new AuditLogQuery(
+                query.tableName(),
+                query.action(),
+                windowStart,
+                now,
+                query.actorEmail(),
+                query.actorName(),
+                query.page(),
+                query.size()
+        );
+    }
+
+    private void validateWindow(Instant from, Instant to) {
+        if (from == null || to == null) {
+            return; // half-bounded windows are allowed
+        }
+        if (from.isAfter(to)) {
+            throw new ValidationException(
+                    "from",
+                    "Mốc thời gian bắt đầu phải trước hoặc bằng mốc thời gian kết thúc"
+            );
+        }
+        Duration span = Duration.between(from, to);
+        if (span.compareTo(Duration.ofDays(MAX_WINDOW_DAYS)) > 0) {
+            throw new ValidationException(
+                    "to",
+                    "Khoảng thời gian không được vượt quá " + MAX_WINDOW_DAYS + " ngày"
+            );
+        }
+    }
+}

--- a/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/AuditLogJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/AuditLogJpaRepository.java
@@ -37,18 +37,34 @@ public interface AuditLogJpaRepository extends JpaRepository<AuditLogJpaEntity, 
      * <p>Date range is half-open {@code [from, to)} — the boundary instant on
      * {@code to} is excluded so two adjacent windows do not double-count
      * (matches {@code GetWindowedAnalyticsUseCase}).
+     *
+     * <p>Actor filtering joins {@code users} on {@code changed_by = u.id} and
+     * does a case-insensitive {@code LIKE} on email and full name. When an
+     * actor filter is set, rows whose {@code changed_by} does not resolve to a
+     * user are excluded automatically (the JOIN drops them); when no actor
+     * filter is set the LEFT JOIN keeps system-generated rows.
      */
     @Query("SELECT a FROM AuditLogJpaEntity a " +
+            "LEFT JOIN com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity u " +
+            "  ON u.id = a.changedBy " +
             "WHERE (:tableName IS NULL OR a.tableName = :tableName) " +
             "  AND (:action IS NULL OR a.action = :action) " +
             "  AND (:from IS NULL OR a.changedAt >= :from) " +
             "  AND (:to IS NULL OR a.changedAt < :to) " +
+            "  AND (:actorEmail IS NULL " +
+            "       OR (u.email IS NOT NULL " +
+            "           AND LOWER(u.email) LIKE LOWER(CONCAT('%', :actorEmail, '%')))) " +
+            "  AND (:actorName IS NULL " +
+            "       OR (u.fullName IS NOT NULL " +
+            "           AND LOWER(u.fullName) LIKE LOWER(CONCAT('%', :actorName, '%')))) " +
             "ORDER BY a.changedAt DESC")
     Page<AuditLogJpaEntity> search(
             @Param("tableName") String tableName,
             @Param("action") String action,
             @Param("from") Instant from,
             @Param("to") Instant to,
+            @Param("actorEmail") String actorEmail,
+            @Param("actorName") String actorName,
             Pageable pageable
     );
 }

--- a/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/AuditLogJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/AuditLogJpaRepository.java
@@ -8,11 +8,19 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
+
 @Repository
 public interface AuditLogJpaRepository extends JpaRepository<AuditLogJpaEntity, Long> {
 
     Page<AuditLogJpaEntity> findAllByOrderByChangedAtDesc(Pageable pageable);
 
+    /**
+     * Existing simple filter (table + action) preserved for backwards
+     * compatibility. New callers should prefer {@link #search(String, String,
+     * Instant, Instant, String, String, Pageable)} which also supports
+     * date-range and actor-identity filtering (issues #187, #188).
+     */
     @Query("SELECT a FROM AuditLogJpaEntity a WHERE " +
             "(:tableName IS NULL OR a.tableName = :tableName) AND " +
             "(:action IS NULL OR a.action = :action) " +
@@ -20,6 +28,27 @@ public interface AuditLogJpaRepository extends JpaRepository<AuditLogJpaEntity, 
     Page<AuditLogJpaEntity> findFiltered(
             @Param("tableName") String tableName,
             @Param("action") String action,
+            Pageable pageable
+    );
+
+    /**
+     * Combined filter used by {@code SearchAuditLogUseCase}.
+     *
+     * <p>Date range is half-open {@code [from, to)} — the boundary instant on
+     * {@code to} is excluded so two adjacent windows do not double-count
+     * (matches {@code GetWindowedAnalyticsUseCase}).
+     */
+    @Query("SELECT a FROM AuditLogJpaEntity a " +
+            "WHERE (:tableName IS NULL OR a.tableName = :tableName) " +
+            "  AND (:action IS NULL OR a.action = :action) " +
+            "  AND (:from IS NULL OR a.changedAt >= :from) " +
+            "  AND (:to IS NULL OR a.changedAt < :to) " +
+            "ORDER BY a.changedAt DESC")
+    Page<AuditLogJpaEntity> search(
+            @Param("tableName") String tableName,
+            @Param("action") String action,
+            @Param("from") Instant from,
+            @Param("to") Instant to,
             Pageable pageable
     );
 }

--- a/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/AuditLogQueryAdapter.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/AuditLogQueryAdapter.java
@@ -1,0 +1,90 @@
+package com.example.lms.shared.infrastructure.persistence;
+
+import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
+import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
+import com.example.lms.shared.application.dto.AuditLogEntryDto;
+import com.example.lms.shared.application.dto.AuditLogQuery;
+import com.example.lms.shared.application.port.AuditLogQueryPort;
+import com.example.lms.shared.exception.EntityNotFoundException;
+import com.example.lms.shared.infrastructure.persistence.entity.AuditLogJpaEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Infrastructure adapter wiring {@link AuditLogQueryPort} to the existing JPA
+ * repository. Resolves actor identities (email + full name) in a single batch
+ * query per page so the controller does not issue N+1 lookups.
+ */
+@Component
+@RequiredArgsConstructor
+public class AuditLogQueryAdapter implements AuditLogQueryPort {
+
+    private final AuditLogJpaRepository auditLogRepository;
+    private final UserJpaRepository userRepository;
+
+    @Override
+    public Page<AuditLogEntryDto> search(AuditLogQuery query) {
+        Page<AuditLogJpaEntity> rawPage = auditLogRepository.search(
+                query.tableName(),
+                query.action(),
+                query.from(),
+                query.to(),
+                PageRequest.of(query.page(), query.size())
+        );
+
+        Map<UUID, UserJpaEntity> actors = batchLoadActors(rawPage);
+        return rawPage.map(entity -> toDto(entity, actors));
+    }
+
+    @Override
+    public AuditLogEntryDto findById(Long id) {
+        AuditLogJpaEntity entity = auditLogRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Nhật ký kiểm toán", id.toString()));
+        Map<UUID, UserJpaEntity> actors = entity.getChangedBy() != null
+                ? userRepository.findByIdIn(Set.of(entity.getChangedBy())).stream()
+                        .collect(Collectors.toMap(UserJpaEntity::getId, u -> u))
+                : Map.of();
+        return toDto(entity, actors);
+    }
+
+    private Map<UUID, UserJpaEntity> batchLoadActors(Page<AuditLogJpaEntity> page) {
+        Set<UUID> actorIds = page.getContent().stream()
+                .map(AuditLogJpaEntity::getChangedBy)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toCollection(HashSet::new));
+        if (actorIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<UUID, UserJpaEntity> result = new HashMap<>(actorIds.size());
+        for (UserJpaEntity user : userRepository.findByIdIn(actorIds)) {
+            result.put(user.getId(), user);
+        }
+        return result;
+    }
+
+    private AuditLogEntryDto toDto(AuditLogJpaEntity entity, Map<UUID, UserJpaEntity> actors) {
+        UserJpaEntity actor = entity.getChangedBy() != null ? actors.get(entity.getChangedBy()) : null;
+        return new AuditLogEntryDto(
+                entity.getId(),
+                entity.getTableName(),
+                entity.getRecordId(),
+                entity.getAction(),
+                entity.getOldData(),
+                entity.getNewData(),
+                entity.getChangedBy(),
+                actor != null ? actor.getEmail() : null,
+                actor != null ? actor.getFullName() : null,
+                entity.getChangedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/AuditLogQueryAdapter.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/AuditLogQueryAdapter.java
@@ -39,6 +39,8 @@ public class AuditLogQueryAdapter implements AuditLogQueryPort {
                 query.action(),
                 query.from(),
                 query.to(),
+                query.actorEmail(),
+                query.actorName(),
                 PageRequest.of(query.page(), query.size())
         );
 

--- a/backend/src/main/java/com/example/lms/shared/infrastructure/web/AuditLogControllerV3.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/web/AuditLogControllerV3.java
@@ -36,8 +36,9 @@ public class AuditLogControllerV3 {
     @Transactional(readOnly = true)
     @Operation(
             summary = "Lấy danh sách nhật ký kiểm toán (phân trang)",
-            description = "Hỗ trợ lọc theo bảng, hành động và khoảng thời gian (from/to ISO-8601, "
-                    + "mặc định 7 ngày gần nhất, tối đa 365 ngày)."
+            description = "Hỗ trợ lọc theo bảng, hành động, khoảng thời gian (from/to ISO-8601, "
+                    + "mặc định 7 ngày gần nhất, tối đa 365 ngày) và actor "
+                    + "(actorEmail, actorName — LIKE không phân biệt hoa thường)."
     )
     public ResponseEntity<ApiResponse<Map<String, Object>>> getAuditLogs(
             @RequestParam(defaultValue = "0") int page,
@@ -45,10 +46,12 @@ public class AuditLogControllerV3 {
             @RequestParam(required = false) String table,
             @RequestParam(required = false) String action,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to,
+            @RequestParam(required = false) String actorEmail,
+            @RequestParam(required = false) String actorName
     ) {
         AuditLogQuery query = new AuditLogQuery(
-                table, action, from, to, null, null, page, size
+                table, action, from, to, actorEmail, actorName, page, size
         );
         Page<AuditLogEntryDto> logs = searchAuditLogUseCase.execute(query);
 
@@ -80,6 +83,8 @@ public class AuditLogControllerV3 {
         map.put("oldData", entry.oldData());
         map.put("newData", entry.newData());
         map.put("changedBy", entry.changedBy() != null ? entry.changedBy().toString() : null);
+        map.put("actorEmail", entry.actorEmail());
+        map.put("actorName", entry.actorName());
         map.put("changedAt", entry.changedAt() != null ? entry.changedAt().toString() : null);
         return map;
     }

--- a/backend/src/main/java/com/example/lms/shared/infrastructure/web/AuditLogControllerV3.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/web/AuditLogControllerV3.java
@@ -1,18 +1,24 @@
 package com.example.lms.shared.infrastructure.web;
 
-import com.example.lms.shared.infrastructure.persistence.AuditLogJpaRepository;
-import com.example.lms.shared.infrastructure.persistence.entity.AuditLogJpaEntity;
+import com.example.lms.shared.application.dto.AuditLogEntryDto;
+import com.example.lms.shared.application.dto.AuditLogQuery;
+import com.example.lms.shared.application.usecase.SearchAuditLogUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -23,25 +29,31 @@ import java.util.Map;
 @SecurityRequirement(name = "Bearer Authentication")
 public class AuditLogControllerV3 {
 
-    private final AuditLogJpaRepository auditLogRepository;
+    private final SearchAuditLogUseCase searchAuditLogUseCase;
 
     @GetMapping
     @PreAuthorize("hasRole('ADMIN')")
     @Transactional(readOnly = true)
-    @Operation(summary = "Lấy danh sách nhật ký kiểm toán (phân trang)")
+    @Operation(
+            summary = "Lấy danh sách nhật ký kiểm toán (phân trang)",
+            description = "Hỗ trợ lọc theo bảng, hành động và khoảng thời gian (from/to ISO-8601, "
+                    + "mặc định 7 ngày gần nhất, tối đa 365 ngày)."
+    )
     public ResponseEntity<ApiResponse<Map<String, Object>>> getAuditLogs(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String table,
-            @RequestParam(required = false) String action) {
-
-        Page<AuditLogJpaEntity> logs = auditLogRepository.findFiltered(
-                table, action, PageRequest.of(page, Math.min(size, 100)));
-
-        var content = logs.getContent().stream().map(this::toMap).toList();
+            @RequestParam(required = false) String action,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to
+    ) {
+        AuditLogQuery query = new AuditLogQuery(
+                table, action, from, to, null, null, page, size
+        );
+        Page<AuditLogEntryDto> logs = searchAuditLogUseCase.execute(query);
 
         Map<String, Object> result = new LinkedHashMap<>();
-        result.put("content", content);
+        result.put("content", logs.getContent().stream().map(this::toMap).toList());
         result.put("page", logs.getNumber());
         result.put("size", logs.getSize());
         result.put("totalElements", logs.getTotalElements());
@@ -55,21 +67,20 @@ public class AuditLogControllerV3 {
     @Transactional(readOnly = true)
     @Operation(summary = "Xem chi tiết nhật ký kiểm toán")
     public ResponseEntity<ApiResponse<Map<String, Object>>> getAuditLogDetail(@PathVariable Long id) {
-        var entry = auditLogRepository.findById(id)
-                .orElseThrow(() -> new com.example.lms.shared.exception.EntityNotFoundException("Nhật ký kiểm toán", id.toString()));
+        AuditLogEntryDto entry = searchAuditLogUseCase.getById(id);
         return ResponseEntity.ok(ApiResponse.success(toMap(entry), "Chi tiết nhật ký kiểm toán"));
     }
 
-    private Map<String, Object> toMap(AuditLogJpaEntity entry) {
+    private Map<String, Object> toMap(AuditLogEntryDto entry) {
         Map<String, Object> map = new LinkedHashMap<>();
-        map.put("id", entry.getId());
-        map.put("tableName", entry.getTableName());
-        map.put("recordId", entry.getRecordId() != null ? entry.getRecordId().toString() : null);
-        map.put("action", entry.getAction());
-        map.put("oldData", entry.getOldData());
-        map.put("newData", entry.getNewData());
-        map.put("changedBy", entry.getChangedBy() != null ? entry.getChangedBy().toString() : null);
-        map.put("changedAt", entry.getChangedAt() != null ? entry.getChangedAt().toString() : null);
+        map.put("id", entry.id());
+        map.put("tableName", entry.tableName());
+        map.put("recordId", entry.recordId() != null ? entry.recordId().toString() : null);
+        map.put("action", entry.action());
+        map.put("oldData", entry.oldData());
+        map.put("newData", entry.newData());
+        map.put("changedBy", entry.changedBy() != null ? entry.changedBy().toString() : null);
+        map.put("changedAt", entry.changedAt() != null ? entry.changedAt().toString() : null);
         return map;
     }
 }

--- a/backend/src/test/java/com/example/lms/course_authoring/application/usecase/ManageCourseCategoryUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/application/usecase/ManageCourseCategoryUseCaseTest.java
@@ -1,0 +1,49 @@
+package com.example.lms.course_authoring.application.usecase;
+
+import com.example.lms.course_authoring.domain.repository.CourseCategoryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ManageCourseCategoryUseCase Tests")
+class ManageCourseCategoryUseCaseTest {
+
+    @Mock
+    private CourseCategoryRepository categoryRepository;
+
+    @Test
+    @DisplayName("getApprovedCourseCountsByCategory delegates to repository (issue #189)")
+    void getApprovedCourseCountsByCategoryDelegates() {
+        ManageCourseCategoryUseCase useCase = new ManageCourseCategoryUseCase(categoryRepository);
+        UUID catA = UUID.randomUUID();
+        UUID catB = UUID.randomUUID();
+        Map<UUID, Long> stub = Map.of(catA, 47L, catB, 12L);
+        when(categoryRepository.countApprovedCoursesByCategory()).thenReturn(stub);
+
+        Map<UUID, Long> result = useCase.getApprovedCourseCountsByCategory();
+
+        assertThat(result).containsAllEntriesOf(stub);
+        verify(categoryRepository).countApprovedCoursesByCategory();
+    }
+
+    @Test
+    @DisplayName("Returns empty map when no categories have APPROVED courses (no rollup, no synthetic data)")
+    void getApprovedCourseCountsByCategoryEmpty() {
+        ManageCourseCategoryUseCase useCase = new ManageCourseCategoryUseCase(categoryRepository);
+        when(categoryRepository.countApprovedCoursesByCategory()).thenReturn(Map.of());
+
+        Map<UUID, Long> result = useCase.getApprovedCourseCountsByCategory();
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3PendingFilterTest.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3PendingFilterTest.java
@@ -1,0 +1,180 @@
+package com.example.lms.course_authoring.infrastructure.web;
+
+import com.example.lms.course_authoring.admin.application.usecase.GetWindowedAnalyticsUseCase;
+import com.example.lms.course_authoring.application.usecase.ApproveCourseUseCase;
+import com.example.lms.course_authoring.application.usecase.RejectCourseUseCase;
+import com.example.lms.course_authoring.domain.model.Course;
+import com.example.lms.course_authoring.domain.repository.CourseRepository;
+import com.example.lms.course_authoring.infrastructure.persistence.repository.CourseCategoryJpaRepository;
+import com.example.lms.course_authoring.infrastructure.persistence.repository.CourseReviewEventJpaRepository;
+import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
+import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
+import com.example.lms.learning_delivery.infrastructure.persistence.JpaEnrollmentRepository;
+import com.example.lms.shared.infrastructure.persistence.repository.PaymentTransactionJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the alignment between the "Chờ duyệt" KPI and the
+ * `GET /admin/courses/all?status=PENDING` table page introduced in
+ * issue #191 (F-C1).
+ *
+ * <p>Before the fix, the KPI used the review-queue predicate
+ * (PENDING ∪ APPROVED+PENDING_REVIEW) while the table filter used the
+ * strict status equality. The two diverged whenever a teacher
+ * resubmitted an APPROVED course.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminCoursesControllerV3 — pending filter alignment (issue #191)")
+class AdminCoursesControllerV3PendingFilterTest {
+
+    @Mock private CourseRepository courseRepository;
+    @Mock private UserJpaRepository userRepository;
+    @Mock private CourseCategoryJpaRepository categoryRepository;
+    @Mock private JpaEnrollmentRepository enrollmentRepository;
+    @Mock private PaymentTransactionJpaRepository paymentTransactionRepository;
+    @Mock private ApproveCourseUseCase approveCourseUseCase;
+    @Mock private RejectCourseUseCase rejectCourseUseCase;
+    @Mock private CourseReviewEventJpaRepository reviewEventRepository;
+    @Mock private GetWindowedAnalyticsUseCase getWindowedAnalyticsUseCase;
+
+    @InjectMocks private AdminCoursesControllerV3 controller;
+
+    private UserJpaEntity adminUser;
+    private UserJpaEntity orgAdminUser;
+    private UUID orgId;
+
+    @BeforeEach
+    void setUp() {
+        orgId = UUID.randomUUID();
+        adminUser = new UserJpaEntity(
+                UUID.randomUUID(), "admin", "admin@m.edu", "pwd",
+                "Admin", UserJpaEntity.UserRole.ADMIN, true,
+                java.time.Instant.now(), null);
+        orgAdminUser = new UserJpaEntity(
+                UUID.randomUUID(), "orgadmin", "orgadmin@m.edu", "pwd",
+                "Org Admin", UserJpaEntity.UserRole.ORG_ADMIN, true,
+                java.time.Instant.now(), null);
+        orgAdminUser.setOrganizationId(orgId);
+    }
+
+    @Test
+    @DisplayName("ADMIN: status=PENDING routes through findReviewQueue (matches KPI)")
+    void adminPendingFilterRoutesThroughReviewQueue() {
+        Page<Course> emptyPage = new PageImpl<>(List.of());
+        when(courseRepository.findReviewQueue(any(Pageable.class))).thenReturn(emptyPage);
+
+        controller.getAllCourses(0, 10, "PENDING", null, null, null, null, adminUser);
+
+        verify(courseRepository).findReviewQueue(any(Pageable.class));
+        // The strict-status path must NOT be taken — that was the source of
+        // the mismatch reported in #191.
+        verify(courseRepository, never()).findByStatus(eq(Course.CourseStatus.PENDING), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("ADMIN: status=pending (lower-case) is also normalised to review queue")
+    void adminPendingFilterIsCaseInsensitive() {
+        Page<Course> emptyPage = new PageImpl<>(List.of());
+        when(courseRepository.findReviewQueue(any(Pageable.class))).thenReturn(emptyPage);
+
+        controller.getAllCourses(0, 10, "pending", null, null, null, null, adminUser);
+
+        verify(courseRepository).findReviewQueue(any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("ADMIN: non-pending status (APPROVED) preserves strict status filter")
+    void adminApprovedFilterUsesStrictStatus() {
+        Page<Course> emptyPage = new PageImpl<>(List.of());
+        when(courseRepository.findByStatus(eq(Course.CourseStatus.APPROVED), any(Pageable.class)))
+                .thenReturn(emptyPage);
+
+        controller.getAllCourses(0, 10, "APPROVED", null, null, null, null, adminUser);
+
+        verify(courseRepository).findByStatus(eq(Course.CourseStatus.APPROVED), any(Pageable.class));
+        verify(courseRepository, never()).findReviewQueue(any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("ORG_ADMIN: status=PENDING routes through findReviewQueueByTeacherIds")
+    void orgAdminPendingFilterRoutesThroughOrgScopedReviewQueue() {
+        when(userRepository.findByOrganizationId(orgId))
+                .thenReturn(List.of(teacher(UUID.randomUUID())));
+        Page<Course> emptyPage = new PageImpl<>(List.of());
+        when(courseRepository.findReviewQueueByTeacherIds(anySet(), any(Pageable.class)))
+                .thenReturn(emptyPage);
+
+        controller.getAllCourses(0, 10, "PENDING", null, null, null, null, orgAdminUser);
+
+        verify(courseRepository).findReviewQueueByTeacherIds(anySet(), any(Pageable.class));
+        verify(courseRepository, never())
+                .findByTeacherIdsAndStatus(anySet(), eq(Course.CourseStatus.PENDING), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("ADMIN: PENDING + search filters by title against the review queue page")
+    @org.mockito.junit.jupiter.MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+    void adminPendingFilterCombinesWithTitleSearch() {
+        UUID matchId = UUID.randomUUID();
+        Course matching = mock(Course.class);
+        when(matching.getId()).thenReturn(matchId);
+        when(matching.getTitle()).thenReturn("Maritime Safety 101");
+        when(matching.getTeacherId()).thenReturn(null);
+        when(matching.getCategoryId()).thenReturn(null);
+        when(matching.getStatus()).thenReturn(Course.CourseStatus.PENDING);
+        when(matching.getDraftChangeStatus()).thenReturn(Course.DraftChangeStatus.NONE);
+
+        Course nonMatching = mock(Course.class);
+        // Only the title is consulted by the filter — stubs for other getters
+        // are LENIENT to keep the test focused on the filter contract.
+        when(nonMatching.getTitle()).thenReturn("Engine Fundamentals");
+
+        when(courseRepository.findReviewQueue(any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(matching, nonMatching)));
+        when(reviewEventRepository.findByCourseIdInOrderByCreatedAtDesc(any())).thenReturn(List.of());
+        when(enrollmentRepository.countEnrollmentsByCourseIds(any())).thenReturn(List.of());
+
+        var response = controller.getAllCourses(0, 10, "PENDING", "safety", null, null, null, adminUser);
+
+        @SuppressWarnings("ConstantConditions")
+        var content = response.getBody().getData().getContent();
+        assertThat(content).extracting(AdminCoursesControllerV3.CourseAdminResponse::getId)
+                .containsExactly(matchId.toString());
+    }
+
+    private UserJpaEntity teacher(UUID id) {
+        UserJpaEntity teacher = new UserJpaEntity(
+                id, "t", "t@m.edu", "pwd", "Teacher",
+                UserJpaEntity.UserRole.TEACHER, true,
+                java.time.Instant.now(), null);
+        teacher.setOrganizationId(orgId);
+        return teacher;
+    }
+
+    // Inline mock helper so we don't need to expand the import block.
+    private static <T> T mock(Class<T> clazz) {
+        return org.mockito.Mockito.mock(clazz);
+    }
+}

--- a/backend/src/test/java/com/example/lms/identity/infrastructure/web/UserControllerV3TeacherKpiTest.java
+++ b/backend/src/test/java/com/example/lms/identity/infrastructure/web/UserControllerV3TeacherKpiTest.java
@@ -1,0 +1,147 @@
+package com.example.lms.identity.infrastructure.web;
+
+import com.example.lms.course_authoring.infrastructure.persistence.JpaCourseRepository;
+import com.example.lms.identity.application.usecase.UpdateUserUseCaseV3;
+import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
+import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
+import com.example.lms.learning_delivery.infrastructure.persistence.JpaEnrollmentRepository;
+import com.example.lms.shared.infrastructure.web.ApiResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the teacher KPI hydration introduced in issue #190 (F-T1).
+ * Verifies that the controller batches the per-teacher course-count query
+ * into a single aggregate (no N+1) and that non-TEACHER rows are not
+ * touched.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserControllerV3 — teacher KPI hydration (issue #190)")
+class UserControllerV3TeacherKpiTest {
+
+    @Mock private UserJpaRepository userRepository;
+    @Mock private UpdateUserUseCaseV3 updateUserUseCaseV3;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private JpaEnrollmentRepository enrollmentRepository;
+    @Mock private JpaCourseRepository courseRepository;
+
+    @InjectMocks private UserControllerV3 controller;
+
+    private UserJpaEntity admin;
+    private UUID teacherAId;
+    private UUID teacherBId;
+    private UUID studentId;
+
+    @BeforeEach
+    void setUp() {
+        admin = userEntity(UUID.randomUUID(), "admin@maritime.edu", "Admin",
+                UserJpaEntity.UserRole.ADMIN);
+        teacherAId = UUID.randomUUID();
+        teacherBId = UUID.randomUUID();
+        studentId = UUID.randomUUID();
+    }
+
+    @Test
+    @DisplayName("getUsers populates coursesCreated for TEACHER rows from a single batch query")
+    void hydratesTeacherCoursesCreated() {
+        List<UserJpaEntity> users = List.of(
+                userEntity(teacherAId, "teacher-a@m.edu", "Teacher A", UserJpaEntity.UserRole.TEACHER),
+                userEntity(teacherBId, "teacher-b@m.edu", "Teacher B", UserJpaEntity.UserRole.TEACHER),
+                userEntity(studentId, "student@m.edu", "Student",      UserJpaEntity.UserRole.STUDENT)
+        );
+        when(userRepository.findAll(any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(users));
+
+        // Teacher A has 5 courses, Teacher B has 0 (absent from the result set
+        // — must default to 0 rather than throw or null).
+        List<Object[]> teacherACountRow = List.<Object[]>of(new Object[]{teacherAId, 5L});
+        when(courseRepository.countCoursesByTeacherIds(any()))
+                .thenReturn(teacherACountRow);
+
+        ResponseEntity<ApiResponse<Page<UserControllerV3.UserResponse>>> response =
+                controller.getUsers(1, 10, null, null, null, admin);
+
+        @SuppressWarnings("ConstantConditions")
+        List<UserControllerV3.UserResponse> rows = response.getBody().getData().getContent();
+        UserControllerV3.UserResponse teacherA = findById(rows, teacherAId);
+        UserControllerV3.UserResponse teacherB = findById(rows, teacherBId);
+        UserControllerV3.UserResponse student = findById(rows, studentId);
+
+        assertThat(teacherA.getCoursesCreated()).isEqualTo(5);
+        assertThat(teacherB.getCoursesCreated()).isEqualTo(0);
+        // STUDENT must not be touched — coursesCreated stays at default 0.
+        assertThat(student.getCoursesCreated()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("Only TEACHER ids are sent to courseRepository — STUDENT/ADMIN rows are filtered")
+    void onlyTeacherIdsSentToBatchQuery() {
+        List<UserJpaEntity> users = List.of(
+                userEntity(teacherAId, "teacher-a@m.edu", "Teacher A", UserJpaEntity.UserRole.TEACHER),
+                userEntity(studentId, "student@m.edu", "Student",      UserJpaEntity.UserRole.STUDENT),
+                userEntity(admin.getId(), "admin@m.edu", "Admin",      UserJpaEntity.UserRole.ADMIN)
+        );
+        when(userRepository.findAll(any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(users));
+        when(courseRepository.countCoursesByTeacherIds(any())).thenReturn(List.of());
+
+        controller.getUsers(1, 10, null, null, null, admin);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<UUID>> captor = ArgumentCaptor.forClass(Collection.class);
+        verify(courseRepository).countCoursesByTeacherIds(captor.capture());
+        assertThat(captor.getValue()).containsExactly(teacherAId);
+    }
+
+    @Test
+    @DisplayName("Skips the batch query when no TEACHER rows are present")
+    void skipsBatchWhenNoTeachers() {
+        List<UserJpaEntity> users = List.of(
+                userEntity(studentId, "student@m.edu", "Student", UserJpaEntity.UserRole.STUDENT)
+        );
+        when(userRepository.findAll(any(PageRequest.class)))
+                .thenReturn(new PageImpl<>(users));
+
+        controller.getUsers(1, 10, null, null, null, admin);
+
+        verify(courseRepository, never()).countCoursesByTeacherIds(any());
+    }
+
+    private UserJpaEntity userEntity(UUID id, String email, String name, UserJpaEntity.UserRole role) {
+        UserJpaEntity user = new UserJpaEntity(
+                id, email.split("@")[0], email, "pwd", name, role,
+                true, Instant.now(), null);
+        user.setAccountStatus("ACTIVE");
+        return user;
+    }
+
+    private UserControllerV3.UserResponse findById(
+            List<UserControllerV3.UserResponse> rows, UUID id) {
+        return rows.stream()
+                .filter(r -> id.toString().equals(r.getId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("User " + id + " not in response"));
+    }
+}

--- a/backend/src/test/java/com/example/lms/shared/application/usecase/SearchAuditLogUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/shared/application/usecase/SearchAuditLogUseCaseTest.java
@@ -1,0 +1,239 @@
+package com.example.lms.shared.application.usecase;
+
+import com.example.lms.shared.application.dto.AuditLogEntryDto;
+import com.example.lms.shared.application.dto.AuditLogQuery;
+import com.example.lms.shared.application.port.AuditLogQueryPort;
+import com.example.lms.shared.exception.ValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SearchAuditLogUseCase Tests")
+class SearchAuditLogUseCaseTest {
+
+    private static final Instant NOW = Instant.parse("2026-04-25T00:00:00Z");
+
+    @Mock private AuditLogQueryPort port;
+
+    private SearchAuditLogUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        Clock fixed = Clock.fixed(NOW, ZoneOffset.UTC);
+        useCase = new SearchAuditLogUseCase(port, fixed);
+    }
+
+    @Nested
+    @DisplayName("Default window (7 days)")
+    class DefaultWindowTests {
+
+        @Test
+        @DisplayName("When neither from nor to provided, defaults to last 7 days [now-7d, now)")
+        void appliesDefaultWindowWhenBothBoundsAbsent() {
+            stubEmptyPage();
+
+            useCase.execute(new AuditLogQuery(null, null, null, null, null, null, 0, 20));
+
+            ArgumentCaptor<AuditLogQuery> captor = ArgumentCaptor.forClass(AuditLogQuery.class);
+            verify(port).search(captor.capture());
+            AuditLogQuery resolved = captor.getValue();
+            assertThat(resolved.from()).isEqualTo(NOW.minus(7, ChronoUnit.DAYS));
+            assertThat(resolved.to()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("When only 'from' provided, does not auto-fill 'to'")
+        void preservesPartialFromOnly() {
+            stubEmptyPage();
+            Instant from = NOW.minus(30, ChronoUnit.DAYS);
+
+            useCase.execute(new AuditLogQuery(null, null, from, null, null, null, 0, 20));
+
+            ArgumentCaptor<AuditLogQuery> captor = ArgumentCaptor.forClass(AuditLogQuery.class);
+            verify(port).search(captor.capture());
+            assertThat(captor.getValue().from()).isEqualTo(from);
+            assertThat(captor.getValue().to()).isNull();
+        }
+
+        @Test
+        @DisplayName("When only 'to' provided, does not auto-fill 'from'")
+        void preservesPartialToOnly() {
+            stubEmptyPage();
+            Instant to = NOW;
+
+            useCase.execute(new AuditLogQuery(null, null, null, to, null, null, 0, 20));
+
+            ArgumentCaptor<AuditLogQuery> captor = ArgumentCaptor.forClass(AuditLogQuery.class);
+            verify(port).search(captor.capture());
+            assertThat(captor.getValue().from()).isNull();
+            assertThat(captor.getValue().to()).isEqualTo(to);
+        }
+    }
+
+    @Nested
+    @DisplayName("Date range validation")
+    class DateRangeValidationTests {
+
+        @Test
+        @DisplayName("Rejects 'from' after 'to'")
+        void rejectsFromAfterTo() {
+            Instant from = NOW;
+            Instant to = NOW.minus(1, ChronoUnit.DAYS);
+
+            assertThatThrownBy(() ->
+                    useCase.execute(new AuditLogQuery(null, null, from, to, null, null, 0, 20)))
+                    .isInstanceOf(ValidationException.class)
+                    .hasMessageContaining("trước hoặc bằng");
+
+            verify(port, never()).search(any());
+        }
+
+        @Test
+        @DisplayName("Accepts 'from' equal to 'to' (zero-width window)")
+        void acceptsFromEqualToTo() {
+            stubEmptyPage();
+
+            useCase.execute(new AuditLogQuery(null, null, NOW, NOW, null, null, 0, 20));
+
+            verify(port).search(any());
+        }
+
+        @Test
+        @DisplayName("Rejects window > 365 days")
+        void rejectsWindowOver365Days() {
+            Instant from = NOW.minus(366, ChronoUnit.DAYS);
+            Instant to = NOW;
+
+            assertThatThrownBy(() ->
+                    useCase.execute(new AuditLogQuery(null, null, from, to, null, null, 0, 20)))
+                    .isInstanceOf(ValidationException.class)
+                    .hasMessageContaining("365");
+        }
+
+        @Test
+        @DisplayName("Accepts window exactly 365 days")
+        void acceptsWindowExactly365Days() {
+            stubEmptyPage();
+            Instant from = NOW.minus(365, ChronoUnit.DAYS);
+
+            useCase.execute(new AuditLogQuery(null, null, from, NOW, null, null, 0, 20));
+
+            verify(port).search(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Query normalisation")
+    class QueryNormalisationTests {
+
+        @Test
+        @DisplayName("Page size > 100 is clamped to 100")
+        void clampsPageSize() {
+            stubEmptyPage();
+
+            useCase.execute(new AuditLogQuery(null, null, null, null, null, null, 0, 999));
+
+            ArgumentCaptor<AuditLogQuery> captor = ArgumentCaptor.forClass(AuditLogQuery.class);
+            verify(port).search(captor.capture());
+            assertThat(captor.getValue().size()).isEqualTo(100);
+        }
+
+        @Test
+        @DisplayName("Negative page is normalised to 0")
+        void normalisesNegativePage() {
+            stubEmptyPage();
+
+            useCase.execute(new AuditLogQuery(null, null, null, null, null, null, -5, 20));
+
+            ArgumentCaptor<AuditLogQuery> captor = ArgumentCaptor.forClass(AuditLogQuery.class);
+            verify(port).search(captor.capture());
+            assertThat(captor.getValue().page()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("Blank filter strings normalised to null so adapter sees a single 'absent' representation")
+        void blankStringsBecomeNull() {
+            stubEmptyPage();
+
+            useCase.execute(new AuditLogQuery("  ", "", null, null, "", "  ", 0, 20));
+
+            ArgumentCaptor<AuditLogQuery> captor = ArgumentCaptor.forClass(AuditLogQuery.class);
+            verify(port).search(captor.capture());
+            AuditLogQuery sent = captor.getValue();
+            assertThat(sent.tableName()).isNull();
+            assertThat(sent.action()).isNull();
+            assertThat(sent.actorEmail()).isNull();
+            assertThat(sent.actorName()).isNull();
+        }
+
+        @Test
+        @DisplayName("Non-blank filters preserved verbatim")
+        void preservesFilters() {
+            stubEmptyPage();
+
+            useCase.execute(new AuditLogQuery("courses", "UPDATE", null, null, "admin@", "Admin Nguyen", 0, 20));
+
+            ArgumentCaptor<AuditLogQuery> captor = ArgumentCaptor.forClass(AuditLogQuery.class);
+            verify(port).search(captor.capture());
+            AuditLogQuery sent = captor.getValue();
+            assertThat(sent.tableName()).isEqualTo("courses");
+            assertThat(sent.action()).isEqualTo("UPDATE");
+            assertThat(sent.actorEmail()).isEqualTo("admin@");
+            assertThat(sent.actorName()).isEqualTo("Admin Nguyen");
+        }
+    }
+
+    @Nested
+    @DisplayName("getById")
+    class GetByIdTests {
+
+        @Test
+        @DisplayName("Rejects null id")
+        void rejectsNullId() {
+            assertThatThrownBy(() -> useCase.getById(null))
+                    .isInstanceOf(ValidationException.class);
+        }
+
+        @Test
+        @DisplayName("Rejects non-positive id")
+        void rejectsZeroAndNegativeId() {
+            assertThatThrownBy(() -> useCase.getById(0L)).isInstanceOf(ValidationException.class);
+            assertThatThrownBy(() -> useCase.getById(-1L)).isInstanceOf(ValidationException.class);
+        }
+
+        @Test
+        @DisplayName("Delegates to port for valid id")
+        void delegatesToPort() {
+            AuditLogEntryDto dto = new AuditLogEntryDto(
+                    42L, "courses", null, "UPDATE", null, null, null, null, null, NOW);
+            when(port.findById(42L)).thenReturn(dto);
+
+            assertThat(useCase.getById(42L)).isSameAs(dto);
+        }
+    }
+
+    private void stubEmptyPage() {
+        when(port.search(any())).thenReturn(new PageImpl<>(List.of()));
+    }
+}

--- a/backend/src/test/java/com/example/lms/shared/application/usecase/SearchAuditLogUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/shared/application/usecase/SearchAuditLogUseCaseTest.java
@@ -205,6 +205,67 @@ class SearchAuditLogUseCaseTest {
     }
 
     @Nested
+    @DisplayName("Actor filter (issue #188)")
+    class ActorFilterTests {
+
+        @Test
+        @DisplayName("Forwards actorEmail filter to port unchanged for case-insensitive LIKE in adapter")
+        void forwardsActorEmail() {
+            stubEmptyPage();
+
+            useCase.execute(new AuditLogQuery(null, null, null, null, "ORGADMIN@maritime.edu", null, 0, 20));
+
+            ArgumentCaptor<AuditLogQuery> captor = ArgumentCaptor.forClass(AuditLogQuery.class);
+            verify(port).search(captor.capture());
+            // Use case must NOT lowercase here — that is the adapter / SQL's job.
+            // Forwarding the user-entered casing keeps display consistent if the
+            // FE echoes the filter back into a chip / breadcrumb.
+            assertThat(captor.getValue().actorEmail()).isEqualTo("ORGADMIN@maritime.edu");
+        }
+
+        @Test
+        @DisplayName("Forwards actorName filter (Vietnamese diacritics preserved)")
+        void forwardsActorNameWithDiacritics() {
+            stubEmptyPage();
+
+            useCase.execute(new AuditLogQuery(null, null, null, null, null, "Nguyễn Lan Hương", 0, 20));
+
+            ArgumentCaptor<AuditLogQuery> captor = ArgumentCaptor.forClass(AuditLogQuery.class);
+            verify(port).search(captor.capture());
+            assertThat(captor.getValue().actorName()).isEqualTo("Nguyễn Lan Hương");
+        }
+
+        @Test
+        @DisplayName("Both actorEmail and actorName can be applied simultaneously")
+        void supportsBothActorFilters() {
+            stubEmptyPage();
+
+            useCase.execute(new AuditLogQuery(null, null, null, null, "huong@", "Hương", 0, 20));
+
+            ArgumentCaptor<AuditLogQuery> captor = ArgumentCaptor.forClass(AuditLogQuery.class);
+            verify(port).search(captor.capture());
+            AuditLogQuery sent = captor.getValue();
+            assertThat(sent.actorEmail()).isEqualTo("huong@");
+            assertThat(sent.actorName()).isEqualTo("Hương");
+        }
+
+        @Test
+        @DisplayName("Actor filter does not interfere with default 7-day window")
+        void actorFilterStillGetsDefaultWindow() {
+            stubEmptyPage();
+
+            useCase.execute(new AuditLogQuery(null, null, null, null, "admin@", null, 0, 20));
+
+            ArgumentCaptor<AuditLogQuery> captor = ArgumentCaptor.forClass(AuditLogQuery.class);
+            verify(port).search(captor.capture());
+            AuditLogQuery sent = captor.getValue();
+            assertThat(sent.from()).isEqualTo(NOW.minus(7, ChronoUnit.DAYS));
+            assertThat(sent.to()).isEqualTo(NOW);
+            assertThat(sent.actorEmail()).isEqualTo("admin@");
+        }
+    }
+
+    @Nested
     @DisplayName("getById")
     class GetByIdTests {
 


### PR DESCRIPTION
## Summary

Backend Stream A of epic #186 — wave 1 batch closing 5 BE issues with shared touch-points (audit log, category, admin courses, user list).

Closes #187, #188, #189, #190, #191. Part of epic #186.

## Per-issue change summary

| # | Type | Surface | What changed |
|---|------|---------|--------------|
| **#187** F-L2 | feat | `/admin/audit-logs` | New `?from=&to=` ISO-8601 query params; default last 7 days; max 365 day window; half-open `[from, to)` math; Vietnamese 400 errors. New `AuditLogQueryPort` + `AuditLogQueryAdapter` (Clean Arch, follows PR #171 precedent). |
| **#188** F-L3 | feat | `/admin/audit-logs` | New `?actorEmail=&actorName=` LIKE filters; LEFT JOIN `users` on `changed_by`; case-insensitive; response now carries `actorEmail`/`actorName` (batched lookup, no N+1). |
| **#189** F-CAT2 | feat | `/admin/course-categories`, `/course-categories` | New `courseCount` field on `CourseCategoryDTO`; counts only APPROVED courses; one batched aggregate per request; absent categories default to 0; per-level (no rollup). |
| **#190** F-T1 | fix | `/users`, `/users/list/all`, `/users/search`, `/users/instructors` | Hydrate `coursesCreated` for TEACHER rows so the teacher KPI strip stops summing zeros. Single batched aggregate; STUDENT/ADMIN filtered before query. `lastLogin` deferred (see commit msg). |
| **#191** F-C1 | fix | `/admin/courses/all?status=PENDING` | Route the PENDING filter through `findReviewQueue` (the same predicate as the KPI `countReviewQueue`). KPI strip and table count now agree even when an APPROVED course has a PENDING_REVIEW draft change. |

## Files

```
NEW
  shared/application/dto/AuditLogEntryDto.java
  shared/application/dto/AuditLogQuery.java
  shared/application/port/AuditLogQueryPort.java
  shared/application/usecase/SearchAuditLogUseCase.java
  shared/infrastructure/persistence/AuditLogQueryAdapter.java
  test/.../shared/application/usecase/SearchAuditLogUseCaseTest.java
  test/.../course_authoring/application/usecase/ManageCourseCategoryUseCaseTest.java
  test/.../identity/infrastructure/web/UserControllerV3TeacherKpiTest.java
  test/.../course_authoring/infrastructure/web/AdminCoursesControllerV3PendingFilterTest.java

MODIFIED
  shared/infrastructure/persistence/AuditLogJpaRepository.java   (+search method)
  shared/infrastructure/web/AuditLogControllerV3.java            (delegated to use case)
  course_authoring/domain/repository/CourseCategoryRepository.java
  course_authoring/infrastructure/persistence/CourseCategoryRepositoryAdapter.java
  course_authoring/infrastructure/persistence/repository/CourseCategoryJpaRepository.java
  course_authoring/application/usecase/ManageCourseCategoryUseCase.java
  course_authoring/infrastructure/web/CourseCategoryControllerV3.java   (DTO + count wiring)
  course_authoring/infrastructure/persistence/JpaCourseRepository.java  (+countCoursesByTeacherIds)
  course_authoring/infrastructure/web/AdminCoursesControllerV3.java     (#191 filter alignment)
  identity/infrastructure/web/UserControllerV3.java                     (#190 enrich helper)
```

## Architecture notes

- **Clean Architecture** preserved: every JPA-touching class lives in `infrastructure/persistence`, the use cases / DTOs / ports remain JPA-agnostic.
- **Port + Adapter (PR #171 precedent)** for the audit log path. Use case is `Clock`-injectable for unit testability.
- **ORG_ADMIN scoping** preserved across all touched endpoints: the user-list and admin-courses endpoints already filter by `organizationId`; the new logic inherits that filter.
- **Half-open windows `[from, to)`** for the audit log date range, matching the convention `GetWindowedAnalyticsUseCase` established.
- **Vietnamese validation messages**: every new `ValidationException` carries Vietnamese field-error text.
- **No N+1**: every enrichment path uses a single batched aggregate per request.
- **Backwards-compatible response shapes**: existing clients see no schema regression. New fields (`courseCount`, `actorEmail`, `actorName`) are additive.

## Test plan

- [x] `mvn test -B` — **1049/1049 green** (was 1021 baseline → +28 new tests from this PR)
- [x] Compile + test-compile clean (no warnings beyond the pre-existing ones)
- [x] Architecture: every new repository method ships behind a domain interface or already-thin controller; no application-layer JPA leak
- [x] ORG_ADMIN scoping: `AdminCoursesControllerV3PendingFilterTest.orgAdminPendingFilterRoutesThroughOrgScopedReviewQueue` asserts the org-scoped review queue is hit, not the system-wide one
- [ ] Live `curl` verification — **not feasible from this worktree**: the running `lms-db-1` container has no published `5432` port, so the freshly-built jar can't connect. The running `lms-backend-1` is on the previous code. Verification will rely on CI + a follow-up smoke test once this branch is rebuilt into the dev compose. The 1049 unit tests cover all routing, validation, and enrichment paths, including the previously-divergent #191 mismatch.

## New unit-test coverage (28 tests)

| Test class | Tests | Covers |
|---|---:|---|
| `SearchAuditLogUseCaseTest` | 18 | Default 7-day window, partial bounds, range validation (incl. 365-day boundary), query normalisation, getById guard, actor-filter passthrough (incl. Vietnamese diacritics) |
| `ManageCourseCategoryUseCaseTest` | 2 | Delegation + empty-map case for `getApprovedCourseCountsByCategory()` |
| `UserControllerV3TeacherKpiTest` | 3 | Hydrates `coursesCreated` from one batch query; only TEACHER ids leave the controller; short-circuits when no teachers in the page |
| `AdminCoursesControllerV3PendingFilterTest` | 5 | ADMIN + ORG_ADMIN routing of `status=PENDING`; case-insensitive matching; non-pending statuses preserve strict equality; PENDING + search title filter |

## Hard rules respected

- No self-merge — leaving for parent review.
- No `@PreAuthorize` bypass — every touched endpoint keeps `ADMIN` / `ADMIN, ORG_ADMIN` per CLAUDE.md security rules.
- No synthetic data — all counts come from real queries, all defaults are 0 (not invented numbers).
- GCP not touched.

## Out of scope / follow-ups

- **`lastLogin` per user** (#190 partial): the schema only tracks login activity in `login_attempts` (security audit) and `user_external_identities.last_login_at` (SSO only). A dedicated PR can aggregate `MAX(login_attempts.attempted_at) WHERE success=true` per email if the FE wants the "Hoạt động 7 ngày" KPI to come alive. The label remains accurate at 0 for now.
- **Distinct "draft changes" filter** (#191 follow-up): if the FE later wants to split "strict PENDING" vs "approved + draft pending" visually, a `?draftChangesOnly=true` flag can be layered on top — current fix collapses both into "Chờ duyệt" because that matches the KPI label.
- **Audit log indexes**: existing `idx_audit_log_changed_at_brin` + `idx_audit_log_changed_by` + `idx_audit_log_table_record` cover the new query plan. No new index needed at expected scale (audit_log < 100K rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)