### PR TITLE
polish(admin-users): SOTA-align consistency với dashboard

### DIFF
--- a/fe/src/app/features/admin/presentation/components/user-management/components/search-filter/search-filter.component.html
+++ b/fe/src/app/features/admin/presentation/components/user-management/components/search-filter/search-filter.component.html
@@ -26,13 +26,16 @@
           <option [value]="roleOpt.value">{{ roleOpt.label }}</option>
         }
       </select>
-      <!-- Status Filter -->
+      <!-- Status Filter — enum-based (ACTIVE/BLOCKED/RESTRICTED) thay vì
+           legacy 'active'/'inactive' boolean để filter granular hơn (F-U1).
+           Khớp `accountStatus` field trên `AdminUser`. -->
       <select [value]="state.statusFilter()"
               (change)="state.onStatusFilterChange($any($event.target).value)"
               class="filter-select">
         <option value="">Tất cả trạng thái</option>
-        <option value="active">Đang hoạt động</option>
-        <option value="inactive">Không hoạt động</option>
+        <option value="ACTIVE">Đang hoạt động</option>
+        <option value="BLOCKED">Bị khóa</option>
+        <option value="RESTRICTED">Hạn chế</option>
       </select>
     </div>
   </div>

--- a/fe/src/app/features/admin/presentation/components/user-management/components/stats-cards/stats-cards.component.html
+++ b/fe/src/app/features/admin/presentation/components/user-management/components/stats-cards/stats-cards.component.html
@@ -1,4 +1,7 @@
 <div class="stats-grid">
