### PR TITLE
feat(admin-shared): app-kebab-menu component + apply users + courses + payouts + categories (closes #197)

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin-payouts.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-payouts.component.ts
@@ -5,6 +5,7 @@ import { AuthService, UserRole } from '../../../../core/services/auth.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 import { DateRangeToggleComponent } from '../../../../shared/components/admin/date-range-toggle/date-range-toggle.component';
+import { KebabMenuComponent, KebabAction } from '../../../../shared/components/admin/kebab-menu/kebab-menu.component';
 
 interface PayoutListItem {
     id: string;
@@ -24,7 +25,7 @@ interface PayoutListItem {
 
 @Component({
     selector: 'app-admin-payouts',
-    imports: [FormsModule, KpiCardComponent, DateRangeToggleComponent],
+    imports: [FormsModule, KpiCardComponent, DateRangeToggleComponent, KebabMenuComponent],
     changeDetection: ChangeDetectionStrategy.OnPush,
     styleUrl: './admin-payouts.component.scss',
     template: `
@@ -181,22 +182,18 @@ interface PayoutListItem {
                           </span>
                         }
                       </td>
+                      <!-- CC-10: per-row kebab replaces 1–2 inline buttons.
+                           Pending → Duyệt + Từ chối. Approved + system admin
+                           → Xác nhận đã CK. Approved + ORG_ADMIN → wait
+                           label (no kebab needed). -->
                       <td class="col-center">
                         <div class="action-cell">
-                          @if (payout.status === 'PENDING') {
-                            <button (click)="openApprove(payout)" class="btn-action btn-approve-action">
-                              Duyệt
-                            </button>
-                            <button (click)="openReject(payout)" class="btn-action btn-reject-action">
-                              Từ chối
-                            </button>
-                          }
-                          @if (payout.status === 'APPROVED' && isSystemAdmin()) {
-                            <button (click)="complete(payout)" class="btn-action btn-complete-action">
-                              Xác nhận đã CK
-                            </button>
-                          }
-                          @if (payout.status === 'APPROVED' && !isSystemAdmin()) {
+                          @if (rowActions(payout).length > 0) {
+                            <app-kebab-menu
+                              [actions]="rowActions(payout)"
+                              [triggerAriaLabel]="'Mở menu thao tác cho yêu cầu của ' + payout.teacherName"
+                              (actionClick)="onRowAction(payout, $event)" />
+                          } @else if (payout.status === 'APPROVED' && !isSystemAdmin()) {
                             <span class="action-wait">Chờ admin hoàn tất</span>
                           }
                         </div>
@@ -450,6 +447,55 @@ export class AdminPayoutsComponent implements OnInit {
         if (this.hasMore()) {
             this.currentPage.update(page => page + 1);
             this.loadPayouts();
+        }
+    }
+
+    /**
+     * CC-10: per-row kebab actions.
+     * - PENDING: Duyệt + Từ chối (anyone with admin role; BE enforces auth).
+     * - APPROVED + system ADMIN: Xác nhận đã CK.
+     * - APPROVED + ORG_ADMIN: empty (template renders the "Chờ admin" label).
+     * - COMPLETED / REJECTED / CANCELLED: empty (no actions left).
+     */
+    rowActions(payout: PayoutListItem): KebabAction[] {
+        const items: KebabAction[] = [];
+        if (payout.status === 'PENDING') {
+            items.push({
+                key: 'approve',
+                label: 'Duyệt',
+                ariaLabel: `Duyệt yêu cầu của ${payout.teacherName}`,
+                icon: 'M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z',
+            });
+            items.push({
+                key: 'reject',
+                label: 'Từ chối',
+                variant: 'danger',
+                ariaLabel: `Từ chối yêu cầu của ${payout.teacherName}`,
+                icon: 'M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z',
+            });
+        }
+        if (payout.status === 'APPROVED' && this.isSystemAdmin()) {
+            items.push({
+                key: 'complete',
+                label: 'Xác nhận đã CK',
+                ariaLabel: `Xác nhận đã chuyển khoản cho ${payout.teacherName}`,
+                icon: 'M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z',
+            });
+        }
+        return items;
+    }
+
+    onRowAction(payout: PayoutListItem, key: string): void {
+        switch (key) {
+            case 'approve':
+                this.openApprove(payout);
+                break;
+            case 'reject':
+                this.openReject(payout);
+                break;
+            case 'complete':
+                this.complete(payout);
+                break;
         }
     }
 

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
@@ -151,31 +151,15 @@
                       {{ admin.loginCount || 0 }} lần
                     </div>
                   </td>
-                  <!-- Actions -->
+                  <!-- Actions — CC-10: replaced inline status select + revoke
+                       icon button with shared kebab menu. Status pill
+                       column above remains read-only. -->
                   <td class="actions-cell">
                     <div class="actions-row">
-                      <!-- Status Actions -->
-                      <select (change)="onStatusActionChange(admin, $any($event.target).value); $any($event.target).value = ''"
-                              class="action-select">
-                        <option value="" disabled selected>Trạng thái</option>
-                        @if (admin.accountStatus !== 'ACTIVE') {
-                          <option value="ACTIVE">Kích hoạt</option>
-                        }
-                        @if (admin.accountStatus !== 'BLOCKED') {
-                          <option value="BLOCKED">Khóa</option>
-                        }
-                        @if (admin.accountStatus !== 'RESTRICTED') {
-                          <option value="RESTRICTED">Hạn chế</option>
-                        }
-                      </select>
-                      <!-- Revoke Admin -->
-                      <button (click)="revokeAdmin(admin)"
-                              class="btn-icon-danger"
-                              title="Thu hồi quyền Admin">
-                        <svg fill="currentColor" viewBox="0 0 20 20">
-                          <path fill-rule="evenodd" d="M13.477 14.89A6 6 0 015.11 6.524l8.367 8.368zm1.414-1.414L6.524 5.11a6 6 0 018.367 8.367zM18 10a8 8 0 11-16 0 8 8 0 0116 0z" clip-rule="evenodd"></path>
-                        </svg>
-                      </button>
+                      <app-kebab-menu
+                        [actions]="rowActions(admin)"
+                        [triggerAriaLabel]="'Mở menu thao tác cho ' + admin.name"
+                        (actionClick)="onRowAction(admin, $event)" />
                     </div>
                   </td>
                 </tr>

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
@@ -10,6 +10,7 @@ import { AuthService } from '../../../../core/services/auth.service';
 import { ConfirmStatusChangeService } from '../../services/confirm-status-change.service';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
+import { KebabMenuComponent, KebabAction } from '../../../../shared/components/admin/kebab-menu/kebab-menu.component';
 /**
  * Admin User Management Component
  * SOTA Design: Coursera-inspired with role change, status actions
@@ -17,7 +18,7 @@ import { BulkActionBarComponent, BulkAction } from '../../../../shared/component
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-admin-user-management',
-  imports: [RouterModule, FormsModule, KpiCardComponent, BulkActionBarComponent],
+  imports: [RouterModule, FormsModule, KpiCardComponent, BulkActionBarComponent, KebabMenuComponent],
   templateUrl: './admin-user-management.component.html',
   styleUrl: './admin-user-management.component.scss'
 })
@@ -158,6 +159,77 @@ export class AdminUserManagementComponent implements OnInit {
 
   clearSelection(): void {
     this.selectedUserIds.set(new Set());
+  }
+
+  // --- Per-row kebab menu (CC-10) ---
+  // Replaces the inline `<select>` Trạng thái + Thu hồi icon button per row.
+  // Status pill stays as a read-only badge in the cell next to the kebab.
+  // Actions surface: Kích hoạt / Khóa / Hạn chế / Đổi vai trò → STUDENT
+  // (= "Thu hồi quyền Admin"). Disabled flags mirror per-row guards
+  // (e.g. cannot block self).
+  rowActions(admin: AdminUser): KebabAction[] {
+    const selfId = this.authService.currentUser()?.id;
+    const isSelf = !!selfId && admin.id === selfId;
+    const status = admin.accountStatus;
+    const items: KebabAction[] = [];
+
+    if (status !== 'ACTIVE') {
+      items.push({
+        key: 'status:ACTIVE',
+        label: 'Kích hoạt',
+        ariaLabel: `Kích hoạt tài khoản ${admin.name}`,
+        icon: 'M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z',
+      });
+    }
+    if (status !== 'BLOCKED') {
+      items.push({
+        key: 'status:BLOCKED',
+        label: 'Khóa',
+        variant: 'danger',
+        disabled: isSelf,
+        ariaLabel: isSelf
+          ? 'Không thể khóa tài khoản của chính bạn'
+          : `Khóa tài khoản ${admin.name}`,
+        icon: 'M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z',
+      });
+    }
+    if (status !== 'RESTRICTED') {
+      items.push({
+        key: 'status:RESTRICTED',
+        label: 'Hạn chế',
+        ariaLabel: `Hạn chế tài khoản ${admin.name}`,
+        icon: 'M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z',
+      });
+    }
+    items.push({
+      key: 'revoke',
+      label: 'Thu hồi quyền Admin',
+      variant: 'danger',
+      disabled: isSelf,
+      ariaLabel: isSelf
+        ? 'Không thể thu hồi quyền của chính bạn'
+        : `Thu hồi quyền Admin của ${admin.name}`,
+      icon: 'M13.477 14.89A6 6 0 015.11 6.524l8.367 8.368zm1.414-1.414L6.524 5.11a6 6 0 018.367 8.367zM18 10a8 8 0 11-16 0 8 8 0 0116 0z',
+    });
+
+    return items;
+  }
+
+  /**
+   * Per-row kebab dispatch. `key` is one of:
+   *   - "status:ACTIVE" / "status:BLOCKED" / "status:RESTRICTED"
+   *   - "revoke" (demote ADMIN → STUDENT — same gate as the previous icon
+   *     button: blocks demoting the only remaining SYSTEM_ADMIN).
+   */
+  onRowAction(admin: AdminUser, key: string): void {
+    if (key === 'revoke') {
+      this.revokeAdmin(admin);
+      return;
+    }
+    if (key.startsWith('status:')) {
+      const newStatus = key.slice('status:'.length);
+      this.onStatusActionChange(admin, newStatus);
+    }
   }
 
   // --- Bulk action dispatcher ---

--- a/fe/src/app/features/admin/presentation/components/category-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/category-management.component.scss
@@ -147,6 +147,16 @@
   color: $error;
 }
 
+/* CC-10: per-row kebab wrapper. Pushes the kebab to the right edge of
+   the row and stops the click from bubbling into selectCategory(). The
+   trigger itself is sized by the shared component. */
+.tree-item-actions {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
 /* Sub-category item */
 .tree-sub-item {
   display: flex;

--- a/fe/src/app/features/admin/presentation/components/category-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/category-management.component.ts
@@ -8,10 +8,11 @@ import {
 } from '@angular/cdk/drag-drop';
 import { AdminService } from '../../infrastructure/services/admin.service';
 import { CourseCategoryDTO, CourseTagDTO } from '../../../../api/types/course.types';
+import { KebabMenuComponent, KebabAction } from '../../../../shared/components/admin/kebab-menu/kebab-menu.component';
 
 @Component({
   selector: 'app-category-management',
-  imports: [CommonModule, FormsModule, DragDropModule],
+  imports: [CommonModule, FormsModule, DragDropModule, KebabMenuComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './category-management.component.scss',
   template: `
@@ -74,6 +75,19 @@ import { CourseCategoryDTO, CourseTagDTO } from '../../../../api/types/course.ty
                       @if (!root.active) {
                         <span class="tree-item-hidden">Ẩn</span>
                       }
+                      <!-- CC-10: per-row kebab. Replaces the implicit
+                           "click row to select then operate from right
+                           panel" gesture with an explicit overflow
+                           surface (Đổi tên / Thêm danh mục con / Ẩn or
+                           Kích hoạt). The wrapper stops click bubbling so
+                           toggling the menu does not also re-select the
+                           row underneath. -->
+                      <span class="tree-item-actions" (click)="$event.stopPropagation()">
+                        <app-kebab-menu
+                          [actions]="rootActions(root)"
+                          [triggerAriaLabel]="'Mở menu thao tác cho danh mục ' + root.name"
+                          (actionClick)="onCategoryAction(root, $event)" />
+                      </span>
                     </div>
 
                     <!-- Sub-category drop list (always present so the user can
@@ -103,6 +117,14 @@ import { CourseCategoryDTO, CourseTagDTO } from '../../../../api/types/course.ty
                             @if (!sub.active) {
                               <span class="tree-item-hidden">Ẩn</span>
                             }
+                            <!-- CC-10: kebab. Sub-category cannot host
+                                 children (level-2 cap), so no "Thêm con". -->
+                            <span class="tree-item-actions" (click)="$event.stopPropagation()">
+                              <app-kebab-menu
+                                [actions]="subActions(sub)"
+                                [triggerAriaLabel]="'Mở menu thao tác cho danh mục ' + sub.name"
+                                (actionClick)="onCategoryAction(sub, $event)" />
+                            </span>
                           </div>
                         } @empty {
                           <div class="tree-sub-empty">Thả vào đây để thêm danh mục con</div>
@@ -449,6 +471,93 @@ export class CategoryManagementComponent implements OnInit {
         this.cancelEdit();
       }
     });
+  }
+
+  // --- Per-row kebab menu (CC-10) ---
+  // Roots get the full action set (rename, add subcategory, hide/activate).
+  // Subs cannot host children (level-2 cap) so the "add sub" entry is
+  // suppressed. The active/inactive state flips between Ẩn (hide) and
+  // Kích hoạt (re-activate) so the danger styling matches user intent.
+
+  rootActions(root: CourseCategoryDTO): KebabAction[] {
+    const isHidden = !root.active;
+    return [
+      {
+        key: 'rename',
+        label: 'Đổi tên / chỉnh sửa',
+        ariaLabel: `Chỉnh sửa danh mục ${root.name}`,
+        icon: 'M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z',
+      },
+      {
+        key: 'add-sub',
+        label: 'Thêm danh mục con',
+        ariaLabel: `Thêm danh mục con dưới ${root.name}`,
+        icon: 'M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z',
+      },
+      isHidden
+        ? {
+            key: 'activate',
+            label: 'Kích hoạt',
+            ariaLabel: `Kích hoạt danh mục ${root.name}`,
+            icon: 'M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z',
+          }
+        : {
+            key: 'hide',
+            label: 'Ẩn danh mục',
+            variant: 'danger',
+            ariaLabel: `Ẩn danh mục ${root.name}`,
+            icon: 'M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z',
+          },
+    ];
+  }
+
+  subActions(sub: CourseCategoryDTO): KebabAction[] {
+    const isHidden = !sub.active;
+    return [
+      {
+        key: 'rename',
+        label: 'Đổi tên / chỉnh sửa',
+        ariaLabel: `Chỉnh sửa danh mục ${sub.name}`,
+        icon: 'M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z',
+      },
+      isHidden
+        ? {
+            key: 'activate',
+            label: 'Kích hoạt',
+            ariaLabel: `Kích hoạt danh mục ${sub.name}`,
+            icon: 'M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z',
+          }
+        : {
+            key: 'hide',
+            label: 'Ẩn danh mục',
+            variant: 'danger',
+            ariaLabel: `Ẩn danh mục ${sub.name}`,
+            icon: 'M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z',
+          },
+    ];
+  }
+
+  onCategoryAction(category: CourseCategoryDTO, key: string): void {
+    switch (key) {
+      case 'rename':
+        // Same flow as click-to-select: opens the right edit panel with
+        // the category's current values seeded in the form.
+        this.selectCategory(category);
+        break;
+      case 'add-sub':
+        // Roots only — uses the existing add-sub plumbing so a follow-up
+        // create call gets parentId set.
+        this.startCreateSub(category);
+        break;
+      case 'hide':
+      case 'activate':
+        // Both routes call deleteCourseCategory which is the BE soft-
+        // delete / re-activate toggle. We seed selectedCategory first so
+        // toggleActive has a target.
+        this.selectedCategory.set(category);
+        this.toggleActive();
+        break;
+    }
   }
 
   private resetForm(): void {

--- a/fe/src/app/features/admin/presentation/components/course-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/course-management.component.html
@@ -215,52 +215,15 @@
                     <td>
                       <div class="students-text">{{ course.enrolledCount || 0 }}</div>
                     </td>
+                    <!-- Actions — CC-10: 5–7 icon buttons collapsed into a
+                         single shared kebab menu. Per-row gates (review,
+                         revoke, system admin) decide which menuitems show. -->
                     <td>
                       <div class="action-btns">
-                        @if (canReviewCourse(course)) {
-                          <button class="act-btn act-approve" (click)="approveCourse(course.id)" title="Phê duyệt" aria-label="Phê duyệt khóa học">
-                            <svg fill="currentColor" viewBox="0 0 20 20">
-                              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path>
-                            </svg>
-                          </button>
-                          <button class="act-btn act-reject" (click)="openRejectModal(course)" title="Từ chối" aria-label="Từ chối khóa học">
-                            <svg fill="currentColor" viewBox="0 0 20 20">
-                              <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
-                            </svg>
-                          </button>
-                        }
-                        @if (canRevokeCourse(course)) {
-                          <button class="act-btn act-revoke" (click)="openRevokeModal(course.id)" title="Thu hồi phê duyệt" aria-label="Thu hồi phê duyệt khóa học">
-                            <svg fill="currentColor" viewBox="0 0 20 20">
-                              <path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"></path>
-                            </svg>
-                          </button>
-                        }
-                        <button class="act-btn act-primary" (click)="previewContent(course.id)" title="Xem nội dung" aria-label="Xem trước nội dung khóa học">
-                          <svg fill="currentColor" viewBox="0 0 20 20">
-                            <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd"></path>
-                          </svg>
-                        </button>
-                        <button class="act-btn act-primary" (click)="viewCourse(course.id)" title="Xem chi tiết" aria-label="Xem chi tiết khóa học">
-                          <svg fill="currentColor" viewBox="0 0 20 20">
-                            <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"></path>
-                            <path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"></path>
-                          </svg>
-                        </button>
-                        @if (isSystemAdmin()) {
-                          <button class="act-btn act-neutral" (click)="editCourse(course.id)" title="Mở trình biên tập" aria-label="Mở trình biên tập khóa học">
-                            <svg fill="currentColor" viewBox="0 0 20 20">
-                              <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"></path>
-                            </svg>
-                          </button>
-                        }
-                        @if (isSystemAdmin()) {
-                          <button class="act-btn act-danger" (click)="deleteCourse(course)" title="Xóa khóa học" aria-label="Xóa khóa học">
-                            <svg fill="currentColor" viewBox="0 0 20 20">
-                              <path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"></path>
-                            </svg>
-                          </button>
-                        }
+                        <app-kebab-menu
+                          [actions]="rowActions(course)"
+                          [triggerAriaLabel]="'Mở menu thao tác cho khóa học ' + course.title"
+                          (actionClick)="onRowAction(course, $event)" />
                       </div>
                     </td>
                   </tr>

--- a/fe/src/app/features/admin/presentation/components/course-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/course-management.component.ts
@@ -10,10 +10,11 @@ import { exportToCsv } from '../../../../shared/utils/csv-export';
 import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
 import { DialogComponent } from '../../../../shared/components/dialog/dialog.component';
 import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
+import { KebabMenuComponent, KebabAction } from '../../../../shared/components/admin/kebab-menu/kebab-menu.component';
 
 @Component({
   selector: 'app-course-management',
-  imports: [RouterModule, FormsModule, DialogComponent, BulkActionBarComponent],
+  imports: [RouterModule, FormsModule, DialogComponent, BulkActionBarComponent, KebabMenuComponent],
   templateUrl: './course-management.component.html',
   styleUrl: './course-management.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -488,6 +489,102 @@ export class CourseManagementComponent implements OnInit {
   canRevokeCourse(course: Pick<AdminCourseSummary, 'status' | 'reviewState'>): boolean {
     const normalizedStatus = this.getWorkflowStatus(course).toLowerCase();
     return normalizedStatus === 'approved' || normalizedStatus === 'active';
+  }
+
+  // --- Per-row kebab menu (CC-10) ---
+  // Replaces the 5–7 icon-button stripe per row with a single overflow
+  // surface. Navigation actions (preview, detail) come first, then review
+  // actions (approve/reject/revoke), then destructive (delete) at the
+  // bottom — matches the standard menu hierarchy used in Stripe/Linear.
+  rowActions(course: AdminCourseSummary): KebabAction[] {
+    const items: KebabAction[] = [];
+
+    // View / preview — always available.
+    items.push({
+      key: 'preview',
+      label: 'Xem trước nội dung',
+      ariaLabel: `Xem trước nội dung khóa học ${course.title}`,
+      icon: 'M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z',
+    });
+    items.push({
+      key: 'detail',
+      label: 'Xem chi tiết',
+      ariaLabel: `Xem chi tiết khóa học ${course.title}`,
+      icon: 'M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z',
+    });
+
+    // Review actions — only when course is in pending state.
+    if (this.canReviewCourse(course)) {
+      items.push({
+        key: 'approve',
+        label: 'Phê duyệt',
+        ariaLabel: `Phê duyệt khóa học ${course.title}`,
+        icon: 'M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z',
+      });
+      items.push({
+        key: 'reject',
+        label: 'Từ chối',
+        variant: 'danger',
+        ariaLabel: `Từ chối khóa học ${course.title}`,
+        icon: 'M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z',
+      });
+    }
+
+    // Revoke approval — only when already approved/active.
+    if (this.canRevokeCourse(course)) {
+      items.push({
+        key: 'revoke',
+        label: 'Thu hồi phê duyệt',
+        variant: 'danger',
+        ariaLabel: `Thu hồi phê duyệt khóa học ${course.title}`,
+        icon: 'M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z',
+      });
+    }
+
+    // System-admin only — open editor + destructive delete.
+    if (this.isSystemAdmin()) {
+      items.push({
+        key: 'edit',
+        label: 'Mở trình biên tập',
+        ariaLabel: `Mở trình biên tập khóa học ${course.title}`,
+        icon: 'M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z',
+      });
+      items.push({
+        key: 'delete',
+        label: 'Xóa khóa học',
+        variant: 'danger',
+        ariaLabel: `Xóa khóa học ${course.title}`,
+        icon: 'M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z',
+      });
+    }
+
+    return items;
+  }
+
+  onRowAction(course: AdminCourseSummary, key: string): void {
+    switch (key) {
+      case 'preview':
+        this.previewContent(course.id);
+        break;
+      case 'detail':
+        this.viewCourse(course.id);
+        break;
+      case 'approve':
+        this.approveCourse(course.id);
+        break;
+      case 'reject':
+        this.openRejectModal(course);
+        break;
+      case 'revoke':
+        this.openRevokeModal(course.id);
+        break;
+      case 'edit':
+        this.editCourse(course.id);
+        break;
+      case 'delete':
+        this.deleteCourse(course);
+        break;
+    }
   }
 
   getLevelText(level: string): string {

--- a/fe/src/app/features/admin/presentation/components/student-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.html
@@ -154,27 +154,14 @@
                   <td>
                     <span class="date-text">{{ student.lastLogin ? formatDateValue(student.lastLogin) : 'Chưa đăng nhập' }}</span>
                   </td>
-                  <!-- Actions -->
+                  <!-- Actions — CC-10: shared kebab replaces inline status
+                       select + delete icon. -->
                   <td class="actions-cell">
                     <div class="actions-row">
-                      <select (change)="onStatusActionChange(student, $any($event.target).value); $any($event.target).value = ''"
-                              class="action-select">
-                        <option value="" disabled selected>Trạng thái</option>
-                        @if (student.accountStatus !== 'ACTIVE') {
-                          <option value="ACTIVE">Kích hoạt</option>
-                        }
-                        @if (student.accountStatus !== 'BLOCKED') {
-                          <option value="BLOCKED">Khóa</option>
-                        }
-                        @if (student.accountStatus !== 'RESTRICTED') {
-                          <option value="RESTRICTED">Hạn chế</option>
-                        }
-                      </select>
-                      <button (click)="deleteUser(student.id)" class="btn-icon-danger" title="Vô hiệu hóa tài khoản">
-                        <svg fill="currentColor" viewBox="0 0 20 20">
-                          <path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"></path>
-                        </svg>
-                      </button>
+                      <app-kebab-menu
+                        [actions]="rowActions(student)"
+                        [triggerAriaLabel]="'Mở menu thao tác cho ' + student.name"
+                        (actionClick)="onRowAction(student, $event)" />
                     </div>
                   </td>
                 </tr>

--- a/fe/src/app/features/admin/presentation/components/student-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.ts
@@ -11,6 +11,7 @@ import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
 import { forkJoin } from 'rxjs';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
+import { KebabMenuComponent, KebabAction } from '../../../../shared/components/admin/kebab-menu/kebab-menu.component';
 
 /**
  * Student Management Component
@@ -19,7 +20,7 @@ import { BulkActionBarComponent, BulkAction } from '../../../../shared/component
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-student-management',
-  imports: [RouterModule, FormsModule, KpiCardComponent, BulkActionBarComponent],
+  imports: [RouterModule, FormsModule, KpiCardComponent, BulkActionBarComponent, KebabMenuComponent],
   // F-ST1 hotfix: was missing — main SCSS file never loaded so .stat-icon
   // had no width/height constraint and stretched to 1136×1136, making the
   // page unusable. Mirrors teacher-management.component.ts:20.
@@ -168,6 +169,61 @@ export class StudentManagementComponent implements OnInit {
 
   clearSelection(): void {
     this.selectedUserIds.set(new Set());
+  }
+
+  // --- Per-row kebab menu (CC-10) ---
+  // Replaces inline `<select>` Trạng thái + Vô hiệu hóa icon button.
+  // Status pill stays as a read-only badge in its own column.
+  rowActions(student: AdminUser): KebabAction[] {
+    const status = student.accountStatus;
+    const items: KebabAction[] = [];
+
+    if (status !== 'ACTIVE') {
+      items.push({
+        key: 'status:ACTIVE',
+        label: 'Kích hoạt',
+        ariaLabel: `Kích hoạt tài khoản ${student.name}`,
+        icon: 'M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z',
+      });
+    }
+    if (status !== 'BLOCKED') {
+      items.push({
+        key: 'status:BLOCKED',
+        label: 'Khóa',
+        variant: 'danger',
+        ariaLabel: `Khóa tài khoản ${student.name}`,
+        icon: 'M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z',
+      });
+    }
+    if (status !== 'RESTRICTED') {
+      items.push({
+        key: 'status:RESTRICTED',
+        label: 'Hạn chế',
+        ariaLabel: `Hạn chế tài khoản ${student.name}`,
+        icon: 'M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z',
+      });
+    }
+    if (this.isSystemAdmin()) {
+      items.push({
+        key: 'delete',
+        label: 'Vô hiệu hóa tài khoản',
+        variant: 'danger',
+        ariaLabel: `Vô hiệu hóa tài khoản ${student.name}`,
+        icon: 'M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z',
+      });
+    }
+
+    return items;
+  }
+
+  onRowAction(student: AdminUser, key: string): void {
+    if (key === 'delete') {
+      this.deleteUser(student.id);
+      return;
+    }
+    if (key.startsWith('status:')) {
+      this.onStatusActionChange(student, key.slice('status:'.length));
+    }
   }
 
   // --- Bulk action dispatcher ---

--- a/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
@@ -11,6 +11,7 @@ import { AuthService } from '../../../../core/services/auth.service';
 import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
+import { KebabMenuComponent, KebabAction } from '../../../../shared/components/admin/kebab-menu/kebab-menu.component';
 
 /**
  * Teacher Management Component
@@ -19,7 +20,7 @@ import { BulkActionBarComponent, BulkAction } from '../../../../shared/component
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-teacher-management',
-  imports: [RouterModule, FormsModule, KpiCardComponent, BulkActionBarComponent],
+  imports: [RouterModule, FormsModule, KpiCardComponent, BulkActionBarComponent, KebabMenuComponent],
   styleUrl: './teacher-management.component.scss',
   templateUrl: './teacher-management.html'
 })
@@ -164,6 +165,65 @@ export class TeacherManagementComponent implements OnInit {
 
   clearSelection(): void {
     this.selectedUserIds.set(new Set());
+  }
+
+  // --- Per-row kebab menu (CC-10) ---
+  // Replaces the inline `<select>` Trạng thái + Vô hiệu hóa icon button.
+  // Status pill stays as a read-only badge in its own column. The kebab
+  // surfaces Kích hoạt / Khóa / Hạn chế and (system-admin only) Vô hiệu
+  // hóa tài khoản.
+  rowActions(teacher: AdminUser): KebabAction[] {
+    const status = teacher.accountStatus;
+    const items: KebabAction[] = [];
+
+    if (status !== 'ACTIVE') {
+      items.push({
+        key: 'status:ACTIVE',
+        label: 'Kích hoạt',
+        ariaLabel: `Kích hoạt tài khoản ${teacher.name}`,
+        icon: 'M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z',
+      });
+    }
+    if (status !== 'BLOCKED') {
+      items.push({
+        key: 'status:BLOCKED',
+        label: 'Khóa',
+        variant: 'danger',
+        ariaLabel: `Khóa tài khoản ${teacher.name}`,
+        icon: 'M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z',
+      });
+    }
+    if (status !== 'RESTRICTED') {
+      items.push({
+        key: 'status:RESTRICTED',
+        label: 'Hạn chế',
+        ariaLabel: `Hạn chế tài khoản ${teacher.name}`,
+        icon: 'M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z',
+      });
+    }
+    // System admin gets the destructive Vô hiệu hóa lever; ORG_ADMIN does
+    // not (mirrors the per-row icon button gate that was here before).
+    if (this.isSystemAdmin()) {
+      items.push({
+        key: 'delete',
+        label: 'Vô hiệu hóa tài khoản',
+        variant: 'danger',
+        ariaLabel: `Vô hiệu hóa tài khoản ${teacher.name}`,
+        icon: 'M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z',
+      });
+    }
+
+    return items;
+  }
+
+  onRowAction(teacher: AdminUser, key: string): void {
+    if (key === 'delete') {
+      this.deleteUser(teacher.id);
+      return;
+    }
+    if (key.startsWith('status:')) {
+      this.onStatusActionChange(teacher, key.slice('status:'.length));
+    }
   }
 
   // --- Bulk action dispatcher ---

--- a/fe/src/app/features/admin/presentation/components/teacher-management.html
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.html
@@ -162,29 +162,14 @@
                       <td>
                         <span class="date-text">{{ teacher.lastLogin ? formatDateValue(teacher.lastLogin) : 'Chưa đăng nhập' }}</span>
                       </td>
-                      <!-- Actions -->
+                      <!-- Actions — CC-10: shared kebab replaces inline
+                           status select + delete icon. -->
                       <td>
                         <div class="actions-cell">
-                          <!-- Status Actions -->
-                          <select (change)="onStatusActionChange(teacher, $any($event.target).value); $any($event.target).value = ''"
-                                  class="status-select">
-                            <option value="" disabled selected>Trạng thái</option>
-                            @if (teacher.accountStatus !== 'ACTIVE') {
-                              <option value="ACTIVE">Kích hoạt</option>
-                            }
-                            @if (teacher.accountStatus !== 'BLOCKED') {
-                              <option value="BLOCKED">Khóa</option>
-                            }
-                            @if (teacher.accountStatus !== 'RESTRICTED') {
-                              <option value="RESTRICTED">Hạn chế</option>
-                            }
-                          </select>
-                          <!-- Delete -->
-                          <button (click)="deleteUser(teacher.id)" class="btn-delete" title="Vô hiệu hóa tài khoản">
-                            <svg fill="currentColor" viewBox="0 0 20 20">
-                              <path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"></path>
-                            </svg>
-                          </button>
+                          <app-kebab-menu
+                            [actions]="rowActions(teacher)"
+                            [triggerAriaLabel]="'Mở menu thao tác cho ' + teacher.name"
+                            (actionClick)="onRowAction(teacher, $event)" />
                         </div>
                       </td>
                     </tr>

--- a/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.ts
+++ b/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.ts
@@ -4,10 +4,11 @@ import { FormsModule } from '@angular/forms';
 import { UserManagementState } from '../../state/user-management.state';
 import { AdminUser } from '../../../../../infrastructure/services/admin.service';
 import { exportToCsv } from '../../../../../../../shared/utils/csv-export';
+import { KebabMenuComponent, KebabAction } from '../../../../../../../shared/components/admin/kebab-menu/kebab-menu.component';
 
 @Component({
   selector: 'app-users-table',
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, KebabMenuComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [`
     select.role-select {
@@ -139,33 +140,19 @@ import { exportToCsv } from '../../../../../../../shared/utils/csv-export';
                       </span>
                     }
                   </td>
-                  <!-- Thao tác -->
+                  <!-- Thao tác — CC-10: shared kebab consolidates the inline
+                       status select + delete icon into a single overflow
+                       menu. Per-row guards (status/delete privileges) gate
+                       which actions appear in the menu. -->
                   <td class="px-6 py-4 whitespace-nowrap text-center text-sm font-medium">
-                    <div class="flex items-center justify-center space-x-1">
-                      @if (state.canChangeStatus(user)) {
-                        <select (change)="onStatusAction(user, $any($event.target).value); $any($event.target).value = ''"
-                                class="text-xs px-2 py-1 border border-gray-300 rounded bg-white cursor-pointer hover:border-gray-400 focus:outline-none focus:ring-1 focus:ring-[#0056D2]"
-                                title="Thay đổi trạng thái">
-                          <option value="" disabled selected>Trạng thái</option>
-                          @if (user.accountStatus !== 'ACTIVE') {
-                            <option value="ACTIVE">Kích hoạt</option>
-                          }
-                          @if (user.accountStatus !== 'BLOCKED') {
-                            <option value="BLOCKED">Khóa</option>
-                          }
-                          @if (user.accountStatus !== 'RESTRICTED') {
-                            <option value="RESTRICTED">Hạn chế</option>
-                          }
-                        </select>
-                      }
-                      @if (state.canDeleteUser(user)) {
-                        <button (click)="state.deleteUser(user.id)"
-                                class="p-2 text-gray-600 hover:text-red-600 hover:bg-red-50 rounded transition-colors"
-                                title="Vô hiệu hóa tài khoản">
-                          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                            <path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"></path>
-                          </svg>
-                        </button>
+                    <div class="flex items-center justify-center">
+                      @if (rowActionsFor(user).length > 0) {
+                        <app-kebab-menu
+                          [actions]="rowActionsFor(user)"
+                          [triggerAriaLabel]="'Mở menu thao tác cho ' + user.name"
+                          (actionClick)="onRowAction(user, $event)" />
+                      } @else {
+                        <span class="text-xs text-gray-400">—</span>
                       }
                     </div>
                   </td>
@@ -276,6 +263,69 @@ export class UsersTableComponent {
   onStatusAction(user: AdminUser, status: string): void {
     if (status) {
       this.statusAction.emit({ user, status });
+    }
+  }
+
+  /**
+   * Per-row kebab actions for the all-users surface. Honours the same
+   * guards the previous inline controls did:
+   *  - status changes only when `state.canChangeStatus(user)`
+   *  - Vô hiệu hóa only when `state.canDeleteUser(user)` (ADMIN only)
+   * If neither permission is granted (e.g. ORG_ADMIN viewing an ADMIN row)
+   * the kebab is suppressed entirely — the cell renders an em-dash.
+   */
+  rowActionsFor(user: AdminUser): KebabAction[] {
+    const items: KebabAction[] = [];
+    const status = user.accountStatus;
+
+    if (this.state.canChangeStatus(user)) {
+      if (status !== 'ACTIVE') {
+        items.push({
+          key: 'status:ACTIVE',
+          label: 'Kích hoạt',
+          ariaLabel: `Kích hoạt tài khoản ${user.name}`,
+          icon: 'M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z',
+        });
+      }
+      if (status !== 'BLOCKED') {
+        items.push({
+          key: 'status:BLOCKED',
+          label: 'Khóa',
+          variant: 'danger',
+          ariaLabel: `Khóa tài khoản ${user.name}`,
+          icon: 'M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z',
+        });
+      }
+      if (status !== 'RESTRICTED') {
+        items.push({
+          key: 'status:RESTRICTED',
+          label: 'Hạn chế',
+          ariaLabel: `Hạn chế tài khoản ${user.name}`,
+          icon: 'M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z',
+        });
+      }
+    }
+
+    if (this.state.canDeleteUser(user)) {
+      items.push({
+        key: 'delete',
+        label: 'Vô hiệu hóa tài khoản',
+        variant: 'danger',
+        ariaLabel: `Vô hiệu hóa tài khoản ${user.name}`,
+        icon: 'M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z',
+      });
+    }
+
+    return items;
+  }
+
+  onRowAction(user: AdminUser, key: string): void {
+    if (key === 'delete') {
+      this.state.deleteUser(user.id);
+      return;
+    }
+    if (key.startsWith('status:')) {
+      this.statusAction.emit({ user, status: key.slice('status:'.length) });
     }
   }
 

--- a/fe/src/app/shared/components/admin/kebab-menu/kebab-menu.component.html
+++ b/fe/src/app/shared/components/admin/kebab-menu/kebab-menu.component.html
@@ -1,0 +1,54 @@
+<!--
+  Kebab menu trigger + popover panel. The host element is `position:
+  relative` so the absolute-positioned panel docks to the trigger's
+  bottom-right corner without touching layout outside the row.
+-->
+<button #trigger
+        type="button"
+        class="kebab-trigger"
+        [class.is-open]="isOpen()"
+        [disabled]="disabled()"
+        [attr.aria-haspopup]="'menu'"
+        [attr.aria-expanded]="isOpen()"
+        [attr.aria-label]="triggerAriaLabel()"
+        (click)="onTriggerClick($event)"
+        (keydown)="onTriggerKeydown($event)">
+  <!-- Three vertical dots (kebab). -->
+  <svg class="kebab-icon"
+       viewBox="0 0 20 20"
+       fill="currentColor"
+       aria-hidden="true">
+    <path d="M10 6a1.5 1.5 0 110-3 1.5 1.5 0 010 3zM10 11.5a1.5 1.5 0 110-3 1.5 1.5 0 010 3zM10 17a1.5 1.5 0 110-3 1.5 1.5 0 010 3z"/>
+  </svg>
+</button>
+
+@if (isOpen()) {
+  <div #panel
+       class="kebab-panel"
+       role="menu"
+       [attr.aria-label]="menuAriaLabel()"
+       (click)="$event.stopPropagation()">
+    @for (action of actions(); track action.key; let i = $index) {
+      <button type="button"
+              role="menuitem"
+              class="kebab-item"
+              [class.is-danger]="action.variant === 'danger'"
+              [class.is-disabled]="action.disabled"
+              [disabled]="action.disabled"
+              [attr.tabindex]="i === activeIndex() ? 0 : -1"
+              [attr.aria-label]="action.ariaLabel || action.label"
+              (click)="onItemClick(action, $event)"
+              (keydown)="onItemKeydown($event, i)">
+        @if (action.icon) {
+          <svg class="kebab-item-icon"
+               viewBox="0 0 20 20"
+               fill="currentColor"
+               aria-hidden="true">
+            <path [attr.d]="action.icon" [attr.fill-rule]="'evenodd'" [attr.clip-rule]="'evenodd'"></path>
+          </svg>
+        }
+        <span class="kebab-item-label">{{ action.label }}</span>
+      </button>
+    }
+  </div>
+}

--- a/fe/src/app/shared/components/admin/kebab-menu/kebab-menu.component.scss
+++ b/fe/src/app/shared/components/admin/kebab-menu/kebab-menu.component.scss
@@ -1,0 +1,170 @@
+@use '../../../../../styles/variables' as *;
+
+/* Shared kebab-menu — admin portal (CC-10 in 2026-04-25 mega audit).
+   Per-row overflow action surface that replaces inline-edit selects + 5–7
+   icon-button stripes. WAI-ARIA Authoring Practices §3.16 menu-button
+   pattern.
+
+   Trigger lives inline with the row's actions cell; panel pops to the
+   bottom-right of the trigger via local stacking context. */
+
+:host {
+  position: relative;
+  display: inline-block;
+  /* High enough to layer over `:hover` row backgrounds and badges within
+     the same cell, low enough to stay under modal backdrops (z-100+) and
+     toast surfaces. */
+  z-index: 5;
+}
+
+/* When open, lift the host above sibling rows so the panel tucks above
+   adjacent row hover states without clipping. */
+:host:has(.kebab-trigger.is-open) {
+  z-index: 20;
+}
+
+.kebab-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* WCAG 2.5.5 (touch target ≥ 24×24, AA compliant via inset). */
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: $radius-md;
+  color: $gray-500;
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+
+  &:hover:not(:disabled) {
+    background: $gray-100;
+    color: $gray-700;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $blue-primary;
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  &.is-open {
+    background: $gray-100;
+    color: $gray-800;
+    border-color: $gray-200;
+  }
+}
+
+.kebab-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.kebab-panel {
+  position: absolute;
+  top: calc(100% + #{$spacing-1});
+  right: 0;
+  min-width: 200px;
+  max-width: 280px;
+  padding: $spacing-1 0;
+  background: $bg-surface;
+  border: 1px solid $border-default;
+  border-radius: $radius-md;
+  box-shadow: $shadow-lg;
+  z-index: $z-dropdown;
+
+  /* Slide-down + fade-in microinteraction matches admin portal modals. */
+  animation: kebab-pop 0.12s ease-out;
+  transform-origin: top right;
+}
+
+@keyframes kebab-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.95) translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.kebab-item {
+  display: flex;
+  align-items: center;
+  gap: $spacing-2;
+  width: 100%;
+  /* Touch-friendly hit area: ~40px tall × full panel width. */
+  padding: $spacing-2 $spacing-3;
+  background: transparent;
+  border: none;
+  color: $text-primary;
+  font-size: $text-sm;
+  font-weight: $font-medium;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.1s ease, color 0.1s ease;
+
+  &:hover:not(:disabled) {
+    background: $gray-50;
+  }
+
+  &:focus-visible {
+    outline: none;
+    background: $blue-light;
+    color: $blue-pressed;
+    /* Inset focus ring so it stays clear of the panel border without
+       breaking the menu rectangle. */
+    box-shadow: inset 0 0 0 2px $blue-primary;
+  }
+
+  &.is-disabled,
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  &.is-danger {
+    color: $error;
+
+    &:hover:not(:disabled) {
+      background: $error-light;
+      color: $error;
+    }
+
+    &:focus-visible {
+      background: $error-light;
+      color: $error;
+      box-shadow: inset 0 0 0 2px $error;
+    }
+  }
+}
+
+.kebab-item-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.kebab-item-label {
+  flex: 1 1 auto;
+}
+
+/* Mobile tweak — keep the panel readable on narrow tables. */
+@media screen and (max-width: $breakpoint-sm) {
+  .kebab-panel {
+    min-width: 180px;
+    max-width: calc(100vw - #{$spacing-6});
+  }
+
+  .kebab-item {
+    padding: $spacing-3 $spacing-3;
+  }
+}

--- a/fe/src/app/shared/components/admin/kebab-menu/kebab-menu.component.ts
+++ b/fe/src/app/shared/components/admin/kebab-menu/kebab-menu.component.ts
@@ -1,0 +1,315 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ElementRef,
+  HostListener,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+  viewChild,
+  effect,
+  PLATFORM_ID,
+} from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
+/**
+ * One kebab-menu action descriptor.
+ *
+ * - `key` — stable identifier, used as `track` key in the action @for + emitted
+ *   to the parent's `actionClick` handler.
+ * - `label` — Vietnamese label rendered inside the menu item.
+ * - `icon` — optional inline SVG path data (the `d` attr of a 20×20 `<path>`).
+ *   Pass empty / omit to render label-only.
+ * - `variant` — `default` keeps the item neutral. `danger` paints it red
+ *   (Khóa, Xóa, Từ chối, Thu hồi). Mutually exclusive — exactly one variant.
+ * - `disabled` — derived per-render by the caller (e.g. block "Khóa" if the
+ *   target is the current user — F-AD2 self-suspend guard mirror).
+ * - `ariaLabel` — overrides `label` for SR. Useful when the visible label is
+ *   short ("Khóa") but the SR copy needs the target name ("Khóa Nguyễn Văn A").
+ */
+export type KebabActionVariant = 'default' | 'danger';
+
+export interface KebabAction {
+  key: string;
+  label: string;
+  icon?: string;
+  variant?: KebabActionVariant;
+  disabled?: boolean;
+  ariaLabel?: string;
+}
+
+/**
+ * Per-row kebab menu (`⋮`) — the admin portal's row-level overflow action
+ * surface. Replaces the inline-edit `<select>` dropdowns + 5–7 icon-button
+ * stripes that bloat row height and confuse non-power users.
+ *
+ * Anatomy: trigger button (`⋮`) → on activation pops a floating menu panel
+ * positioned to the bottom-right of the trigger. Each entry is a `<button
+ * role="menuitem">`; danger variant turns red.
+ *
+ * Behaviour:
+ * - Open: click trigger, or focus + Enter / Space / ArrowDown.
+ * - Navigate: ArrowUp / ArrowDown wraps. Home / End jump to ends.
+ * - Select: Enter / Space fires the action then closes.
+ * - Dismiss: click outside, Esc, Tab away — focus returns to the trigger.
+ *
+ * Accessibility (WAI-ARIA Authoring Practices §3.16 — menu button):
+ * - Trigger: `aria-haspopup="menu"`, `aria-expanded`, `aria-label`.
+ * - Panel: `role="menu"`, each item `role="menuitem"`. `aria-orientation`
+ *   defaults to vertical which is what we want.
+ * - Touch targets: each item ≥ 44×24 (label) ⨉ 40px tall (touch-friendly).
+ * - `:focus-visible` ring honours the design system's primary blue.
+ *
+ * Positioning: pure CSS via the local stacking context (`position: absolute`
+ * on the panel, `position: relative` on the host). Default placement is
+ * bottom-right; the panel uses `right: 0` so it tucks under the trigger
+ * without overflowing the table's right edge. For a single-action surface
+ * the menu naturally compresses.
+ *
+ * Usage:
+ * ```html
+ * <app-kebab-menu
+ *   [actions]="actionsFor(user)"
+ *   triggerAriaLabel="Mở menu thao tác cho {{ user.name }}"
+ *   (actionClick)="onRowAction(user, $event)" />
+ * ```
+ */
+@Component({
+  selector: 'app-kebab-menu',
+  imports: [],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './kebab-menu.component.html',
+  styleUrl: './kebab-menu.component.scss',
+})
+export class KebabMenuComponent {
+  private host = inject(ElementRef<HTMLElement>);
+  private platformId = inject(PLATFORM_ID);
+
+  // Ordered list of menu items rendered in the panel. Order = render order
+  // (top → bottom).
+  actions = input.required<KebabAction[]>();
+
+  // SR label for the trigger. Falls back to a generic Vietnamese label.
+  triggerAriaLabel = input<string>('Mở menu thao tác');
+
+  // SR label for the menu panel. Defaults to "Thao tác".
+  menuAriaLabel = input<string>('Thao tác');
+
+  // Optional disabled state for the trigger (e.g. row has no actions). When
+  // true the kebab still renders but is non-interactive — preserves layout
+  // alignment with rows that do have a working menu.
+  disabled = input<boolean>(false);
+
+  // Emitted with the action's `key` when its menuitem is activated. Caller
+  // dispatches by key and runs the per-action handler (modal, API, toast).
+  actionClick = output<string>();
+
+  // Open / close state. Public-readonly via computed below — direct mutation
+  // happens only via toggle / open / close to keep the focus-management story
+  // local to this component.
+  private _isOpen = signal(false);
+  isOpen = computed(() => this._isOpen());
+
+  // Index of the active (visually highlighted) menuitem during keyboard
+  // navigation. -1 when no item is highlighted (mouse hover takes over via
+  // `:hover` then). Reset on close.
+  activeIndex = signal(-1);
+
+  // Refs needed for focus restoration.
+  triggerRef = viewChild<ElementRef<HTMLButtonElement>>('trigger');
+  panelRef = viewChild<ElementRef<HTMLDivElement>>('panel');
+
+  constructor() {
+    // When the panel opens, schedule focus to land on the active item (or
+    // first item if none is active). Done in an effect so we react to both
+    // initial open and re-open without bespoke wiring.
+    effect(() => {
+      if (!this._isOpen()) return;
+      if (!isPlatformBrowser(this.platformId)) return;
+
+      // Defer to next tick so the @if-rendered panel is in the DOM.
+      queueMicrotask(() => {
+        const panel = this.panelRef()?.nativeElement;
+        if (!panel) return;
+        const items = this.menuItems();
+        const idx = this.activeIndex();
+        const target = idx >= 0 && idx < items.length ? items[idx] : items[0];
+        target?.focus();
+      });
+    });
+  }
+
+  // ----- Trigger handlers -----
+
+  toggle(): void {
+    if (this.disabled()) return;
+    if (this._isOpen()) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  open(initialIndex = 0): void {
+    if (this.disabled()) return;
+    if (this._isOpen()) return;
+    // Skip past disabled items at the front so the focus ring lands somewhere
+    // useful.
+    const acts = this.actions();
+    let idx = initialIndex;
+    while (idx < acts.length && acts[idx]?.disabled) idx++;
+    if (idx >= acts.length) idx = -1;
+    this.activeIndex.set(idx);
+    this._isOpen.set(true);
+  }
+
+  close(restoreFocus = true): void {
+    if (!this._isOpen()) return;
+    this._isOpen.set(false);
+    this.activeIndex.set(-1);
+    if (restoreFocus) {
+      // Microtask so the panel teardown isn't fighting the focus call.
+      queueMicrotask(() => this.triggerRef()?.nativeElement.focus());
+    }
+  }
+
+  onTriggerClick(event: MouseEvent): void {
+    event.stopPropagation();
+    this.toggle();
+  }
+
+  onTriggerKeydown(event: KeyboardEvent): void {
+    if (this.disabled()) return;
+    switch (event.key) {
+      case 'Enter':
+      case ' ':
+      case 'ArrowDown':
+        event.preventDefault();
+        this.open(0);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.open(this.actions().length - 1);
+        break;
+      case 'Escape':
+        if (this._isOpen()) {
+          event.preventDefault();
+          this.close();
+        }
+        break;
+    }
+  }
+
+  // ----- Menu item handlers -----
+
+  onItemClick(action: KebabAction, event: MouseEvent): void {
+    event.stopPropagation();
+    if (action.disabled) return;
+    this.actionClick.emit(action.key);
+    this.close();
+  }
+
+  onItemKeydown(event: KeyboardEvent, index: number): void {
+    const items = this.actions();
+    switch (event.key) {
+      case 'ArrowDown': {
+        event.preventDefault();
+        const next = this.findNextEnabled(index, 1);
+        if (next !== -1) this.focusItem(next);
+        break;
+      }
+      case 'ArrowUp': {
+        event.preventDefault();
+        const prev = this.findNextEnabled(index, -1);
+        if (prev !== -1) this.focusItem(prev);
+        break;
+      }
+      case 'Home': {
+        event.preventDefault();
+        const first = this.findNextEnabled(-1, 1);
+        if (first !== -1) this.focusItem(first);
+        break;
+      }
+      case 'End': {
+        event.preventDefault();
+        const last = this.findNextEnabled(items.length, -1);
+        if (last !== -1) this.focusItem(last);
+        break;
+      }
+      case 'Enter':
+      case ' ': {
+        event.preventDefault();
+        const action = items[index];
+        if (action && !action.disabled) {
+          this.actionClick.emit(action.key);
+          this.close();
+        }
+        break;
+      }
+      case 'Escape': {
+        event.preventDefault();
+        this.close();
+        break;
+      }
+      case 'Tab':
+        // Tabbing out of the panel closes — focus naturally moves on; we do
+        // NOT restore focus to the trigger because the user's intent was to
+        // leave the menu surface entirely.
+        this.close(false);
+        break;
+    }
+  }
+
+  // ----- Outside-click + escape global handlers -----
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (!this._isOpen()) return;
+    const target = event.target as Node | null;
+    if (target && this.host.nativeElement.contains(target)) return;
+    // Outside click — close without restoring focus (the user clicked
+    // somewhere else on purpose; stealing focus back would be surprising).
+    this.close(false);
+  }
+
+  @HostListener('document:keydown.escape')
+  onDocumentEscape(): void {
+    if (this._isOpen()) this.close();
+  }
+
+  // ----- Helpers -----
+
+  /** Find the next non-disabled item index in `direction` (+1 or -1). */
+  private findNextEnabled(from: number, direction: 1 | -1): number {
+    const items = this.actions();
+    const len = items.length;
+    if (len === 0) return -1;
+
+    // Wrap-around: "next from last" → first; "prev from first" → last.
+    let idx = from + direction;
+    let safety = len;
+    while (safety-- > 0) {
+      if (idx < 0) idx = len - 1;
+      else if (idx >= len) idx = 0;
+      if (!items[idx]?.disabled) return idx;
+      idx += direction;
+    }
+    return -1;
+  }
+
+  private menuItems(): HTMLButtonElement[] {
+    const panel = this.panelRef()?.nativeElement;
+    if (!panel) return [];
+    return Array.from(
+      panel.querySelectorAll<HTMLButtonElement>('button[role="menuitem"]')
+    );
+  }
+
+  private focusItem(index: number): void {
+    this.activeIndex.set(index);
+    const items = this.menuItems();
+    items[index]?.focus();
+  }
+}


### PR DESCRIPTION
Closes #197. Part of epic #186 (Wave 2).

## What

Per-row overflow action surface (`⋮` kebab menu) — replaces inline-edit `<select>` dropdowns and 5–7 stacked icon buttons across the admin portal. WAI-ARIA Authoring Practices §3.16 menu-button pattern. Mirrors the shared-component approach pioneered by `<app-bulk-action-bar>` (PR #205) and `<app-kpi-card>` (PR #174).

## Files

| File | Change |
|---|---|
| `fe/src/app/shared/components/admin/kebab-menu/` *(new)* | `<app-kebab-menu>` with `actions` / `triggerAriaLabel` / `menuAriaLabel` / `disabled` inputs + `actionClick` output. `KebabAction` shape mirrors `BulkAction` (key/label/icon/variant default\|danger/disabled/ariaLabel) so handlers stay symmetric across bulk + per-row surfaces. ARIA: `aria-haspopup="menu"`, `aria-expanded`, `role="menu"`, `role="menuitem"`. Keyboard: ArrowUp/Down wraps, Home/End jumps, Enter/Space activates, Esc closes, Tab-out closes without focus restore. SSR-safe focus management via `isPlatformBrowser`. |
| `.../admin-user-management.component.{ts,html}` | Status `<select>` + Thu hồi quyền Admin icon button → kebab. Self-suspend guard preserved via `disabled` + explanatory `ariaLabel`. |
| `.../teacher-management.{ts,html}` | Status select + Vô hiệu hóa icon → kebab. `Vô hiệu hóa tài khoản` gated by `isSystemAdmin()` (mirrors previous icon-button @if). |
| `.../student-management.{ts,html}` | Same pattern. |
| `.../user-management/components/users-table/users-table.component.ts` (all-users surface) | Status select + delete icon → kebab. Per-row guards `state.canChangeStatus / state.canDeleteUser` decide which menuitems show; cell renders `—` when no actions are available (e.g. ORG_ADMIN viewing an ADMIN row). |
| `.../course-management.component.{ts,html}` | 5–7 icon-button stripe (Phê duyệt / Từ chối / Thu hồi / Xem trước / Xem chi tiết / Mở trình biên tập / Xóa) → single kebab. Menu order: navigation (preview, detail) → review (approve, reject, revoke) → destructive (edit, delete). System-admin gates preserved. |
| `.../admin-payouts.component.ts` | Inline action buttons (Duyệt / Từ chối / Xác nhận đã CK) → kebab. APPROVED + ORG_ADMIN row keeps the existing "Chờ admin hoàn tất" hint label (kebab suppressed). |
| `.../category-management.component.{ts,scss}` | Tree rows now expose Đổi tên / Thêm danh mục con (roots only — level-2 cap) / Ẩn or Kích hoạt via per-row kebab. Click on the kebab wrapper stops bubbling so the row-level click-to-select isn't triggered alongside. |

15 files, +1112 / −154.

## Convention compliance

- [x] OnPush mọi component
- [x] Signal inputs / outputs / `inject()` — no constructor DI
- [x] `@if` / `@for` — no `*ngIf`
- [x] Không `standalone: true` explicit (Angular 20+ default)
- [x] Tokens-based SCSS (`$spacing-*`, `$gray-*`, `$blue-primary`, `$blue-light`, `$radius-*`, `$shadow-lg`, `$z-dropdown`)
- [x] WCAG 2.2: trigger 32×32 (visible), each menuitem ≥40px tall (touch). `aria-haspopup` / `aria-expanded` on trigger, `role=menu` + `role=menuitem` on panel. `:focus-visible` ring with inset 2px primary blue on items, primary blue on trigger. Keyboard nav follows APG menu-button pattern.
- [x] Vietnamese diacritics throughout
- [x] SSR-safe — focus management gated by `isPlatformBrowser(platformId)`

## Audit constraints honored

- **Per-row guards preserved** across every surface — kebab simply consolidates the existing `@if` gates into a single overflow trigger.
- **Self-suspend block** mirrors PR #178 / #205 F-AD2 pattern: when admin row is the current user, "Khóa" / "Thu hồi quyền Admin" come back as `disabled: true` with a Vietnamese `ariaLabel` explaining why.
- **Admin-only gates** for destructive course / user actions (edit, delete) mirror the previous `@if (isSystemAdmin())` icon-button gates exactly.

## Verification

- `tsc --noEmit -p tsconfig.app.json` clean.
- `ng build --configuration=development` succeeds; only pre-existing Sass `@import` deprecation warnings unrelated to this PR.
- agent-browser interactive verification was attempted via fresh sessions but the worktree dev server hit the same Vite WebSocket proxy lockup that blocked PR #205's E2E run (admin pages with N parallel API calls trigger the lockup; home + login pages are fine). Build success + per-surface manual diff review covers the integration.

## Test plan

- [ ] Login as `admin@maritime.edu` / `admin123`.
- [ ] `/admin/users/admins` — each row shows a single `⋮` trigger; opening surfaces Kích hoạt / Khóa / Hạn chế / Thu hồi quyền Admin per status. Self-suspend disabled with explanatory ariaLabel.
- [ ] `/admin/users/teachers` and `/admin/users/students` — same pattern + Vô hiệu hóa tài khoản (system admin only).
- [ ] `/admin/users` (all-users refactored) — kebab respects `canChangeStatus` / `canDeleteUser`; rows ORG_ADMIN cannot operate render `—`.
- [ ] `/admin/courses` — kebab menu offers preview, detail, approve/reject (pending only), revoke (approved only), edit + delete (system admin only). Bulk action bar (PR #205) untouched.
- [ ] `/admin/payouts` — PENDING rows show Duyệt + Từ chối; APPROVED + system admin shows Xác nhận đã CK; APPROVED + ORG_ADMIN keeps the "Chờ admin hoàn tất" label.
- [ ] `/admin/categories` — tree rows expose Đổi tên / Thêm danh mục con (roots) / Ẩn or Kích hoạt; click on kebab does NOT also re-select the row.
- [ ] Keyboard: focus the trigger → Enter opens, ArrowDown navigates with wrap, Enter selects, Esc closes, focus returns to trigger.
- [ ] Outside click closes without focus restore.
- [ ] Mobile (375×812): panel min-width 180px, items 12px vertical padding (touch-friendly).

## Risk & rollback

Risk: low-medium. Pure UI consolidation — no new API surface, no domain logic changes, all per-row guards preserved 1:1. `git revert` removes the shared component + restores per-surface bespoke implementations. No data migration. No BE changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)