### PR TITLE
feat(admin-shared): app-bulk-action-bar + integrate users family + courses (closes #196)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
@@ -85,6 +85,13 @@
           <table class="data-table">
             <thead>
               <tr>
+                <th class="col-checkbox">
+                  <input type="checkbox"
+                         class="row-checkbox"
+                         [checked]="allVisibleSelected()"
+                         (change)="toggleSelectAll()"
+                         aria-label="Chọn tất cả quản trị viên đang hiển thị" />
+                </th>
                 <th>Quản trị viên</th>
                 <th>Vai trò</th>
                 <th>Trạng thái</th>
@@ -95,7 +102,15 @@
             </thead>
             <tbody>
               @for (admin of filteredAdmins(); track admin.id) {
-                <tr>
+                <tr [class.row-selected]="isSelected(admin.id)">
+                  <!-- Bulk select -->
+                  <td class="col-checkbox">
+                    <input type="checkbox"
+                           class="row-checkbox"
+                           [checked]="isSelected(admin.id)"
+                           (change)="toggleSelection(admin.id)"
+                           [attr.aria-label]="'Chọn ' + admin.name" />
+                  </td>
                   <!-- User Info -->
                   <td>
                     <div class="user-cell">
@@ -172,6 +187,14 @@
     </div>
   </div>
 </div>
+
+<!-- Bulk action bar — slides up from bottom while selectedCount > 0. -->
+<app-bulk-action-bar
+  [selectedCount]="selectedCount()"
+  [actions]="bulkActions()"
+  countLabel="quản trị viên đã chọn"
+  (actionClick)="onBulkAction($event)"
+  (clear)="clearSelection()" />
 
 <!-- Create Admin Modal -->
 @if (showCreateModal()) {

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.scss
@@ -322,6 +322,24 @@ $orange-700: #9A3412;
   }
 }
 
+/* Bulk select column — CC-06 */
+.col-checkbox {
+  width: 40px;
+  padding-right: 0;
+  text-align: center;
+}
+
+.row-checkbox {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: $blue-primary;
+}
+
+.data-table tbody tr.row-selected {
+  background: rgba($blue-primary, 0.04);
+}
+
 /* Status badges */
 .badge {
   display: inline-flex;

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
@@ -2,10 +2,13 @@ import { Component, signal, computed, inject, OnInit, ChangeDetectionStrategy } 
 
 import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
+import { forkJoin } from 'rxjs';
 import { AdminService, AdminUser, UserAccountStatus, UpdateUserStatusRequest } from '../../infrastructure/services/admin.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
+import { AuthService } from '../../../../core/services/auth.service';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
+import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
 /**
  * Admin User Management Component
  * SOTA Design: Coursera-inspired with role change, status actions
@@ -13,7 +16,7 @@ import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/k
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-admin-user-management',
-  imports: [RouterModule, FormsModule, KpiCardComponent],
+  imports: [RouterModule, FormsModule, KpiCardComponent, BulkActionBarComponent],
   templateUrl: './admin-user-management.component.html',
   styleUrl: './admin-user-management.component.scss'
 })
@@ -21,6 +24,7 @@ export class AdminUserManagementComponent implements OnInit {
   private adminService = inject(AdminService);
   private toast = inject(ToastService);
   private confirmDialog = inject(ConfirmDialogService);
+  private authService = inject(AuthService);
 
   // State
   allUsers = signal<AdminUser[]>([]);
@@ -30,6 +34,38 @@ export class AdminUserManagementComponent implements OnInit {
   showCreateModal = signal(false);
   newAdminName = signal('');
   newAdminEmail = signal('');
+
+  // Bulk selection state — CC-06 (mega audit). Set keyed by user id so we
+  // skip toUpperCase/toLowerCase normalization concerns. Selection is
+  // cleared after every successful bulk action and on every loadUsers().
+  selectedUserIds = signal<Set<string>>(new Set());
+  selectedCount = computed(() => this.selectedUserIds().size);
+
+  // Bulk action descriptors — derived so disabled states stay reactive to
+  // selection changes (e.g. "Khóa" disables when the current admin is in
+  // the selection — F-AD2 self-suspend block).
+  bulkActions = computed<BulkAction[]>(() => {
+    const selfId = this.authService.currentUser()?.id;
+    const selectedHasSelf = !!selfId && this.selectedUserIds().has(selfId);
+    return [
+      {
+        key: 'block',
+        label: 'Khóa',
+        variant: 'danger',
+        disabled: selectedHasSelf,
+        ariaLabel: selectedHasSelf
+          ? 'Không thể khóa tài khoản của chính bạn'
+          : 'Khóa các tài khoản đã chọn',
+        icon: 'M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z',
+      },
+      {
+        key: 'activate',
+        label: 'Kích hoạt',
+        ariaLabel: 'Kích hoạt các tài khoản đã chọn',
+        icon: 'M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z',
+      },
+    ];
+  });
 
   // Computed - filter for admins (ADMIN + ORG_ADMIN)
   adminUsers = computed(() => this.allUsers().filter(u => u.role === 'admin' || u.role === 'org_admin'));
@@ -72,9 +108,107 @@ export class AdminUserManagementComponent implements OnInit {
     this.adminService.getUsers({ page: 1, limit: 1000 }).subscribe({
       next: (response) => {
         this.allUsers.set(response.data || []);
+        this.clearSelection();
         this.isLoading.set(false);
       },
       error: () => this.isLoading.set(false)
+    });
+  }
+
+  // --- Bulk selection helpers ---
+
+  isSelected(userId: string): boolean {
+    return this.selectedUserIds().has(userId);
+  }
+
+  toggleSelection(userId: string): void {
+    const next = new Set(this.selectedUserIds());
+    if (next.has(userId)) {
+      next.delete(userId);
+    } else {
+      next.add(userId);
+    }
+    this.selectedUserIds.set(next);
+  }
+
+  toggleSelectAll(): void {
+    const visibleIds = this.filteredAdmins().map(a => a.id);
+    const current = this.selectedUserIds();
+    const allSelected = visibleIds.length > 0 && visibleIds.every(id => current.has(id));
+    if (allSelected) {
+      // Drop only the visible rows from the selection — preserves any
+      // off-page selections (here we paginate client-side so this is moot
+      // but keeps the helper consistent with the wider users surface).
+      const next = new Set(current);
+      visibleIds.forEach(id => next.delete(id));
+      this.selectedUserIds.set(next);
+    } else {
+      this.selectedUserIds.set(new Set([...current, ...visibleIds]));
+    }
+  }
+
+  allVisibleSelected = computed(() => {
+    const visible = this.filteredAdmins();
+    if (visible.length === 0) return false;
+    const selected = this.selectedUserIds();
+    return visible.every(a => selected.has(a.id));
+  });
+
+  clearSelection(): void {
+    this.selectedUserIds.set(new Set());
+  }
+
+  // --- Bulk action dispatcher ---
+
+  async onBulkAction(key: string): Promise<void> {
+    const ids = Array.from(this.selectedUserIds());
+    if (ids.length === 0) return;
+
+    if (key === 'block') {
+      await this.bulkUpdateStatus(ids, UserAccountStatus.BLOCKED);
+    } else if (key === 'activate') {
+      await this.bulkUpdateStatus(ids, UserAccountStatus.ACTIVE);
+    }
+  }
+
+  private async bulkUpdateStatus(userIds: string[], status: UserAccountStatus): Promise<void> {
+    // Self-suspend safety net — also enforced via disabled action button so
+    // this branch is defence-in-depth. Mirrors the F-AD2 confirm guard in
+    // the per-row inline-edit dropdown.
+    const selfId = this.authService.currentUser()?.id;
+    if (status === UserAccountStatus.BLOCKED && selfId && userIds.includes(selfId)) {
+      this.toast.error('Không thể khóa tài khoản của chính bạn.');
+      return;
+    }
+
+    const isBlock = status === UserAccountStatus.BLOCKED;
+    const confirmed = await this.confirmDialog.confirm({
+      title: isBlock ? 'Khóa tài khoản hàng loạt' : 'Kích hoạt tài khoản hàng loạt',
+      message: isBlock
+        ? `Bạn có chắc muốn khóa ${userIds.length} tài khoản Quản trị viên đã chọn? Họ sẽ mất quyền truy cập hệ thống cho đến khi được mở khóa.`
+        : `Bạn có chắc muốn kích hoạt lại ${userIds.length} tài khoản đã chọn?`,
+      confirmText: isBlock ? `Khóa ${userIds.length} tài khoản` : `Kích hoạt ${userIds.length} tài khoản`,
+      variant: isBlock ? 'danger' : 'warning'
+    });
+    if (!confirmed) return;
+
+    const requests = userIds.map(id =>
+      this.adminService.updateUserStatus(id, { status, reason: '' })
+    );
+
+    forkJoin(requests).subscribe({
+      next: () => {
+        this.toast.success(
+          isBlock
+            ? `Đã khóa ${userIds.length} tài khoản thành công`
+            : `Đã kích hoạt ${userIds.length} tài khoản thành công`
+        );
+        this.loadUsers();
+      },
+      error: () => {
+        this.toast.error('Một số tài khoản không thể cập nhật. Vui lòng thử lại.');
+        this.loadUsers();
+      }
     });
   }
 

--- a/fe/src/app/features/admin/presentation/components/course-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/course-management.component.html
@@ -138,17 +138,6 @@
         </div>
       </div>
 
-      @if (selectedCount() > 0) {
-        <div class="bulk-bar">
-          <div class="bulk-label">Đã chọn {{ selectedCount() }} khóa học</div>
-          <div class="bulk-actions">
-            <button class="btn-bulk-approve" (click)="bulkApprove()">Duyệt ({{ selectedCount() }})</button>
-            <button class="btn-bulk-reject" (click)="openBulkRejectModal()">Từ chối ({{ selectedCount() }})</button>
-            <button class="btn-bulk-clear" (click)="clearSelection()">Bỏ chọn</button>
-          </div>
-        </div>
-      }
-
       <div class="table-card">
         @if (courses().length > 0) {
           <div class="table-scroll">
@@ -401,17 +390,47 @@
   size="md"
   variant="danger"
   (close)="closeBulkRejectModal()">
-  <textarea class="modal-textarea textarea-danger"
+  <!-- Reason taxonomy — picking a preset seeds the textarea so reviewers
+       stay consistent across batches. "Lý do khác" clears the field. -->
+  <fieldset class="reject-preset-fieldset">
+    <legend class="reject-preset-legend">Chọn lý do mẫu</legend>
+    <div class="reject-preset-grid">
+      @for (preset of REJECT_REASON_PRESETS; track preset.key) {
+        <label class="reject-preset-option"
+               [class.is-active]="selectedRejectPreset() === preset.key">
+          <input type="radio"
+                 name="bulkRejectPreset"
+                 [value]="preset.key"
+                 [checked]="selectedRejectPreset() === preset.key"
+                 (change)="onSelectRejectPreset(preset.key)" />
+          <span>{{ preset.label }}</span>
+        </label>
+      }
+    </div>
+  </fieldset>
+  <label class="modal-field-label" for="bulk-reject-textarea">Lý do từ chối *</label>
+  <textarea id="bulk-reject-textarea"
+            class="modal-textarea textarea-danger"
             [ngModel]="bulkRejectReason()"
             (ngModelChange)="bulkRejectReason.set($event)"
             name="bulkRejectReason"
-            rows="4"
+            rows="5"
             placeholder="Vui lòng giải thích lý do từ chối..."></textarea>
   <div dialogFooter>
     <button class="btn-cancel" (click)="closeBulkRejectModal()">Hủy</button>
     <button class="btn-danger" (click)="confirmBulkReject()" [disabled]="!bulkRejectReason().trim()">Từ chối ({{ selectedCount() }})</button>
   </div>
 </app-dialog>
+
+<!-- Bulk action bar — slides up from bottom while selectedCount > 0.
+     Per audit guidance, bulk approve is NOT exposed (too high stakes); only
+     bulk reject with reason taxonomy + clear are available here. -->
+<app-bulk-action-bar
+  [selectedCount]="selectedCount()"
+  [actions]="bulkActions()"
+  countLabel="khóa học đã chọn"
+  (actionClick)="onBulkAction($event)"
+  (clear)="clearSelection()" />
 
 <app-dialog
   [open]="showRevokeModal()"

--- a/fe/src/app/features/admin/presentation/components/course-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/course-management.component.scss
@@ -209,83 +209,65 @@
   }
 }
 
-/* ===== BULK BAR ===== */
-.bulk-bar {
-  @extend .card;
-  background: rgba($blue-primary, 0.05);
-  border-color: rgba($blue-primary, 0.2);
-  padding: $spacing-4 $spacing-5;
-  margin-bottom: $spacing-4;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
+/* ===== BULK BAR =====
+   Source of truth lives in <app-bulk-action-bar> (CC-06). The legacy
+   .bulk-bar / .btn-bulk-* selectors below were removed — the shared
+   bottom-fixed pill replaces them across the admin portal. */
 
-.bulk-label {
-  font-size: $text-sm;
-  font-weight: $font-medium;
-  color: $blue-hover;
-}
-
-.bulk-actions {
-  display: flex;
-  align-items: center;
-  gap: $spacing-3;
-}
-
-.btn-bulk-approve {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: $spacing-2 $spacing-4;
-  background: $success;
-  color: white;
-  font-size: $text-sm;
-  font-weight: $font-medium;
+/* ===== REJECT PRESET TAXONOMY (bulk reject modal) ===== */
+.reject-preset-fieldset {
   border: none;
-  border-radius: $radius-sm;
-  cursor: pointer;
-  transition: background $transition-fast;
-
-  &:hover { background: $success; }
-
-  svg { width: $icon-sm; height: $icon-sm; }
+  padding: 0;
+  margin: 0 0 $spacing-4 0;
 }
 
-.btn-bulk-reject {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: $spacing-2 $spacing-4;
-  background: $error;
-  color: white;
+.reject-preset-legend {
   font-size: $text-sm;
   font-weight: $font-medium;
-  border: none;
-  border-radius: $radius-sm;
-  cursor: pointer;
-  transition: background $transition-fast;
-
-  &:hover { background: $error; }
-
-  svg { width: $icon-sm; height: $icon-sm; }
+  color: $text-primary;
+  margin-bottom: $spacing-2;
+  padding: 0;
 }
 
-.btn-bulk-clear {
+.reject-preset-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: $spacing-2;
+
+  @media (max-width: $breakpoint-sm) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.reject-preset-option {
   display: inline-flex;
   align-items: center;
+  gap: $spacing-2;
   padding: $spacing-2 $spacing-3;
+  border: 1px solid $border-default;
+  border-radius: $radius-md;
   font-size: $text-sm;
   color: $text-secondary;
-  background: transparent;
-  border: none;
-  border-radius: $radius-sm;
+  background: white;
   cursor: pointer;
-  transition: background $transition-fast, color $transition-fast;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+
+  input[type="radio"] {
+    accent-color: $error;
+    margin: 0;
+    flex-shrink: 0;
+  }
 
   &:hover {
-    background: $gray-100;
+    border-color: $error;
     color: $text-primary;
+  }
+
+  &.is-active {
+    border-color: $error;
+    background: rgba($error, 0.04);
+    color: $text-primary;
+    font-weight: $font-medium;
   }
 }
 
@@ -1232,12 +1214,6 @@
   .detail-stats { grid-template-columns: repeat(2, 1fr); }
   .detail-info-grid { grid-template-columns: 1fr; }
 
-  .bulk-bar {
-    flex-direction: column;
-    gap: $spacing-3;
-    align-items: flex-start;
-  }
-
   .pagination-bar {
     flex-direction: column;
     gap: $spacing-3;
@@ -1345,9 +1321,9 @@
   .metric-sub { display: block !important; }
   .metric-value { font-size: 16px !important; }
 
-  // Hide: filters, bulk bar, actions, pagination, modals, skeleton
+  // Hide: filters, bulk bar (shared component), actions, pagination, modals, skeleton
   .filter-bar { display: none !important; }
-  .bulk-bar { display: none !important; }
+  app-bulk-action-bar { display: none !important; }
   .action-btns { display: none !important; }
   .pagination-bar { display: none !important; }
   .modal-backdrop { display: none !important; }

--- a/fe/src/app/features/admin/presentation/components/course-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/course-management.component.ts
@@ -9,10 +9,11 @@ import { AuthService } from '../../../../core/services/auth.service';
 import { exportToCsv } from '../../../../shared/utils/csv-export';
 import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
 import { DialogComponent } from '../../../../shared/components/dialog/dialog.component';
+import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
 
 @Component({
   selector: 'app-course-management',
-  imports: [RouterModule, FormsModule, DialogComponent],
+  imports: [RouterModule, FormsModule, DialogComponent, BulkActionBarComponent],
   templateUrl: './course-management.component.html',
   styleUrl: './course-management.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -83,6 +84,48 @@ export class CourseManagementComponent implements OnInit {
 
   showBulkRejectModal = signal(false);
   bulkRejectReason = signal('');
+
+  // Reject reason taxonomy — picks one of these (Inspire / Coursera /
+  // Udemy review pattern) and the chosen text becomes the seed of the
+  // freeform reason field. Keeps reviewers consistent across batches.
+  readonly REJECT_REASON_PRESETS = [
+    { key: 'INSUFFICIENT_CONTENT', label: 'Nội dung chưa đủ phong phú', text: 'Nội dung khóa học chưa đáp ứng yêu cầu tối thiểu về độ phong phú và đầy đủ. Vui lòng bổ sung tài liệu, video, bài tập và đánh giá để học viên có trải nghiệm học tập trọn vẹn.' },
+    { key: 'POOR_QUALITY', label: 'Chất lượng video / âm thanh thấp', text: 'Chất lượng video, âm thanh hoặc tài liệu chưa đạt chuẩn. Vui lòng kiểm tra ánh sáng, âm thanh, hình ảnh và đảm bảo tất cả tài liệu đều rõ ràng.' },
+    { key: 'COPYRIGHT', label: 'Vi phạm bản quyền', text: 'Khóa học có sử dụng nội dung không có quyền hợp pháp. Vui lòng thay thế bằng tài liệu do bạn sở hữu hoặc có giấy phép sử dụng.' },
+    { key: 'METADATA', label: 'Thông tin / mô tả không đầy đủ', text: 'Tiêu đề, mô tả, danh mục hoặc mục tiêu học tập chưa rõ ràng. Vui lòng cập nhật thông tin chi tiết để học viên dễ dàng tìm và lựa chọn.' },
+    { key: 'OTHER', label: 'Lý do khác', text: '' },
+  ] as const;
+
+  selectedRejectPreset = signal<string>('INSUFFICIENT_CONTENT');
+
+  // CC-06 — bulk action bar. Per audit guidance, bulk approve is NOT exposed
+  // (too high stakes; reviewers must inspect each course individually). Only
+  // "Reject" with reason taxonomy + Clear are surfaced.
+  bulkActions = computed<BulkAction[]>(() => [
+    {
+      key: 'reject',
+      label: 'Từ chối',
+      variant: 'danger',
+      ariaLabel: 'Từ chối các khóa học đã chọn',
+      icon: 'M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z',
+    },
+  ]);
+
+  onBulkAction(key: string): void {
+    if (key === 'reject') {
+      this.openBulkRejectModal();
+    }
+  }
+
+  onSelectRejectPreset(presetKey: string): void {
+    this.selectedRejectPreset.set(presetKey);
+    const preset = this.REJECT_REASON_PRESETS.find(p => p.key === presetKey);
+    if (preset && preset.text) {
+      this.bulkRejectReason.set(preset.text);
+    } else if (presetKey === 'OTHER') {
+      this.bulkRejectReason.set('');
+    }
+  }
 
   pendingVisibleCourses = computed(() =>
     this.courses().filter(course => this.canReviewCourse(course))

--- a/fe/src/app/features/admin/presentation/components/student-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.html
@@ -85,6 +85,13 @@
           <table class="data-table">
             <thead>
               <tr>
+                <th class="col-checkbox">
+                  <input type="checkbox"
+                         class="row-checkbox"
+                         [checked]="allVisibleSelected()"
+                         (change)="toggleSelectAll()"
+                         aria-label="Chọn tất cả học viên đang hiển thị" />
+                </th>
                 <th>Học viên</th>
                 <th>Vai trò</th>
                 <th>Trạng thái</th>
@@ -95,7 +102,15 @@
             </thead>
             <tbody>
               @for (student of filteredStudents(); track student.id) {
-                <tr>
+                <tr [class.row-selected]="isSelected(student.id)">
+                  <!-- Bulk select -->
+                  <td class="col-checkbox">
+                    <input type="checkbox"
+                           class="row-checkbox"
+                           [checked]="isSelected(student.id)"
+                           (change)="toggleSelection(student.id)"
+                           [attr.aria-label]="'Chọn ' + student.name" />
+                  </td>
                   <!-- User Info -->
                   <td>
                     <div class="user-cell">
@@ -301,3 +316,11 @@
     </div>
   </div>
 }
+
+<!-- Bulk action bar — slides up from bottom while selectedCount > 0. -->
+<app-bulk-action-bar
+  [selectedCount]="selectedCount()"
+  [actions]="bulkActions()"
+  countLabel="học viên đã chọn"
+  (actionClick)="onBulkAction($event)"
+  (clear)="clearSelection()" />

--- a/fe/src/app/features/admin/presentation/components/student-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.scss
@@ -257,6 +257,22 @@
 
   &:last-child { border-bottom: none; }
   &:hover { background: $gray-50; }
+
+  &.row-selected { background: rgba($blue-primary, 0.04); }
+}
+
+/* Bulk select column — CC-06 */
+.col-checkbox {
+  width: 40px;
+  padding-right: 0;
+  text-align: center;
+}
+
+.row-checkbox {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: $blue-primary;
 }
 
 /* User cell */

--- a/fe/src/app/features/admin/presentation/components/student-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.ts
@@ -7,7 +7,9 @@ import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
+import { forkJoin } from 'rxjs';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
+import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
 
 /**
  * Student Management Component
@@ -16,7 +18,7 @@ import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/k
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-student-management',
-  imports: [RouterModule, FormsModule, KpiCardComponent],
+  imports: [RouterModule, FormsModule, KpiCardComponent, BulkActionBarComponent],
   // F-ST1 hotfix: was missing — main SCSS file never loaded so .stat-icon
   // had no width/height constraint and stretched to 1136×1136, making the
   // page unusable. Mirrors teacher-management.component.ts:20.
@@ -62,6 +64,26 @@ export class StudentManagementComponent implements OnInit {
   studentCourses = signal<any[]>([]);
   isLoadingCourses = signal(false);
 
+  // Bulk selection state — CC-06.
+  selectedUserIds = signal<Set<string>>(new Set());
+  selectedCount = computed(() => this.selectedUserIds().size);
+
+  bulkActions = computed<BulkAction[]>(() => [
+    {
+      key: 'block',
+      label: 'Khóa',
+      variant: 'danger',
+      ariaLabel: 'Khóa các tài khoản học viên đã chọn',
+      icon: 'M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z',
+    },
+    {
+      key: 'activate',
+      label: 'Kích hoạt',
+      ariaLabel: 'Kích hoạt các tài khoản học viên đã chọn',
+      icon: 'M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z',
+    },
+  ]);
+
   // Computed - filter for students (UserRole.STUDENT = 'student')
   studentUsers = computed(() => this.allUsers().filter(u => u.role === 'student'));
 
@@ -103,9 +125,87 @@ export class StudentManagementComponent implements OnInit {
     this.adminService.getUsers({ page: 1, limit: 200, role: 'STUDENT' }).subscribe({
       next: (response) => {
         this.allUsers.set(response.data || []);
+        this.clearSelection();
         this.isLoading.set(false);
       },
       error: () => this.isLoading.set(false)
+    });
+  }
+
+  // --- Bulk selection helpers (CC-06) ---
+
+  isSelected(userId: string): boolean {
+    return this.selectedUserIds().has(userId);
+  }
+
+  toggleSelection(userId: string): void {
+    const next = new Set(this.selectedUserIds());
+    next.has(userId) ? next.delete(userId) : next.add(userId);
+    this.selectedUserIds.set(next);
+  }
+
+  toggleSelectAll(): void {
+    const visibleIds = this.filteredStudents().map(s => s.id);
+    const current = this.selectedUserIds();
+    const allSelected = visibleIds.length > 0 && visibleIds.every(id => current.has(id));
+    if (allSelected) {
+      const next = new Set(current);
+      visibleIds.forEach(id => next.delete(id));
+      this.selectedUserIds.set(next);
+    } else {
+      this.selectedUserIds.set(new Set([...current, ...visibleIds]));
+    }
+  }
+
+  allVisibleSelected = computed(() => {
+    const visible = this.filteredStudents();
+    if (visible.length === 0) return false;
+    const selected = this.selectedUserIds();
+    return visible.every(s => selected.has(s.id));
+  });
+
+  clearSelection(): void {
+    this.selectedUserIds.set(new Set());
+  }
+
+  // --- Bulk action dispatcher ---
+
+  async onBulkAction(key: string): Promise<void> {
+    const ids = Array.from(this.selectedUserIds());
+    if (ids.length === 0) return;
+    if (key === 'block') await this.bulkUpdateStatus(ids, UserAccountStatus.BLOCKED);
+    else if (key === 'activate') await this.bulkUpdateStatus(ids, UserAccountStatus.ACTIVE);
+  }
+
+  private async bulkUpdateStatus(userIds: string[], status: UserAccountStatus): Promise<void> {
+    const isBlock = status === UserAccountStatus.BLOCKED;
+    const confirmed = await this.confirmDialog.confirm({
+      title: isBlock ? 'Khóa tài khoản hàng loạt' : 'Kích hoạt tài khoản hàng loạt',
+      message: isBlock
+        ? `Bạn có chắc muốn khóa ${userIds.length} tài khoản học viên đã chọn? Họ sẽ không đăng nhập được cho đến khi mở khóa.`
+        : `Bạn có chắc muốn kích hoạt lại ${userIds.length} tài khoản học viên đã chọn?`,
+      confirmText: isBlock ? `Khóa ${userIds.length} tài khoản` : `Kích hoạt ${userIds.length} tài khoản`,
+      variant: isBlock ? 'danger' : 'warning'
+    });
+    if (!confirmed) return;
+
+    const requests = userIds.map(id =>
+      this.adminService.updateUserStatus(id, { status, reason: '' })
+    );
+
+    forkJoin(requests).subscribe({
+      next: () => {
+        this.toast.success(
+          isBlock
+            ? `Đã khóa ${userIds.length} tài khoản học viên`
+            : `Đã kích hoạt ${userIds.length} tài khoản học viên`
+        );
+        this.loadUsers();
+      },
+      error: () => {
+        this.toast.error('Một số tài khoản không thể cập nhật. Vui lòng thử lại.');
+        this.loadUsers();
+      }
     });
   }
 

--- a/fe/src/app/features/admin/presentation/components/teacher-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.component.scss
@@ -258,6 +258,22 @@ $purple-bg: #FAF5FF;
 
   &:last-child { border-bottom: none; }
   &:hover { background: $gray-50; }
+
+  &.row-selected { background: rgba($blue-primary, 0.04); }
+}
+
+/* Bulk select column — CC-06 */
+.col-checkbox {
+  width: 40px;
+  padding-right: 0;
+  text-align: center;
+}
+
+.row-checkbox {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: $blue-primary;
 }
 
 /* ===== TABLE: TEACHER INFO CELL ===== */

--- a/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
@@ -9,6 +9,7 @@ import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.s
 import { AuthService } from '../../../../core/services/auth.service';
 import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
+import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
 
 /**
  * Teacher Management Component
@@ -17,7 +18,7 @@ import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/k
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-teacher-management',
-  imports: [RouterModule, FormsModule, KpiCardComponent],
+  imports: [RouterModule, FormsModule, KpiCardComponent, BulkActionBarComponent],
   styleUrl: './teacher-management.component.scss',
   templateUrl: './teacher-management.html'
 })
@@ -51,6 +52,33 @@ export class TeacherManagementComponent implements OnInit {
   teacherCourses = signal<any[]>([]);  // Owned courses
   coopCourses = signal<any[]>([]);     // Co-op courses (invited as teaching staff)
   isLoadingCourses = signal(false);
+
+  // Bulk selection state — CC-06. The current user can never be in this set
+  // because TEACHER cannot be the logged-in admin (role mismatch), but the
+  // self-suspend guard is left in for symmetry with the wider users surface.
+  selectedUserIds = signal<Set<string>>(new Set());
+  selectedCount = computed(() => this.selectedUserIds().size);
+
+  bulkActions = computed<BulkAction[]>(() => {
+    const selfId = this.authService.currentUser()?.id;
+    const selectedHasSelf = !!selfId && this.selectedUserIds().has(selfId);
+    return [
+      {
+        key: 'block',
+        label: 'Khóa',
+        variant: 'danger',
+        disabled: selectedHasSelf,
+        ariaLabel: 'Khóa các tài khoản giảng viên đã chọn',
+        icon: 'M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z',
+      },
+      {
+        key: 'activate',
+        label: 'Kích hoạt',
+        ariaLabel: 'Kích hoạt các tài khoản giảng viên đã chọn',
+        icon: 'M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z',
+      },
+    ];
+  });
 
   // Computed - filter for teachers (UserRole.TEACHER = 'teacher')
   teacherUsers = computed(() => this.allUsers().filter(u => u.role === 'teacher'));
@@ -93,9 +121,87 @@ export class TeacherManagementComponent implements OnInit {
     this.adminService.getUsers({ page: 1, limit: 200, role: 'TEACHER' }).subscribe({
       next: (response) => {
         this.allUsers.set(response.data || []);
+        this.clearSelection();
         this.isLoading.set(false);
       },
       error: () => this.isLoading.set(false)
+    });
+  }
+
+  // --- Bulk selection helpers (CC-06) ---
+
+  isSelected(userId: string): boolean {
+    return this.selectedUserIds().has(userId);
+  }
+
+  toggleSelection(userId: string): void {
+    const next = new Set(this.selectedUserIds());
+    next.has(userId) ? next.delete(userId) : next.add(userId);
+    this.selectedUserIds.set(next);
+  }
+
+  toggleSelectAll(): void {
+    const visibleIds = this.filteredTeachers().map(t => t.id);
+    const current = this.selectedUserIds();
+    const allSelected = visibleIds.length > 0 && visibleIds.every(id => current.has(id));
+    if (allSelected) {
+      const next = new Set(current);
+      visibleIds.forEach(id => next.delete(id));
+      this.selectedUserIds.set(next);
+    } else {
+      this.selectedUserIds.set(new Set([...current, ...visibleIds]));
+    }
+  }
+
+  allVisibleSelected = computed(() => {
+    const visible = this.filteredTeachers();
+    if (visible.length === 0) return false;
+    const selected = this.selectedUserIds();
+    return visible.every(t => selected.has(t.id));
+  });
+
+  clearSelection(): void {
+    this.selectedUserIds.set(new Set());
+  }
+
+  // --- Bulk action dispatcher ---
+
+  async onBulkAction(key: string): Promise<void> {
+    const ids = Array.from(this.selectedUserIds());
+    if (ids.length === 0) return;
+    if (key === 'block') await this.bulkUpdateStatus(ids, UserAccountStatus.BLOCKED);
+    else if (key === 'activate') await this.bulkUpdateStatus(ids, UserAccountStatus.ACTIVE);
+  }
+
+  private async bulkUpdateStatus(userIds: string[], status: UserAccountStatus): Promise<void> {
+    const isBlock = status === UserAccountStatus.BLOCKED;
+    const confirmed = await this.confirmDialog.confirm({
+      title: isBlock ? 'Khóa tài khoản hàng loạt' : 'Kích hoạt tài khoản hàng loạt',
+      message: isBlock
+        ? `Bạn có chắc muốn khóa ${userIds.length} tài khoản giảng viên đã chọn? Họ sẽ không đăng nhập được cho đến khi mở khóa.`
+        : `Bạn có chắc muốn kích hoạt lại ${userIds.length} tài khoản giảng viên đã chọn?`,
+      confirmText: isBlock ? `Khóa ${userIds.length} tài khoản` : `Kích hoạt ${userIds.length} tài khoản`,
+      variant: isBlock ? 'danger' : 'warning'
+    });
+    if (!confirmed) return;
+
+    const requests = userIds.map(id =>
+      this.adminService.updateUserStatus(id, { status, reason: '' })
+    );
+
+    forkJoin(requests).subscribe({
+      next: () => {
+        this.toast.success(
+          isBlock
+            ? `Đã khóa ${userIds.length} tài khoản giảng viên`
+            : `Đã kích hoạt ${userIds.length} tài khoản giảng viên`
+        );
+        this.loadUsers();
+      },
+      error: () => {
+        this.toast.error('Một số tài khoản không thể cập nhật. Vui lòng thử lại.');
+        this.loadUsers();
+      }
     });
   }
 

--- a/fe/src/app/features/admin/presentation/components/teacher-management.html
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.html
@@ -85,6 +85,13 @@
               <table class="data-table">
                 <thead>
                   <tr>
+                    <th class="col-checkbox">
+                      <input type="checkbox"
+                             class="row-checkbox"
+                             [checked]="allVisibleSelected()"
+                             (change)="toggleSelectAll()"
+                             aria-label="Chọn tất cả giảng viên đang hiển thị" />
+                    </th>
                     <th>Giảng viên</th>
                     <th>Vai trò</th>
                     <th>Trạng thái</th>
@@ -95,7 +102,15 @@
                 </thead>
                 <tbody>
                   @for (teacher of filteredTeachers(); track teacher.id) {
-                    <tr>
+                    <tr [class.row-selected]="isSelected(teacher.id)">
+                      <!-- Bulk select -->
+                      <td class="col-checkbox">
+                        <input type="checkbox"
+                               class="row-checkbox"
+                               [checked]="isSelected(teacher.id)"
+                               (change)="toggleSelection(teacher.id)"
+                               [attr.aria-label]="'Chọn ' + teacher.name" />
+                      </td>
                       <!-- User Info -->
                       <td>
                         <div class="teacher-cell">
@@ -405,3 +420,11 @@
         </div>
       </div>
     }
+
+    <!-- Bulk action bar — slides up from bottom while selectedCount > 0. -->
+    <app-bulk-action-bar
+      [selectedCount]="selectedCount()"
+      [actions]="bulkActions()"
+      countLabel="giảng viên đã chọn"
+      (actionClick)="onBulkAction($event)"
+      (clear)="clearSelection()" />

--- a/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.ts
+++ b/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.ts
@@ -78,6 +78,14 @@ import { exportToCsv } from '../../../../../../../shared/utils/csv-export';
           <table class="min-w-full divide-y divide-gray-200">
             <thead class="bg-gray-50">
               <tr>
+                <th class="px-4 py-3 text-center text-xs font-medium text-gray-700 uppercase tracking-wider w-10">
+                  <input type="checkbox"
+                         class="w-4 h-4 cursor-pointer"
+                         style="accent-color: #0056D2"
+                         [checked]="state.allVisibleSelected()"
+                         (change)="state.toggleSelectAll()"
+                         aria-label="Chọn tất cả người dùng đang hiển thị" />
+                </th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">Người dùng</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider">Vai trò</th>
                 <th class="px-6 py-3 text-center text-xs font-medium text-gray-700 uppercase tracking-wider">Thao tác</th>
@@ -88,7 +96,17 @@ import { exportToCsv } from '../../../../../../../shared/utils/csv-export';
             </thead>
             <tbody class="bg-white divide-y divide-gray-100">
               @for (user of state.filteredUsers(); track user.id) {
-                <tr class="hover:bg-gray-50 transition-colors">
+                <tr class="hover:bg-gray-50 transition-colors"
+                    [class.bg-blue-50]="state.isSelected(user.id)">
+                  <!-- Bulk select -->
+                  <td class="px-4 py-4 whitespace-nowrap text-center">
+                    <input type="checkbox"
+                           class="w-4 h-4 cursor-pointer"
+                           style="accent-color: #0056D2"
+                           [checked]="state.isSelected(user.id)"
+                           (change)="state.toggleSelection(user.id)"
+                           [attr.aria-label]="'Chọn ' + user.name" />
+                  </td>
                   <!-- Người dùng -->
                   <td class="px-6 py-4 whitespace-nowrap">
                     <div class="flex items-center">

--- a/fe/src/app/features/admin/presentation/components/user-management/state/user-management.state.ts
+++ b/fe/src/app/features/admin/presentation/components/user-management/state/user-management.state.ts
@@ -99,6 +99,45 @@ export class UserManagementState {
   isLoadingUsers = signal(false);
   isDeletingUser = signal(false);
 
+  // Bulk selection state — CC-06 (mega audit). Set keyed by user id; cleared
+  // on every page change / load / successful bulk action.
+  selectedUserIds = signal<Set<string>>(new Set());
+  selectedCount = computed(() => this.selectedUserIds().size);
+
+  isSelected(userId: string): boolean {
+    return this.selectedUserIds().has(userId);
+  }
+
+  toggleSelection(userId: string): void {
+    const next = new Set(this.selectedUserIds());
+    next.has(userId) ? next.delete(userId) : next.add(userId);
+    this.selectedUserIds.set(next);
+  }
+
+  toggleSelectAll(): void {
+    const visibleIds = this.filteredUsers().map(u => u.id);
+    const current = this.selectedUserIds();
+    const allSelected = visibleIds.length > 0 && visibleIds.every(id => current.has(id));
+    if (allSelected) {
+      const next = new Set(current);
+      visibleIds.forEach(id => next.delete(id));
+      this.selectedUserIds.set(next);
+    } else {
+      this.selectedUserIds.set(new Set([...current, ...visibleIds]));
+    }
+  }
+
+  allVisibleSelected = computed(() => {
+    const visible = this.filteredUsers();
+    if (visible.length === 0) return false;
+    const selected = this.selectedUserIds();
+    return visible.every(u => selected.has(u.id));
+  });
+
+  clearSelection(): void {
+    this.selectedUserIds.set(new Set());
+  }
+
   // Role checks
   /** True if current user is ADMIN (not ORG_ADMIN) */
   readonly isSystemAdmin = computed(() => this.authService.userRole() === 'admin');
@@ -175,6 +214,7 @@ export class UserManagementState {
           }));
 
           this._localUsers.set(normalizedUsers);
+          this.clearSelection();
 
           if (response.pagination) {
             this.pagination.set({

--- a/fe/src/app/features/admin/presentation/components/user-management/user-management-refactored.component.html
+++ b/fe/src/app/features/admin/presentation/components/user-management/user-management-refactored.component.html
@@ -43,3 +43,11 @@
 <app-bulk-import-modal
   (startImport)="startBulkImport()"
   (downloadTemplate)="downloadTemplate()" />
+
+<!-- Bulk action bar — slides up from bottom while selectedCount > 0. -->
+<app-bulk-action-bar
+  [selectedCount]="state.selectedCount()"
+  [actions]="bulkActions()"
+  countLabel="người dùng đã chọn"
+  (actionClick)="onBulkAction($event)"
+  (clear)="state.clearSelection()" />

--- a/fe/src/app/features/admin/presentation/components/user-management/user-management-refactored.component.ts
+++ b/fe/src/app/features/admin/presentation/components/user-management/user-management-refactored.component.ts
@@ -1,7 +1,8 @@
-import { Component, inject, OnInit, DestroyRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, inject, OnInit, DestroyRef, ChangeDetectionStrategy } from '@angular/core';
 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import * as XLSX from 'xlsx';
+import { forkJoin } from 'rxjs';
 
 import { UserManagementState } from './state/user-management.state';
 import { UserStatsCardsComponent } from './components/stats-cards/stats-cards.component';
@@ -10,8 +11,11 @@ import { UsersTableComponent } from './components/users-table/users-table.compon
 import { CreateUserModalComponent } from './components/create-user-modal/create-user-modal.component';
 import { EditUserModalComponent } from './components/edit-user-modal/edit-user-modal.component';
 import { BulkImportModalComponent } from './components/bulk-import-modal/bulk-import-modal.component';
-import { AdminService, AdminUser } from '../../../infrastructure/services/admin.service';
+import { AdminService, AdminUser, UserAccountStatus } from '../../../infrastructure/services/admin.service';
 import { ToastService } from '../../../../../core/services/toast.service';
+import { ConfirmDialogService } from '../../../../../core/services/confirm-dialog.service';
+import { AuthService } from '../../../../../core/services/auth.service';
+import { BulkActionBarComponent, BulkAction } from '../../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
 
 /**
  * Refactored User Management Component
@@ -35,7 +39,8 @@ import { ToastService } from '../../../../../core/services/toast.service';
     UsersTableComponent,
     CreateUserModalComponent,
     EditUserModalComponent,
-    BulkImportModalComponent
+    BulkImportModalComponent,
+    BulkActionBarComponent
 ],
   providers: [UserManagementState],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -47,6 +52,80 @@ export class UserManagementRefactoredComponent implements OnInit {
   private adminService = inject(AdminService);
   private destroyRef = inject(DestroyRef);
   private toastService = inject(ToastService);
+  private confirmDialog = inject(ConfirmDialogService);
+  private authService = inject(AuthService);
+
+  // CC-06 — bulk actions for the all-users surface. "Khóa" disables when
+  // the current user is in the selection (F-AD2 self-suspend defence-in-depth).
+  bulkActions = computed<BulkAction[]>(() => {
+    const selfId = this.authService.currentUser()?.id;
+    const selectedHasSelf = !!selfId && this.state.selectedUserIds().has(selfId);
+    return [
+      {
+        key: 'block',
+        label: 'Khóa',
+        variant: 'danger',
+        disabled: selectedHasSelf,
+        ariaLabel: selectedHasSelf
+          ? 'Không thể khóa tài khoản của chính bạn'
+          : 'Khóa các tài khoản đã chọn',
+        icon: 'M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z',
+      },
+      {
+        key: 'activate',
+        label: 'Kích hoạt',
+        ariaLabel: 'Kích hoạt các tài khoản đã chọn',
+        icon: 'M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z',
+      },
+    ];
+  });
+
+  async onBulkAction(key: string): Promise<void> {
+    const ids = Array.from(this.state.selectedUserIds());
+    if (ids.length === 0) return;
+    if (key === 'block') await this.bulkUpdateStatus(ids, UserAccountStatus.BLOCKED);
+    else if (key === 'activate') await this.bulkUpdateStatus(ids, UserAccountStatus.ACTIVE);
+  }
+
+  private async bulkUpdateStatus(userIds: string[], status: UserAccountStatus): Promise<void> {
+    const selfId = this.authService.currentUser()?.id;
+    if (status === UserAccountStatus.BLOCKED && selfId && userIds.includes(selfId)) {
+      this.toastService.error('Không thể khóa tài khoản của chính bạn.');
+      return;
+    }
+
+    const isBlock = status === UserAccountStatus.BLOCKED;
+    const confirmed = await this.confirmDialog.confirm({
+      title: isBlock ? 'Khóa tài khoản hàng loạt' : 'Kích hoạt tài khoản hàng loạt',
+      message: isBlock
+        ? `Bạn có chắc muốn khóa ${userIds.length} tài khoản đã chọn?`
+        : `Bạn có chắc muốn kích hoạt lại ${userIds.length} tài khoản đã chọn?`,
+      confirmText: isBlock ? `Khóa ${userIds.length} tài khoản` : `Kích hoạt ${userIds.length} tài khoản`,
+      variant: isBlock ? 'danger' : 'warning'
+    });
+    if (!confirmed) return;
+
+    const requests = userIds.map(id =>
+      this.adminService.updateUserStatus(id, { status, reason: '' })
+    );
+
+    forkJoin(requests)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.toastService.success(
+            isBlock
+              ? `Đã khóa ${userIds.length} tài khoản thành công`
+              : `Đã kích hoạt ${userIds.length} tài khoản thành công`
+          );
+          this.state.loadUsers(this.state.currentPage());
+        },
+        error: () => {
+          this.toastService.error('Một số tài khoản không thể cập nhật. Vui lòng thử lại.');
+          this.state.loadUsers(this.state.currentPage());
+        }
+      });
+  }
 
   ngOnInit(): void {
     this.state.loadUsers(1);

--- a/fe/src/app/shared/components/admin/bulk-action-bar/bulk-action-bar.component.html
+++ b/fe/src/app/shared/components/admin/bulk-action-bar/bulk-action-bar.component.html
@@ -1,0 +1,53 @@
+<!--
+  Slide-up sticky bar. The wrapper stays mounted so the slide animation runs
+  on entry/exit; visibility is driven by the .is-visible modifier class.
+-->
+<div class="bulk-bar"
+     [class.is-visible]="isVisible()"
+     role="region"
+     aria-label="Thanh thao tác hàng loạt"
+     [attr.aria-hidden]="isVisible() ? null : 'true'">
+  <div class="bulk-bar-inner">
+    <!-- Selection count — announced to SR via aria-live on parent region. -->
+    <div class="bulk-count" aria-live="polite">
+      <span class="bulk-count-value">{{ selectedCount() }}</span>
+      <span class="bulk-count-label">{{ countLabel() }}</span>
+    </div>
+
+    <span class="bulk-divider" aria-hidden="true"></span>
+
+    <!-- Action buttons. -->
+    <div class="bulk-actions">
+      @for (action of actions(); track action.key) {
+        <button type="button"
+                class="bulk-action-btn"
+                [class.is-danger]="action.variant === 'danger'"
+                [disabled]="action.disabled || !isVisible()"
+                [attr.aria-label]="action.ariaLabel || action.label"
+                [attr.tabindex]="isVisible() ? null : -1"
+                (click)="onAction(action)">
+          @if (action.icon) {
+            <svg class="bulk-action-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path [attr.d]="action.icon"></path>
+            </svg>
+          }
+          <span>{{ action.label }}</span>
+        </button>
+      }
+    </div>
+
+    <!-- Trailing clear / dismiss. -->
+    <button type="button"
+            class="bulk-clear-btn"
+            [attr.tabindex]="isVisible() ? null : -1"
+            [attr.aria-label]="clearLabel()"
+            (click)="onClear()">
+      <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd"
+              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+              clip-rule="evenodd"></path>
+      </svg>
+      <span>{{ clearLabel() }}</span>
+    </button>
+  </div>
+</div>

--- a/fe/src/app/shared/components/admin/bulk-action-bar/bulk-action-bar.component.scss
+++ b/fe/src/app/shared/components/admin/bulk-action-bar/bulk-action-bar.component.scss
@@ -1,0 +1,195 @@
+@use '../../../../../styles/variables' as *;
+
+/* Shared bulk-action bar — admin portal (Linear / GitHub / Stripe pattern).
+   CC-06 in 2026-04-25 mega audit. Slides up from the bottom edge of the
+   viewport when the parent surface has at least one row selected.
+
+   The bar is rendered unconditionally (slide animation needs both states
+   present) and toggled via the .is-visible modifier. Pointer + keyboard
+   focus are gated by [disabled] / [tabindex=-1] on each button while the
+   bar is collapsed. */
+
+:host {
+  display: contents;
+}
+
+.bulk-bar {
+  position: fixed;
+  bottom: $spacing-6;
+  left: 50%;
+  transform: translate(-50%, calc(100% + #{$spacing-6}));
+  z-index: 60; // above sticky table headers; below modal backdrop (z-100+).
+  pointer-events: none; // pass through clicks while collapsed.
+  transition: transform 0.18s ease-out, opacity 0.18s ease-out;
+  opacity: 0;
+  width: max-content;
+  max-width: calc(100vw - #{$spacing-8});
+
+  &.is-visible {
+    transform: translate(-50%, 0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+.bulk-bar-inner {
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+  padding: $spacing-2 $spacing-3 $spacing-2 $spacing-4;
+  background: $gray-900;
+  color: white;
+  border-radius: $radius-full;
+  box-shadow: $shadow-2xl;
+  font-size: $text-sm;
+  line-height: $leading-tight;
+}
+
+.bulk-count {
+  display: inline-flex;
+  align-items: baseline;
+  gap: $spacing-1;
+  font-weight: $font-medium;
+  white-space: nowrap;
+
+  .bulk-count-value {
+    font-weight: $font-semibold;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .bulk-count-label {
+    color: rgba(255, 255, 255, 0.72);
+    font-size: $text-xs;
+  }
+}
+
+.bulk-divider {
+  width: 1px;
+  height: 18px;
+  background: rgba(255, 255, 255, 0.18);
+  flex-shrink: 0;
+}
+
+.bulk-actions {
+  display: flex;
+  align-items: center;
+  gap: $spacing-1;
+  flex-wrap: wrap;
+}
+
+.bulk-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-1;
+  padding: $spacing-1 $spacing-3;
+  background: transparent;
+  border: none;
+  color: white;
+  font-size: $text-sm;
+  font-weight: $font-medium;
+  border-radius: $radius-md;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  white-space: nowrap;
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #60a5fa; // light-blue contrast against $gray-900
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  &.is-danger {
+    color: #fca5a5; // red-300, readable on dark bg
+
+    &:hover:not(:disabled) {
+      background: rgba(220, 38, 38, 0.18);
+      color: #fecaca; // red-200 on hover
+    }
+  }
+}
+
+.bulk-action-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.bulk-clear-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-1;
+  padding: $spacing-1 $spacing-2;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: $text-xs;
+  font-weight: $font-medium;
+  border-radius: $radius-md;
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease;
+  margin-left: $spacing-1;
+
+  svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: white;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #60a5fa;
+    outline-offset: 2px;
+  }
+}
+
+/* Mobile bottom-sheet variant.
+   The bar grows to the full width minus a small inset and the actions wrap
+   onto a second row if needed. The clear button stays at the trailing edge. */
+@media screen and (max-width: $breakpoint-sm) {
+  .bulk-bar {
+    bottom: $spacing-3;
+    left: $spacing-3;
+    right: $spacing-3;
+    transform: translateY(calc(100% + #{$spacing-3}));
+    width: auto;
+    max-width: none;
+
+    &.is-visible {
+      transform: translateY(0);
+    }
+  }
+
+  .bulk-bar-inner {
+    border-radius: $radius-lg; // softer pill for full-width sheet
+    padding: $spacing-2 $spacing-3;
+    gap: $spacing-2;
+    flex-wrap: wrap;
+  }
+
+  .bulk-divider {
+    display: none;
+  }
+
+  .bulk-actions {
+    flex: 1 1 auto;
+    justify-content: flex-end;
+  }
+
+  .bulk-action-btn span {
+    // Hide labels — keep icons only on very narrow screens.
+    @media (max-width: 380px) {
+      display: none;
+    }
+  }
+}

--- a/fe/src/app/shared/components/admin/bulk-action-bar/bulk-action-bar.component.ts
+++ b/fe/src/app/shared/components/admin/bulk-action-bar/bulk-action-bar.component.ts
@@ -1,0 +1,97 @@
+import { Component, input, output, computed, ChangeDetectionStrategy } from '@angular/core';
+
+/**
+ * One bulk action descriptor. The handler is intentionally synchronous (or
+ * fires its own async work) — the bar does not wait for resolution. Callers
+ * own the modal/confirm flow per action.
+ *
+ * - `key` — stable identifier, used as `track` key in the action @for.
+ * - `icon` — optional inline SVG path data (the `d` attr of the `<path>`).
+ *   Pass empty string to omit the icon glyph.
+ * - `variant` — `default` keeps the action neutral. `danger` paints it red
+ *   (Khóa, Reject, Delete). Mutually exclusive — exactly one variant.
+ * - `disabled` — derived per-render by the caller (e.g. block "Khóa" if the
+ *   selection contains the current user — F-AD2 self-suspend guard).
+ */
+export type BulkActionVariant = 'default' | 'danger';
+
+export interface BulkAction {
+  key: string;
+  label: string;
+  icon?: string;
+  variant?: BulkActionVariant;
+  disabled?: boolean;
+  ariaLabel?: string;
+}
+
+/**
+ * Sticky bottom bulk action bar (Linear / GitHub / Stripe pattern). Slides
+ * up from the bottom of the viewport when the parent component has at least
+ * one item selected; collapses when selection is cleared.
+ *
+ * Anatomy: `[N selected | Action 1 | Action 2 | ... | Bỏ chọn]`.
+ *
+ * Accessibility:
+ * - `role="region"` + `aria-live="polite"` so screen readers announce the
+ *   selection count change without stealing focus from the table.
+ * - Each action button forwards `aria-label` (falls back to `label`).
+ * - Bar is hidden via `display: none` when `selectedCount === 0`, so it does
+ *   not capture keyboard focus when collapsed.
+ *
+ * Mobile (< 640px):
+ * - Bottom-sheet style: full-width pill, actions wrap onto a second line if
+ *   needed; "Bỏ chọn" stays visible.
+ *
+ * Usage:
+ * ```html
+ * <app-bulk-action-bar
+ *   [selectedCount]="selectedCount()"
+ *   [actions]="bulkActions()"
+ *   (actionClick)="onBulkAction($event)"
+ *   (clear)="clearSelection()" />
+ * ```
+ */
+@Component({
+  selector: 'app-bulk-action-bar',
+  imports: [],
+  templateUrl: './bulk-action-bar.component.html',
+  styleUrl: './bulk-action-bar.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BulkActionBarComponent {
+  // Number of selected items. Bar is visible iff > 0.
+  selectedCount = input.required<number>();
+
+  // Action descriptors. Order = render order (left → right).
+  actions = input.required<BulkAction[]>();
+
+  // Vietnamese label rendered before the action buttons. The component
+  // formats the count itself; caller passes singular/plural noun via this
+  // prop (e.g. "đã chọn" → "{N} đã chọn"). Falls back to "đã chọn".
+  countLabel = input<string>('đã chọn');
+
+  // Custom Vietnamese label for the trailing clear button.
+  clearLabel = input<string>('Bỏ chọn');
+
+  // Emitted with the action's `key` when its button is clicked. Caller
+  // dispatches by key and runs the per-action handler (modal, API, toast).
+  actionClick = output<string>();
+
+  // Emitted when the trailing clear button is clicked.
+  clear = output<void>();
+
+  // Visibility — Bar collapses entirely when nothing is selected. We render
+  // the host element conditionally (parent's @if) OR keep it mounted with
+  // `aria-hidden`. Here we render unconditionally and toggle a class so the
+  // slide-up transition runs naturally on selection change.
+  isVisible = computed(() => this.selectedCount() > 0);
+
+  onAction(action: BulkAction): void {
+    if (action.disabled) return;
+    this.actionClick.emit(action.key);
+  }
+
+  onClear(): void {
+    this.clear.emit();
+  }
+}


### PR DESCRIPTION
Closes #196. Part of epic #186 (Wave 2 — Stream D).

## What

Sticky bottom bulk action bar (Linear / GitHub / Stripe pattern). Slides up from the bottom edge of the viewport when the parent surface has at least one row selected; collapses when selection is cleared.

## Files

| File | Change |
|---|---|
| `fe/src/app/shared/components/admin/bulk-action-bar/` *(new)* | `<app-bulk-action-bar>` with `selectedCount` / `actions` / `countLabel` / `clearLabel` inputs + `actionClick` / `clear` outputs. ARIA region + polite live region for SR. Mobile bottom-sheet variant. |
| `.../user-management/state/user-management.state.ts` | New selection state (signal `Set<string>`) + helpers (`isSelected` / `toggleSelection` / `toggleSelectAll` / `clearSelection` / `allVisibleSelected`). Cleared on `loadUsers()`. |
| `.../user-management/components/users-table/users-table.component.ts` | Checkbox column added (header + per-row), wired to state helpers. Selected row tinted with `bg-blue-50`. |
| `.../user-management/user-management-refactored.component.{ts,html}` | `bulkActions` computed (Khóa danger + Kích hoạt) — Khóa disabled when current user id is in the selection (F-AD2 defence-in-depth). `onBulkAction` dispatches `forkJoin` of `updateUserStatus` calls with confirm modal. |
| `admin-user-management.component.{ts,html,scss}` | Same pattern — count label "quản trị viên đã chọn"; self-suspend guard. |
| `teacher-management.component.{ts,scss}` + `teacher-management.html` | Same — count label "giảng viên đã chọn". |
| `student-management.component.{ts,html,scss}` | Same — count label "học viên đã chọn". |
| `course-management.component.{ts,html,scss}` | Replaces bespoke `.bulk-bar` div + `.btn-bulk-approve` / `.btn-bulk-reject` / `.btn-bulk-clear` (~70 lines of dup SCSS) with shared component. **Per audit guidance, bulk approve is NOT exposed** — only "Từ chối" with reason taxonomy. New 5-preset radio fieldset in bulk-reject modal seeds the textarea (Insufficient content / Poor quality / Copyright / Metadata / Other). |

19 files, +1077 / −90.

## Convention compliance

- [x] OnPush mọi component
- [x] Signal inputs / outputs / inject — no constructor DI
- [x] `@if` / `@for` — no `*ngIf`
- [x] Không `standalone: true` explicit (Angular 20+ default)
- [x] Tokens-based SCSS (`$spacing-*`, `$blue-primary`, `$gray-900`, `$radius-*`, `$shadow-2xl`)
- [x] WCAG 2.2: `role="region"` + `aria-live="polite"` on bar; per-action `aria-label` (falls back to label); `tabindex=-1` + `aria-hidden="true"` while collapsed; focus-visible ring (2px light-blue) high-contrast on dark bg
- [x] Vietnamese diacritics throughout
- [x] Self-suspend BLOCKED in bulk Khóa (defence-in-depth: button disabled + dispatcher returns early + toast on the all-users surface)

## Audit constraints honored

- **Bulk approve courses NOT exposed** (per epic #186 task brief: "KHÔNG bulk approve per audit guidance — too high stakes")
- **Bulk reject** uses reason taxonomy (Inspire / Coursera / Udemy review pattern)
- **Self-suspend block** mirrors PR #178 F-AD2 confirm guard

## Verification

- TypeScript compile clean (`tsc --noEmit -p tsconfig.app.json`)
- `ng build --configuration=development` succeeds (only pre-existing Sass `@import` deprecation warnings unrelated to this PR)
- agent-browser E2E was attempted but the worktree dev server hit a Vite WS proxy lockup mid-session; build success + targeted unit-of-work review covers the integration surface.

## Test plan

- [ ] Login as admin@maritime.edu / admin123
- [ ] `/admin/users/admins` — select 2 admins via checkboxes; bar slides up "2 quản trị viên đã chọn | Khóa | Kích hoạt | Bỏ chọn"
- [ ] Select self (admin@maritime.edu) — Khóa button disabled with `aria-label` "Không thể khóa tài khoản của chính bạn"
- [ ] Click Khóa with 2 non-self admins → confirm modal "Khóa tài khoản hàng loạt" → confirm → 2 forkJoin calls → success toast → list refreshes; selection cleared
- [ ] Same flow on `/admin/users/teachers`, `/admin/users/students`, `/admin/users/all`
- [ ] `/admin/courses` — select 3 pending courses; bar shows only "Từ chối" + Bỏ chọn (no Duyệt) → click Từ chối → modal opens with 5 preset radios; clicking "Vi phạm bản quyền" seeds textarea → submit → 3 courses rejected
- [ ] Mobile (375×812): bar full-width bottom sheet; action labels visible >380px, icon-only <380px
- [ ] SR: focus the page, select a row — VoiceOver / NVDA announces "{N} {label}" via aria-live polite

## Risk & rollback

Risk: low-medium. New shared component behind opt-in integration — does not modify core CRUD paths. `git revert` removes the bar + restores per-surface bespoke implementations. No data migration. No BE changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)