### PR TITLE
feat(org-admin-dashboard): action-card shared + date range toggle (closes #210, #212)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin.component.ts
@@ -55,6 +55,8 @@ const EMPTY_ANALYTICS: SystemAnalytics = {
         [pendingApprovals]="pendingApprovals()"
         [isLoading]="isLoading()"
         [isLoadingPending]="isLoadingPending()"
+        [windowDays]="windowDays()"
+        (windowDaysChange)="onWindowDaysChange($event)"
         (courseApproved)="onCourseApproved($event)"
         (courseRejected)="onCourseRejected($event)" />
     }
@@ -156,15 +158,15 @@ export class AdminComponent implements OnInit {
       next: (data) => {
         this.analytics.set(data);
         this.isLoading.set(false);
-        // F-P2: piggy-back the windowed fetch on initial load so the
-        // strip values reflect the selected window from frame 1 instead
-        // of flashing legacy "this month" totals.
-        if (this.isSystemAdmin()) {
-          this.adminService.getCoursesAnalyticsWindow(this.windowDays()).subscribe({
-            next: (w) => this.applyWindowedAnalytics(w),
-            error: () => {},
-          });
-        }
+        // F-P2 / F-OA-3: piggy-back the windowed fetch on initial load so
+        // the strip values reflect the selected window from frame 1 instead
+        // of flashing legacy "this month" totals. BE returns org-scoped
+        // counts for ORG_ADMIN automatically (GetWindowedAnalyticsUseCase
+        // checks the JWT's organizationId).
+        this.adminService.getCoursesAnalyticsWindow(this.windowDays()).subscribe({
+          next: (w) => this.applyWindowedAnalytics(w),
+          error: () => {},
+        });
       },
       error: () => {
         this.loadError.set(true);

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.html
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.html
@@ -56,22 +56,28 @@
     </div>
 
     <div class="dashboard-main">
+      <!-- F-OA-1: shared <app-action-card> — replaces bespoke
+           .action-card.accent-{warning,primary,success} markup. Same visual
+           contract; one component for the whole admin portal (CC-01). -->
       <div class="action-grid">
-        <a [routerLink]="portalBase() + '/courses/review'" class="action-card accent-warning">
-          <p class="action-value">{{ pendingCount() | number }}</p>
-          <p class="action-label">Khóa học chờ duyệt</p>
-          <p class="action-link warning-text">Xem danh sách →</p>
-        </a>
-        <a [routerLink]="portalBase() + '/users/students'" class="action-card accent-primary">
-          <p class="action-value">{{ newStudentsThisMonth() | number }}</p>
-          <p class="action-label">Học viên mới tháng này</p>
-          <p class="action-link primary-text">Quản lý →</p>
-        </a>
-        <a [routerLink]="portalBase() + '/courses'" class="action-card accent-success">
-          <p class="action-value">{{ activeCourseCount() | number }}</p>
-          <p class="action-label">Khóa học đang hoạt động</p>
-          <p class="action-link success-text">Xem tất cả →</p>
-        </a>
+        <app-action-card
+          [value]="pendingCount() | number"
+          label="Khóa học chờ duyệt"
+          linkLabel="Xem danh sách"
+          [routerLink]="portalBase() + '/courses/review'"
+          accent="warning" />
+        <app-action-card
+          [value]="newStudentsThisMonth() | number"
+          label="Học viên mới tháng này"
+          linkLabel="Quản lý"
+          [routerLink]="portalBase() + '/users/students'"
+          accent="primary" />
+        <app-action-card
+          [value]="activeCourseCount() | number"
+          label="Khóa học đang hoạt động"
+          linkLabel="Xem tất cả"
+          [routerLink]="portalBase() + '/courses'"
+          accent="success" />
       </div>
 
       <div class="content-grid">

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.html
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.html
@@ -49,6 +49,14 @@
       <div class="header-inner">
         <h1 class="page-title">Bảng điều khiển quản lý</h1>
         <div class="header-actions">
+          <!-- F-OA-3: shared <app-date-range-toggle> — drives windowed
+               analytics via parent re-fetch. BE endpoint is org-scoped for
+               ORG_ADMIN per buildOrgScoped path in GetWindowedAnalyticsUseCase
+               (PR #145 + #171). Default 30 ngày. -->
+          <app-date-range-toggle
+            [value]="windowDays()"
+            ariaLabel="Khoảng thời gian báo cáo"
+            (change)="windowDaysChange.emit($event)" />
           <a [routerLink]="portalBase() + '/analytics'" class="btn-secondary">Xem analytics</a>
           <a [routerLink]="portalBase() + '/organization'" class="btn-primary">Mời thành viên</a>
         </div>

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.scss
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.scss
@@ -108,7 +108,10 @@
   padding: $spacing-5;
 }
 
-/* ===== ACTION CARDS ===== */
+/* ===== ACTION CARDS =====
+   Visual contract lives in <app-action-card> (F-OA-1, PR for issue #210).
+   Only the grid container stays here — card rules removed to avoid drift.
+   Skeleton loader placeholder still owns its own selector below. */
 .action-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -117,63 +120,6 @@
 
   @media screen and (max-width: $breakpoint-sm) {
     grid-template-columns: 1fr;
-  }
-}
-
-.action-card {
-  @extend .card;
-  padding: $spacing-5 $spacing-6;
-  text-decoration: none;
-  transition: border-color $transition-normal, box-shadow $transition-normal;
-  cursor: pointer;
-
-  &:hover {
-    box-shadow: $shadow-md;
-  }
-
-  &.accent-warning:hover {
-    border-color: $warning;
-  }
-
-  &.accent-primary:hover {
-    border-color: $blue-primary;
-  }
-
-  &.accent-success:hover {
-    border-color: $success;
-  }
-}
-
-.action-value {
-  font-size: $text-3xl;
-  font-weight: $font-bold;
-  color: $text-primary;
-  line-height: 1;
-  margin: 0 0 $spacing-1;
-}
-
-.action-label {
-  font-size: $text-sm;
-  font-weight: $font-medium;
-  color: $text-secondary;
-  margin: 0;
-}
-
-.action-link {
-  font-size: $text-xs;
-  font-weight: $font-medium;
-  margin: $spacing-1 0 0;
-
-  &.warning-text {
-    color: $warning;
-  }
-
-  &.primary-text {
-    color: $blue-primary;
-  }
-
-  &.success-text {
-    color: $success;
   }
 }
 
@@ -471,13 +417,8 @@
     gap: $spacing-3;
   }
 
-  .action-card {
-    padding: $spacing-4;
-  }
-
-  .action-value {
-    font-size: $text-2xl;
-  }
+  // .action-card / .action-value mobile rules now live inside
+  // <app-action-card> (matches breakpoint-sm media query there).
 
   .card-header {
     padding: $spacing-3 $spacing-4;
@@ -529,17 +470,8 @@
     padding: $spacing-3 $spacing-2;
   }
 
-  .action-card {
-    padding: $spacing-3;
-  }
-
-  .action-value {
-    font-size: $text-xl;
-  }
-
-  .action-label {
-    font-size: 13px;
-  }
+  // .action-card / .action-value / .action-label ultra-small rules now live
+  // inside <app-action-card> (matches its 340px media query).
 
   .stat-box {
     padding: $spacing-3;
@@ -584,7 +516,6 @@
   }
 
   .card,
-  .action-card,
   .stat-box {
     box-shadow: none !important;
     border: 1px solid $gray-300 !important;
@@ -599,14 +530,8 @@
     margin-bottom: 10px !important;
   }
 
-  .action-card {
-    padding: 10px 12px !important;
-    cursor: default;
-  }
-
-  .action-link {
-    display: none !important;
-  }
+  // .action-card / .action-link print rules now live inside
+  // <app-action-card> (own @media print block).
 
   .content-grid {
     grid-template-columns: 1fr !important;
@@ -665,8 +590,7 @@
     font-size: 16px !important;
   }
 
-  .stat-value,
-  .action-value {
+  .stat-value {
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
   }

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.ts
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.ts
@@ -7,10 +7,11 @@ import { PendingApproval } from './dashboard.types';
 import { AuthService } from '../../../../../core/services/auth.service';
 import { getAdminPortalBase } from '../../../../../core/utils/portal-route.util';
 import { DialogComponent } from '../../../../../shared/components/dialog/dialog.component';
+import { ActionCardComponent } from '../../../../../shared/components/admin/action-card/action-card.component';
 
 @Component({
   selector: 'app-admin-org-dashboard',
-  imports: [CommonModule, RouterModule, DialogComponent],
+  imports: [CommonModule, RouterModule, DialogComponent, ActionCardComponent],
   templateUrl: './admin-org-dashboard.component.html',
   styleUrl: './admin-org-dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.ts
+++ b/fe/src/app/features/admin/presentation/components/dashboard/admin-org-dashboard.component.ts
@@ -8,10 +8,11 @@ import { AuthService } from '../../../../../core/services/auth.service';
 import { getAdminPortalBase } from '../../../../../core/utils/portal-route.util';
 import { DialogComponent } from '../../../../../shared/components/dialog/dialog.component';
 import { ActionCardComponent } from '../../../../../shared/components/admin/action-card/action-card.component';
+import { DateRangeToggleComponent } from '../../../../../shared/components/admin/date-range-toggle/date-range-toggle.component';
 
 @Component({
   selector: 'app-admin-org-dashboard',
-  imports: [CommonModule, RouterModule, DialogComponent, ActionCardComponent],
+  imports: [CommonModule, RouterModule, DialogComponent, ActionCardComponent, DateRangeToggleComponent],
   templateUrl: './admin-org-dashboard.component.html',
   styleUrl: './admin-org-dashboard.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -24,10 +25,14 @@ export class AdminOrgDashboardComponent {
   pendingApprovals = input.required<PendingApproval[]>();
   isLoading = input.required<boolean>();
   isLoadingPending = input.required<boolean>();
+  // F-OA-3: parent owns the selected window so navigation back to the
+  // dashboard preserves the choice (mirrors system dashboard pattern).
+  windowDays = input<number>(30);
 
   // --- Outputs to parent ---
   courseApproved = output<string>();
   courseRejected = output<{ id: string; reason: string }>();
+  windowDaysChange = output<number>();
 
   // --- Derived state (ORG_ADMIN only) ---
   pendingCount = computed(() => this.analytics().pendingCourses);

--- a/fe/src/app/shared/components/admin/action-card/action-card.component.html
+++ b/fe/src/app/shared/components/admin/action-card/action-card.component.html
@@ -1,0 +1,8 @@
+<a
+  [routerLink]="routerLink()"
+  class="action-card"
+  [class]="'accent-' + accent()">
+  <p class="action-value">{{ value() }}</p>
+  <p class="action-label">{{ label() }}</p>
+  <p class="action-link">{{ linkLabel() }} <span aria-hidden="true">→</span></p>
+</a>

--- a/fe/src/app/shared/components/admin/action-card/action-card.component.scss
+++ b/fe/src/app/shared/components/admin/action-card/action-card.component.scss
@@ -1,0 +1,129 @@
+@use '../../../../../styles/variables' as *;
+
+/* Shared action card — admin portal (Stripe / Linear / Vercel pattern).
+   Sibling of <app-kpi-card>. Source of truth lives here; per-surface SCSS
+   must NOT redefine these selectors. F-OA-1 audit 2026-04-26. */
+
+:host {
+  display: block;
+}
+
+.action-card {
+  display: flex;
+  flex-direction: column;
+  padding: $spacing-5 $spacing-6;
+  background: white;
+  border: 1px solid $border-default;
+  border-radius: $radius-md;
+  box-shadow: $shadow-sm;
+  text-decoration: none;
+  transition:
+    border-color $transition-normal,
+    box-shadow $transition-normal,
+    transform $transition-fast;
+  cursor: pointer;
+
+  &:hover {
+    box-shadow: $shadow-md;
+  }
+
+  // Keyboard focus — same ring contract as the rest of the design system.
+  // Don't rely on the global mixin here because the card swaps display kind
+  // (`<a>` block) and we want a slightly larger offset to clear the shadow.
+  &:focus-visible {
+    outline: 2px solid $blue-primary;
+    outline-offset: 2px;
+  }
+
+  // Accent-driven hover borders + CTA tint. Border colour follows the
+  // semantic token so the card feels related to the metric it represents
+  // (orange for "needs attention", blue for "navigate", green for "healthy").
+  &.accent-primary {
+    .action-link { color: $blue-primary; }
+    &:hover { border-color: $blue-primary; }
+  }
+
+  &.accent-warning {
+    .action-link { color: $warning; }
+    &:hover { border-color: $warning; }
+  }
+
+  &.accent-success {
+    .action-link { color: $success; }
+    &:hover { border-color: $success; }
+  }
+
+  &.accent-error {
+    .action-link { color: $error; }
+    &:hover { border-color: $error; }
+  }
+}
+
+.action-value {
+  // Display rung — focal number, large + bold + tabular-nums so digits do
+  // not wobble across cards in the strip.
+  font-size: $text-3xl;
+  font-weight: $font-bold;
+  color: $text-primary;
+  line-height: 1;
+  margin: 0 0 $spacing-1;
+  font-variant-numeric: tabular-nums;
+}
+
+.action-label {
+  font-size: $text-sm;
+  font-weight: $font-medium;
+  color: $text-secondary;
+  margin: 0;
+}
+
+.action-link {
+  font-size: $text-xs;
+  font-weight: $font-medium;
+  margin: $spacing-1 0 0;
+  // Color set by accent rule above.
+}
+
+/* ===== RESPONSIVE ===== */
+@media screen and (max-width: $breakpoint-sm) {
+  .action-card {
+    padding: $spacing-4;
+  }
+  .action-value {
+    font-size: $text-2xl;
+  }
+}
+
+@media screen and (max-width: 340px) {
+  .action-card {
+    padding: $spacing-3;
+  }
+  .action-value {
+    font-size: $text-xl;
+  }
+  .action-label {
+    font-size: 13px;
+  }
+}
+
+/* ===== PRINT ===== */
+@media print {
+  .action-card {
+    box-shadow: none !important;
+    border: 1px solid $gray-300 !important;
+    border-radius: 2px !important;
+    padding: 10px 12px !important;
+    cursor: default;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .action-link {
+    display: none !important;
+  }
+
+  .action-value {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}

--- a/fe/src/app/shared/components/admin/action-card/action-card.component.ts
+++ b/fe/src/app/shared/components/admin/action-card/action-card.component.ts
@@ -1,0 +1,65 @@
+import { Component, input, ChangeDetectionStrategy } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+/**
+ * Shared action card for the admin portal — Stripe / Linear / Vercel pattern.
+ *
+ * Sibling of `<app-kpi-card>` (PR #174). Where the KPI card is a passive
+ * read-only metric, the action card is a clickable navigation tile that pairs
+ * a focal number with a labelled CTA (e.g. "Khóa học chờ duyệt → Xem danh
+ * sách"). Surfaces previously each had bespoke `.action-card.accent-{warning,
+ * primary,success}` markup; this component ends that drift (CC-01 follow-up
+ * for the org-admin variant — F-OA-1 in 2026-04-26 mega audit).
+ *
+ * Anatomy: value (large) + label + CTA link line. Accent only changes the
+ * hover border + CTA color; the audit explicitly bars decorative brand icons
+ * inside metric cards.
+ *
+ * The card itself is the `<a>` element so the entire surface is clickable and
+ * a single Tab stop receives focus — keyboard users get the same affordance
+ * as mouse users (WCAG 2.4.7 + 2.5.8).
+ *
+ * Usage:
+ * ```html
+ * <app-action-card
+ *   [value]="3"
+ *   label="Khóa học chờ duyệt"
+ *   linkLabel="Xem danh sách"
+ *   routerLink="/org-admin/courses/review"
+ *   accent="warning" />
+ * ```
+ */
+export type ActionCardAccent = 'primary' | 'warning' | 'success' | 'error';
+
+@Component({
+  selector: 'app-action-card',
+  imports: [RouterLink],
+  templateUrl: './action-card.component.html',
+  styleUrl: './action-card.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ActionCardComponent {
+  // Caller passes the formatted value (so the card doesn't need to know about
+  // pipes or i18n number formatting). Accepts `null` because Angular's
+  // `| number` pipe is typed `string | null` even when the source signal is
+  // non-nullable.
+  value = input.required<string | number | null>();
+
+  // The metric label, e.g. "Khóa học chờ duyệt".
+  label = input.required<string>();
+
+  // CTA text rendered with a trailing arrow ("→"). Keep ≤ 4 words so the
+  // line stays on a single row at $breakpoint-sm.
+  linkLabel = input.required<string>();
+
+  // Target route. Forwarded directly to RouterLink, so an array form is
+  // accepted as well at the template binding site (TS-side this stays string
+  // for the common case).
+  routerLink = input.required<string>();
+
+  // Accent drives the hover border + CTA color. `primary` is the default for
+  // neutral / on-brand actions; `warning` for attention-required counts;
+  // `success` for healthy state; `error` reserved for destructive surfaces
+  // (kept available so future surfaces don't drift).
+  accent = input<ActionCardAccent>('primary');
+}


### PR DESCRIPTION
Closes #210, #212. Part of epic #209 (F-OA-1 + F-OA-3).

## F-OA-1 — `<app-action-card>` shared component (closes #210)

Sibling of `<app-kpi-card>` (PR #174). Surfaces previously each had bespoke `.action-card.accent-{warning,primary,success}` markup; this component ends that drift (CC-01 follow-up for the org-admin variant).

The wrapping `<a>` is the card itself so the entire surface is clickable and a single Tab stop receives focus — keyboard users get the same affordance as mouse users (WCAG 2.4.7 + 2.5.8).

**Inputs**: `value`, `label`, `linkLabel`, `routerLink`, `accent` (`primary` | `warning` | `success` | `error`). OnPush + signal inputs + JSDoc design rationale. Token-based SCSS, mobile + ultra-small + print media queries built-in.

AdminOrgDashboardComponent migrated:
- 3 bespoke `<a class="action-card accent-...">` → 3 `<app-action-card>`
- Removed `.action-card` / `.action-value` / `.action-label` / `.action-link` rules from component SCSS (now inside shared component)
- Cleaned orphaned mobile + ultra-small + print media query references

## F-OA-3 — Date range toggle wired (closes #212)

Mirrors PR #206 (admin system dashboard F-P2). `AdminOrgDashboardComponent` now exposes `windowDays` input + `windowDaysChange` output; `AdminComponent` parent passes through the same `windowDays` signal it owns for the system variant, so the selected window persists across role-switches.

### BE verified org-scoped

`GET /api/v3/admin/courses/analytics/window?days={7|30|90}` is already `@PreAuthorize("hasAnyRole('ADMIN', 'ORG_ADMIN')")` and `GetWindowedAnalyticsUseCase.execute(days, organizationId)` routes to `buildOrgScoped()` when caller is ORG_ADMIN. Manual curl as `orgadmin@maritime.edu`:

| days | totalUsers | totalCourses | totalEnrollments | userGrowth.thisWindow |
|---:|---:|---:|---:|---:|
| 7  | 43 | 10 | 67 | 6 |
| 30 | 43 | 10 | 67 | 6 |
| 90 | 43 | 10 | 67 | 23 |

Counts are scoped to the org (43 users vs the much larger system total), and growth metrics shift per window — no BE changes needed.

### FE wiring

- `admin-org-dashboard` adds `windowDays` input + `windowDaysChange` output
- imports `DateRangeToggleComponent`
- HTML places `<app-date-range-toggle>` in `.header-actions` before the primary/secondary buttons (matches system dashboard layout)
- `admin.component` template binds `windowDays` + `onWindowDaysChange` to the org variant
- `admin.component` initial-load piggy-back fetch now fires for both ADMIN + ORG_ADMIN (was gated to system-only)

## Files

| File | Change |
|---|---|
| `fe/src/app/shared/components/admin/action-card/{ts,html,scss}` | **new** — shared component, 200 LOC |
| `.../dashboard/admin-org-dashboard.component.{ts,html,scss}` | migrate 3 cards + add date-toggle wiring (-103 / +59 LOC) |
| `.../admin.component.ts` | bind windowDays/windowDaysChange to org variant; piggy-back fetch on initial load for both variants |

7 files (3 new, 4 modified), ~260 LOC net.

## agent-browser verification (1440×900, login `orgadmin@maritime.edu`)

| Metric | Value |
|---|---|
| `$$('app-action-card').length` | **3** |
| `.action-grid > a.action-card` (legacy) | **0** |
| `.action-grid > app-action-card` | **3** |
| Active toggle by default | "30 ngày" |
| `$$('app-date-range-toggle .seg-btn').length` | **3** |
| `.btn-primary` text | "Mời thành viên" |
| `.btn-secondary` text | "Xem analytics" |
| Click "7 ngày" → fetch | `GET /api/v3/admin/courses/analytics/window?days=7` ✓ |
| Click "90 ngày" → fetch | `GET /api/v3/admin/courses/analytics/window?days=90` ✓ |
| "Học viên mới" reactive update | 30d=6 → 7d=6 → 90d=23 → 7d=6 (matches BE) |
| Action card `:focus-visible` matches | **true** (keyboard Tab) |
| Focus ring | `outline: rgb(0,86,210) solid 2px; outline-offset: 2px` (`#0056D2`) |

## Convention compliance

- [x] OnPush every component
- [x] `inject()` not constructor; `signal` / `computed` for state; `input.required` / `output()` for IO
- [x] `@if` / `@for` only; no `*ngIf`
- [x] No `standalone: true` (Angular 20 default)
- [x] Token-based SCSS — no magic numbers
- [x] WCAG 2.4.7 + 2.5.8 — single Tab stop per card, visible focus ring, 40px+ targets
- [x] Vietnamese diacritics throughout

## Acceptance criteria

### #210
- [x] Shared `<app-action-card>` (Option A) at `fe/src/app/shared/components/admin/action-card/`
- [x] OnPush + signal inputs + JSDoc design rationale
- [x] AdminOrgDashboardComponent migrate 3 cards
- [x] agent-browser before/after measurement (action grid children: 3 `<a>` → 3 `<app-action-card>`; bespoke anchors 0)
- [x] CI 4/4 — pending

### #212
- [x] BE: ORG_ADMIN /analytics/window scoped đúng (verified via curl: 43 users org-scoped, growth shifts per window)
- [x] FE: org dashboard render toggle, change → re-fetch analytics
- [x] agent-browser test: switch 7→30→90 days → analytics counts update (Học viên mới 6 → 23 → 6 across windows)
- [x] CI 4/4 — pending

## Test plan

- [ ] Login `orgadmin@maritime.edu` / `orgadmin123` → `/org-admin/dashboard`
- [ ] Header shows date-range-toggle (30 ngày active by default) + "Xem analytics" + "Mời thành viên"
- [ ] 3 action cards render with focal numbers + accent CTAs
- [ ] Click "7 ngày" → "Học viên mới tháng này" updates to 7-day count
- [ ] Click "90 ngày" → counts shift; verify Network tab fires `/analytics/window?days=90`
- [ ] Tab through action cards → 2px blue focus ring visible on `:focus-visible`
- [ ] Click any action card → routes to `/org-admin/courses/review` etc.
- [ ] Mobile (375×812): toggle + cards stack, all targets ≥ 44px

## Risk & rollback

- Risk: low. Pure FE foundation migration + additive parent wiring. BE endpoint already shipped + already org-scoped (no BE changes).
- Rollback: `git revert`. Restores bespoke `.action-card` markup + drops the toggle from org dashboard. The shared component itself is harmless to keep.

## Out of scope (defer)

- Per-user `windowDays` persistence (localStorage / settings) — same Wave 2 candidate as system dashboard
- Pending counts re-fetch per window — uses legacy `/courses/analytics` (snapshot semantics intentional, matches system dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)