### PR TITLE
polish(admin-users-family): F-AD1 + F-T2 button color + C11 relative time

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
@@ -138,9 +138,13 @@
                       {{ getStatusLabel(admin.accountStatus) }}
                     </span>
                   </td>
-                  <!-- Last Login -->
-                  <td class="date-text">
-                    {{ admin.lastLogin ? formatDateValue(admin.lastLogin) : 'Chưa đăng nhập' }}
+                  <!-- Last Login — relative time (Linear/GitHub/Stripe pattern,
+                       đồng bộ users/all PR #224). cursor-help + title chỉ khi
+                       có lastLogin (tránh hand cursor + tooltip rỗng). -->
+                  <td class="date-text"
+                      [class.cursor-help]="admin.lastLogin"
+                      [attr.title]="admin.lastLogin || null">
+                    {{ admin.lastLogin ? formatRelativeTime(admin.lastLogin) : 'Chưa đăng nhập' }}
                   </td>
                   <!-- Login Count -->
                   <td>
@@ -213,7 +217,7 @@
         </div>
         <div class="modal-footer">
           <button (click)="closeCreateModal()" class="btn-secondary">Hủy</button>
-          <button (click)="createAdmin()" [disabled]="!newAdminName() || !newAdminEmail()" class="btn-orange">
+          <button (click)="createAdmin()" [disabled]="!newAdminName() || !newAdminEmail()" class="btn-primary">
             Thêm quản trị viên
           </button>
         </div>

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.scss
@@ -609,17 +609,20 @@ $orange-700: #9A3412;
   &:hover { background: $gray-50; }
 }
 
