### PR TITLE
feat(admin-organizations): KPI strip + clearer token label (closes #200, #202)

### DIFF
--- a/backend/src/main/java/com/example/lms/identity/application/dto/OrganizationStatsResponse.java
+++ b/backend/src/main/java/com/example/lms/identity/application/dto/OrganizationStatsResponse.java
@@ -1,0 +1,25 @@
+package com.example.lms.identity.application.dto;
+
+/**
+ * Aggregate stats over all organizations — powers the KPI strip on
+ * `/admin/organizations` (issue #200, F-ORG-1).
+ *
+ * <ul>
+ *   <li>{@code totalOrgs} — count of all organizations.</li>
+ *   <li>{@code activeOrgs} — count where {@code enabled = true}.</li>
+ *   <li>{@code totalMembers} — count of users with non-null
+ *       {@code organization_id} (members across all orgs).</li>
+ *   <li>{@code activeInvites} — count of {@code organization_invites} in
+ *       {@code ACTIVE} status whose {@code expires_at} is still in the
+ *       future. Mirrors the {@code findActiveBy*} predicate used elsewhere.</li>
+ * </ul>
+ *
+ * <p>ADMIN role only — ORG_ADMIN does not see this aggregate (their list is
+ * scoped to their own org).
+ */
+public record OrganizationStatsResponse(
+        long totalOrgs,
+        long activeOrgs,
+        long totalMembers,
+        long activeInvites
+) {}

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/OrganizationInviteJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/OrganizationInviteJpaRepository.java
@@ -69,8 +69,20 @@ public interface OrganizationInviteJpaRepository extends JpaRepository<Organizat
     @Query("""
         UPDATE OrganizationInviteJpaEntity i
         SET i.status = 'EXPIRED'
-        WHERE i.status = 'ACTIVE'
+          WHERE i.status = 'ACTIVE'
           AND i.expiresAt <= :now
         """)
     int markExpiredInvites(@Param("now") Instant now);
+
+    /**
+     * Count active (status=ACTIVE, not expired) invites across all
+     * organizations. Powers `/admin/organizations/stats` KPI strip
+     * (issue #200, F-ORG-1).
+     */
+    @Query("""
+        SELECT COUNT(i) FROM OrganizationInviteJpaEntity i
+        WHERE i.status = 'ACTIVE'
+          AND i.expiresAt > :now
+        """)
+    long countActiveInvites(@Param("now") Instant now);
 }

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/OrganizationJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/OrganizationJpaRepository.java
@@ -13,4 +13,7 @@ public interface OrganizationJpaRepository extends JpaRepository<OrganizationJpa
     Optional<OrganizationJpaEntity> findByCode(String code);
 
     boolean existsByCode(String code);
+
+    /** Count organizations with {@code enabled = true} (issue #200, F-ORG-1). */
+    long countByEnabledTrue();
 }

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/repository/UserJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/repository/UserJpaRepository.java
@@ -130,5 +130,9 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, UUID> {
             @Param("from") java.time.Instant from,
             @Param("to") java.time.Instant to
     );
+
+    /** Count members across all organizations (issue #200, F-ORG-1). */
+    @Query("SELECT COUNT(u) FROM UserJpaEntity u WHERE u.organizationId IS NOT NULL")
+    long countByOrganizationIdIsNotNull();
 }
 

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/web/OrganizationControllerV3.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/web/OrganizationControllerV3.java
@@ -4,6 +4,8 @@ import com.example.lms.identity.application.dto.*;
 import com.example.lms.identity.application.usecase.*;
 import com.example.lms.identity.domain.model.Organization;
 import com.example.lms.identity.domain.repository.OrganizationRepository;
+import com.example.lms.identity.infrastructure.persistence.OrganizationInviteJpaRepository;
+import com.example.lms.identity.infrastructure.persistence.OrganizationJpaRepository;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
 import com.example.lms.shared.exception.EntityNotFoundException;
@@ -21,6 +23,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +49,8 @@ public class OrganizationControllerV3 {
     private final ListInvitesUseCase listInvitesUseCase;
     private final RevokeInviteUseCase revokeInviteUseCase;
     private final UserJpaRepository userJpaRepo;
+    private final OrganizationJpaRepository orgJpaRepo;
+    private final OrganizationInviteJpaRepository inviteJpaRepo;
 
     // ==================== Organization CRUD ====================
 
@@ -65,6 +70,19 @@ public class OrganizationControllerV3 {
                     .orElse(ResponseEntity.ok(ApiResponse.success(List.of())));
         }
         return ResponseEntity.ok(ApiResponse.success(listOrganizationsUseCase.execute()));
+    }
+
+    @GetMapping("/stats")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Thống kê tổ chức (ADMIN only)")
+    public ResponseEntity<ApiResponse<OrganizationStatsResponse>> getStats() {
+        OrganizationStatsResponse stats = new OrganizationStatsResponse(
+                orgJpaRepo.count(),
+                orgJpaRepo.countByEnabledTrue(),
+                userJpaRepo.countByOrganizationIdIsNotNull(),
+                inviteJpaRepo.countActiveInvites(Instant.now())
+        );
+        return ResponseEntity.ok(ApiResponse.success(stats));
     }
 
     @GetMapping("/{id}")

