### PR TITLE
fix(admin-sidebar): bổ sung 'Quản trị viên' vào users family group

### DIFF
--- a/fe/src/app/shared/components/navigation/sidebar.config.ts
+++ b/fe/src/app/shared/components/navigation/sidebar.config.ts
@@ -193,8 +193,14 @@ const allAdminMenuItems: SidebarMenuItem[] = [
     route: '/admin/users',
     icon: 'users',
     group: 'Quản lý',
+    // Children theo role hierarchy descending (All -> Admins -> Teachers ->
+    // Students) cho navigation affordance đồng bộ KPI drill-down PR #224.
+    // 'Quản trị viên' route /admin/users/admins được systemAdminGuard chặn
+    // ORG_ADMIN ở route layer; ORG_ADMIN dùng `orgAdminSidebarConfig`
+    // riêng nên không thấy item này (no FE filter cần thiết).
     children: [
       { label: 'Tất cả', route: '/admin/users/all', icon: 'users' },
+      { label: 'Quản trị viên', route: '/admin/users/admins', icon: 'shield' },
       { label: 'Giảng viên', route: '/admin/users/teachers', icon: 'briefcase' },
       { label: 'Học viên', route: '/admin/users/students', icon: 'graduation-cap' }
     ]


### PR DESCRIPTION
## Summary

User feedback (browser screenshot 2026-04-26): sidebar admin group "Người dùng" thiếu mục **"Quản trị viên"** dù route `/admin/users/admins` đã tồn tại + page polished ở PR #226 + KPI drill-down wire ở PR #224.

Closes #227

## Change type

- [x] Bug fix (sidebar nav inconsistency)

## What changed

`fe/src/app/shared/components/navigation/sidebar.config.ts:196-203` — `adminSidebarConfig.menuItems['Người dùng'].children` từ 3 → 4 mục:

```diff
 children: [
   { label: 'Tất cả', route: '/admin/users/all', icon: 'users' },
+  { label: 'Quản trị viên', route: '/admin/users/admins', icon: 'shield' },
   { label: 'Giảng viên', route: '/admin/users/teachers', icon: 'briefcase' },
   { label: 'Học viên', route: '/admin/users/students', icon: 'graduation-cap' }
 ]
```

Position 2 (sau "Tất cả", trước "Giảng viên") theo role hierarchy descending: **All → Admins → Teachers → Students**.

Icon `shield` (semantic: protection/authority cho admin role).

## Why

PR #224 wire `[route]="/admin/users/admins"` cho KPI card "Quản trị viên" trên `/admin/users/all` → ADMIN có thể drill-down tới page admins. Nhưng sidebar không expose route này → ADMIN nav back qua sidebar không tìm thấy item, phải dùng URL bar hoặc browser history.

Vi phạm DRY information architecture (KPI + sidebar phải align). Fix surgical 1 dòng SCSS config.

## Verified browser eval

```js
sidebar.sub-menu .sub-menu-item:
[
  { text: "Tất cả",          href: "/admin/users/all" },
  { text: "Quản trị viên",   href: "/admin/users/admins" },  ← NEW
  { text: "Giảng viên",      href: "/admin/users/teachers" },
  { text: "Học viên",        href: "/admin/users/students" }
]
```

## ORG_ADMIN không bị ảnh hưởng

`adminSidebarConfig` chỉ áp cho user role `'admin'`. ORG_ADMIN dùng `orgAdminSidebarConfig` riêng (line 252-297) — không có mục admin management vì `systemAdminGuard` chặn route `/admin/users/admins` cho ORG_ADMIN. Không cần FE filter conditional.

## Risk & rollback

- **Risk**: rất thấp — 1 line config thêm child item.
- **Rollback**: `git revert <SHA>`.

## Testing

- [x] Production build: `npm run build` SUCCESS
- [x] Browser eval verified 4 children render đúng href + thứ tự
- [x] CI pending after push

## Checklist

- [x] Tuân thủ Conventional Commits
- [x] Không commit secret
- [x] Không cập nhật docs
- [x] Self-reviewed diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)