-.btn-orange {
+/* F-AD1 (CC-02): primary CTA modal footer — đồng bộ blue token thay
+   `$orange-primary` cũ. Red/orange chỉ dành cho semantic destructive
+   (CLAUDE.md design token), không phải primary action. */
+.btn-primary {
   padding: $spacing-2 $spacing-4;
   font-size: $text-sm;
   color: $text-inverse;
-  background: $orange-primary;
+  background: $blue-primary;
   border: none;
   border-radius: $radius-sm;
   cursor: pointer;
   transition: background $transition-normal;
 
-  &:hover { background: $orange-hover; }
+  &:hover { background: $blue-hover; }
   &:disabled { opacity: 0.5; cursor: not-allowed; }
 }
 

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
@@ -11,6 +11,7 @@ import { ConfirmStatusChangeService } from '../../services/confirm-status-change
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
 import { KebabMenuComponent, KebabAction } from '../../../../shared/components/admin/kebab-menu/kebab-menu.component';
+import { formatRelativeTimeVN } from '../../../../shared/utils/relative-time.util';
 /**
  * Admin User Management Component
  * SOTA Design: Coursera-inspired with role change, status actions
@@ -417,6 +418,12 @@ export class AdminUserManagementComponent implements OnInit {
     return d.toLocaleDateString('vi-VN', {
       day: '2-digit', month: '2-digit', year: 'numeric'
     });
+  }
+
+  // Cột "Hoạt động cuối" — relative time (Linear/GitHub/Stripe pattern,
+  // đồng bộ users/all PR #224). Tooltip [title] giữ ISO timestamp gốc.
+  formatRelativeTime(input: Date | string | null | undefined): string {
+    return formatRelativeTimeVN(input);
   }
 
   getDefaultAvatar(email: string): string {

--- a/fe/src/app/features/admin/presentation/components/student-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.html
@@ -150,9 +150,15 @@
                       {{ student.coursesEnrolled || 0 }} khóa học
                     </button>
                   </td>
-                  <!-- Last Login -->
+                  <!-- Last Login — relative time (Linear/GitHub/Stripe pattern,
+                       đồng bộ users/all PR #224). cursor-help + title chỉ khi
+                       có lastLogin (tránh hand cursor + tooltip rỗng). -->
                   <td>
-                    <span class="date-text">{{ student.lastLogin ? formatDateValue(student.lastLogin) : 'Chưa đăng nhập' }}</span>
+                    <span class="date-text"
+                          [class.cursor-help]="student.lastLogin"
+                          [attr.title]="student.lastLogin || null">
+                      {{ student.lastLogin ? formatRelativeTime(student.lastLogin) : 'Chưa đăng nhập' }}
+                    </span>
                   </td>
                   <!-- Actions — CC-10: shared kebab replaces inline status
                        select + delete icon. -->

--- a/fe/src/app/features/admin/presentation/components/student-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.ts
@@ -12,6 +12,7 @@ import { forkJoin } from 'rxjs';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
 import { KebabMenuComponent, KebabAction } from '../../../../shared/components/admin/kebab-menu/kebab-menu.component';
+import { formatRelativeTimeVN } from '../../../../shared/utils/relative-time.util';
 
 /**
  * Student Management Component
@@ -435,6 +436,12 @@ export class StudentManagementComponent implements OnInit {
     return d.toLocaleDateString('vi-VN', {
       day: '2-digit', month: '2-digit', year: 'numeric'
     });
+  }
+
+  // Cột "Hoạt động cuối" — relative time (Linear/GitHub/Stripe pattern,
+  // đồng bộ users/all PR #224). Tooltip [title] giữ ISO timestamp gốc.
+  formatRelativeTime(input: Date | string | null | undefined): string {
+    return formatRelativeTimeVN(input);
   }
 
   getDefaultAvatar(email: string): string {

--- a/fe/src/app/features/admin/presentation/components/teacher-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.component.scss
@@ -659,17 +659,20 @@ $purple-bg: #FAF5FF;
   &:hover { background: $gray-50; }
 }
 
-.btn-purple {
+/* F-T2 (CC-02): primary CTA modal footer — đồng bộ blue token thay
+   `$purple` cũ. Purple ngoài design token primary, tạo inconsistency
+   cross-portal. Mọi admin surface phải dùng `$blue-primary`. */
+.btn-primary {
   padding: $spacing-2 $spacing-4;
   font-size: $text-sm;
   color: white;
-  background: $purple;
+  background: $blue-primary;
   border: none;
   border-radius: $radius-sm;
   cursor: pointer;
   transition: background $transition-normal;
 
-  &:hover { background: $purple-hover; }
+  &:hover { background: $blue-hover; }
   &:disabled { opacity: 0.5; cursor: not-allowed; }
 }
 

--- a/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
@@ -12,6 +12,7 @@ import { getAdminPortalBase } from '../../../../core/utils/portal-route.util';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
 import { KebabMenuComponent, KebabAction } from '../../../../shared/components/admin/kebab-menu/kebab-menu.component';
+import { formatRelativeTimeVN } from '../../../../shared/utils/relative-time.util';
 
 /**
  * Teacher Management Component
@@ -527,6 +528,12 @@ export class TeacherManagementComponent implements OnInit {
     return d.toLocaleDateString('vi-VN', {
       day: '2-digit', month: '2-digit', year: 'numeric'
     });
+  }
+
+  // Cột "Hoạt động cuối" — relative time (Linear/GitHub/Stripe pattern,
+  // đồng bộ users/all PR #224). Tooltip [title] giữ ISO timestamp gốc.
+  formatRelativeTime(input: Date | string | null | undefined): string {
+    return formatRelativeTimeVN(input);
   }
 
   getDefaultAvatar(email: string): string {

--- a/fe/src/app/features/admin/presentation/components/teacher-management.html
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.html
@@ -158,9 +158,15 @@
                           }
                         </button>
                       </td>
-                      <!-- Last Login -->
+                      <!-- Last Login — relative time (Linear/GitHub/Stripe pattern,
+                           đồng bộ users/all PR #224). cursor-help + title chỉ khi
+                           có lastLogin (tránh hand cursor + tooltip rỗng). -->
                       <td>
-                        <span class="date-text">{{ teacher.lastLogin ? formatDateValue(teacher.lastLogin) : 'Chưa đăng nhập' }}</span>
+                        <span class="date-text"
+                              [class.cursor-help]="teacher.lastLogin"
+                              [attr.title]="teacher.lastLogin || null">
+                          {{ teacher.lastLogin ? formatRelativeTime(teacher.lastLogin) : 'Chưa đăng nhập' }}
+                        </span>
                       </td>
                       <!-- Actions — CC-10: shared kebab replaces inline
                            status select + delete icon. -->
@@ -212,7 +218,7 @@
             </div>
             <div class="modal-footer">
               <button (click)="closeCreateModal()" class="btn-secondary">Hủy</button>
-              <button (click)="createTeacher()" [disabled]="!newTeacherName() || !newTeacherEmail()" class="btn-purple">
+              <button (click)="createTeacher()" [disabled]="!newTeacherName() || !newTeacherEmail()" class="btn-primary">
                 Thêm giảng viên
               </button>
             </div>


### PR DESCRIPTION
## Summary

Sub-agent audit Users Family phát hiện 3 inconsistency với users/all đã ship PR #224. Apply fix atomic 8 file FE.

## Linked issues

Closes #225

## Change type

- [x] Bug fix (F-AD1, F-T2 button color anti-pattern)
- [x] Refactor / cleanup (C11 consistency)

## What changed

### F-AD1 (P0) — admins page modal CTA RED/ORANGE → BLUE
- `admin-user-management.scss:612` rename `.btn-orange` → `.btn-primary`, `$orange-primary` → `$blue-primary`, `$orange-hover` → `$blue-hover`
- `admin-user-management.component.html:216` class binding update
- Đồng bộ CC-02 design token: red CHỈ semantic destructive

### F-T2 (P0) — teachers page modal CTA PURPLE → BLUE
- `teacher-management.scss:662` rename `.btn-purple` → `.btn-primary`, `$purple` → `$blue-primary`
- `teacher-management.html:215` class binding update

### C11 (P1) — Relative time "Hoạt động cuối" cho 3 surface
- `admin-user-management.component.{ts,html}` + `teacher-management.{component.ts,html}` + `student-management.component.{ts,html}` (8 file)
- Import `formatRelativeTimeVN` (util từ PR #222)
- Thêm `formatRelativeTime()` method (delegate util, accept `Date | string | null | undefined`)
- HTML: `formatDateValue()` → `formatRelativeTime()` + `[class.cursor-help]` conditional + `[attr.title]` null khi no lastLogin
- Đồng bộ users/all PR #224 + dashboard PR #222

## Why

Sub-agent audit users family với scope: tìm DIFF giữa 3 surface với users/all đã polish. Kết quả:

- F-AD1, F-T2: button color leftover từ trước Phase 1-2, vi phạm CC-02 ("Red ONLY for semantic destructive")
- C11: 3 surface dùng full date toLocaleDateString trong khi util `formatRelativeTimeVN` đã có (PR #222) + users/all đã apply (PR #224)

3 surface giờ pattern-equivalent với users/all. Cross-surface visual unity.

## Out-of-scope (audit recommend defer)

- F-AD2 inline role dropdown: đã mitigated bằng confirm modal (ConfirmStatusChangeService), risk LOW, defer redesign
- F-ST1 icon rendering bug: ĐÃ FIX trong student-management.scss (width/height constraint)
- F-T1 teacher KPI 0/0/0: BE data quality issue, không phải FE
- C10 KPI drill-down cho 3 surface: KPI labels (Tổng Admin, Super Admin, Bị khóa, Hoạt động gần đây / Đã đăng ký, Mới trong tuần) không match clean drill-down route, defer Phase 4

## Testing

- [x] Production build: `npm run build` SUCCESS
- [x] Browser eval verified (3 surface):
  - `/admin/users/admins` create modal: `class="btn-primary"` "Thêm quản trị viên"
  - `/admin/users/teachers` create modal: `class="btn-primary"` "Thêm giảng viên"
  - 3 surface cell `Chưa đăng nhập`: `cursor-help=false` + `title=null` (đúng conditional)
- [x] Existing util tests: 15/15 PASS (no util changes)
- [x] CI: pending after push

## Risk & rollback

- **Risk**: thấp.
  - Rename SCSS class `.btn-orange/.btn-purple` → `.btn-primary` (2 file, 1 callsite mỗi). Grep confirm KHÔNG có usage khác.
  - C11 chỉ thay 1 cell mỗi surface (Hoạt động cuối). `formatRelativeTime` delegate util pure function.
  - Không thay đổi BE, util signature, route guard.
- **Rollback**: `git revert <SHA>`. Không có DB migration.

## Checklist

- [x] Tuân thủ Conventional Commits
- [x] Không commit secret
- [x] Không cập nhật docs (UI-only changes)
- [x] Không dead code / TODO
- [x] CI sẽ chạy
- [x] Self-reviewed diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)