### PR TITLE
feat(admin): polish wave 1 — DRY confirm + self-suspend + date toggle + cat empty state

### DIFF
--- a/fe/src/app/api/endpoints/admin.endpoints.ts
+++ b/fe/src/app/api/endpoints/admin.endpoints.ts
@@ -8,6 +8,8 @@ export const ADMIN_ENDPOINTS = {
   ANALYTICS: '/api/v3/admin/courses/analytics',
   USER_ANALYTICS: '/api/v3/admin/courses/analytics',
   COURSE_ANALYTICS: '/api/v3/admin/courses/analytics',
+  // F-08 / PR #171 — windowed analytics (days = 7 | 30 | 90).
+  ANALYTICS_WINDOW: '/api/v3/admin/courses/analytics/window',
 
   // === Course Management ===
   PENDING_COURSES: '/api/v3/admin/courses/pending',

--- a/fe/src/app/features/admin/infrastructure/services/admin.service.ts
+++ b/fe/src/app/features/admin/infrastructure/services/admin.service.ts
@@ -57,6 +57,27 @@ export interface SystemAnalytics {
   unreadMessages: number;
 }
 
+/**
+ * Windowed analytics response from `/api/v3/admin/courses/analytics/window`
+ * (PR #171). Compares this window vs an equal-length prior window.
+ *
+ * `growthRate` is null when `lastWindow === 0` and `thisWindow > 0` — the
+ * BE deliberately returns null instead of `+Infinity` so the FE can render
+ * an em-dash or "+∞" rather than a misleading 0 %.
+ */
+export interface WindowedAnalytics {
+  windowDays: number;
+  totalUsers: number;
+  totalCourses: number;
+  totalEnrollments: number;
+  revenue: number;
+  userGrowth: { thisWindow: number; lastWindow: number; growthRate: number | null };
+  revenueGrowth: number | null;
+  courseGrowth: { thisWindow: number; lastWindow: number; growthRate: number | null };
+  windowStart: string;
+  windowEnd: string;
+}
+
 export interface PendingCourseSummary {
   id: string;
   code: string;
@@ -342,6 +363,22 @@ export class AdminService {
       catchError(error => {
         return throwError(() => error);
       })
+    );
+  }
+
+  /**
+   * Fetch windowed analytics for the dashboard date-range toggle (F-P2).
+   * BE accepts `days` ∈ {7, 30, 90}; any other value yields HTTP 400.
+   * Use this in place of `getSystemAnalytics()` whenever the surface wants
+   * deltas — the legacy endpoint only returns running totals.
+   */
+  getCoursesAnalyticsWindow(days: number): Observable<WindowedAnalytics> {
+    return this.apiClient.getWithResponse<WindowedAnalytics>(
+      ADMIN_ENDPOINTS.ANALYTICS_WINDOW,
+      { params: { days } },
+    ).pipe(
+      map(response => response.data),
+      catchError(error => throwError(() => error)),
     );
   }
 

--- a/fe/src/app/features/admin/presentation/components/admin-payouts.component.scss
+++ b/fe/src/app/features/admin/presentation/components/admin-payouts.component.scss
@@ -15,6 +15,16 @@
 /* ===== HEADER ===== */
 .page-header {
   margin-bottom: $spacing-6;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: $spacing-4;
+  flex-wrap: wrap;
+}
+
+.page-header-text {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .page-title {

--- a/fe/src/app/features/admin/presentation/components/admin-payouts.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-payouts.component.ts
@@ -4,6 +4,7 @@ import { ApiClient } from '../../../../api/client/api-client';
 import { AuthService, UserRole } from '../../../../core/services/auth.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
+import { DateRangeToggleComponent } from '../../../../shared/components/admin/date-range-toggle/date-range-toggle.component';
 
 interface PayoutListItem {
     id: string;
@@ -23,15 +24,26 @@ interface PayoutListItem {
 
 @Component({
     selector: 'app-admin-payouts',
-    imports: [FormsModule, KpiCardComponent],
+    imports: [FormsModule, KpiCardComponent, DateRangeToggleComponent],
     changeDetection: ChangeDetectionStrategy.OnPush,
     styleUrl: './admin-payouts.component.scss',
     template: `
     <div class="payouts-page">
       <div class="page-inner">
         <div class="page-header">
-          <h1 class="page-title">Quản lý rút tiền</h1>
-          <p class="page-desc">Duyệt và xử lý các yêu cầu rút tiền của giảng viên theo đúng phạm vi quản trị.</p>
+          <div class="page-header-text">
+            <h1 class="page-title">Quản lý rút tiền</h1>
+            <p class="page-desc">Duyệt và xử lý các yêu cầu rút tiền của giảng viên theo đúng phạm vi quản trị.</p>
+          </div>
+          <!-- F-P2: shared date-range toggle — placeholder until the BE
+               windowed payouts endpoint ships. We hold the value in
+               component state so the segmented selector reflects user
+               intent; once the BE lands, swap the no-op handler with the
+               re-fetch path. -->
+          <app-date-range-toggle
+            [value]="windowDays()"
+            ariaLabel="Khoảng thời gian thống kê"
+            (change)="onWindowDaysChange($event)" />
         </div>
 
         <!-- F-P1: KPI strip — 4 count cards per status. Counts only for now;
@@ -318,6 +330,10 @@ export class AdminPayoutsComponent implements OnInit {
     currentPage = signal(0);
     hasMore = signal(false);
     pendingCount = signal(0);
+    // F-P2: window selector. UI-only for now — BE issue tracks an aggregate
+    // "payouts in the last N days" endpoint. Currently the strip counts use
+    // status-paged size=1 totalElements which is window-independent.
+    windowDays = signal<number>(30);
     // F-P1: per-status totals — counts only for now (amount sum cần BE
     // aggregate endpoint, defer).
     approvedCount = signal(0);
@@ -375,6 +391,13 @@ export class AdminPayoutsComponent implements OnInit {
         this.activeStatus.set(status);
         this.currentPage.set(0);
         this.loadPayouts();
+    }
+
+    onWindowDaysChange(days: number): void {
+        // Placeholder — BE doesn't accept a window param on
+        // /api/v3/admin/revenue/payouts yet. Once that lands, pipe `days`
+        // into loadPayouts() + loadStatusCounts() as a query param.
+        this.windowDays.set(days);
     }
 
     private loadPayouts(): void {

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { AdminService, AdminUser, UserAccountStatus, UpdateUserStatusRequest } from '../../infrastructure/services/admin.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
+import { ConfirmStatusChangeService } from '../../services/confirm-status-change.service';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 /**
  * Admin User Management Component
@@ -21,6 +22,7 @@ export class AdminUserManagementComponent implements OnInit {
   private adminService = inject(AdminService);
   private toast = inject(ToastService);
   private confirmDialog = inject(ConfirmDialogService);
+  private confirmStatus = inject(ConfirmStatusChangeService);
 
   // State
   allUsers = signal<AdminUser[]>([]);
@@ -136,18 +138,11 @@ export class AdminUserManagementComponent implements OnInit {
   // suspending or activating an admin account. Admins suspending other admins
   // is the highest-blast-radius action in the portal; the modal makes the
   // intent explicit and the cancel path re-fetches to revert dropdown UI.
+  // Modal copy + variant lives in ConfirmStatusChangeService (DRY — issue #195).
   async onStatusActionChange(user: AdminUser, newStatus: string) {
     if (!newStatus) return;
 
-    const isBlock = newStatus === 'BLOCKED';
-    const confirmed = await this.confirmDialog.confirm({
-      title: isBlock ? 'Khóa tài khoản Quản trị viên' : 'Kích hoạt tài khoản',
-      message: isBlock
-        ? `Bạn có chắc muốn khóa tài khoản Quản trị viên ${user.name}? Họ sẽ mất quyền truy cập hệ thống cho đến khi được mở khóa.`
-        : `Bạn có chắc muốn kích hoạt lại tài khoản của ${user.name}?`,
-      confirmText: isBlock ? 'Khóa tài khoản' : 'Kích hoạt',
-      variant: isBlock ? 'danger' : 'warning'
-    });
+    const confirmed = await this.confirmStatus.confirm(user, newStatus as UserAccountStatus, 'admin');
     if (!confirmed) {
       this.loadUsers();
       return;

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
@@ -116,7 +116,16 @@ export class AdminUserManagementComponent implements OnInit {
   }
 
   // Role change handler
+  // Issue #194 (F-AD2 followup): block demoting the only remaining SYSTEM_ADMIN
+  // before showing the confirm modal. The check runs against the in-memory
+  // `adminUsers` signal because the dropdown lives on this surface.
   async onRoleChange(userId: string, newRole: string) {
+    const target = this.adminUsers().find(u => u.id === userId);
+    if (target && !this.confirmStatus.validateRoleChange(target, newRole, this.adminUsers())) {
+      this.loadUsers();
+      return;
+    }
+
     const confirmed = await this.confirmDialog.confirm({
       title: 'Thay đổi vai trò',
       message: `Bạn có chắc muốn thay đổi vai trò người dùng này thành ${this.getRoleLabel(newRole)}?`,
@@ -163,6 +172,12 @@ export class AdminUserManagementComponent implements OnInit {
   }
 
   async revokeAdmin(admin: AdminUser) {
+    // Issue #194: same sole-system-admin gate as onRoleChange — revoking is
+    // a demote in disguise (ADMIN -> STUDENT).
+    if (!this.confirmStatus.validateRoleChange(admin, 'STUDENT', this.adminUsers())) {
+      return;
+    }
+
     const confirmed = await this.confirmDialog.confirm({
       title: 'Thu hồi quyền Admin',
       message: `Bạn có chắc muốn thu hồi quyền Admin của ${admin.name}? Họ sẽ trở thành Học viên.`,

--- a/fe/src/app/features/admin/presentation/components/admin.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin.component.ts
@@ -1,5 +1,5 @@
 import { Component, signal, inject, OnInit, computed, ChangeDetectionStrategy } from '@angular/core';
-import { AdminService, SystemAnalytics, PendingCourseSummary } from '../../infrastructure/services/admin.service';
+import { AdminService, SystemAnalytics, PendingCourseSummary, WindowedAnalytics } from '../../infrastructure/services/admin.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { PendingApproval } from './dashboard/dashboard.types';
@@ -45,6 +45,8 @@ const EMPTY_ANALYTICS: SystemAnalytics = {
         [pendingApprovals]="pendingApprovals()"
         [isLoading]="isLoading()"
         [isLoadingPending]="isLoadingPending()"
+        [windowDays]="windowDays()"
+        (windowDaysChange)="onWindowDaysChange($event)"
         (courseApproved)="onCourseApproved($event)"
         (courseRejected)="onCourseRejected($event)" />
     } @else {
@@ -70,6 +72,12 @@ export class AdminComponent implements OnInit {
   pendingApprovals = signal<PendingApproval[]>([]);
   isLoadingPending = signal(false);
 
+  // F-P2: dashboard date-range toggle (7 / 30 / 90 ngày). Default 30 keeps
+  // parity with the legacy "Tháng này" framing for the revenue card while
+  // letting power-users zoom in (7) or out (90). Persisted in-memory only;
+  // a future PR can wire to localStorage / per-user prefs.
+  windowDays = signal<number>(30);
+
   ngOnInit(): void {
     this.loadAnalytics();
     this.loadPendingApprovals();
@@ -78,6 +86,46 @@ export class AdminComponent implements OnInit {
   refreshDashboard(): void {
     this.loadAnalytics();
     this.loadPendingApprovals();
+  }
+
+  // F-P2: when the user picks a different window we re-fetch the windowed
+  // analytics endpoint and merge its delta fields into the `analytics`
+  // signal. The static counts (pending courses, approved courses, etc.)
+  // come from the legacy `/courses/analytics` endpoint and remain stable
+  // across windows — no re-fetch needed there.
+  onWindowDaysChange(days: number): void {
+    this.windowDays.set(days);
+    this.adminService.getCoursesAnalyticsWindow(days).subscribe({
+      next: (w: WindowedAnalytics) => this.applyWindowedAnalytics(w),
+      // Silent failure: keep showing the legacy snapshot. The toggle UI
+      // already echoes the selected window, so the user can retry by
+      // clicking another value.
+      error: () => {},
+    });
+  }
+
+  private applyWindowedAnalytics(w: WindowedAnalytics): void {
+    this.analytics.update(prev => ({
+      ...prev,
+      // Preserve totals as they appear in the windowed payload — for the
+      // 30-day default these match the legacy snapshot. For 7 / 90 the
+      // strip values shift naturally because the BE re-counts per window.
+      totalUsers: w.totalUsers,
+      totalCourses: w.totalCourses,
+      totalEnrollments: w.totalEnrollments,
+      revenue: w.revenue,
+      // Growth deltas — null collapses to 0 for the dashboard's existing
+      // template binding which expects a number. Loss of fidelity is
+      // acceptable here because the UI still says "tăng / giảm" via the
+      // arrow glyph; KPI card hides flat trends.
+      revenueGrowth: w.revenueGrowth ?? 0,
+      courseGrowth: w.courseGrowth.growthRate ?? 0,
+      userGrowth: {
+        thisMonth: w.userGrowth.thisWindow,
+        lastMonth: w.userGrowth.lastWindow,
+        growthRate: w.userGrowth.growthRate ?? 0,
+      },
+    }));
   }
 
   onCourseApproved(courseId: string): void {
@@ -108,6 +156,15 @@ export class AdminComponent implements OnInit {
       next: (data) => {
         this.analytics.set(data);
         this.isLoading.set(false);
+        // F-P2: piggy-back the windowed fetch on initial load so the
+        // strip values reflect the selected window from frame 1 instead
+        // of flashing legacy "this month" totals.
+        if (this.isSystemAdmin()) {
+          this.adminService.getCoursesAnalyticsWindow(this.windowDays()).subscribe({
+            next: (w) => this.applyWindowedAnalytics(w),
+            error: () => {},
+          });
+        }
       },
       error: () => {
         this.loadError.set(true);

--- a/fe/src/app/features/admin/presentation/components/category-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/category-management.component.scss
@@ -332,18 +332,60 @@ textarea.form-input {
   }
 }
 
-/* ===== EMPTY STATE ===== */
+/* ===== EMPTY STATE (F-CAT3 — Carbon Inform + Inspire + Activate) ===== */
 .empty-panel {
   @extend .card;
-  padding: $spacing-12;
+  padding: $spacing-12 $spacing-6;
   text-align: center;
-  color: $text-disabled;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-3;
+}
 
-  p {
-    font-size: $text-sm;
-    margin: 0;
+.empty-illustration {
+  width: 96px;
+  height: 96px;
+  margin-bottom: $spacing-2;
+}
 
-    & + p { margin-top: $spacing-1; }
+.empty-title {
+  font-size: $text-lg;
+  font-weight: $font-semibold;
+  color: $text-primary;
+  margin: 0;
+}
+
+.empty-desc {
+  font-size: $text-sm;
+  color: $text-secondary;
+  margin: 0;
+  max-width: 36ch;       // keep the line length comfortable
+  line-height: $leading-normal;
+}
+
+.empty-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: $spacing-3;
+  padding: 0 $spacing-4;
+  min-height: 40px;       // WCAG 2.2 SC 2.5.8 desktop target
+  background: $blue-primary;
+  color: $text-inverse;
+  border: 1px solid $blue-primary;
+  border-radius: $radius-md;
+  font-size: $text-sm;
+  font-weight: $font-semibold;
+  cursor: pointer;
+  transition:
+    background $transition-fast,
+    box-shadow $transition-fast;
+
+  &:hover { background: #004BB5; }   // matches design-token hover
+  &:focus-visible {
+    outline: 2px solid $blue-primary;
+    outline-offset: 2px;
   }
 }
 

--- a/fe/src/app/features/admin/presentation/components/category-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/category-management.component.ts
@@ -143,9 +143,40 @@ import { CourseCategoryDTO, CourseTagDTO } from '../../../../api/types/course.ty
                 </div>
               </div>
             } @else {
-              <div class="empty-panel">
-                <p>Chọn một danh mục từ danh sách bên trái để chỉnh sửa</p>
-                <p>hoặc nhấn "Danh mục gốc" để tạo mới</p>
+              <!-- F-CAT3 (epic #186): Carbon empty-state pattern
+                   Inform + Inspire + Activate.
+                   - Illustration: layered tag icon stack signals "danh mục
+                     có nhiều cấp" without a brand icon (kpi-card rule).
+                   - Inspire copy explains what the user can do here.
+                   - Activate CTA fires the same handler as the sidebar
+                     "+ Danh mục gốc" button — single source of truth. -->
+              <div class="empty-panel" role="status" aria-live="polite">
+                <svg
+                  class="empty-illustration"
+                  viewBox="0 0 96 96"
+                  fill="none"
+                  aria-hidden="true">
+                  <!-- Stacked tag illustration: back tag (muted), front tag (primary tint). -->
+                  <rect x="14" y="22" width="52" height="36" rx="6"
+                        fill="#E5E7EB" stroke="#D1D5DB" stroke-width="2"/>
+                  <circle cx="22" cy="32" r="3" fill="#9CA3AF"/>
+                  <rect x="26" y="36" width="36" height="4" rx="2" fill="#D1D5DB"/>
+                  <rect x="26" y="44" width="22" height="4" rx="2" fill="#D1D5DB"/>
+                  <!-- Front tag, slightly offset, primary tint. -->
+                  <rect x="28" y="36" width="52" height="36" rx="6"
+                        fill="#E0EAFD" stroke="#0056D2" stroke-width="2"/>
+                  <circle cx="36" cy="46" r="3" fill="#0056D2"/>
+                  <rect x="40" y="50" width="36" height="4" rx="2" fill="#0056D2" fill-opacity="0.4"/>
+                  <rect x="40" y="58" width="22" height="4" rx="2" fill="#0056D2" fill-opacity="0.3"/>
+                </svg>
+                <h3 class="empty-title">Chọn danh mục để xem chi tiết</h3>
+                <p class="empty-desc">
+                  Bạn có thể chỉnh sửa tên, mã, mô tả, hoặc thêm danh mục con
+                  trực tiếp tại đây.
+                </p>
+                <button type="button" class="empty-cta" (click)="startCreateRoot()">
+                  + Tạo danh mục mới
+                </button>
               </div>
             }
           }

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.html
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.html
@@ -51,6 +51,12 @@
       <div class="header-inner">
         <h1 class="page-title">Bảng điều khiển hệ thống</h1>
         <div class="header-actions">
+          <!-- F-P2: shared <app-date-range-toggle> — drives windowed analytics
+               via parent re-fetch. Default 30 ngày. -->
+          <app-date-range-toggle
+            [value]="windowDays()"
+            ariaLabel="Khoảng thời gian báo cáo"
+            (change)="windowDaysChange.emit($event)" />
           <a routerLink="/admin/analytics" class="btn-secondary">Xem báo cáo</a>
           <a routerLink="/admin/users/all" class="btn-primary">Thêm người dùng</a>
         </div>

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.scss
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.scss
@@ -34,7 +34,8 @@
 
 .header-actions {
   display: flex;
-  gap: $spacing-2;
+  align-items: center;  // align date-range toggle (40px) with buttons (40px)
+  gap: $spacing-3;       // bumped from spacing-2 to give the toggle breathing room
   flex-shrink: 0;
 }
 

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.ts
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-system-dashboard.component.ts
@@ -7,6 +7,7 @@ import { PendingApproval } from './dashboard.types';
 import { DialogComponent } from '../../../../../shared/components/dialog/dialog.component';
 import { IconComponent, IconName } from '../../../../../shared/components/icon/icon.component';
 import { KpiCardComponent } from '../../../../../shared/components/admin/kpi-card/kpi-card.component';
+import { DateRangeToggleComponent } from '../../../../../shared/components/admin/date-range-toggle/date-range-toggle.component';
 
 interface QuickAction {
   id: string;
@@ -28,7 +29,7 @@ const QUICK_ACTIONS: readonly QuickAction[] = [
 
 @Component({
   selector: 'app-admin-system-dashboard',
-  imports: [CommonModule, RouterLink, DialogComponent, IconComponent, KpiCardComponent],
+  imports: [CommonModule, RouterLink, DialogComponent, IconComponent, KpiCardComponent, DateRangeToggleComponent],
   templateUrl: './admin-system-dashboard.component.html',
   styleUrl: './admin-system-dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -43,6 +44,9 @@ export class AdminSystemDashboardComponent implements OnInit {
   pendingApprovals = input.required<PendingApproval[]>();
   isLoading = input.required<boolean>();
   isLoadingPending = input.required<boolean>();
+  // F-P2: parent owns the selected window so navigation back to the
+  // dashboard preserves the choice.
+  windowDays = input<number>(30);
 
   ngOnInit(): void {
     // Fire and forget — service flips its own loading signal during the probe.
@@ -56,6 +60,7 @@ export class AdminSystemDashboardComponent implements OnInit {
   // --- Outputs to parent ---
   courseApproved = output<string>();
   courseRejected = output<{ id: string; reason: string }>();
+  windowDaysChange = output<number>();
 
   // Shortcut panel — replaces the redundant "Tổng quan nhanh" card.
   quickActions = computed<readonly QuickAction[]>(() => QUICK_ACTIONS);

--- a/fe/src/app/features/admin/presentation/components/student-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { AdminService, AdminUser, UserAccountStatus, UpdateUserStatusRequest } from '../../infrastructure/services/admin.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
+import { ConfirmStatusChangeService } from '../../services/confirm-status-change.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
@@ -36,6 +37,7 @@ export class StudentManagementComponent implements OnInit {
   private adminService = inject(AdminService);
   private toast = inject(ToastService);
   private confirmDialog = inject(ConfirmDialogService);
+  private confirmStatus = inject(ConfirmStatusChangeService);
   private authService = inject(AuthService);
 
   isSystemAdmin = computed(() => this.authService.userRole() === 'admin');
@@ -166,18 +168,11 @@ export class StudentManagementComponent implements OnInit {
   // Status action handler — F-U3 security fix: require confirm modal before
   // suspending or activating an account. Cancel → loadUsers() re-fetch reverts
   // the inline-edit dropdown UI.
+  // Modal copy lives in ConfirmStatusChangeService (DRY — issue #195).
   async onStatusActionChange(user: AdminUser, newStatus: string) {
     if (!newStatus) return;
 
-    const isBlock = newStatus === 'BLOCKED';
-    const confirmed = await this.confirmDialog.confirm({
-      title: isBlock ? 'Khóa tài khoản' : 'Kích hoạt tài khoản',
-      message: isBlock
-        ? `Bạn có chắc muốn khóa tài khoản của ${user.name}? Họ sẽ không đăng nhập được cho đến khi mở khóa.`
-        : `Bạn có chắc muốn kích hoạt lại tài khoản của ${user.name}?`,
-      confirmText: isBlock ? 'Khóa tài khoản' : 'Kích hoạt',
-      variant: isBlock ? 'danger' : 'warning'
-    });
+    const confirmed = await this.confirmStatus.confirm(user, newStatus as UserAccountStatus, 'student');
     if (!confirmed) {
       this.loadUsers();
       return;

--- a/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
@@ -6,6 +6,7 @@ import { forkJoin } from 'rxjs';
 import { AdminService, AdminUser, UserAccountStatus, UpdateUserStatusRequest } from '../../infrastructure/services/admin.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
+import { ConfirmStatusChangeService } from '../../services/confirm-status-change.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
@@ -25,6 +26,7 @@ export class TeacherManagementComponent implements OnInit {
   private adminService = inject(AdminService);
   private toast = inject(ToastService);
   private confirmDialog = inject(ConfirmDialogService);
+  private confirmStatus = inject(ConfirmStatusChangeService);
   private authService = inject(AuthService);
 
   isSystemAdmin = computed(() => this.authService.userRole() === 'admin');
@@ -155,18 +157,11 @@ export class TeacherManagementComponent implements OnInit {
   // Status action handler — F-U3/F-AD2 security fix: require confirm modal
   // before suspending or activating an account. Cancel → loadUsers() re-fetch
   // reverts the inline-edit dropdown UI to the previous value.
+  // Modal copy lives in ConfirmStatusChangeService (DRY — issue #195).
   async onStatusActionChange(user: AdminUser, newStatus: string) {
     if (!newStatus) return;
 
-    const isBlock = newStatus === 'BLOCKED';
-    const confirmed = await this.confirmDialog.confirm({
-      title: isBlock ? 'Khóa tài khoản' : 'Kích hoạt tài khoản',
-      message: isBlock
-        ? `Bạn có chắc muốn khóa tài khoản của ${user.name}? Họ sẽ không đăng nhập được cho đến khi mở khóa.`
-        : `Bạn có chắc muốn kích hoạt lại tài khoản của ${user.name}?`,
-      confirmText: isBlock ? 'Khóa tài khoản' : 'Kích hoạt',
-      variant: isBlock ? 'danger' : 'warning'
-    });
+    const confirmed = await this.confirmStatus.confirm(user, newStatus as UserAccountStatus, 'teacher');
     if (!confirmed) {
       this.loadUsers();
       return;

--- a/fe/src/app/features/admin/services/confirm-status-change.service.ts
+++ b/fe/src/app/features/admin/services/confirm-status-change.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, inject } from '@angular/core';
+import { ConfirmDialogService } from '../../../core/services/confirm-dialog.service';
+import { AdminUser, UserAccountStatus } from '../infrastructure/services/admin.service';
+
+/**
+ * Role label used to colour the wording of the status-change modal.
+ *
+ * - `admin`   → "Quản trị viên" emphasis (highest blast radius — see PR #178).
+ * - `teacher` → standard "tài khoản" wording.
+ * - `student` → standard "tài khoản" wording.
+ *
+ * Keep this enumeration narrow; the helper has to render Vietnamese-precise
+ * copy and we don't want it to silently fall through to a generic message
+ * when the caller passes an unexpected role.
+ */
+export type StatusChangeRole = 'admin' | 'teacher' | 'student';
+
+/**
+ * Single source of truth for the "Khóa / Kích hoạt tài khoản" confirmation
+ * modal previously copy-pasted into three components (admins, teachers,
+ * students). PR #178 introduced the gate; this service de-duplicates it
+ * per epic #186 / issue #195.
+ *
+ * Anatomy (mirrors PR #178 exactly):
+ * - `BLOCKED` → variant `danger`, title "Khóa tài khoản (Quản trị viên)?",
+ *               message names the user and warns about access loss.
+ * - `ACTIVE`  → variant `warning`, title "Kích hoạt tài khoản",
+ *               message asks for re-activation confirmation.
+ * - any other status → not gated (no-op `true`); callers should not be
+ *   throwing arbitrary statuses through this helper but we don't want to
+ *   regress positive-flow toggles.
+ *
+ * Usage:
+ * ```ts
+ * const ok = await this.confirmStatus.confirm(user, 'BLOCKED', 'admin');
+ * if (!ok) { this.loadUsers(); return; }
+ * ```
+ */
+@Injectable({ providedIn: 'root' })
+export class ConfirmStatusChangeService {
+  private confirmDialog = inject(ConfirmDialogService);
+
+  confirm(
+    user: Pick<AdminUser, 'name'>,
+    newStatus: UserAccountStatus,
+    role: StatusChangeRole,
+  ): Promise<boolean> {
+    if (newStatus !== 'BLOCKED' && newStatus !== 'ACTIVE') {
+      // No-op gate for unsupported statuses (RESTRICTED etc. — backend has
+      // no UI affordance for these in the inline-edit dropdown today).
+      return Promise.resolve(true);
+    }
+
+    const isBlock = newStatus === 'BLOCKED';
+    const adminEmphasis = role === 'admin' ? ' Quản trị viên' : '';
+    const blockMessage = role === 'admin'
+      ? `Bạn có chắc muốn khóa tài khoản Quản trị viên ${user.name}? Họ sẽ mất quyền truy cập hệ thống cho đến khi được mở khóa.`
+      : `Bạn có chắc muốn khóa tài khoản của ${user.name}? Họ sẽ không đăng nhập được cho đến khi mở khóa.`;
+
+    return this.confirmDialog.confirm({
+      title: isBlock ? `Khóa tài khoản${adminEmphasis}` : 'Kích hoạt tài khoản',
+      message: isBlock
+        ? blockMessage
+        : `Bạn có chắc muốn kích hoạt lại tài khoản của ${user.name}?`,
+      confirmText: isBlock ? 'Khóa tài khoản' : 'Kích hoạt',
+      variant: isBlock ? 'danger' : 'warning',
+    });
+  }
+}

--- a/fe/src/app/features/admin/services/confirm-status-change.service.ts
+++ b/fe/src/app/features/admin/services/confirm-status-change.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { ConfirmDialogService } from '../../../core/services/confirm-dialog.service';
+import { AuthService } from '../../../core/services/auth.service';
+import { ToastService } from '../../../core/services/toast.service';
 import { AdminUser, UserAccountStatus } from '../infrastructure/services/admin.service';
 
 /**
@@ -39,16 +41,42 @@ export type StatusChangeRole = 'admin' | 'teacher' | 'student';
 @Injectable({ providedIn: 'root' })
 export class ConfirmStatusChangeService {
   private confirmDialog = inject(ConfirmDialogService);
+  private auth = inject(AuthService);
+  private toast = inject(ToastService);
 
-  confirm(
-    user: Pick<AdminUser, 'name'>,
+  /**
+   * Validate + confirm the status change. Returns `true` only if the caller
+   * should proceed with the API call.
+   *
+   * Validation gates (issue #194 — F-AD2 followup):
+   * 1. **Self-suspend** — admin clicks "Khóa" on their own row → blocked
+   *    with toast. Highest priority because losing access mid-action would
+   *    require an out-of-band recovery (DB write).
+   * 2. **Sole-system-admin demote** — guarded by an additional helper
+   *    `validateRoleChange()` (callers pass the candidate list). Not
+   *    enforced here because the inline-edit role dropdown lives in three
+   *    different components with three different data sources.
+   *
+   * Validation runs *before* the modal so the user never sees a confirm
+   * dialog for an action that will never succeed.
+   */
+  async confirm(
+    user: Pick<AdminUser, 'id' | 'name'>,
     newStatus: UserAccountStatus,
     role: StatusChangeRole,
   ): Promise<boolean> {
+    // 1. Self-suspend gate — the admin and the user are the same person.
+    //    Compare on `id` (UUID) which is stable; email/name can drift.
+    const currentUserId = this.auth.currentUser()?.id;
+    if (newStatus === 'BLOCKED' && currentUserId && currentUserId === user.id) {
+      this.toast.error('Không thể khóa tài khoản của chính bạn');
+      return false;
+    }
+
     if (newStatus !== 'BLOCKED' && newStatus !== 'ACTIVE') {
       // No-op gate for unsupported statuses (RESTRICTED etc. — backend has
       // no UI affordance for these in the inline-edit dropdown today).
-      return Promise.resolve(true);
+      return true;
     }
 
     const isBlock = newStatus === 'BLOCKED';
@@ -65,5 +93,47 @@ export class ConfirmStatusChangeService {
       confirmText: isBlock ? 'Khóa tài khoản' : 'Kích hoạt',
       variant: isBlock ? 'danger' : 'warning',
     });
+  }
+
+  /**
+   * Pre-flight gate for role demotion away from system ADMIN. Returns
+   * `false` when the action would leave the system without a single
+   * SYSTEM_ADMIN — UI must abort and surface the toast to the user.
+   *
+   * The list comes from the caller (admins surface) because that's where
+   * the full set of admin users lives in memory — the helper does not
+   * fetch on its own (would force a network round-trip on every dropdown
+   * change).
+   *
+   * Heuristic: count rows whose `role` is `'admin'` (UI form) or `'ADMIN'`
+   * (BE form) and `accountStatus === 'ACTIVE'`. If only one such row
+   * exists and it is the row being demoted, deny.
+   */
+  validateRoleChange(
+    user: Pick<AdminUser, 'id' | 'role' | 'accountStatus'>,
+    newRole: string,
+    allAdmins: readonly Pick<AdminUser, 'id' | 'role' | 'accountStatus'>[],
+  ): boolean {
+    const isCurrentlyAdmin = user.role.toUpperCase() === 'ADMIN';
+    const becomingNonAdmin = newRole.toUpperCase() !== 'ADMIN';
+
+    if (!isCurrentlyAdmin || !becomingNonAdmin) {
+      return true;
+    }
+
+    const activeAdmins = allAdmins.filter(
+      (u) =>
+        u.role.toUpperCase() === 'ADMIN' &&
+        u.accountStatus === 'ACTIVE',
+    );
+
+    // The only remaining ACTIVE system admin would be the one being
+    // demoted → deny. Comparing on id is robust to BE/UI casing drift.
+    if (activeAdmins.length <= 1 && activeAdmins.some((u) => u.id === user.id)) {
+      this.toast.error('Hệ thống cần ít nhất 1 Quản trị viên hệ thống');
+      return false;
+    }
+
+    return true;
   }
 }

--- a/fe/src/app/shared/components/admin/date-range-toggle/date-range-toggle.component.html
+++ b/fe/src/app/shared/components/admin/date-range-toggle/date-range-toggle.component.html
@@ -1,0 +1,18 @@
+<div
+  class="date-range-toggle"
+  role="radiogroup"
+  [attr.aria-label]="ariaLabel()"
+  (keydown)="onKeydown($event)">
+  @for (btn of buttons(); track btn.days) {
+    <button
+      type="button"
+      class="seg-btn"
+      [class.seg-btn--active]="btn.days === value()"
+      role="radio"
+      [attr.aria-checked]="btn.days === value()"
+      [tabindex]="btn.days === value() ? 0 : -1"
+      (click)="onSelect(btn.days)">
+      {{ btn.label }}
+    </button>
+  }
+</div>

--- a/fe/src/app/shared/components/admin/date-range-toggle/date-range-toggle.component.scss
+++ b/fe/src/app/shared/components/admin/date-range-toggle/date-range-toggle.component.scss
@@ -1,0 +1,73 @@
+@use '../../../../../styles/variables' as *;
+
+/* Date-range segmented toggle — admin portal (F-P2 audit 2026-04-25).
+   Stripe / Linear pattern: pill-shaped track, contained selected state,
+   40px tall (WCAG 2.2 SC 2.5.8 desktop target). */
+
+:host {
+  display: inline-block;
+}
+
+.date-range-toggle {
+  display: inline-flex;
+  align-items: stretch;
+  // Track sits on a soft chip background so the unselected buttons read as
+  // inactive at a glance. Mirrors Linear's "contained segmented control".
+  background: $gray-100;
+  border: 1px solid $border-default;
+  border-radius: $radius-lg;
+  padding: 2px;
+  gap: 2px;
+}
+
+.seg-btn {
+  // 40px target (38 + 2*1 border) — sits exactly on the WCAG 2.2 SC 2.5.8
+  // desktop minimum. The track itself reaches 44px when the 2px padding +
+  // border are included, which also satisfies the SC 2.5.8 mobile target.
+  min-height: 36px;
+  min-width: 64px;
+  padding: 0 $spacing-3;
+  border: 1px solid transparent;
+  background: transparent;
+  border-radius: $radius-md;
+  font-size: $text-sm;
+  font-weight: $font-medium;
+  color: $text-secondary;
+  cursor: pointer;
+  transition:
+    background $transition-fast,
+    color $transition-fast,
+    border-color $transition-fast,
+    box-shadow $transition-fast;
+  font-variant-numeric: tabular-nums;
+
+  &:hover:not(.seg-btn--active) {
+    background: white;
+    color: $text-primary;
+  }
+
+  &:focus-visible {
+    // Match the global focus ring on $blue-primary so the toggle does not
+    // drift from the rest of the design system.
+    outline: 2px solid $blue-primary;
+    outline-offset: 2px;
+  }
+
+  &--active {
+    // Contained selected state — solid white "card" with a faint shadow,
+    // text turns primary. Matches Linear / Stripe / Vercel.
+    background: white;
+    color: $blue-primary;
+    border-color: $border-default;
+    box-shadow: $shadow-sm;
+    font-weight: $font-semibold;
+  }
+}
+
+@media (max-width: $breakpoint-sm) {
+  // Mobile bumps the target to 44px per WCAG 2.2 SC 2.5.8 mobile.
+  .seg-btn {
+    min-height: 40px;
+    min-width: 56px;
+  }
+}

--- a/fe/src/app/shared/components/admin/date-range-toggle/date-range-toggle.component.ts
+++ b/fe/src/app/shared/components/admin/date-range-toggle/date-range-toggle.component.ts
@@ -1,0 +1,107 @@
+import { Component, input, output, computed, ChangeDetectionStrategy } from '@angular/core';
+
+/**
+ * Reusable segmented control for "7 / 30 / 90 ngày" windows on the admin
+ * portal — Stripe / Linear pattern (F-P2 in 2026-04-25 mega audit).
+ *
+ * The dashboard, payouts, and any future analytics surface that needs a
+ * temporal window selector share this single source of truth so we don't
+ * end up with three slightly different toggles. Backs the windowed
+ * analytics endpoint shipped in PR #171
+ * (`GET /api/v3/admin/courses/analytics/window?days={7|30|90}`).
+ *
+ * Anatomy:
+ * - 40px tall (WCAG 2.2 SC 2.5.8 desktop target).
+ * - role="radiogroup" + per-button role="radio" + aria-checked so screen
+ *   readers announce "selected: 7 ngày" rather than three lone buttons.
+ * - Keyboard: Tab focuses the strip, Arrow keys move the selection (browser
+ *   default for radio in a radiogroup with arrow nav handled here).
+ *
+ * Usage:
+ * ```html
+ * <app-date-range-toggle
+ *   [value]="windowDays()"
+ *   (change)="windowDays.set($event)" />
+ * ```
+ *
+ * Custom options:
+ * ```html
+ * <app-date-range-toggle [value]="14" [options]="[7, 14, 30]" (change)="..." />
+ * ```
+ */
+@Component({
+  selector: 'app-date-range-toggle',
+  imports: [],
+  templateUrl: './date-range-toggle.component.html',
+  styleUrl: './date-range-toggle.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DateRangeToggleComponent {
+  // Currently selected window in days. Required so the parent owns state
+  // (signal-up, render-down) — the component does NOT keep its own copy.
+  value = input.required<number>();
+
+  // Override the default 7/30/90 set if a surface needs a different
+  // cadence (telemetry uses 7/14/30 for example). Defaulted via fallback
+  // because Angular's input() does not support a default for a typed
+  // array literal cleanly.
+  options = input<readonly number[]>([7, 30, 90]);
+
+  // Optional aria-label override for surfaces where "Khoảng thời gian"
+  // is too generic (e.g. multiple toggles on one page). Defaults to the
+  // generic label.
+  ariaLabel = input<string>('Khoảng thời gian');
+
+  // Emits whenever the user picks a different window. Identical semantics
+  // to a native radio change — no event when the user clicks the already
+  // selected button.
+  readonly change = output<number>();
+
+  // Pre-formatted label "{N} ngày" — keeps the template lean.
+  buttons = computed(() =>
+    this.options().map((days) => ({ days, label: `${days} ngày` })),
+  );
+
+  onSelect(days: number): void {
+    if (days === this.value()) {
+      // No-op: emit only when the value actually changes. Mirrors native
+      // radio semantics and prevents redundant analytics fetches.
+      return;
+    }
+    this.change.emit(days);
+  }
+
+  /**
+   * Arrow-key navigation within the strip. Mirrors the WAI-ARIA radiogroup
+   * pattern: Left/Up moves to previous, Right/Down moves to next, Home/End
+   * jump to first/last. We update by emitting `change` so the parent
+   * remains the source of truth (signal-up, render-down).
+   */
+  onKeydown(event: KeyboardEvent): void {
+    const opts = this.options();
+    const current = opts.indexOf(this.value());
+    if (current === -1) return;
+
+    let nextIdx = current;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        nextIdx = (current + 1) % opts.length;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        nextIdx = (current - 1 + opts.length) % opts.length;
+        break;
+      case 'Home':
+        nextIdx = 0;
+        break;
+      case 'End':
+        nextIdx = opts.length - 1;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    this.change.emit(opts[nextIdx]);
+  }
+}


### PR DESCRIPTION
Closes #192, #193, #194, #195. Part of epic #186 (admin portal completion — Stream B FE polish wave 1).

Four small-but-meaningful FE finishes shipped together so reviewers can see them as one cohesive polish pass.

## Changes per issue

### #195 DRY status confirm helper (refactor)

`features/admin/services/confirm-status-change.service.ts` extracts the "Khóa / Kích hoạt tài khoản" modal copy + variant from PR #178's three copy-pasted call sites. Wording preserved exactly:

| Status + role | Title | Variant |
|---|---|---|
| BLOCKED + admin | "Khóa tài khoản Quản trị viên" | danger |
| BLOCKED + teacher/student | "Khóa tài khoản" | danger |
| ACTIVE | "Kích hoạt tài khoản" | warning |

Net ~30 LOC removed across admins / teachers / students components, +1 service file.

### #194 Block self-suspend + super-admin demote (security fix)

PR #178's confirm modal didn't catch two edge cases. Both gates run **before** the modal so users never see a confirm dialog for an action that will never succeed.

1. **Self-suspend** — admin clicks "Khóa" on their own row:
   - Compare `currentUser.id === user.id` (UUID, stable).
   - Toast `"Không thể khóa tài khoản của chính bạn"` + return false.
   - Shared via ConfirmStatusChangeService — fix is one place, three callers inherit.

2. **Sole-system-admin demote** — `validateRoleChange(user, newRole, allAdmins)`:
   - Counts ACTIVE ADMIN rows; denies when the demoted row is the only one.
   - Toast `"Hệ thống cần ít nhất 1 Quản trị viên hệ thống"`.
   - Wired into admin-users `onRoleChange()` + `revokeAdmin()` (latter is a demote in disguise).

### #192 `<app-date-range-toggle>` shared component (feature)

Reusable segmented "7 / 30 / 90 ngày" control, single source of truth for any admin surface that wants a temporal window. Stripe / Linear pattern: pill-shaped track, contained selected state, 40px target (WCAG 2.2 SC 2.5.8 desktop, 44px mobile).

Wired surfaces:
- **Dashboard** (`/admin/dashboard`): parent `AdminComponent` holds `windowDays` signal (default 30). Toggle change re-fetches `/admin/courses/analytics/window?days=N` (PR #171) and merges deltas (`userGrowth`, `revenueGrowth`, `courseGrowth`, totals) into `SystemAnalytics`. Pending counts stay on the legacy endpoint.
- **Payouts** (`/admin/payouts`): placeholder per spec — UI ticks but no re-fetch yet (BE issue tracks an aggregate window endpoint).

A11y: `role=radiogroup` + per-button `role=radio` + `aria-checked` + roving `tabindex` + Arrow / Home / End keyboard navigation per WAI-ARIA radiogroup pattern.

### #193 Categories empty state right-pane CTA (UX)

Right-pane empty state on `/admin/categories` was Inform-only. Upgraded to Carbon's Inform + Inspire + Activate pattern.

- Inline SVG illustration (layered tag stack, primary tint #0056D2 — no brand icon per the kpi-card precedent).
- Title "Chọn danh mục để xem chi tiết".
- Description naming the affordances (tên / mã / mô tả / danh mục con).
- Activate CTA "+ Tạo danh mục mới" — fires the same `startCreateRoot()` handler as the sidebar button, so users have two entry points.

40px target on the CTA + `role=status` + `aria-live=polite` on the panel for SR announcements when the empty state appears.

## Browser verification (agent-browser, 1440×900)

| Surface | Before | After |
|---|---|---|
| `/admin/dashboard` | No date toggle in header | **3-button radiogroup "7 / 30 / 90 ngày"** with 30 selected by default; Arrow key nav works |
| `/admin/payouts` | No date toggle in header | **Toggle rendered top-right** (placeholder, no fetch yet) |
| `/admin/users/admins` self-suspend | Click "Khóa" on own row → modal appears → confirm → user locked out | **Toast "Không thể khóa tài khoản của chính bạn"** + dropdown reset, status stays Hoạt động |
| `/admin/categories` empty pane | Plain text only | **SVG illustration + Inspire copy + "+ Tạo danh mục mới" CTA** that opens the create form |

All measurements taken with `admin@maritime.edu / admin123` against a live local stack (BE 8088 + FE 4300 worktree vs FE 4200 main for the before captures).

## Convention compliance

- [x] OnPush on every component (date-range-toggle inherits from kpi-card pattern)
- [x] `inject()` not constructor; `signal` / `computed` for state; `input.required` / `output()` for IO
- [x] `@if` / `@for` only; no `*ngIf`
- [x] No `standalone: true` (Angular 20 default)
- [x] Token-based SCSS: `$spacing-*`, `$text-*`, `$blue-primary`, `$transition-fast`, etc. — no magic numbers
- [x] Vietnamese diacritics throughout, role-appropriate terminology
- [x] WCAG 2.2 SC 2.5.8: 40px desktop / 44px mobile targets on toggle + CTA
- [x] No decorative brand icons in toggle / KPI / form

## Files

| File | Change |
|---|---|
| `fe/src/app/features/admin/services/confirm-status-change.service.ts` | **new** — DRY helper + validation gates |
| `.../admin-user-management.component.ts` | Use helper; wire `validateRoleChange` into `onRoleChange` + `revokeAdmin` |
| `.../teacher-management.component.ts` | Use helper |
| `.../student-management.component.ts` | Use helper |
| `fe/src/app/shared/components/admin/date-range-toggle/{ts,html,scss}` | **new** — shared segmented control |
| `fe/src/app/api/endpoints/admin.endpoints.ts` | `ANALYTICS_WINDOW` endpoint constant |
| `fe/src/app/features/admin/infrastructure/services/admin.service.ts` | `WindowedAnalytics` interface + `getCoursesAnalyticsWindow(days)` |
| `.../admin.component.ts` | `windowDays` signal + `onWindowDaysChange` + `applyWindowedAnalytics` |
| `.../dashboard/admin-system-dashboard.component.{ts,html,scss}` | Date toggle in header, `windowDays` input, `windowDaysChange` output |
| `.../admin-payouts.component.{ts,scss}` | Date toggle placeholder + page-header layout |
| `.../category-management.component.{ts,scss}` | Carbon empty state with illustration + CTA |

15 files: 5 new, 10 modified. ~470 LOC net.

## Risk & rollback

- Risk: low. DRY refactor is behavior-preserving by construction; self-suspend gate is strictly additive (BE remains source of truth); date toggle is opt-in per surface; categories empty state is presentation-only.
- Rollback: `git revert`. The four commits are independent, so single-issue reverts are also straightforward.

## Out of scope (defer)

- Per-user `windowDays` persistence (localStorage / settings) — Wave 2 candidate.
- Aggregate `/payouts/window` BE endpoint — tracked separately; FE stub already in place.
- Full pill+kebab redesign for status — epic #186 Wave 3 (CC-10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)