--- a/fe/src/app/api/endpoints/organization.endpoints.ts
+++ b/fe/src/app/api/endpoints/organization.endpoints.ts
@@ -1,5 +1,6 @@
 export const ORGANIZATION_ENDPOINTS = {
   BASE: '/api/v3/organizations',
+  STATS: '/api/v3/organizations/stats',
   BY_ID: (id: string) => `/api/v3/organizations/${id}`,
   MEMBERS: (id: string) => `/api/v3/organizations/${id}/members`,
   REMOVE_MEMBER: (id: string, userId: string) => `/api/v3/organizations/${id}/members/${userId}`,

--- a/fe/src/app/features/admin/infrastructure/services/organization.service.ts
+++ b/fe/src/app/features/admin/infrastructure/services/organization.service.ts
@@ -17,6 +17,16 @@ export class OrganizationService {
     );
   }
 
+  /**
+   * Aggregate stats over all organizations — KPI strip on /admin/organizations
+   * (issue #200, F-ORG-1). ADMIN role only.
+   */
+  getStats(): Observable<OrganizationStats> {
+    return this.api.get<ApiResponse<OrganizationStats>>(ORGANIZATION_ENDPOINTS.STATS).pipe(
+      map(res => res.data)
+    );
+  }
+
   getOrganization(id: string): Observable<Organization> {
     return this.api.get<ApiResponse<Organization>>(ORGANIZATION_ENDPOINTS.BY_ID(id)).pipe(
       map(res => res.data)
@@ -126,4 +136,11 @@ export interface OrgPaymentConfig {
   teacherSharePct: number;
   orgSharePct: number;
   minPayoutAmount: number;
+}
+
+export interface OrganizationStats {
+  totalOrgs: number;
+  activeOrgs: number;
+  totalMembers: number;
+  activeInvites: number;
 }

--- a/fe/src/app/features/admin/presentation/components/organization-list.component.html
+++ b/fe/src/app/features/admin/presentation/components/organization-list.component.html
@@ -16,6 +16,16 @@
       }
     </div>
 
+    @if (stats(); as s) {
+      <!-- KPI strip — F-ORG-1, mirrors dashboard / users family pattern via shared kpi-card -->
+      <div class="kpi-strip">
+        <app-kpi-card label="Tổng tổ chức" [value]="s.totalOrgs" />
+        <app-kpi-card label="Đang hoạt động" [value]="s.activeOrgs" variant="success" />
+        <app-kpi-card label="Thành viên" [value]="s.totalMembers" sub="trong các tổ chức" />
+        <app-kpi-card label="Lời mời còn hiệu lực" [value]="s.activeInvites" sub="chưa hết hạn" />
+      </div>
+    }
+
     <!-- Create Form (inline card) -->
     @if (canCreateOrganizations() && showCreateForm()) {
       <div class="create-form-card">
@@ -93,7 +103,9 @@
                   <div class="org-meta">
                     <span class="org-code">{{ org.code }}</span>
                     <span class="dot-separator">&middot;</span>
-                    <span>Token: {{ org.tokenExpiryDays }} ngày</span>
+                    <span title="Thời hạn token đăng nhập của thành viên trong tổ chức">
+                      Hạn token: {{ org.tokenExpiryDays }} ngày
+                    </span>
                   </div>
                 </div>
               </div>

--- a/fe/src/app/features/admin/presentation/components/organization-list.component.scss
+++ b/fe/src/app/features/admin/presentation/components/organization-list.component.scss
@@ -20,6 +20,25 @@
   margin-bottom: $spacing-6;
 }
 
+/* ===== KPI STRIP =====
+   F-ORG-1: 4 cards top, mirrors dashboard / users family pattern.
+   Uses shared <app-kpi-card> so visual contract is consistent.
+*/
+.kpi-strip {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: $spacing-4;
+  margin-bottom: $spacing-6;
+
+  @media (min-width: 640px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
 .page-header-text {
   h1 {
     font-size: $text-2xl;

--- a/fe/src/app/features/admin/presentation/components/organization-list.component.ts
+++ b/fe/src/app/features/admin/presentation/components/organization-list.component.ts
@@ -1,13 +1,14 @@
 import { Component, signal, inject, OnInit, ChangeDetectionStrategy, computed } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { OrganizationService } from '../../infrastructure/services/organization.service';
+import { OrganizationService, OrganizationStats } from '../../infrastructure/services/organization.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { Organization } from '../../../../shared/types/user.types';
+import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 
 @Component({
   selector: 'app-organization-list',
-  imports: [RouterModule],
+  imports: [RouterModule, KpiCardComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './organization-list.component.html',
   styleUrl: './organization-list.component.scss',
@@ -18,6 +19,7 @@ export class OrganizationListComponent implements OnInit {
   private authService = inject(AuthService);
 
   organizations = signal<Organization[]>([]);
+  stats = signal<OrganizationStats | null>(null);
   isLoading = signal(true);
   showCreateForm = signal(false);
   isCreating = signal(false);
@@ -25,6 +27,9 @@ export class OrganizationListComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadOrganizations();
+    if (this.canCreateOrganizations()) {
+      this.loadStats();
+    }
   }
 
   loadOrganizations(): void {
@@ -37,6 +42,20 @@ export class OrganizationListComponent implements OnInit {
       error: () => {
         this.toast.error('Không thể tải danh sách tổ chức');
         this.isLoading.set(false);
+      }
+    });
+  }
+
+  /**
+   * Load aggregate KPI stats. Only ADMIN role can call /stats endpoint —
+   * ORG_ADMIN sees their own org list scoped, doesn't need fleet-wide stats.
+   * Fail silently if endpoint not authorized — KPI strip just doesn't render.
+   */
+  private loadStats(): void {
+    this.orgService.getStats().subscribe({
+      next: (stats) => this.stats.set(stats),
+      error: () => {
+        // Silent fail: KPI strip simply hidden via @if(stats())
       }
     });
   }


### PR DESCRIPTION
Closes #200, #202. Part of epic #186 (admin portal completion).

## Findings addressed

- **F-ORG-1** (#200): Aggregate KPI strip via shared `<app-kpi-card>`. New BE endpoint `GET /api/v3/organizations/stats` (ADMIN only). 4 KPIs: Tổng tổ chức / Đang hoạt động / Thành viên / Lời mời còn hiệu lực.
- **F-ORG-3** (#202): Token label "Token: 30 ngày" → "Hạn token: 30 ngày" + title attribute tooltip.

#201 F-ORG-2 đã closed separately — empty state pre-existing.

## Changes (10 files)

### BE (5 files)
- New `OrganizationStatsResponse` record
- `OrganizationJpaRepository.countByEnabledTrue()` (derived query)
- `UserJpaRepository.countByOrganizationIdIsNotNull()` (count members across orgs)
- `OrganizationInviteJpaRepository.countActiveInvites(now)` (status=ACTIVE + not expired)
- `OrganizationControllerV3` — new `GET /stats` endpoint, ADMIN only

### FE (5 files)
- New `OrganizationStats` interface in service + `getStats()` method
- `ORGANIZATION_ENDPOINTS.STATS` constant
- Component imports shared `<app-kpi-card>` from PR #174 (1 visual language)
- Component template: KPI strip top via @if(stats(); as s)
- Component template: token label clarification + tooltip
- SCSS: .kpi-strip grid 1col mobile / 2col tablet / 4col desktop (consistent với pattern các surface khác)

## Convention compliance

- [x] OnPush, signal/computed/inject — không constructor DI
- [x] @if/@for, không *ngIf
- [x] Không `standalone: true` explicit
- [x] Reuse shared kpi-card (CC-01 foundation từ PR #174)
- [x] Tokens-based SCSS
- [x] Vietnamese diacritics + role-appropriate terminology
- [x] WCAG: title attribute cho tooltip
- [x] Clean Architecture: Port chưa cần (chỉ thêm read-only count queries)
- [x] @PreAuthorize ADMIN only cho /stats

## Test plan

- [ ] Login admin → /admin/organizations → 4 KPI cards render với count thật
- [ ] Login orgadmin → /admin/organizations → KPI strip hidden (forbidden silent fail)
- [ ] Token label hover → tooltip xuất hiện
- [ ] Mobile (375): KPI 1-col stack, KPI 2x2 tablet, 4x1 desktop
- [ ] CI 4/4 expect xanh

## Out of scope

- Per-org stats drill-in (defer)
- Token expiry warning if < 7 days remaining (audit recommend nhưng tokenExpiryDays là setting per-org, không phải absolute timestamp — defer to product clarification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)