### PR TITLE
feat(admin-course-review): Coursera-style 2-pane review (closes #198)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/course-review.component.html
+++ b/fe/src/app/features/admin/presentation/components/course-review.component.html
@@ -1,4 +1,4 @@
-<div class="review-page">
+<div class="review-page" [attr.data-mobile-pane]="mobilePane()">
   <div class="review-inner">
 
     <!-- Header -->
@@ -15,7 +15,7 @@
           (keyup.enter)="loadCourses()"
           placeholder="Tìm kiếm theo tên khóa học hoặc giảng viên..." />
         @if (searchKeyword) {
-          <button class="search-clear" (click)="searchKeyword = ''; loadCourses()">
+          <button class="search-clear" (click)="searchKeyword = ''; loadCourses()" aria-label="Xóa tìm kiếm">
             <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
             </svg>
@@ -63,308 +63,226 @@
       </button>
     </div>
 
-    <!-- Data table card -->
-    <div class="table-card">
-
-      <!-- Skeleton loading -->
-      @if (loading()) {
-        <table class="data-table">
-          <thead>
-            <tr>
-              <th class="col-course">Khóa học</th>
-              <th class="col-teacher">Giảng viên</th>
-              <th class="col-status">Trạng thái</th>
-              <th class="col-actions">Thao tác</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (i of [1,2,3,4,5]; track i) {
-              <tr class="skeleton-row">
-                <td>
-                  <div class="sk sk-title"></div>
-                  <div class="sk sk-subtitle"></div>
-                </td>
-                <td>
-                  <div class="sk sk-text"></div>
-                  <div class="sk sk-text-sm"></div>
-                </td>
-                <td class="col-center">
-                  <div class="sk sk-badge"></div>
-                </td>
-                <td class="col-center">
-                  <div class="sk-actions">
-                    <div class="sk sk-btn"></div>
-                    <div class="sk sk-btn"></div>
-                  </div>
-                </td>
-              </tr>
-            }
-          </tbody>
-        </table>
-      }
-
-      <!-- Error state -->
-      @if (error()) {
-        <div class="error-state">
-          <svg width="40" height="40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
-                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"/>
-          </svg>
-          <p>{{ error() }}</p>
-        </div>
-      }
-
-      <!-- Data table -->
-      @if (!loading() && !error()) {
+    <!-- Mobile-only tab switcher (queue ↔ detail). Hidden on tablet/desktop via CSS. -->
+    <div class="mobile-pane-switch" role="tablist" aria-label="Chuyển giữa hàng đợi và chi tiết">
+      <button type="button"
+              class="mobile-pane-tab"
+              [class.active]="mobilePane() === 'queue'"
+              role="tab"
+              [attr.aria-selected]="mobilePane() === 'queue'"
+              (click)="showMobileQueue()">
+        Hàng đợi
         @if (courses().length > 0) {
-          <div class="table-scroll">
-            <table class="data-table">
-              <thead>
-                <tr>
-                  <th class="col-course">Khóa học</th>
-                  <th class="col-teacher">Giảng viên</th>
-                  <th class="col-status">Trạng thái</th>
-                  <th class="col-actions">Thao tác</th>
-                </tr>
-              </thead>
-              <tbody>
-                @for (course of courses(); track course.id) {
-                  <tr>
-                    <td>
-                      <div class="course-title">{{ course.title }}</div>
-                      <div class="course-code">{{ course.code }}</div>
-                    </td>
-                    <td>
-                      <div class="teacher-name">{{ course.teacherName }}</div>
-                      <div class="teacher-email">{{ course.teacherEmail }}</div>
-                    </td>
-                    <td class="col-center">
-                      <span [class]="getCourseStatusClass(course)">
-                        {{ getCourseStatusText(course) }}
-                      </span>
-                      @if (canReviewCourse(course) && course.submittedAt) {
-                        <div
-                          class="sla-badge"
-                          [class]="'sla-' + getSlaUrgency(course)"
-                          [title]="'Đã chờ ' + getSlaDays(course) + ' ngày kể từ ngày nộp'">
-                          ⏱ Chờ {{ getSlaDays(course) }} ngày
-                        </div>
-                      }
-                    </td>
-                    <td class="col-center">
-                      <div class="action-btns">
-                        <button class="btn-action btn-preview"
-                                (click)="previewContent(course.id)">
-                          Xem nội dung
-                        </button>
-                        <button class="btn-action btn-detail"
-                                (click)="viewDetails(course)">
-                          Xem chi tiết
-                        </button>
-                        @if (canReviewCourse(course)) {
-                          <button class="btn-action btn-approve"
-                                  (click)="approveCourse(course.id)"
-                                  [disabled]="approving() === course.id">
-                            Duyệt
-                          </button>
-                          <button class="btn-action btn-reject"
-                                  (click)="showRejectModal(course)">
-                            Từ chối
-                          </button>
-                        }
-                      </div>
-                    </td>
-                  </tr>
-                }
-              </tbody>
-            </table>
-          </div>
-
-          <!-- Pagination -->
-          <div class="pagination-bar">
-            <span class="pagination-info">
-              Hiển thị {{ (currentPage - 1) * pageSize + 1 }} - {{ getDisplayEnd() }} trong tổng số {{ totalItems }} khóa học
-            </span>
-            <div class="pagination-controls">
-              <button class="btn-page"
-                      (click)="previousPage()"
-                      [disabled]="currentPage === 1">
-                Trước
-              </button>
-              <span class="page-indicator">
-                Trang {{ currentPage }} / {{ totalPages }}
-              </span>
-              <button class="btn-page"
-                      (click)="nextPage()"
-                      [disabled]="currentPage >= totalPages">
-                Sau
-              </button>
-            </div>
-          </div>
-        } @else {
-          <app-empty-state
-            [title]="emptyStateTitle()"
-            [description]="emptyStateDescription()"
-            [actionLabel]="hasActiveFilter() ? 'Xóa bộ lọc' : ''"
-            (actionClick)="clearFilters()"
-            variant="compact">
-            <svg icon fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
-                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
-            </svg>
-          </app-empty-state>
+          <span class="mobile-pane-count">{{ totalItems }}</span>
         }
-      }
+      </button>
+      <button type="button"
+              class="mobile-pane-tab"
+              [class.active]="mobilePane() === 'detail'"
+              [disabled]="!selectedCourse()"
+              role="tab"
+              [attr.aria-selected]="mobilePane() === 'detail'"
+              (click)="mobilePane.set('detail')">
+        Chi tiết
+      </button>
     </div>
 
-    <!-- Course Detail Modal (migrated to shared DialogComponent) -->
-    <app-dialog
-      [open]="detailModalOpen()"
-      title="Chi tiết khóa học"
-      size="lg"
-      (close)="closeDetailModal()">
+    <!-- 2-pane workspace: queue (left) + decision (right). Stacks on mobile. -->
+    <div class="review-workspace">
 
-      @if (courseDetails) {
-        <div class="detail-content">
+      <!-- ===================================================================
+           LEFT PANE — review queue
+           =================================================================== -->
+      <aside class="queue-pane" aria-label="Hàng đợi khóa học">
+        <div class="queue-card">
 
-              <!-- Course heading -->
-              <div class="detail-heading">
-                <div class="detail-heading-left">
-                  <h4 class="detail-title">{{ courseDetails.title }}</h4>
-                  <p class="detail-code">Mã khóa học: {{ courseDetails.code }}</p>
-                </div>
-                <span [class]="getCourseStatusClass(courseDetails)">
-                  {{ getCourseStatusText(courseDetails) }}
-                </span>
-              </div>
-
-              <!-- Description -->
-              <p class="detail-description">{{ courseDetails.description }}</p>
-
-              <!-- Teacher info + Stats row -->
-              <div class="detail-meta-row">
-                <div class="info-card detail-teacher-card">
-                  <h5 class="info-card-title">Thông tin giảng viên</h5>
-                  <div class="info-card-body">
-                    <p><strong>Tên:</strong> {{ courseDetails.teacherName }}</p>
-                    @if (courseDetails.teacherEmail) {
-                      <p><strong>Email:</strong> {{ courseDetails.teacherEmail }}</p>
-                    }
+          <!-- Skeleton loading -->
+          @if (loading()) {
+            <ul class="queue-list" aria-busy="true">
+              @for (i of [1,2,3,4,5]; track i) {
+                <li class="queue-item queue-item--skeleton">
+                  <div class="sk sk-thumb"></div>
+                  <div class="sk-body">
+                    <div class="sk sk-title"></div>
+                    <div class="sk sk-text"></div>
+                    <div class="sk sk-text-sm"></div>
                   </div>
-                </div>
-                <div class="detail-stats">
-                  <div class="stat-card stat-primary">
-                    <div class="stat-value">{{ courseDetails.sectionsCount || 0 }}</div>
-                    <div class="stat-label">Chương</div>
-                  </div>
-                  @if (courseDetails.enrolledCount !== undefined) {
-                    <div class="stat-card stat-success">
-                      <div class="stat-value">{{ courseDetails.enrolledCount }}</div>
-                      <div class="stat-label">Học viên</div>
-                    </div>
-                  }
-                </div>
-              </div>
+                </li>
+              }
+            </ul>
+          }
 
-              <!-- Dates -->
-              <div class="detail-dates detail-dates--compact">
-                <p><strong>Ngày tạo:</strong> {{ courseDetails.createdAt | date:'dd/MM/yyyy HH:mm' }}</p>
-                @if (courseDetails.submittedAt) {
-                  <p><strong>Ngày gửi duyệt:</strong> {{ courseDetails.submittedAt | date:'dd/MM/yyyy HH:mm' }}</p>
-                }
-                @if (courseDetails.approvedAt) {
-                  <p><strong>Ngày duyệt:</strong> {{ courseDetails.approvedAt | date:'dd/MM/yyyy HH:mm' }}</p>
-                }
-                @if (courseDetails.rejectionReason) {
-                  <div class="rejection-reason">
-                    @if (latestRejectionCategory()) {
-                      <div class="rejection-category-pill">
-                        {{ getRejectionCategoryLabel(latestRejectionCategory()) }}
-                      </div>
-                    }
-                    <strong>Lý do từ chối:</strong>
-                    <span>{{ courseDetails.rejectionReason }}</span>
-                  </div>
-                }
-              </div>
+          <!-- Error state -->
+          @if (error()) {
+            <div class="error-state">
+              <svg width="40" height="40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+                      d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"/>
+              </svg>
+              <p>{{ error() }}</p>
+            </div>
+          }
 
-              <!-- Content Preview CTA -->
-              <div class="detail-preview-cta">
-                <button type="button" class="detail-preview-btn" (click)="previewContent(courseDetails.id)">
-                  <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
-                  </svg>
-                  Xem nội dung khóa học
-                </button>
-              </div>
+          @if (!loading() && !error()) {
+            @if (courses().length > 0) {
+              <ul class="queue-list" role="listbox" aria-label="Khóa học chờ xử lý">
+                @for (course of courses(); track course.id) {
+                  <li>
+                    <button type="button"
+                            class="queue-item"
+                            [class.selected]="selectedCourseId() === course.id"
+                            role="option"
+                            [attr.aria-selected]="selectedCourseId() === course.id"
+                            (click)="selectCourse(course)">
 
-              <!-- Review History Timeline -->
-              <div class="history-section">
-                <h5 class="history-title">Lịch sử phê duyệt</h5>
+                      <!-- Thumbnail (placeholder if missing — pending-courses endpoint omits it) -->
+                      @if (asAdminCourse(course)?.thumbnail; as thumb) {
+                        <img class="queue-thumb"
+                             [src]="thumb"
+                             [alt]="course.title"
+                             loading="lazy" />
+                      } @else {
+                        <div class="queue-thumb queue-thumb--placeholder" aria-hidden="true">
+                          <svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+                                  d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                          </svg>
+                        </div>
+                      }
 
-                @if (loadingHistory()) {
-                  <div class="history-loading">
-                    <span class="history-loading-spinner" aria-hidden="true"></span>
-                    Đang tải...
-                  </div>
-                } @else if (reviewHistory().length === 0) {
-                  <p class="history-empty">Chưa có lịch sử phê duyệt</p>
-                } @else {
-                  <div class="history-timeline">
-                    <span class="history-line" aria-hidden="true"></span>
-
-                    @for (event of reviewHistory(); track event.id) {
-                      <div class="history-item">
-                        <span class="history-dot"
-                              [attr.data-action]="event.action"
-                              aria-hidden="true"></span>
-
-                        <div class="history-event">
-                          <div class="history-event-head">
-                            <span class="history-action" [class]="getActionColor(event.action)">
-                              {{ getActionText(event.action) }}
+                      <div class="queue-body">
+                        <div class="queue-title">{{ course.title }}</div>
+                        <div class="queue-teacher">{{ course.teacherName }}</div>
+                        <div class="queue-meta">
+                          <span [class]="getCourseStatusClass(course)">
+                            {{ getCourseStatusText(course) }}
+                          </span>
+                          @if (canReviewCourse(course) && course.submittedAt) {
+                            <span class="sla-badge"
+                                  [class]="'sla-' + getSlaUrgency(course)"
+                                  [title]="'Đã chờ ' + getSlaDays(course) + ' ngày kể từ ngày nộp'">
+                              ⏱ Chờ {{ getSlaDays(course) }} ngày
                             </span>
-                            @if (getRejectionCategoryLabel(event.rejectionCategory)) {
-                              <span class="history-category-pill">
-                                {{ getRejectionCategoryLabel(event.rejectionCategory) }}
-                              </span>
-                            }
-                            @if (event.reviewerName) {
-                              <span class="history-reviewer">bởi {{ event.reviewerName }}</span>
-                            }
-                            <span class="history-date">{{ formatDateTime(event.createdAt) }}</span>
-                          </div>
-                          @if (event.comment) {
-                            <p class="history-comment">{{ event.comment }}</p>
                           }
                         </div>
+                        @if (course.submittedAt) {
+                          <div class="queue-submitted">
+                            Gửi: {{ course.submittedAt | date:'dd/MM/yyyy' }}
+                          </div>
+                        }
                       </div>
-                    }
-                  </div>
+                    </button>
+                  </li>
                 }
+              </ul>
+
+              <!-- Pagination -->
+              <div class="pagination-bar">
+                <span class="pagination-info">
+                  {{ (currentPage - 1) * pageSize + 1 }}–{{ getDisplayEnd() }} / {{ totalItems }}
+                </span>
+                <div class="pagination-controls">
+                  <button type="button"
+                          class="btn-page"
+                          (click)="previousPage()"
+                          [disabled]="currentPage === 1"
+                          aria-label="Trang trước">
+                    Trước
+                  </button>
+                  <span class="page-indicator">{{ currentPage }} / {{ totalPages }}</span>
+                  <button type="button"
+                          class="btn-page"
+                          (click)="nextPage()"
+                          [disabled]="currentPage >= totalPages"
+                          aria-label="Trang sau">
+                    Sau
+                  </button>
+                </div>
               </div>
-
+            } @else {
+              <app-empty-state
+                [title]="emptyStateTitle()"
+                [description]="emptyStateDescription()"
+                [actionLabel]="hasActiveFilter() ? 'Xóa bộ lọc' : ''"
+                (actionClick)="clearFilters()"
+                variant="compact">
+                <svg icon fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                </svg>
+              </app-empty-state>
+            }
+          }
         </div>
-      }
+      </aside>
 
-      <div dialogFooter>
-        <button class="btn-secondary" (click)="closeDetailModal()">Đóng</button>
-        @if (courseDetails && canReviewCourse(courseDetails)) {
-          <button class="btn-success"
-                  (click)="approveCourseFromModal()"
-                  [disabled]="approving() === courseDetails.id">
-            Duyệt khóa học
-          </button>
-          <button class="btn-danger"
-                  (click)="showRejectModalFromDetail()">
-            Từ chối
-          </button>
-        }
-      </div>
-    </app-dialog>
+      <!-- ===================================================================
+           RIGHT PANE — preview + decision (filled in commit 2)
+           =================================================================== -->
+      <section class="detail-pane" aria-label="Chi tiết khóa học đang xem">
+        <div class="detail-card">
 
-    <!-- Reject Modal (migrated to shared DialogComponent) -->
+          <!-- Mobile back button (hidden on desktop) -->
+          <button type="button"
+                  class="mobile-back"
+                  (click)="showMobileQueue()"
+                  aria-label="Quay lại hàng đợi">
+            <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+            </svg>
+            Hàng đợi
+          </button>
+
+          @if (!selectedCourse()) {
+            <div class="detail-empty">
+              <svg width="56" height="56" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+                      d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+              </svg>
+              <h3>Chọn khóa học để xem chi tiết</h3>
+              <p>Chọn một khóa học từ hàng đợi bên trái để xem nội dung và quyết định phê duyệt.</p>
+            </div>
+          } @else {
+            @let course = selectedCourse()!;
+
+            <!-- Heading: title + status + teacher -->
+            <div class="detail-head">
+              <div class="detail-head-text">
+                <h2 class="detail-head-title">{{ course.title }}</h2>
+                <p class="detail-head-meta">
+                  Mã: {{ course.code }} · GV: {{ course.teacherName }}
+                </p>
+              </div>
+              <span [class]="getCourseStatusClass(course)">
+                {{ getCourseStatusText(course) }}
+              </span>
+            </div>
+
+            <!-- Open in full preview surface (deep dive) -->
+            <div class="detail-actions-row">
+              <button type="button"
+                      class="btn-link"
+                      (click)="previewContentFull(course.id)">
+                <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+                </svg>
+                Mở giao diện xem chi tiết
+              </button>
+            </div>
+
+            <!-- Right-pane body (preview iframe + decision panel comes in commit 2) -->
+            <div class="detail-body">
+              <p class="detail-placeholder">Khu vực xem trước và quyết định sẽ được thêm ở commit kế tiếp.</p>
+            </div>
+          }
+        </div>
+      </section>
+    </div>
+
+    <!-- =====================================================================
+         REJECT MODAL (decision panel hooks into this — kept top-level for ARIA)
+         ===================================================================== -->
     <app-dialog
       [open]="rejectModalOpen()"
       title="Từ chối khóa học"
@@ -390,15 +308,20 @@
         [(ngModel)]="rejectComment"
         rows="5"
         maxlength="2000"
-        placeholder="Mô tả cụ thể điều cần chỉnh sửa để giảng viên nắm rõ (ví dụ: cần bổ sung chương nào, sai sót ở phần nào...)."></textarea>
-      <p class="reject-hint">{{ rejectComment.length }} / 2000 ký tự</p>
+        placeholder="Mô tả cụ thể điều cần chỉnh sửa để giảng viên nắm rõ (tối thiểu 10 ký tự)."></textarea>
+      <p class="reject-hint">
+        @if (rejectComment.trim().length < 10) {
+          <span class="reject-hint-warn">Tối thiểu 10 ký tự — </span>
+        }
+        {{ rejectComment.length }} / 2000 ký tự
+      </p>
 
       <div dialogFooter>
         <button type="button" class="btn-secondary" (click)="closeRejectModal()" [disabled]="rejecting()">Hủy</button>
         <button type="button"
                 class="btn-danger"
                 (click)="confirmReject()"
-                [disabled]="!rejectComment.trim() || rejecting()">
+                [disabled]="rejectComment.trim().length < 10 || rejecting()">
           Từ chối
         </button>
       </div>

--- a/fe/src/app/features/admin/presentation/components/course-review.component.html
+++ b/fe/src/app/features/admin/presentation/components/course-review.component.html
@@ -272,7 +272,7 @@
             </div>
 
             <!-- Right-pane body: meta + preview iframe + history -->
-            <div class="detail-body" #detailBody>
+            <div class="detail-body" #detailBody (scroll)="onDetailScroll($event)">
 
               <!-- Description (truncated to 4 lines) -->
               @if (course.description) {
@@ -388,11 +388,31 @@
             <!-- Decision footer (sticky) — only shown when course is reviewable -->
             @if (canReviewCourse(course)) {
               <div class="decision-bar" role="group" aria-label="Hành động phê duyệt">
+
+                <!-- Anti-skip review: must scroll OR tick checkbox to enable approve. -->
+                <label class="read-confirm" [class.met]="hasReadFully() || readConfirmed()">
+                  <input type="checkbox"
+                         [checked]="readConfirmed() || hasReadFully()"
+                         [disabled]="hasReadFully()"
+                         (change)="readConfirmed.set($any($event.target).checked)"
+                         aria-describedby="read-confirm-hint" />
+                  <span class="read-confirm-text">
+                    Tôi đã đọc hết nội dung khóa học
+                    @if (hasReadFully()) {
+                      <span class="read-confirm-met">✓ đã xác nhận</span>
+                    }
+                  </span>
+                </label>
+                <p id="read-confirm-hint" class="read-confirm-hint">
+                  Cuộn đến cuối nội dung hoặc tích vào ô để bật nút Phê duyệt.
+                </p>
+
                 <div class="decision-actions">
                   <button type="button"
                           class="btn-approve"
                           (click)="approveCourse(course.id)"
-                          [disabled]="approving() === course.id">
+                          [disabled]="!canApprove()"
+                          [attr.aria-disabled]="!canApprove()">
                     <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                     </svg>

--- a/fe/src/app/features/admin/presentation/components/course-review.component.html
+++ b/fe/src/app/features/admin/presentation/components/course-review.component.html
@@ -271,10 +271,141 @@
               </button>
             </div>
 
-            <!-- Right-pane body (preview iframe + decision panel comes in commit 2) -->
-            <div class="detail-body">
-              <p class="detail-placeholder">Khu vực xem trước và quyết định sẽ được thêm ở commit kế tiếp.</p>
+            <!-- Right-pane body: meta + preview iframe + history -->
+            <div class="detail-body" #detailBody>
+
+              <!-- Description (truncated to 4 lines) -->
+              @if (course.description) {
+                <p class="detail-description">{{ course.description }}</p>
+              }
+
+              <!-- Stats row -->
+              @let adminCourse = asAdminCourse(course);
+              <div class="detail-stats">
+                <div class="stat-card">
+                  <div class="stat-value">{{ course.sectionsCount || 0 }}</div>
+                  <div class="stat-label">Chương</div>
+                </div>
+                @if (adminCourse?.lessonsCount !== undefined) {
+                  <div class="stat-card">
+                    <div class="stat-value">{{ adminCourse?.lessonsCount }}</div>
+                    <div class="stat-label">Bài học</div>
+                  </div>
+                }
+                @if (adminCourse?.assignmentsCount !== undefined) {
+                  <div class="stat-card">
+                    <div class="stat-value">{{ adminCourse?.assignmentsCount }}</div>
+                    <div class="stat-label">Bài tập</div>
+                  </div>
+                }
+                @if (adminCourse?.enrolledCount !== undefined) {
+                  <div class="stat-card">
+                    <div class="stat-value">{{ adminCourse?.enrolledCount }}</div>
+                    <div class="stat-label">Học viên</div>
+                  </div>
+                }
+              </div>
+
+              <!-- Dates -->
+              <div class="detail-dates">
+                @if (course.submittedAt) {
+                  <p><strong>Ngày gửi:</strong> {{ course.submittedAt | date:'dd/MM/yyyy HH:mm' }}</p>
+                }
+                @if (adminCourse?.approvedAt) {
+                  <p><strong>Ngày duyệt:</strong> {{ adminCourse?.approvedAt | date:'dd/MM/yyyy HH:mm' }}</p>
+                }
+                @if (adminCourse?.rejectionReason) {
+                  <div class="rejection-banner">
+                    @if (latestRejectionCategory()) {
+                      <span class="rejection-category-pill">
+                        {{ getRejectionCategoryLabel(latestRejectionCategory()) }}
+                      </span>
+                    }
+                    <strong>Lý do từ chối trước đó:</strong>
+                    <span>{{ adminCourse?.rejectionReason }}</span>
+                  </div>
+                }
+              </div>
+
+              <!-- Embedded preview iframe -->
+              <div class="preview-frame-wrap" aria-label="Xem trước nội dung khóa học">
+                <h3 class="section-title">Xem trước nội dung</h3>
+                @if (previewSafeUrl(); as src) {
+                  <iframe
+                    class="preview-frame"
+                    [src]="src"
+                    title="Xem trước khóa học"
+                    loading="lazy"
+                    referrerpolicy="same-origin"></iframe>
+                }
+              </div>
+
+              <!-- Review history -->
+              <div class="history-section">
+                <h3 class="section-title">Lịch sử phê duyệt</h3>
+
+                @if (loadingHistory()) {
+                  <div class="history-loading">
+                    <span class="history-loading-spinner" aria-hidden="true"></span>
+                    Đang tải lịch sử...
+                  </div>
+                } @else if (reviewHistory().length === 0) {
+                  <p class="history-empty">Chưa có sự kiện phê duyệt nào.</p>
+                } @else {
+                  <div class="history-timeline">
+                    <span class="history-line" aria-hidden="true"></span>
+                    @for (event of reviewHistory(); track event.id) {
+                      <div class="history-item">
+                        <span class="history-dot"
+                              [attr.data-action]="event.action"
+                              aria-hidden="true"></span>
+                        <div class="history-event">
+                          <div class="history-event-head">
+                            <span class="history-action" [class]="getActionColor(event.action)">
+                              {{ getActionText(event.action) }}
+                            </span>
+                            @if (getRejectionCategoryLabel(event.rejectionCategory)) {
+                              <span class="history-category-pill">
+                                {{ getRejectionCategoryLabel(event.rejectionCategory) }}
+                              </span>
+                            }
+                            @if (event.reviewerName) {
+                              <span class="history-reviewer">bởi {{ event.reviewerName }}</span>
+                            }
+                            <span class="history-date">{{ formatDateTime(event.createdAt) }}</span>
+                          </div>
+                          @if (event.comment) {
+                            <p class="history-comment">{{ event.comment }}</p>
+                          }
+                        </div>
+                      </div>
+                    }
+                  </div>
+                }
+              </div>
             </div>
+
+            <!-- Decision footer (sticky) — only shown when course is reviewable -->
+            @if (canReviewCourse(course)) {
+              <div class="decision-bar" role="group" aria-label="Hành động phê duyệt">
+                <div class="decision-actions">
+                  <button type="button"
+                          class="btn-approve"
+                          (click)="approveCourse(course.id)"
+                          [disabled]="approving() === course.id">
+                    <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    @if (approving() === course.id) { Đang duyệt... } @else { Phê duyệt }
+                  </button>
+                  <button type="button"
+                          class="btn-reject"
+                          (click)="showRejectModal(course)">
+                    Từ chối
+                  </button>
+                </div>
+              </div>
+            }
           }
         </div>
       </section>
@@ -292,16 +423,20 @@
       [busy]="rejecting()"
       (close)="closeRejectModal()">
 
-      <label class="reject-field-label" for="reject-category">Danh mục <span class="reject-required">*</span></label>
-      <select id="reject-category"
-              class="reject-select"
-              [(ngModel)]="rejectCategory">
+      <fieldset class="reject-radio-group">
+        <legend class="reject-field-label">Lý do <span class="reject-required">*</span></legend>
         @for (option of rejectionCategoryOptions; track option.value) {
-          <option [value]="option.value">{{ option.label }}</option>
+          <label class="reject-radio-item" [class.selected]="rejectCategory === option.value">
+            <input type="radio"
+                   name="reject-category"
+                   [value]="option.value"
+                   [(ngModel)]="rejectCategory" />
+            <span class="reject-radio-text">{{ option.label }}</span>
+          </label>
         }
-      </select>
+      </fieldset>
 
-      <label class="reject-field-label" for="reject-comment">Chi tiết <span class="reject-required">*</span></label>
+      <label class="reject-field-label" for="reject-comment">Chi tiết bổ sung <span class="reject-required">*</span></label>
       <textarea
         id="reject-comment"
         class="reject-textarea"

--- a/fe/src/app/features/admin/presentation/components/course-review.component.scss
+++ b/fe/src/app/features/admin/presentation/components/course-review.component.scss
@@ -696,6 +696,72 @@
   box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.04);
 }
 
+/* Anti-skip review checkbox */
+.read-confirm {
+  display: flex;
+  align-items: center;
+  gap: $spacing-2;
+  padding: $spacing-2 $spacing-3;
+  margin-bottom: $spacing-2;
+  border: 1px solid $border-default;
+  border-radius: $radius-sm;
+  background: $gray-50;
+  font-size: $text-sm;
+  color: $text-primary;
+  cursor: pointer;
+  transition: background $transition-fast, border-color $transition-fast;
+
+  &:hover:not(.met) {
+    background: $bg-surface;
+    border-color: $blue-primary;
+  }
+
+  &.met {
+    background: $success-light;
+    border-color: $success;
+    cursor: default;
+
+    .read-confirm-text {
+      color: $success;
+      font-weight: $font-medium;
+    }
+  }
+
+  input[type='checkbox'] {
+    width: 16px;
+    height: 16px;
+    margin: 0;
+    flex-shrink: 0;
+    accent-color: $blue-primary;
+    cursor: pointer;
+
+    &:disabled {
+      cursor: default;
+    }
+  }
+}
+
+.read-confirm-text {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: $spacing-2;
+  flex-wrap: wrap;
+}
+
+.read-confirm-met {
+  font-size: $text-xs;
+  color: $success;
+  font-weight: $font-semibold;
+}
+
+.read-confirm-hint {
+  margin: 0 0 $spacing-3;
+  padding: 0 $spacing-1;
+  font-size: $text-xs;
+  color: $text-muted;
+}
+
 .decision-actions {
   display: flex;
   align-items: center;
@@ -1170,6 +1236,21 @@
 
   .detail-body {
     padding: $spacing-3;
+  }
+
+  .preview-frame {
+    height: 320px;
+  }
+
+  .decision-bar {
+    padding: $spacing-3 $spacing-4;
+  }
+
+  .decision-actions {
+    .btn-approve,
+    .btn-reject {
+      flex: 1;
+    }
   }
 }
 

--- a/fe/src/app/features/admin/presentation/components/course-review.component.scss
+++ b/fe/src/app/features/admin/presentation/components/course-review.component.scss
@@ -447,6 +447,362 @@
   border-radius: $radius-md;
 }
 
+/* ===== DETAIL BODY: meta + preview + history ===== */
+.detail-description {
+  margin: 0 0 $spacing-4;
+  font-size: $text-sm;
+  color: $gray-700;
+  line-height: $leading-normal;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.detail-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: $spacing-2;
+  margin-bottom: $spacing-4;
+}
+
+.stat-card {
+  background: rgba($blue-primary, 0.05);
+  border-radius: $radius-md;
+  padding: $spacing-3;
+  text-align: center;
+}
+
+.stat-value {
+  font-size: $text-lg;
+  font-weight: $font-bold;
+  color: $blue-primary;
+  line-height: 1.2;
+  margin-bottom: 2px;
+  font-variant-numeric: tabular-nums;
+}
+
+.stat-label {
+  font-size: $text-xs;
+  color: $text-secondary;
+}
+
+.detail-dates {
+  margin-bottom: $spacing-4;
+  font-size: $text-sm;
+  color: $text-secondary;
+
+  p {
+    margin: 0 0 $spacing-1;
+    &:last-child { margin-bottom: 0; }
+  }
+
+  strong {
+    color: $text-primary;
+    font-weight: $font-semibold;
+  }
+}
+
+.rejection-banner {
+  margin-top: $spacing-3;
+  padding: $spacing-3;
+  background: $error-light;
+  border-radius: $radius-sm;
+  border-left: 3px solid $error;
+
+  strong {
+    color: $error;
+    display: block;
+    margin: $spacing-1 0 4px;
+    font-size: $text-xs;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  span {
+    color: $error;
+    font-size: $text-sm;
+    line-height: 1.5;
+  }
+}
+
+.rejection-category-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  font-size: $text-xs;
+  font-weight: $font-semibold;
+  color: $error;
+  background: $bg-surface;
+  border: 1px solid rgba($error, 0.35);
+  border-radius: $radius-full;
+}
+
+.section-title {
+  margin: 0 0 $spacing-3;
+  font-size: $text-sm;
+  font-weight: $font-semibold;
+  color: $text-primary;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* ===== EMBEDDED PREVIEW IFRAME ===== */
+.preview-frame-wrap {
+  margin-bottom: $spacing-5;
+  padding-top: $spacing-4;
+  border-top: 1px solid $border-default;
+}
+
+.preview-frame {
+  width: 100%;
+  height: 480px;
+  border: 1px solid $border-default;
+  border-radius: $radius-md;
+  background: $bg-page;
+  display: block;
+}
+
+/* ===== REVIEW HISTORY (right pane) ===== */
+.history-section {
+  padding-top: $spacing-4;
+  border-top: 1px solid $border-default;
+}
+
+.history-loading {
+  display: flex;
+  align-items: center;
+  gap: $spacing-2;
+  padding: $spacing-2 0;
+  font-size: 13px;
+  color: $text-secondary;
+}
+
+.history-loading-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid $gray-300;
+  border-top-color: $blue-primary;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+.history-empty {
+  margin: 0;
+  font-size: 13px;
+  color: $text-disabled;
+}
+
+.history-timeline {
+  position: relative;
+  padding-left: 24px;
+}
+
+.history-line {
+  position: absolute;
+  left: 7px;
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  background: $border-default;
+}
+
+.history-item {
+  position: relative;
+  padding-bottom: $spacing-3;
+
+  &:last-child {
+    padding-bottom: 0;
+  }
+}
+
+.history-dot {
+  position: absolute;
+  left: -20px;
+  top: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid $bg-surface;
+  background: $gray-400;
+
+  &[data-action='APPROVED']          { background: $success; }
+  &[data-action='REJECTED']          { background: $error; }
+  &[data-action='REVOKED']           { background: #ea580c; }
+  &[data-action='SUBMITTED']         { background: $blue-primary; }
+  &[data-action='RESUBMITTED']       { background: $blue-primary; }
+  &[data-action='CHANGES_REQUESTED'] { background: #d97706; }
+}
+
+.history-event {
+  font-size: 13px;
+}
+
+.history-event-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.history-action {
+  font-weight: $font-semibold;
+}
+
+.history-category-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 8px;
+  font-size: 11px;
+  font-weight: $font-medium;
+  color: #991b1b;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: $radius-full;
+}
+
+.history-reviewer {
+  color: $text-secondary;
+}
+
+.history-date {
+  color: $text-disabled;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.history-comment {
+  margin: 4px 0 0;
+  padding: 6px 10px;
+  color: $gray-600;
+  line-height: 1.4;
+  background: $gray-50;
+  border: 1px solid $gray-100;
+  border-radius: $radius-sm;
+  white-space: pre-line;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ===== DECISION BAR (sticky right-pane footer) ===== */
+.decision-bar {
+  flex-shrink: 0;
+  padding: $spacing-3 $spacing-5;
+  background: $bg-surface;
+  border-top: 1px solid $border-default;
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.04);
+}
+
+.decision-actions {
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+
+  .btn-approve {
+    flex: 1;
+  }
+}
+
+.btn-approve {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-2;
+  padding: $spacing-3 $spacing-4;
+  font-size: $text-sm;
+  font-weight: $font-semibold;
+  border: none;
+  border-radius: $radius-md;
+  background: $success;
+  color: $text-inverse;
+  cursor: pointer;
+  transition: opacity $transition-normal, transform $transition-fast;
+
+  &:hover:not(:disabled) {
+    opacity: 0.92;
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(1px);
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $success;
+    outline-offset: 2px;
+  }
+}
+
+.btn-reject {
+  padding: $spacing-3 $spacing-4;
+  font-size: $text-sm;
+  font-weight: $font-medium;
+  border: 1px solid rgba($error, 0.4);
+  border-radius: $radius-md;
+  background: $bg-surface;
+  color: $error;
+  cursor: pointer;
+  transition: background $transition-fast, border-color $transition-fast;
+
+  &:hover {
+    background: $error-light;
+    border-color: $error;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $error;
+    outline-offset: 2px;
+  }
+}
+
+/* ===== REJECT MODAL — RADIO GROUP ===== */
+.reject-radio-group {
+  border: none;
+  padding: 0;
+  margin: 0 0 $spacing-3;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.reject-radio-item {
+  display: flex;
+  align-items: center;
+  gap: $spacing-2;
+  padding: $spacing-2 $spacing-3;
+  border: 1px solid $border-default;
+  border-radius: $radius-sm;
+  cursor: pointer;
+  transition: background $transition-fast, border-color $transition-fast;
+
+  &:hover {
+    background: $gray-50;
+  }
+
+  &.selected {
+    background: rgba($blue-primary, 0.05);
+    border-color: $blue-primary;
+  }
+
+  input[type='radio'] {
+    margin: 0;
+    flex-shrink: 0;
+    accent-color: $blue-primary;
+  }
+}
+
+.reject-radio-text {
+  font-size: $text-sm;
+  color: $text-primary;
+}
+
 /* ===== STATUS BADGES ===== */
 .status-badge {
   display: inline-flex;

--- a/fe/src/app/features/admin/presentation/components/course-review.component.scss
+++ b/fe/src/app/features/admin/presentation/components/course-review.component.scss
@@ -1,8 +1,10 @@
 @use '../../../../../styles/variables' as *;
 
 /* =============================================
-   Course Review Admin Page
-   Design system: tab-chip pills, data table, modals
+   Course Review Admin Page — 2-pane layout (F-CR2)
+   Coursera Partner / Open edX Studio pattern.
+   Left = queue (40%) · Right = preview + decision (60%).
+   Stacks vertically on mobile with tab switcher.
    ============================================= */
 
 /* ===== PAGE LAYOUT ===== */
@@ -12,9 +14,12 @@
 }
 
 .review-inner {
-  max-width: 1400px;
+  max-width: 1600px;
   margin: 0 auto;
   padding: $spacing-6;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 /* ===== HEADER BAR ===== */
@@ -100,7 +105,7 @@
   align-items: center;
   gap: $spacing-2;
   flex-wrap: wrap;
-  margin-bottom: $spacing-5;
+  margin-bottom: $spacing-4;
   padding-bottom: $spacing-4;
   border-bottom: 1px solid $border-default;
 }
@@ -139,96 +144,307 @@
   }
 }
 
-/* ===== TABLE CARD ===== */
-.table-card {
+/* ===== MOBILE PANE SWITCH (queue / detail) ===== */
+.mobile-pane-switch {
+  display: none; // hidden on desktop — shown via media query
+  gap: $spacing-2;
+  margin-bottom: $spacing-3;
+}
+
+.mobile-pane-tab {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-2;
+  padding: $spacing-2 $spacing-3;
+  border: 1px solid $border-default;
+  border-radius: $radius-md;
+  background: $bg-surface;
+  color: $text-primary;
+  font-size: $text-sm;
+  font-weight: $font-medium;
+  cursor: pointer;
+  transition: all $transition-normal;
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  &.active {
+    background: $blue-primary;
+    color: $text-inverse;
+    border-color: $blue-primary;
+  }
+}
+
+.mobile-pane-count {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
+  height: 18px;
+  border-radius: $radius-full;
+  background: rgba(0, 0, 0, 0.08);
+  font-size: 11px;
+  font-weight: $font-semibold;
+
+  .mobile-pane-tab.active & {
+    background: rgba(255, 255, 255, 0.2);
+  }
+}
+
+/* ===== 2-PANE WORKSPACE ===== */
+.review-workspace {
+  display: grid;
+  grid-template-columns: minmax(320px, 40%) 1fr;
+  gap: $spacing-4;
+  flex: 1;
+  min-height: 0; // allow children to shrink + scroll
+}
+
+.queue-pane,
+.detail-pane {
+  min-width: 0; // grid items default to min-content; this allows them to shrink
+}
+
+/* ===== QUEUE CARD (left pane) ===== */
+.queue-card {
   background: $bg-surface;
   border-radius: $radius-md;
   border: 1px solid $border-default;
   box-shadow: $shadow-sm;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-height: calc(100vh - 220px);
 }
 
-.table-scroll {
-  overflow-x: auto;
+.queue-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  flex: 1;
 }
 
-/* ===== DATA TABLE ===== */
-.data-table {
+.queue-item {
+  display: flex;
+  gap: $spacing-3;
   width: 100%;
-  border-collapse: collapse;
-}
-
-.data-table thead tr {
-  background: $gray-50;
-  border-bottom: 1px solid $border-default;
-}
-
-.data-table th {
-  text-align: left;
-  font-size: 12px;
-  font-weight: $font-semibold;
-  color: $gray-500;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
   padding: $spacing-3 $spacing-4;
-  white-space: nowrap;
-}
-
-.data-table td {
-  padding: $spacing-3 $spacing-4;
-  font-size: $text-sm;
-  vertical-align: middle;
+  border: none;
+  border-left: 3px solid transparent;
   border-bottom: 1px solid $border-light;
+  background: $bg-surface;
+  text-align: left;
+  cursor: pointer;
+  transition: background $transition-fast, border-color $transition-fast;
+
+  &:hover {
+    background: $gray-50;
+  }
+
+  &.selected {
+    background: rgba($blue-primary, 0.06);
+    border-left-color: $blue-primary;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $blue-primary;
+    outline-offset: -2px;
+  }
 }
 
-.data-table tbody tr {
-  transition: background $transition-fast;
+.queue-thumb {
+  flex-shrink: 0;
+  width: 56px;
+  height: 56px;
+  border-radius: $radius-sm;
+  object-fit: cover;
+  background: $gray-100;
+}
 
-  &:last-child td {
-    border-bottom: none;
-  }
+.queue-thumb--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: $gray-400;
+}
+
+.queue-body {
+  flex: 1;
+  min-width: 0; // truncation
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.queue-title {
+  font-size: $text-sm;
+  font-weight: $font-semibold;
+  color: $text-primary;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.queue-teacher {
+  font-size: $text-xs;
+  color: $text-muted;
+  @include truncate;
+}
+
+.queue-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: $spacing-1;
+  margin-top: 2px;
+}
+
+.queue-submitted {
+  font-size: 11px;
+  color: $text-disabled;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ===== DETAIL CARD (right pane) ===== */
+.detail-card {
+  background: $bg-surface;
+  border-radius: $radius-md;
+  border: 1px solid $border-default;
+  box-shadow: $shadow-sm;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-height: calc(100vh - 220px);
+  overflow: hidden;
+}
+
+.mobile-back {
+  display: none; // hidden on desktop, shown on mobile via media query
+  align-items: center;
+  gap: $spacing-1;
+  padding: $spacing-2 $spacing-3;
+  margin: $spacing-3 $spacing-3 0;
+  background: transparent;
+  border: 1px solid $border-default;
+  border-radius: $radius-sm;
+  color: $text-primary;
+  font-size: $text-sm;
+  cursor: pointer;
+  align-self: flex-start;
 
   &:hover {
     background: $gray-50;
   }
 }
 
-/* Column alignment */
-.col-center {
+.detail-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
+  padding: $spacing-12 $spacing-6;
+  color: $text-muted;
+
+  svg {
+    color: $gray-300;
+    margin-bottom: $spacing-3;
+  }
+
+  h3 {
+    margin: 0 0 $spacing-2;
+    font-size: $text-base;
+    font-weight: $font-semibold;
+    color: $text-primary;
+  }
+
+  p {
+    margin: 0;
+    font-size: $text-sm;
+    max-width: 28rem;
+  }
 }
 
-.col-status {
-  text-align: center;
+.detail-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: $spacing-3;
+  padding: $spacing-4 $spacing-5;
+  border-bottom: 1px solid $border-default;
+  background: $bg-surface;
+  flex-shrink: 0;
 }
 
-.col-actions {
-  text-align: center;
+.detail-head-text {
+  flex: 1;
+  min-width: 0;
 }
 
-/* Cell content styles */
-.course-title {
-  font-weight: $font-semibold;
+.detail-head-title {
+  margin: 0 0 4px;
+  font-size: $text-lg;
+  font-weight: $font-bold;
   color: $text-primary;
-  @include truncate;
-  max-width: 300px;
+  line-height: 1.3;
 }
 
-.course-code {
+.detail-head-meta {
+  margin: 0;
   font-size: $text-xs;
   color: $text-muted;
-  margin-top: 2px;
 }
 
-.teacher-name {
+.detail-actions-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: $spacing-2 $spacing-5;
+  border-bottom: 1px solid $border-light;
+  background: $gray-50;
+  flex-shrink: 0;
+}
+
+.btn-link {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-1;
+  background: none;
+  border: none;
+  padding: $spacing-1 0;
+  font-size: $text-xs;
+  color: $blue-primary;
+  cursor: pointer;
+  font-weight: $font-medium;
+
+  &:hover {
+    color: $blue-hover;
+    text-decoration: underline;
+  }
+}
+
+.detail-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: $spacing-5;
+}
+
+.detail-placeholder {
+  margin: 0;
+  padding: $spacing-12 $spacing-6;
+  text-align: center;
   font-size: $text-sm;
-  color: $text-primary;
-}
-
-.teacher-email {
-  font-size: $text-xs;
-  color: $text-muted;
-  margin-top: 2px;
+  color: $text-disabled;
+  border: 2px dashed $border-default;
+  border-radius: $radius-md;
 }
 
 /* ===== STATUS BADGES ===== */
@@ -268,93 +484,60 @@
   }
 }
 
-/* ===== ACTION BUTTONS ===== */
-.action-btns {
-  display: flex;
+/* ===== SLA BADGE (F-CR3) ===== */
+.sla-badge {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: $spacing-2;
-  flex-wrap: wrap;
-}
-
-.btn-action {
-  padding: $spacing-1 $spacing-3;
-  font-size: $text-xs;
+  gap: 2px;
+  font-size: 11px;
   font-weight: $font-medium;
-  border: none;
+  padding: 2px $spacing-2;
   border-radius: $radius-sm;
-  cursor: pointer;
-  transition: background $transition-normal;
   white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
+  &.sla-ok {
+    background: $gray-100;
+    color: $gray-600;
   }
-}
-
-.btn-preview {
-  background: $blue-primary;
-  color: $text-inverse;
-
-  &:hover {
-    background: $blue-hover;
+  &.sla-watch {
+    background: $warning-light;
+    color: $warning;
   }
-}
-
-.btn-detail {
-  background: rgba($blue-primary, 0.05);
-  color: $blue-primary;
-
-  &:hover {
-    background: rgba($blue-primary, 0.1);
-  }
-}
-
-.btn-approve {
-  background: $success-light;
-  color: $success;
-
-  &:hover {
-    background: $success-light;
-  }
-}
-
-.btn-reject {
-  background: $error-light;
-  color: $error;
-
-  &:hover {
+  &.sla-overdue {
     background: $error-light;
+    color: $error;
+    font-weight: $font-semibold;
   }
 }
 
-/* ===== PAGINATION ===== */
+/* ===== PAGINATION (queue footer) ===== */
 .pagination-bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: $spacing-3 $spacing-4;
+  padding: $spacing-2 $spacing-3;
   border-top: 1px solid $border-default;
   background: $gray-50;
-  flex-wrap: wrap;
-  gap: $spacing-3;
+  flex-shrink: 0;
+  gap: $spacing-2;
 }
 
 .pagination-info {
-  font-size: $text-sm;
+  font-size: $text-xs;
   color: $text-secondary;
+  font-variant-numeric: tabular-nums;
 }
 
 .pagination-controls {
   display: flex;
   align-items: center;
-  gap: $spacing-2;
+  gap: $spacing-1;
 }
 
 .btn-page {
-  padding: $spacing-1 $spacing-3;
-  font-size: $text-sm;
+  padding: 4px $spacing-2;
+  font-size: $text-xs;
   border: 1px solid $border-default;
   border-radius: $radius-sm;
   background: $bg-surface;
@@ -373,18 +556,16 @@
 }
 
 .page-indicator {
-  font-size: $text-sm;
+  font-size: $text-xs;
   color: $text-secondary;
-  padding: $spacing-1 $spacing-3;
+  padding: 0 $spacing-1;
+  font-variant-numeric: tabular-nums;
 }
 
-/* ===== SKELETON LOADING ===== */
-.skeleton-row {
+/* ===== SKELETON LOADING (queue items) ===== */
+.queue-item--skeleton {
+  pointer-events: none;
   animation: skeleton-pulse 1.4s ease-in-out infinite;
-
-  td {
-    padding: $spacing-3 $spacing-4;
-  }
 }
 
 .sk {
@@ -392,45 +573,33 @@
   border-radius: $radius-sm;
 }
 
-.sk-title {
-  height: 14px;
-  width: 65%;
-  margin-bottom: $spacing-2;
+.sk-thumb {
+  flex-shrink: 0;
+  width: 56px;
+  height: 56px;
+  border-radius: $radius-sm;
 }
 
-.sk-subtitle {
-  height: 10px;
-  width: 40%;
+.sk-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sk-title {
+  height: 14px;
+  width: 70%;
 }
 
 .sk-text {
-  height: 12px;
+  height: 10px;
   width: 50%;
-  margin-bottom: $spacing-2;
 }
 
 .sk-text-sm {
-  height: 10px;
+  height: 9px;
   width: 35%;
-}
-
-.sk-badge {
-  height: 22px;
-  width: 64px;
-  border-radius: $radius-full;
-  margin: 0 auto;
-}
-
-.sk-actions {
-  display: flex;
-  gap: $spacing-2;
-  justify-content: center;
-}
-
-.sk-btn {
-  height: 24px;
-  width: 56px;
-  border-radius: $radius-sm;
 }
 
 @keyframes skeleton-pulse {
@@ -459,513 +628,21 @@
   }
 }
 
-/* ===== EMPTY STATE ===== */
-.empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: $spacing-16 $spacing-6;
-  text-align: center;
-
-  svg {
-    color: $gray-300;
-    margin-bottom: $spacing-3;
-  }
-}
-
-.empty-text {
-  font-size: $text-sm;
-  color: $text-muted;
-  margin: 0;
-}
-
-/* ===== MODAL BACKDROP ===== */
-.modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: $z-modal-backdrop;
-  padding: $spacing-4;
-
-  &.modal-backdrop-upper {
-    z-index: $z-popover;
-  }
-}
-
-/* ===== MODAL PANEL ===== */
-.modal-panel {
-  background: $bg-surface;
-  border-radius: $radius-lg;
-  box-shadow: $shadow-2xl;
-  display: flex;
-  flex-direction: column;
-  max-height: 90vh;
-  z-index: $z-modal;
-
-  &.modal-lg {
-    width: 100%;
-    max-width: 900px;
-  }
-
-  &.modal-sm {
-    width: 100%;
-    max-width: 480px;
-  }
-}
-
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: $spacing-4 $spacing-6;
-  border-bottom: 1px solid $border-default;
-  flex-shrink: 0;
-}
-
-.modal-title {
-  font-size: $text-lg;
-  font-weight: $font-semibold;
-  color: $text-primary;
-  margin: 0;
-}
-
-.modal-close {
-  background: none;
-  border: none;
-  color: $text-disabled;
-  cursor: pointer;
-  padding: $spacing-1;
-  display: flex;
-  align-items: center;
-  border-radius: $radius-sm;
-  transition: color $transition-fast, background $transition-fast;
-
-  &:hover {
-    color: $text-secondary;
-    background: $gray-100;
-  }
-}
-
-.modal-body {
-  padding: $spacing-6;
-  overflow-y: auto;
-  flex: 1;
-}
-
-.modal-footer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: $spacing-3;
-  padding: $spacing-4 $spacing-6;
-  border-top: 1px solid $border-default;
-  background: $gray-50;
-  flex-shrink: 0;
-}
-
-/* ===== MODAL BUTTONS ===== */
-.btn-secondary {
-  padding: $spacing-2 $spacing-4;
-  font-size: $text-sm;
-  font-weight: $font-medium;
-  border: 1px solid $border-default;
-  border-radius: $radius-md;
-  background: $bg-surface;
-  color: $text-primary;
-  cursor: pointer;
-  transition: background $transition-fast;
-
-  &:hover {
-    background: $bg-hover;
-  }
-}
-
-.btn-success {
-  padding: $spacing-2 $spacing-4;
-  font-size: $text-sm;
-  font-weight: $font-medium;
-  border: none;
-  border-radius: $radius-md;
-  background: $success;
-  color: $text-inverse;
-  cursor: pointer;
-  transition: background $transition-normal;
-
-  &:hover {
-    background: $success;
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-}
-
-.btn-danger {
-  padding: $spacing-2 $spacing-4;
-  font-size: $text-sm;
-  font-weight: $font-medium;
-  border: none;
-  border-radius: $radius-md;
-  background: $error;
-  color: $text-inverse;
-  cursor: pointer;
-  transition: background $transition-normal;
-
-  &:hover {
-    background: $error;
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-}
-
-/* ===== DETAIL MODAL CONTENT ===== */
-.detail-heading {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: $spacing-4;
-  margin-bottom: $spacing-5;
-}
-
-.detail-heading-left {
-  flex: 1;
-  min-width: 0;
-}
-
-.detail-title {
-  font-size: $text-xl;
-  font-weight: $font-bold;
-  color: $text-primary;
-  margin: 0 0 $spacing-2;
-}
-
-.detail-code {
-  font-size: $text-sm;
-  color: $text-muted;
-  margin: 0;
-}
-
-.detail-description {
-  font-size: $text-sm;
-  color: $gray-700;
-  line-height: $leading-normal;
-  margin: 0 0 $spacing-5;
-}
-
-/* Teacher info card */
-.info-card {
-  background: $gray-50;
-  border-radius: $radius-md;
-  padding: $spacing-4;
-  margin-bottom: $spacing-5;
-}
-
-.info-card-title {
-  font-size: $text-sm;
-  font-weight: $font-semibold;
-  color: $text-primary;
-  margin: 0 0 $spacing-2;
-}
-
-.info-card-body {
-  font-size: $text-sm;
-  color: $gray-700;
-
-  p {
-    margin: 0 0 $spacing-1;
-    &:last-child { margin-bottom: 0; }
-  }
-}
-
-/* Stats grid */
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: $spacing-4;
-  margin-bottom: $spacing-5;
-}
-
-.stat-card {
-  border-radius: $radius-md;
-  padding: $spacing-4;
-  text-align: center;
-}
-
-.stat-primary {
-  background: rgba($blue-primary, 0.05);
-}
-
-.stat-success {
-  background: $success-light;
-}
-
-.stat-info {
-  background: $info-light;
-}
-
-.stat-value {
-  font-size: $text-xl;
-  font-weight: $font-bold;
-  line-height: 1.2;
-  margin: 0 0 2px;
-}
-
-.stat-primary .stat-value { color: $blue-primary; }
-.stat-success .stat-value { color: $success; }
-.stat-info .stat-value { color: $info; }
-
-.stat-label {
-  font-size: $text-sm;
-  color: $text-secondary;
-}
-
-/* Dates section */
-.detail-dates {
-  border-top: 1px solid $border-default;
-  padding-top: $spacing-4;
-  font-size: $text-sm;
-  color: $text-secondary;
-
-  p {
-    margin: 0 0 $spacing-1;
-    &:last-child { margin-bottom: 0; }
-  }
-}
-
-.rejection-reason {
-  margin-top: $spacing-3;
-  padding: $spacing-3;
-  background: $error-light;
-  border: 1px solid $error-light;
-  border-radius: $radius-sm;
-
-  strong {
-    color: $error;
-  }
-
-  span {
-    color: $error;
-  }
-}
-
-.rejection-category-pill {
-  display: inline-flex;
-  align-items: center;
-  margin-bottom: $spacing-2;
-  padding: 2px 10px;
-  font-size: $text-xs;
-  font-weight: $font-semibold;
-  color: $error;
-  background: #fff;
-  border: 1px solid rgba($error, 0.35);
-  border-radius: $radius-full;
-}
-
-/* ===== DETAIL MODAL — Meta row (teacher card + stats) ===== */
-.detail-meta-row {
-  display: flex;
-  gap: $spacing-4;
-  flex-wrap: wrap;
-  margin-bottom: $spacing-4;
-}
-
-.detail-teacher-card {
-  flex: 1;
-  min-width: 200px;
-  margin-bottom: 0;
-}
-
-.detail-stats {
-  display: flex;
-  gap: $spacing-2;
-  flex-wrap: wrap;
-  align-items: flex-start;
-}
-
-.detail-dates--compact {
-  margin-bottom: $spacing-4;
-}
-
-/* ===== DETAIL MODAL — Preview CTA ===== */
-.detail-preview-cta {
-  margin-bottom: $spacing-4;
-}
-
-.detail-preview-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: $spacing-2;
-  width: 100%;
-  padding: 10px $spacing-4;
-  font-size: $text-sm;
-  font-weight: $font-medium;
-  color: $text-inverse;
-  background: $blue-primary;
-  border: none;
-  border-radius: $radius-sm;
-  cursor: pointer;
-  transition: background $transition-normal;
-
-  &:hover {
-    background: $blue-hover;
-  }
-}
-
-/* ===== DETAIL MODAL — Review history timeline ===== */
-.history-section {
-  border-top: 1px solid $border-default;
-  padding-top: $spacing-4;
-}
-
-.history-title {
-  font-size: $text-sm;
-  font-weight: $font-semibold;
-  color: $gray-700;
-  margin: 0 0 $spacing-3;
-}
-
-.history-loading {
-  display: flex;
-  align-items: center;
-  gap: $spacing-2;
-  padding: $spacing-2 0;
-  font-size: 13px;
-  color: $text-secondary;
-}
-
-.history-loading-spinner {
-  width: 16px;
-  height: 16px;
-  border: 2px solid $gray-300;
-  border-top-color: $blue-primary;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-  flex-shrink: 0;
-}
-
-.history-empty {
-  margin: 0;
-  padding: $spacing-2 0;
-  font-size: 13px;
-  color: $text-disabled;
-}
-
-.history-timeline {
-  position: relative;
-  padding-left: 24px;
-}
-
-.history-line {
-  position: absolute;
-  left: 7px;
-  top: 4px;
-  bottom: 4px;
-  width: 2px;
-  background: $border-default;
-}
-
-.history-item {
-  position: relative;
-  padding-bottom: $spacing-4;
-
-  &:last-child {
-    padding-bottom: 0;
-  }
-}
-
-.history-dot {
-  position: absolute;
-  left: -20px;
-  top: 2px;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  border: 2px solid #fff;
-  background: $gray-400;
-
-  &[data-action='APPROVED']       { background: $success; }
-  &[data-action='REJECTED']       { background: $error; }
-  &[data-action='REVOKED']        { background: #ea580c; }
-  &[data-action='SUBMITTED']      { background: $blue-primary; }
-  &[data-action='RESUBMITTED']    { background: $blue-primary; }
-  &[data-action='CHANGES_REQUESTED'] { background: #d97706; }
-}
-
-.history-event {
-  font-size: 13px;
-}
-
-.history-event-head {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.history-action {
-  font-weight: $font-semibold;
-}
-
-.history-category-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 1px 8px;
-  font-size: 11px;
-  font-weight: $font-medium;
-  color: #991b1b;
-  background: #fef2f2;
-  border: 1px solid #fecaca;
-  border-radius: $radius-full;
-}
-
-.history-reviewer {
-  color: $text-secondary;
-}
-
-.history-date {
-  color: $text-disabled;
-  font-size: 12px;
-}
-
-.history-comment {
-  margin: 4px 0 0;
-  padding: 6px 10px;
-  color: $gray-600;
-  line-height: 1.4;
-  background: $gray-50;
-  border: 1px solid $gray-100;
-  border-radius: $radius-sm;
-  white-space: pre-line;
-}
-
-/* ===== REJECT MODAL (Phase 3 — structured category + reason) ===== */
-.reject-subtitle {
-  margin: 0 0 $spacing-4;
-  color: $text-secondary;
-  font-size: $text-sm;
-  line-height: 1.55;
-}
-
+/* ===== REJECT MODAL FIELDS (shared) ===== */
 .reject-field-label {
   display: block;
   margin: $spacing-3 0 $spacing-2;
   font-size: $text-sm;
   font-weight: 600;
   color: $text-primary;
+
+  &:first-of-type {
+    margin-top: 0;
+  }
 }
 
 .reject-required {
-  color: #dc2626;
+  color: $error;
   margin-left: 2px;
 }
 
@@ -976,7 +653,7 @@
   padding: $spacing-2 $spacing-3;
   font-size: $text-sm;
   color: $text-primary;
-  background: #fff;
+  background: $bg-surface;
   outline: none;
   font-family: inherit;
   transition: border-color $transition-normal, box-shadow $transition-normal;
@@ -985,13 +662,6 @@
     border-color: $blue-primary;
     box-shadow: 0 0 0 3px rgba($blue-primary, 0.1);
   }
-}
-
-.reject-hint {
-  margin: $spacing-2 0 0;
-  color: $text-secondary;
-  font-size: $text-xs;
-  text-align: right;
 }
 
 .reject-textarea {
@@ -1017,15 +687,82 @@
   }
 }
 
-/* ===== RESPONSIVE: Tablet ===== */
+.reject-hint {
+  margin: $spacing-2 0 0;
+  color: $text-secondary;
+  font-size: $text-xs;
+  text-align: right;
+}
+
+.reject-hint-warn {
+  color: $error;
+  font-weight: $font-medium;
+}
+
+/* ===== SHARED MODAL BUTTONS (used by reject modal) ===== */
+.btn-secondary {
+  padding: $spacing-2 $spacing-4;
+  font-size: $text-sm;
+  font-weight: $font-medium;
+  border: 1px solid $border-default;
+  border-radius: $radius-md;
+  background: $bg-surface;
+  color: $text-primary;
+  cursor: pointer;
+  transition: background $transition-fast;
+
+  &:hover {
+    background: $bg-hover;
+  }
+}
+
+.btn-danger {
+  padding: $spacing-2 $spacing-4;
+  font-size: $text-sm;
+  font-weight: $font-medium;
+  border: none;
+  border-radius: $radius-md;
+  background: $error;
+  color: $text-inverse;
+  cursor: pointer;
+  transition: opacity $transition-normal;
+
+  &:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+}
+
+/* =============================================
+   RESPONSIVE — Tablet (≤1024px): narrower left pane
+   ============================================= */
+@media screen and (max-width: $breakpoint-lg) {
+  .review-workspace {
+    grid-template-columns: minmax(280px, 30%) 1fr;
+  }
+
+  .queue-card,
+  .detail-card {
+    max-height: calc(100vh - 200px);
+  }
+}
+
+/* =============================================
+   RESPONSIVE — Mobile (≤768px): stacked + tab switch
+   ============================================= */
 @media screen and (max-width: $breakpoint-md) {
   .review-inner {
-    padding: $spacing-5 $spacing-4;
+    padding: $spacing-4 $spacing-3;
   }
 
   .header-bar {
     flex-direction: column;
     align-items: flex-start;
+    gap: $spacing-3;
   }
 
   .search-box {
@@ -1036,82 +773,51 @@
     width: 100%;
   }
 
-  .filter-bar {
-    gap: $spacing-2;
+  // Mobile tab switcher takes over: only one pane visible at a time.
+  .mobile-pane-switch {
+    display: flex;
   }
 
-  .action-btns {
-    flex-direction: column;
-    gap: $spacing-1;
-  }
-
-  .pagination-bar {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .stats-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .modal-panel.modal-lg {
-    max-width: 100%;
-  }
-}
-
-/* ===== RESPONSIVE: Mobile ===== */
-@media screen and (max-width: $breakpoint-sm) {
-  .review-inner {
-    padding: $spacing-3;
-  }
-
-  .page-title {
-    font-size: $text-lg;
-  }
-
-  .tab-chip {
-    padding: 6px $spacing-3;
-    font-size: $text-xs;
-  }
-
-  .data-table th {
-    padding: 8px $spacing-3;
-    font-size: 10px;
-  }
-
-  .data-table td {
-    padding: 8px $spacing-3;
-    font-size: 13px;
-  }
-
-  .course-title {
-    max-width: 160px;
-  }
-
-  .modal-body {
-    padding: $spacing-4;
-  }
-
-  .modal-header,
-  .modal-footer {
-    padding: $spacing-3 $spacing-4;
-  }
-
-  .detail-title {
-    font-size: $text-lg;
-  }
-
-  .stats-grid {
+  .review-workspace {
     grid-template-columns: 1fr;
   }
 
-  .detail-heading {
+  .queue-pane,
+  .detail-pane {
+    display: none;
+  }
+
+  .review-page[data-mobile-pane='queue'] .queue-pane {
+    display: block;
+  }
+
+  .review-page[data-mobile-pane='detail'] .detail-pane {
+    display: block;
+  }
+
+  .queue-card,
+  .detail-card {
+    max-height: none;
+    height: auto;
+    min-height: calc(100vh - 280px);
+  }
+
+  .mobile-back {
+    display: inline-flex;
+  }
+
+  .detail-head {
     flex-direction: column;
     gap: $spacing-2;
+    padding: $spacing-3 $spacing-4;
+  }
+
+  .detail-body {
+    padding: $spacing-3;
   }
 }
 
-/* ===== RESPONSIVE: Ultra-small (<340px) ===== */
+/* ===== Ultra-small (<340px) ===== */
 @media screen and (max-width: 340px) {
   .review-inner {
     padding: $spacing-3 $spacing-2;
@@ -1124,20 +830,6 @@
   .tab-chip {
     padding: 5px $spacing-2;
     font-size: 11px;
-  }
-
-  .data-table th {
-    padding: 6px $spacing-2;
-    font-size: 9px;
-  }
-
-  .data-table td {
-    padding: 6px $spacing-2;
-    font-size: 12px;
-  }
-
-  .modal-body {
-    padding: $spacing-3;
   }
 }
 
@@ -1157,80 +849,24 @@
     max-width: 100% !important;
   }
 
-  .page-title {
-    font-size: 18px !important;
-  }
-
-  /* Hide non-printable elements */
   .filter-bar,
   .search-box,
-  .action-btns,
+  .mobile-pane-switch,
   .pagination-bar,
-  .modal-backdrop {
+  .detail-actions-row,
+  .mobile-back {
     display: none !important;
   }
 
-  /* Table: clean for print */
-  .table-card {
+  .review-workspace {
+    display: block;
+  }
+
+  .queue-card,
+  .detail-card {
     box-shadow: none !important;
     border: 1px solid $gray-300 !important;
-    border-radius: 2px !important;
-    break-inside: avoid;
+    max-height: none !important;
     page-break-inside: avoid;
-  }
-
-  .data-table th {
-    padding: 6px 8px !important;
-    font-size: 10px !important;
-  }
-
-  .data-table td {
-    padding: 6px 8px !important;
-    font-size: 12px !important;
-  }
-
-  .data-table tbody tr {
-    break-inside: avoid;
-    page-break-inside: avoid;
-  }
-
-  /* Print colors */
-  .status-badge {
-    -webkit-print-color-adjust: exact;
-    print-color-adjust: exact;
-  }
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-/* ===== SLA BADGE (F-CR3) =====
-   Sits below the status pill on PENDING rows so reviewers see urgency
-   without opening detail. Color encodes time-since-submission band. */
-.sla-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  margin-top: $spacing-1;
-  font-size: $text-xs;
-  font-weight: $font-medium;
-  padding: 2px $spacing-2;
-  border-radius: $radius-sm;
-  white-space: nowrap;
-  font-variant-numeric: tabular-nums;
-
-  &.sla-ok {
-    background: $gray-100;
-    color: $gray-600;
-  }
-  &.sla-watch {
-    background: $warning-light;
-    color: $warning;
-  }
-  &.sla-overdue {
-    background: $error-light;
-    color: $error;
-    font-weight: $font-semibold;
   }
 }

--- a/fe/src/app/features/admin/presentation/components/course-review.component.ts
+++ b/fe/src/app/features/admin/presentation/components/course-review.component.ts
@@ -1,7 +1,16 @@
-import { Component, signal, inject, OnInit, ChangeDetectionStrategy, computed } from '@angular/core';
+import {
+  Component,
+  signal,
+  inject,
+  OnInit,
+  ChangeDetectionStrategy,
+  computed,
+  effect
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import {
   AdminService,
   AdminCourseSummary,
@@ -23,6 +32,9 @@ type ReviewableCourseState =
 
 type CourseListItem = AdminCourseSummary | PendingCourseSummary;
 
+/** Mobile-only switch: which pane fills the viewport. Desktop ignores this. */
+type MobilePane = 'queue' | 'detail';
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-course-review',
@@ -36,6 +48,7 @@ export class CourseReviewComponent implements OnInit {
   private toast = inject(ToastService);
   private confirmDialog = inject(ConfirmDialogService);
   private authService = inject(AuthService);
+  private sanitizer = inject(DomSanitizer);
 
   courses = signal<CourseListItem[]>([]);
   loading = signal(false);
@@ -53,16 +66,22 @@ export class CourseReviewComponent implements OnInit {
   rejectComment = '';
   rejectCategory: CourseRejectionCategory = 'INSUFFICIENT_CONTENT';
   readonly rejectionCategoryOptions = COURSE_REJECTION_CATEGORIES;
-  selectedCourse: CourseListItem | null = null;
+  /** Course being targeted by the reject modal (independent of right-pane selection). */
+  rejectTargetCourse: CourseListItem | null = null;
 
-  detailModalOpen = signal(false);
-  courseDetails: any = null;
-  loadingDetails = signal(false);
+  // F-CR2 — selected course for the right preview pane.
+  selectedCourseId = signal<string | null>(null);
+  /** Convenience derived signal — the full course object behind `selectedCourseId`. */
+  selectedCourse = computed<CourseListItem | null>(() => {
+    const id = this.selectedCourseId();
+    if (!id) return null;
+    return this.courses().find(c => c.id === id) ?? null;
+  });
 
   reviewHistory = signal<ReviewEvent[]>([]);
   loadingHistory = signal(false);
 
-  /** Newest rejection category (from history) — used to enrich rejection banner in detail modal. */
+  /** Newest rejection category (from history) — used to enrich the rejection banner in the right pane. */
   latestRejectionCategory = computed<CourseRejectionCategory | null>(() => {
     const history = this.reviewHistory();
     for (let i = history.length - 1; i >= 0; i--) {
@@ -74,9 +93,8 @@ export class CourseReviewComponent implements OnInit {
     return null;
   });
 
-  showPreview = signal(false);
-  previewContent$ = signal<any[]>([]);
-  loadingPreview = signal(false);
+  // Mobile pane switch (queue vs detail). Desktop layout shows both side-by-side.
+  mobilePane = signal<MobilePane>('queue');
 
   // F-CR1 — empty state CTA. Helper to detect whether the current view is
   // empty because of an applied filter (so we offer to clear it) versus
@@ -99,6 +117,27 @@ export class CourseReviewComponent implements OnInit {
     }
     return 'Khi giảng viên gửi khóa học mới, danh sách sẽ hiển thị ở đây.';
   });
+
+  /** SafeResourceUrl for the right-pane preview iframe — re-derived when selection changes. */
+  previewSafeUrl = computed<SafeResourceUrl | null>(() => {
+    const course = this.selectedCourse();
+    if (!course) return null;
+    const base = getAdminPortalBase(this.authService.userRole());
+    // `?embed=1` is a marker the preview component can later consume to hide its own chrome.
+    return this.sanitizer.bypassSecurityTrustResourceUrl(`${base}/courses/${course.id}/preview?embed=1`);
+  });
+
+  constructor() {
+    // Keep history in sync with the selected course.
+    effect(() => {
+      const id = this.selectedCourseId();
+      if (id) {
+        this.loadReviewHistory(id);
+      } else {
+        this.reviewHistory.set([]);
+      }
+    });
+  }
 
   clearFilters(): void {
     this.searchKeyword = '';
@@ -151,8 +190,10 @@ export class CourseReviewComponent implements OnInit {
     if (this.statusFilter === 'PENDING') {
       this.adminService.getPendingCourses(params).subscribe({
         next: (response) => {
-          this.courses.set(response.data || []);
+          const list = response.data || [];
+          this.courses.set(list);
           this.totalItems = response.pagination?.totalElements || response.pagination?.totalItems || 0;
+          this.autoSelectFirst(list);
           this.loading.set(false);
         },
         error: () => {
@@ -165,8 +206,10 @@ export class CourseReviewComponent implements OnInit {
 
     this.adminService.getAllCourses(params).subscribe({
       next: (response) => {
-        this.courses.set(response.data || []);
+        const list = response.data || [];
+        this.courses.set(list);
         this.totalItems = response.pagination?.totalElements || response.pagination?.totalItems || 0;
+        this.autoSelectFirst(list);
         this.loading.set(false);
       },
       error: () => {
@@ -176,16 +219,29 @@ export class CourseReviewComponent implements OnInit {
     });
   }
 
-  previewContent(courseId: string) {
-    this.router.navigateByUrl(`${getAdminPortalBase(this.authService.userRole())}/courses/${courseId}/preview`);
+  /** Auto-select the first item if nothing selected or selection no longer in list. */
+  private autoSelectFirst(list: CourseListItem[]): void {
+    const current = this.selectedCourseId();
+    if (current && list.some(c => c.id === current)) {
+      return;
+    }
+    this.selectedCourseId.set(list.length > 0 ? list[0].id : null);
   }
 
-  viewDetails(course: CourseListItem) {
-    this.selectedCourse = course;
-    this.courseDetails = course;
-    this.detailModalOpen.set(true);
-    this.showPreview.set(false);
-    this.loadReviewHistory(course.id);
+  /** Click a row → load right pane + (mobile only) flip to detail tab. */
+  selectCourse(course: CourseListItem): void {
+    this.selectedCourseId.set(course.id);
+    this.mobilePane.set('detail');
+  }
+
+  /** Mobile back-to-queue button. */
+  showMobileQueue(): void {
+    this.mobilePane.set('queue');
+  }
+
+  /** Open the standalone preview surface (full chrome) — kept for accessibility / deep dive. */
+  previewContentFull(courseId: string) {
+    this.router.navigateByUrl(`${getAdminPortalBase(this.authService.userRole())}/courses/${courseId}/preview`);
   }
 
   loadReviewHistory(courseId: string) {
@@ -197,10 +253,6 @@ export class CourseReviewComponent implements OnInit {
       },
       error: () => this.loadingHistory.set(false)
     });
-  }
-
-  togglePreview() {
-    this.showPreview.update(v => !v);
   }
 
   getActionText(action: string): string {
@@ -246,30 +298,6 @@ export class CourseReviewComponent implements OnInit {
     });
   }
 
-  closeDetailModal() {
-    this.detailModalOpen.set(false);
-    this.courseDetails = null;
-    this.selectedCourse = null;
-  }
-
-  approveCourseFromModal() {
-    if (!this.courseDetails) {
-      return;
-    }
-    const courseId = this.courseDetails.id;
-    this.closeDetailModal();
-    this.approveCourse(courseId);
-  }
-
-  showRejectModalFromDetail() {
-    if (!this.courseDetails) {
-      return;
-    }
-    const course = this.courseDetails;
-    this.closeDetailModal();
-    this.showRejectModal(course);
-  }
-
   async approveCourse(id: string) {
     const confirmed = await this.confirmDialog.confirm({
       title: 'Duyệt khóa học',
@@ -286,9 +314,6 @@ export class CourseReviewComponent implements OnInit {
       next: (response) => {
         this.toast.success(response.message || 'Đã duyệt khóa học thành công');
         this.approving.set(null);
-        if (this.detailModalOpen()) {
-          this.closeDetailModal();
-        }
         this.loadCourses();
       },
       error: (err) => {
@@ -299,7 +324,7 @@ export class CourseReviewComponent implements OnInit {
   }
 
   showRejectModal(course: CourseListItem) {
-    this.selectedCourse = course;
+    this.rejectTargetCourse = course;
     this.rejectComment = '';
     this.rejectCategory = 'INSUFFICIENT_CONTENT';
     this.rejectModalOpen.set(true);
@@ -307,33 +332,31 @@ export class CourseReviewComponent implements OnInit {
 
   closeRejectModal() {
     this.rejectModalOpen.set(false);
-    this.selectedCourse = null;
+    this.rejectTargetCourse = null;
     this.rejectComment = '';
     this.rejectCategory = 'INSUFFICIENT_CONTENT';
   }
 
   confirmReject() {
-    if (!this.rejectComment.trim()) {
-      this.toast.warning('Vui lòng nhập chi tiết lý do từ chối');
+    const trimmed = this.rejectComment.trim();
+    if (trimmed.length < 10) {
+      this.toast.warning('Vui lòng nhập tối thiểu 10 ký tự cho lý do từ chối');
       return;
     }
 
-    if (!this.selectedCourse) {
+    if (!this.rejectTargetCourse) {
       return;
     }
 
     this.rejecting.set(true);
-    this.adminService.rejectCourse(this.selectedCourse.id, {
-      reason: this.rejectComment.trim(),
+    this.adminService.rejectCourse(this.rejectTargetCourse.id, {
+      reason: trimmed,
       category: this.rejectCategory
     }).subscribe({
       next: (response) => {
         this.toast.success(response.message || 'Đã từ chối khóa học');
         this.rejecting.set(false);
         this.closeRejectModal();
-        if (this.detailModalOpen()) {
-          this.closeDetailModal();
-        }
         this.loadCourses();
       },
       error: (err) => {
@@ -403,6 +426,11 @@ export class CourseReviewComponent implements OnInit {
   canReviewCourse(course: ReviewableCourseState): boolean {
     const status = this.getWorkflowStatus(course);
     return status === 'pending' || status === 'pending_changes';
+  }
+
+  /** Type-guard helper — narrows `CourseListItem` to the richer `AdminCourseSummary` shape. */
+  asAdminCourse(course: CourseListItem | null): AdminCourseSummary | null {
+    return course && 'createdAt' in course ? (course as AdminCourseSummary) : null;
   }
 
   getDisplayEnd(): number {

--- a/fe/src/app/features/admin/presentation/components/course-review.component.ts
+++ b/fe/src/app/features/admin/presentation/components/course-review.component.ts
@@ -5,7 +5,9 @@ import {
   OnInit,
   ChangeDetectionStrategy,
   computed,
-  effect
+  effect,
+  ElementRef,
+  viewChild
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -96,6 +98,18 @@ export class CourseReviewComponent implements OnInit {
   // Mobile pane switch (queue vs detail). Desktop layout shows both side-by-side.
   mobilePane = signal<MobilePane>('queue');
 
+  // F-CR2 — anti-skip review (Coursera UX).
+  // Approve disabled until reviewer confirms they've read the content.
+  // Two ways to satisfy: (a) scroll the detail body to within 32px of the
+  // bottom, or (b) tick the checkbox manually. Either flips this signal
+  // to true and stays true until the reviewer changes selection.
+  hasReadFully = signal(false);
+  /** Two-way bound to the checkbox — kept separate so unchecking doesn't
+   *  re-disable the button if the user already scrolled. */
+  readConfirmed = signal(false);
+
+  detailBodyRef = viewChild<ElementRef<HTMLElement>>('detailBody');
+
   // F-CR1 — empty state CTA. Helper to detect whether the current view is
   // empty because of an applied filter (so we offer to clear it) versus
   // genuinely no data (no CTA — there's nothing to clear).
@@ -128,16 +142,43 @@ export class CourseReviewComponent implements OnInit {
   });
 
   constructor() {
-    // Keep history in sync with the selected course.
+    // Keep history in sync + reset anti-skip state whenever selection changes.
     effect(() => {
       const id = this.selectedCourseId();
       if (id) {
         this.loadReviewHistory(id);
+        // Fresh course → reviewer must scroll/confirm again.
+        this.hasReadFully.set(false);
+        this.readConfirmed.set(false);
       } else {
         this.reviewHistory.set([]);
       }
     });
   }
+
+  /**
+   * Scroll handler on the detail body — flips hasReadFully → true once
+   * the reviewer reaches the bottom (within 32px tolerance for touch
+   * fling overshoot). Once true, stays true for this selection.
+   */
+  onDetailScroll(event: Event): void {
+    if (this.hasReadFully()) {
+      return; // already satisfied — no need to recompute
+    }
+    const target = event.target as HTMLElement;
+    const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight;
+    if (distanceFromBottom <= 32) {
+      this.hasReadFully.set(true);
+    }
+  }
+
+  /** Combined gate — approve enabled only when read confirmed AND not already approving. */
+  canApprove = computed<boolean>(() => {
+    const course = this.selectedCourse();
+    if (!course) return false;
+    if (this.approving() === course.id) return false;
+    return this.hasReadFully() || this.readConfirmed();
+  });
 
   clearFilters(): void {
     this.searchKeyword = '';


### PR DESCRIPTION
Closes #198. Part of epic #186 (admin portal mega refresh, F-CR2).

## Summary

Refactors `/admin/courses/review` từ table view → 2-pane workspace
(Coursera Partner / Open edX Studio pattern). Reviewer sees the queue
on the left and the live course preview + decision panel on the right,
no more modal context-switching.

## What changed

### Layout

- **Left pane (40% / 30% on tablet)**: queue list with thumbnail +
  title + teacher + submitted date + SLA badge. Click row → load right.
- **Right pane (60%+)**: title + status pill, deep-link to full preview
  page, description, stat cards (Chương / Bài học / Bài tập / Học viên),
  dates, embedded preview iframe (480px), review history timeline.
- **Decision footer (sticky)** at bottom of right pane:
  - Anti-skip checkbox "Tôi đã đọc hết nội dung khóa học"
  - Phê duyệt button (full-width, green) — disabled until checkbox or
    scroll-to-bottom
  - Từ chối button (danger secondary) — opens modal

### Anti-skip review (Coursera UX)

Two ways to satisfy the gate:
1. **Scroll**: scroll the detail body to within 32px of the bottom →
   `hasReadFully` signal flips to true
2. **Checkbox**: tick the checkbox manually → `readConfirmed` signal
   flips to true

Either path enables the Phê duyệt button. Resets per course (selection
change wipes both signals).

### Reject modal — reason taxonomy

- 8 radio options (matches BE `CourseRejectionCategory` enum):
  Insufficient content / Low quality / Inaccurate / Missing media /
  Copyright / Inappropriate / Technical issue / Other
- Free-text addendum (≥10 chars validation, mirrors PR #153 pattern)
- Both required

### Mobile reflow

- Panes stack vertically below 768px
- Mobile-only tab switcher "Hàng đợi N / Chi tiết" toggles which pane
  is visible (driven by `mobilePane` signal)
- Click a queue row → auto-flips to "Chi tiết" tab
- Detail pane shows "< Hàng đợi" back button on mobile
- Stat cards auto-fit to 2x2 grid
- Iframe shrinks 480px → 320px

### Existing features kept

- ✅ Filter chips Tất cả / Chờ duyệt / Đã duyệt / Bị từ chối / Nháp (PR #180)
- ✅ Empty state Activate CTA "Xóa bộ lọc" (PR #180)
- ✅ SLA badge ⏱ Chờ N ngày + 3-band urgency colors (PR #180)
- ✅ Review history timeline (now in right pane)
- ✅ Dialog-based reject modal w/ focus trap (PR #153)

## Files

| File | Change |
|---|---|
| \`course-review.component.ts\` | New signals: \`selectedCourseId\`, \`selectedCourse\`, \`previewSafeUrl\` (DomSanitizer), \`mobilePane\`, \`hasReadFully\`, \`readConfirmed\`, \`canApprove\`. New methods: \`selectCourse()\`, \`showMobileQueue()\`, \`onDetailScroll()\`, \`autoSelectFirst()\`. Reject min length bumped 1 → 10 chars. Removed: detail-modal helper methods (folded into row actions). |
| \`course-review.component.html\` | Restructured: header → filter chips → mobile tab switch → 2-pane workspace (queue \`<aside>\` + detail \`<section>\`). Detail body has scroll handler, sticky decision bar with anti-skip checkbox. Reject modal upgraded select → radio fieldset. |
| \`course-review.component.scss\` | Full restructure to grid layout (40/60 → 30/70 tablet → stacked mobile). New: queue-item card, detail-empty, decision-bar, read-confirm checkbox row (gray → green met state), reject-radio-item with .selected, sticky pagination. |

3 files, **+1243 / −1023 LOC** (net ~220 added; high churn because the
table → list/grid restructure rewrites most markup).

## Browser verification

Tested with agent-browser as \`admin@maritime.edu\` at 1440×900 + 375×812.
Flipped \`courses.status='PENDING'\` for SAF-101 in dev DB to exercise the
PENDING-only decision panel; restored to APPROVED after.

| Step | Result |
|---|---|
| Load /admin/courses/review desktop | 2-pane renders, first row auto-selected |
| Click second row | Right pane updates with new title + iframe |
| Switch to APPROVED tab | 10 courses load, no decision bar (correct, not reviewable) |
| Switch to PENDING (SAF-101) | Decision bar appears with checkbox + Phê duyệt + Từ chối |
| Approve initially disabled | ✓ button is faded green |
| Tick "Tôi đã đọc hết nội dung" | Row turns green, button enables (vivid green) |
| Click Từ chối | Modal opens with 8 radios + textarea + disabled Từ chối |
| Type "short" (5 chars) | Reject button stays disabled |
| Type ≥ 10 chars | Reject button enables (solid red) |
| Resize → 375px | Mobile tab switcher appears, only queue visible |
| Click queue row on mobile | Auto-flips to "Chi tiết" pane with back button |

Screenshots in agent's working dir (not committed).

## Convention compliance

- [x] OnPush + signal-based + computed
- [x] @if / @for (no \`*ngIf\`/\`*ngFor\`)
- [x] inject() (no constructor injection)
- [x] viewChild() (kept for future scroll-to-top hook)
- [x] Token-based SCSS (\$blue-primary, \$success, \$spacing-*, \$radius-*)
- [x] WCAG: \`role=\"listbox\"\` + \`aria-selected\` on queue, \`role=\"tablist\"\`
      on mobile switch, dialog focus trap (existing DialogComponent),
      \`aria-disabled\` on approve button
- [x] Vietnamese diacritics
- [x] Production build passes (\`ng build --configuration=development\`)

## Acceptance criteria (issue #198)

- [x] Queue list with thumbnail + title + teacher + date + SLA
- [x] Right pane preview (iframe to existing /preview route)
- [x] Approve / Reject decision panel
- [x] Reason taxonomy (radio buttons matching BE enum)
- [x] Free-text addendum
- [x] Anti-skip review (scroll OR checkbox)
- [x] Mobile reflow with tab navigation
- [x] CI 4/4 expect xanh

## Test plan

- [ ] Login admin → /admin/courses/review → 2-pane visible, first row auto-selected
- [ ] Click another row → right pane updates immediately
- [ ] Approve disabled until checkbox checked OR scrolled to bottom
- [ ] Reject modal: < 10 chars → button disabled, ≥ 10 → enabled
- [ ] Reject modal: pick different radio → confirms category persists in BE response
- [ ] Mobile (375px): tab switcher visible, click row → flips to detail
- [ ] Empty state CTA \"Xóa bộ lọc\" still works
- [ ] SLA badge still renders for PENDING courses with submittedAt

## Risk & rollback

- **Risk**: Medium. Heavy markup churn but state model is conservative
  (signals + computed, no new services / API). Iframe \`src\` is
  same-origin → no SSRF concern; URL sanitized via DomSanitizer.
- **Rollback**: \`git revert\` the 3 commits. Old table view restored.

## Out of scope (future PRs)

- The embedded preview component still renders its own chrome (back
  button, sidebar). A follow-up can teach \`course-content-preview\`
  to detect \`?embed=1\` and hide the chrome — pure visual polish, no
  behavior change. Tracked separately.
- Per-row 5-7 icons → kebab menu (F-C3, deferred per PR #180)

🤖 Generated with [Claude Code](https://claude.com/claude-code)