### PR TITLE
feat(org-admin-dashboard): header primary action buttons (closes #211)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.html
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.html
@@ -48,6 +48,10 @@
     <div class="header-bar">
       <div class="header-inner">
         <h1 class="page-title">Bảng điều khiển quản lý</h1>
+        <div class="header-actions">
+          <a [routerLink]="portalBase() + '/analytics'" class="btn-secondary">Xem analytics</a>
+          <a [routerLink]="portalBase() + '/organization'" class="btn-primary">Mời thành viên</a>
+        </div>
       </div>
     </div>
 

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.scss
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.scss
@@ -17,6 +17,11 @@
   max-width: 1400px;
   margin: 0 auto;
   padding: $spacing-4 $spacing-6;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-4;
+  flex-wrap: wrap;
 }
 
 .page-title {
@@ -25,6 +30,51 @@
   color: $text-primary;
   margin: 0;
   line-height: $leading-tight;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+  flex-shrink: 0;
+}
+
+/* Header action buttons — primary "Mời thành viên" + secondary "Xem analytics".
+   Mirrors admin-system-dashboard pattern (PR #159). Stripe/Linear convention. */
+.btn-primary,
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: $spacing-2 $spacing-4;
+  min-height: 40px; // WCAG 2.2 SC 2.5.8 touch target
+  font-size: $text-sm;
+  font-weight: $font-semibold;
+  border-radius: $radius-md;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background $transition-fast, border-color $transition-fast, color $transition-fast;
+  white-space: nowrap;
+
+  @include focus-visible;
+}
+
+.btn-primary {
+  background: $blue-primary;
+  color: white;
+  border: 1px solid $blue-primary;
+
+  &:hover { background: $blue-hover; border-color: $blue-hover; }
+  &:active { background: $blue-pressed; border-color: $blue-pressed; }
+}
+
+.btn-secondary {
+  background: white;
+  color: $text-primary;
+  border: 1px solid $border-default;
+
+  &:hover { background: $gray-50; border-color: $border-dark; }
+  &:active { background: $gray-100; }
 }
 
 /* ===== MAIN ===== */
@@ -402,6 +452,20 @@
     font-size: $text-lg;
   }
 
+  .header-inner {
+    flex-wrap: wrap;
+  }
+
+  .header-actions {
+    width: 100%;
+  }
+
+  .btn-primary,
+  .btn-secondary {
+    flex: 1;
+    min-height: 44px; // iOS 44pt touch target
+  }
+
   .action-grid {
     grid-template-columns: 1fr;
     gap: $spacing-3;
@@ -555,6 +619,10 @@
   }
 
   .action-btns {
+    display: none !important;
+  }
+
+  .header-actions {
     display: none !important;
   }
 


### PR DESCRIPTION
Closes #211. Part of epic #209 (F-OA-2).

## Changes

Mirrors PR #159 pattern (admin system dashboard F-03). AdminOrgDashboardComponent header now has button group top-right:

- **Primary** "Mời thành viên" → `/org-admin/organization` (existing OrganizationDetail with invite UI)
- **Secondary** "Xem analytics" → `/org-admin/analytics`

| File | Change |
|---|---|
| `admin-org-dashboard.component.html` | `.header-inner` now hosts `.header-actions` div with 2 anchor buttons. |
| `admin-org-dashboard.component.scss` | `.header-inner` flex space-between layout; new `.header-actions` + `.btn-primary` + `.btn-secondary` rules ported from `admin-system-dashboard.component.scss`. Mobile responsive: stacks full-width with 44px touch target. Print: header-actions hidden. |

2 files, +72 LOC, 0 deletions.

## Convention compliance

- [x] `ChangeDetectionStrategy.OnPush` giữ nguyên
- [x] `signal()` / `computed()` / `input()` / `output()` — `portalBase` đã là `computed` từ trước
- [x] `@if` / `@for` only — không `*ngIf`/`*ngFor`
- [x] No `standalone: true`
- [x] Token-based SCSS (`$blue-primary`, `$radius-md`, `@include focus-visible`, etc.)
- [x] Vietnamese có dấu, terminology phù hợp ORG_ADMIN

## agent-browser verification

Tested locally, login `orgadmin@maritime.edu` / `orgadmin123` at `/org-admin/dashboard`.

### Desktop 1440×900

| Metric | Value |
|---|---:|
| `.header-actions` element count | **1** |
| `.btn-primary` height | **40px** ✓ WCAG 2.2 SC 2.5.8 |
| `.btn-primary` background | `rgb(0, 86, 210)` = `#0056D2` ✓ |
| `.btn-primary` text color | `rgb(255, 255, 255)` ✓ |
| `.btn-primary` href | `/org-admin/organization` ✓ |
| `.btn-secondary` height | **40px** ✓ |
| `.btn-secondary` background | `rgb(255, 255, 255)` ✓ |
| `.btn-secondary` href | `/org-admin/analytics` ✓ |
| `.header-inner` display | `flex` + `justify-content: space-between` ✓ |
| Buttons positioned right | x=1154 + 1288 (viewport 1440) ✓ |

### Mobile 375×812

| Metric | Value |
|---|---:|
| `.btn-primary` height | **44px** ✓ iOS 44pt target |
| `.btn-secondary` height | **44px** ✓ |
| `.header-actions` width | 336px (= viewport - padding) ✓ full-width |
| Both buttons same row, side-by-side (flex 1) | y=115.5 ✓ |

### Click-through

- Click `Xem analytics` → `/org-admin/analytics` ✓
- Click `Mời thành viên` → `/org-admin/organization` ✓

## Acceptance criteria (issue #211)

- [x] AdminOrgDashboardComponent header có 2 buttons
- [x] Primary blue (#0056D2), secondary white-bordered
- [x] WCAG 2.2 SC 2.5.8 ≥ 40px touch target (44px on mobile)
- [x] agent-browser verify mobile reflow
- [x] CI 4/4 — pending

## Test plan

- [ ] Login `orgadmin@maritime.edu` / `orgadmin123` → `/org-admin/dashboard`
- [ ] 2 buttons render top-right (`Xem analytics` + `Mời thành viên`)
- [ ] Click `Xem analytics` → `/org-admin/analytics`
- [ ] Click `Mời thành viên` → `/org-admin/organization`
- [ ] DevTools Tab key → focus ring visible 2px `#0056D2`
- [ ] DevTools 375×812 → buttons stack full-width 44px
- [ ] Print preview → header-actions hidden

## Risk & rollback

- Risk: thấp. Pure FE template + SCSS additions, không đụng TS logic, không đụng BE.
- Rollback: `git revert`. UX quay về header chỉ có H1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)