+  <!-- "Tổng người dùng" KHÔNG drill-down vì current page là /admin/users/all.
+       Còn 3 card breakdown role -> drill-down filter view tương ứng
+       (Stripe / Coursera / Vercel pattern, đồng bộ dashboard PR #222). -->
   <app-kpi-card
     [value]="state.totalUsers()"
     label="Tổng người dùng"
@@ -7,15 +10,18 @@
   <app-kpi-card
     [value]="state.totalTeachers()"
     label="Giảng viên"
-    sub="Đang giảng dạy" />
+    sub="Đang giảng dạy"
+    route="/admin/users/teachers" />
 
   <app-kpi-card
     [value]="state.totalStudents()"
     label="Học viên"
-    sub="Đang học tập" />
+    sub="Đang học tập"
+    route="/admin/users/students" />
 
   <app-kpi-card
     [value]="state.totalAdmins()"
     label="Quản trị viên"
-    sub="Quản lý hệ thống" />
+    sub="Quản lý hệ thống"
+    route="/admin/users/admins" />
 </div>

--- a/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.ts
+++ b/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.ts
@@ -5,6 +5,7 @@ import { UserManagementState } from '../../state/user-management.state';
 import { AdminUser } from '../../../../../infrastructure/services/admin.service';
 import { exportToCsv } from '../../../../../../../shared/utils/csv-export';
 import { KebabMenuComponent, KebabAction } from '../../../../../../../shared/components/admin/kebab-menu/kebab-menu.component';
+import { formatRelativeTimeVN } from '../../../../../../../shared/utils/relative-time.util';
 
 @Component({
   selector: 'app-users-table',
@@ -165,9 +166,11 @@ import { KebabMenuComponent, KebabAction } from '../../../../../../../shared/com
                       {{ state.getStatusLabel(user.accountStatus) }}
                     </span>
                   </td>
-                  <!-- Hoạt động cuối -->
-                  <td class="px-6 py-4 whitespace-nowrap text-xs text-gray-600">
-                    {{ user.lastLogin ? state.formatDate(user.lastLogin) : 'Chưa đăng nhập' }}
+                  <!-- Hoạt động cuối — Linear / GitHub / Stripe pattern:
+                       relative time + tooltip ISO. Đồng bộ dashboard PR #222. -->
+                  <td class="px-6 py-4 whitespace-nowrap text-xs text-gray-600 cursor-help"
+                      [title]="user.lastLogin || ''">
+                    {{ user.lastLogin ? formatRelativeTime(user.lastLogin) : 'Chưa đăng nhập' }}
                   </td>
                   <!-- Thống kê -->
                   <td class="px-6 py-4 whitespace-nowrap text-xs text-gray-600">
@@ -259,6 +262,14 @@ export class UsersTableComponent {
   readonly state = inject(UserManagementState);
 
   statusAction = output<{ user: AdminUser; status: string }>();
+
+  // Cột "Hoạt động cuối" — relative time (Linear / GitHub / Stripe pattern).
+  // Tooltip [title] giữ ISO timestamp cho tra cứu chính xác.
+  // AdminUser.lastLogin là `Date | null` (admin.service:885 convert ISO->Date),
+  // util accept union nên truyền thẳng Date.
+  formatRelativeTime(input: Date | string | null | undefined): string {
+    return formatRelativeTimeVN(input);
+  }
 
   onStatusAction(user: AdminUser, status: string): void {
     if (status) {

--- a/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.ts
+++ b/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.ts
@@ -167,9 +167,12 @@ import { formatRelativeTimeVN } from '../../../../../../../shared/utils/relative
                     </span>
                   </td>
                   <!-- Hoạt động cuối — Linear / GitHub / Stripe pattern:
-                       relative time + tooltip ISO. Đồng bộ dashboard PR #222. -->
-                  <td class="px-6 py-4 whitespace-nowrap text-xs text-gray-600 cursor-help"
-                      [title]="user.lastLogin || ''">
+                       relative time + tooltip ISO. Đồng bộ dashboard PR #222.
+                       cursor-help + title chỉ khi có lastLogin (tránh tooltip
+                       rỗng + hand cursor confusing trên cell "Chưa đăng nhập"). -->
+                  <td class="px-6 py-4 whitespace-nowrap text-xs text-gray-600"
+                      [class.cursor-help]="user.lastLogin"
+                      [attr.title]="user.lastLogin || null">
                     {{ user.lastLogin ? formatRelativeTime(user.lastLogin) : 'Chưa đăng nhập' }}
                   </td>
                   <!-- Thống kê -->

--- a/fe/src/app/features/admin/presentation/components/user-management/state/user-management.state.ts
+++ b/fe/src/app/features/admin/presentation/components/user-management/state/user-management.state.ts
@@ -550,7 +550,7 @@ export class UserManagementState {
   getStatusLabel(status: string): string {
     switch (status) {
       case 'ACTIVE': return 'Hoạt động';
-      case 'BLOCKED': return 'Đã khóa';
+      case 'BLOCKED': return 'Bị khóa';
       case 'RESTRICTED': return 'Hạn chế';
       default: return 'Không xác định';
     }

--- a/fe/src/app/features/admin/presentation/components/user-management/state/user-management.state.ts
+++ b/fe/src/app/features/admin/presentation/components/user-management/state/user-management.state.ts
@@ -185,8 +185,12 @@ export class UserManagementState {
     }
 
     if (this.statusFilter()) {
-      const isActive = this.statusFilter() === 'active';
-      users = users.filter(user => user.isActive === isActive);
+      // Filter F-U1 — enum-based match `accountStatus` (ACTIVE/BLOCKED/
+      // RESTRICTED) thay vì legacy `isActive` boolean. BE param ignored
+      // (UserControllerV3 không filter status), client-side filter từ
+      // `_localUsers()` page hiện tại.
+      const filter = this.statusFilter();
+      users = users.filter(user => user.accountStatus === filter);
     }
 
     return users;

--- a/fe/src/app/shared/utils/relative-time.util.spec.ts
+++ b/fe/src/app/shared/utils/relative-time.util.spec.ts
@@ -71,4 +71,16 @@ describe('formatRelativeTimeVN', () => {
     const result = formatRelativeTimeVN(t, NOW);
     expect(result).toMatch(/\d{1,2}\/\d{1,2}\/\d{4}/);
   });
+
+  // Union type — accept Date instance trực tiếp (admin.service convert
+  // ISO -> Date, template render dùng Date không phải ISO string)
+  it('accept Date instance trực tiếp (không cần convert ISO)', () => {
+    const date = new Date(NOW - 5 * 60_000);
+    expect(formatRelativeTimeVN(date, NOW)).toBe('5 phút trước');
+  });
+
+  it('Date >= 30 ngày fallback toLocaleDateString vi-VN', () => {
+    const date = new Date(NOW - 60 * 86_400_000);
+    expect(formatRelativeTimeVN(date, NOW)).toMatch(/\d{1,2}\/\d{1,2}\/\d{4}/);
+  });
 });

--- a/fe/src/app/shared/utils/relative-time.util.ts
+++ b/fe/src/app/shared/utils/relative-time.util.ts
@@ -1,20 +1,28 @@
 /**
- * Format an ISO timestamp as a Vietnamese relative time phrase
+ * Format a timestamp as a Vietnamese relative time phrase
  * (Linear / GitHub / Stripe pattern). Falls back to localized date for
  * timestamps older than 30 days so admins still see absolute dates for
  * archival data without needing tooltip hover.
  *
+ * Accepts ISO string, `Date` instance, hoặc null/undefined. FE service
+ * thường convert ISO -> Date (xem `admin.service.ts:885`), template render
+ * có thể nhận Date trực tiếp — union type tránh boilerplate ở call site.
+ *
  * Usage:
  *   formatRelativeTimeVN('2026-04-26T10:30:00Z') -> "5 phút trước"
+ *   formatRelativeTimeVN(new Date()) -> "vừa xong"
  *   formatRelativeTimeVN('2026-03-01T10:30:00Z') -> "01/03/2026"
  *
  * Future timestamps (clock skew between client + server) collapse to
  * "vừa xong" rather than "in 3 minutes" — admins do not expect to see
  * future-dated audit records on the dashboard.
  */
-export function formatRelativeTimeVN(iso: string | null | undefined, now: number = Date.now()): string {
-  if (!iso) return '';
-  const then = new Date(iso).getTime();
+export function formatRelativeTimeVN(
+  input: string | Date | null | undefined,
+  now: number = Date.now(),
+): string {
+  if (!input) return '';
+  const then = input instanceof Date ? input.getTime() : new Date(input).getTime();
   if (Number.isNaN(then)) return '';
 
   const diffMs = now - then;
@@ -34,5 +42,6 @@ export function formatRelativeTimeVN(iso: string | null | undefined, now: number
     return `${weeks} tuần trước`;
   }
 
-  return new Date(iso).toLocaleDateString('vi-VN');
+  const fallbackDate = input instanceof Date ? input : new Date(input);
+  return fallbackDate.toLocaleDateString('vi-VN');
 }


### PR DESCRIPTION
## Summary

Áp 3 polish nhỏ vào `/admin/users/all` đồng bộ pattern dashboard PR #222 (Phase 3 SOTA-align). Util `formatRelativeTimeVN` mở rộng accept `Date` instance để khớp `AdminUser.lastLogin` type.

## Linked issues

Closes #223

## Change type

- [x] Refactor / cleanup
- [x] Bug fix (filter status incomplete F-U1)

## What changed

### C10 — Stats cards drill-down (3/4 cards)
- `stats-cards.component.html` — pass `[route]` cho 3 KPI:
  - Giảng viên → `/admin/users/teachers`
  - Học viên → `/admin/users/students`
  - Quản trị viên → `/admin/users/admins`
- "Tổng người dùng" giữ `<div>` (current page là `/admin/users/all`, không drill-down chính nó)

### C11 — Relative time "Hoạt động cuối"
- `users-table.component.ts` (inline template): `state.formatDate(...)` → `formatRelativeTime(...)` + `[title]` tooltip ISO + `cursor-help`
- Util `formatRelativeTimeVN` mở rộng signature: `string | Date | null | undefined` (was `string | null | undefined`)
- `AdminUser.lastLogin` là `Date` (admin.service line 885 convert ISO → Date), template render dùng Date trực tiếp — union tránh boilerplate
- Spec test 13 → 15 cases: thêm Date instance + Date >= 30 ngày fallback

### C12 — Filter status BLOCKED + RESTRICTED (F-U1 audit)
- `search-filter.component.html` — 4 option enum-based:
  - "" Tất cả trạng thái
  - "ACTIVE" Đang hoạt động
  - "BLOCKED" Bị khóa
  - "RESTRICTED" Hạn chế
- `user-management.state.ts` filter computed line 187-190: từ `user.isActive === isActive` boolean → `user.accountStatus === filter` enum match
- BE `UserControllerV3` không thực sự filter status (nhận param nhưng ignore), client-side filter từ `_localUsers()` page hiện tại

## Why

PR #222 ship Phase 3 dashboard SOTA-align: KPI drill-down, relative time util, count badge. Surface `/admin/users/all` chia sẻ shared `<app-kpi-card>` + `formatRelativeTimeVN` util — cần wire để consistency cross-surface.

F-U1 từ Phase 1-2 audit (`docs/reports/2026-04-25-admin-portal-mega-audit.md`): filter status thiếu BLOCKED/RESTRICTED dù schema có 3 trạng thái. Đây là follow-up còn sót.

## Testing

- [x] Unit tests: `relative-time.util.spec.ts` 15/15 PASS (was 13, thêm 2 case Date)
- [x] Production build: `npm run build` SUCCESS, no TS error
- [x] Manual smoke (Chromium 1440×900):
  - 3 KPI cards có href đúng `/admin/users/{teachers,students,admins}`
  - Aria-label `Mở chi tiết: ...` (kế thừa từ kpi-card PR #222)
  - Filter status dropdown 4 option ACTIVE/BLOCKED/RESTRICTED + Tất cả
  - Cell "Hoạt động cuối" có `cursor-help` + `[title]` ISO timestamp

## Risk & rollback

- **Risk**: thấp.
  - Filter logic thay từ `isActive` boolean → `accountStatus` enum: backward-compat broken cho 'active'/'inactive' legacy values, nhưng không có code/URL nào persist filter state cũ → safe.
  - `formatRelativeTimeVN` signature mở rộng (string-only → union) — backward-compat OK (mọi caller cũ vẫn pass string).
- **Rollback**: `git revert <SHA>`. Không có DB migration.

## Checklist

- [x] Tuân thủ Conventional Commits
- [x] Không commit secret
- [x] Không cập nhật docs (UI-only changes)
- [x] Không dead code / TODO
- [x] CI sẽ chạy
- [x] Self-reviewed diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)