### PR TITLE
feat(admin-users): expose organizationId + scope admins page theo tổ chức (multi-org SOTA)

### DIFF
--- a/backend/src/main/java/com/example/lms/identity/infrastructure/web/UserControllerV3.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/web/UserControllerV3.java
@@ -5,6 +5,8 @@ import com.example.lms.identity.domain.model.User;
 import com.example.lms.identity.domain.valueobject.PasswordPolicy;
 import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
+import com.example.lms.identity.infrastructure.persistence.OrganizationJpaRepository;
+import com.example.lms.identity.infrastructure.persistence.entity.OrganizationJpaEntity;
 import com.example.lms.course_authoring.infrastructure.persistence.JpaCourseRepository;
 import com.example.lms.course_authoring.infrastructure.persistence.entity.CourseJpaEntity;
 import com.example.lms.learning_delivery.infrastructure.persistence.JpaEnrollmentRepository;
@@ -58,6 +60,7 @@ public class UserControllerV3 {
     private final PasswordEncoder passwordEncoder;
     private final JpaEnrollmentRepository enrollmentRepository;
     private final JpaCourseRepository courseRepository;
+    private final OrganizationJpaRepository organizationRepository;
 
     @Operation(summary = "Get all users with pagination and filtering")
     @GetMapping
@@ -68,6 +71,10 @@ public class UserControllerV3 {
             @RequestParam(required = false) String search,
             @RequestParam(required = false) String role,
             @RequestParam(required = false) String status,
+            // Issue #229: ADMIN có thể filter user theo tổ chức cụ thể.
+            // ORG_ADMIN auto-scoped tới organization của họ — param này
+            // bị ignore cho ORG_ADMIN role (security: không cho cross-org).
+            @RequestParam(required = false) UUID organizationId,
             @org.springframework.security.core.annotation.AuthenticationPrincipal UserJpaEntity currentUser
     ) {
         PageRequest pageable = PageRequest.of(Math.max(0, page - 1), limit);
@@ -89,20 +96,16 @@ public class UserControllerV3 {
 
         Page<UserJpaEntity> users;
 
-        // ORG_ADMIN: filter to users within their organization
+        // ORG_ADMIN: filter to users within their organization (organizationId
+        // param từ FE bị ignore — auto-scope to own org, security boundary).
         if (isOrgAdmin(currentUser)) {
             UUID orgId = currentUser.getOrganizationId();
-            if (hasRole && hasSearch) {
-                users = userRepository.searchByOrganizationIdAndRoleAndKeyword(orgId, roleEnum, search, pageable);
-            } else if (hasRole) {
-                users = userRepository.findByOrganizationIdAndRole(orgId, roleEnum, pageable);
-            } else if (hasSearch) {
-                users = userRepository.searchByOrganizationIdAndKeyword(orgId, search, pageable);
-            } else {
-                users = userRepository.findByOrganizationId(orgId, pageable);
-            }
+            users = queryUsersInOrg(orgId, roleEnum, search, hasRole, hasSearch, pageable);
+        } else if (organizationId != null) {
+            // ADMIN with org filter (#229): scope to selected organization
+            users = queryUsersInOrg(organizationId, roleEnum, search, hasRole, hasSearch, pageable);
         } else {
-            // ADMIN: sees all users (unchanged)
+            // ADMIN: sees all users across orgs (unchanged behavior)
             if (hasRole && hasSearch) {
                 users = userRepository.searchUsersByRole(roleEnum, search, pageable);
             } else if (hasRole) {
@@ -114,12 +117,49 @@ public class UserControllerV3 {
             }
         }
 
-        Page<UserResponse> response = users.map(this::toResponse);
+        // Issue #229: batch lookup org names cho mọi user trong page có
+        // organizationId (avoid N+1 query). System ADMIN không thuộc org
+        // sẽ có organizationId=null và không cần lookup.
+        Map<UUID, String> orgNameMap = buildOrgNameMap(users.getContent());
+        Page<UserResponse> response = users.map(u -> toResponse(u, orgNameMap));
+
         // Issue #190 (F-T1): hydrate coursesCreated for TEACHER rows so the
         // teacher-management KPI strip ("Đang dạy", "Khóa học") shows real
         // numbers instead of zeros. Batched to a single SQL aggregate.
         enrichTeacherCourseCounts(response.getContent());
         return ResponseEntity.ok(ApiResponse.success(response, "Danh sách người dùng"));
+    }
+
+    /**
+     * Issue #229: 4-branch query helper cho org-scoped user list. Tránh
+     * duplicate logic giữa ORG_ADMIN auto-scope và ADMIN explicit filter.
+     */
+    private Page<UserJpaEntity> queryUsersInOrg(UUID orgId, UserJpaEntity.UserRole roleEnum,
+                                                  String search, boolean hasRole, boolean hasSearch,
+                                                  Pageable pageable) {
+        if (hasRole && hasSearch) {
+            return userRepository.searchByOrganizationIdAndRoleAndKeyword(orgId, roleEnum, search, pageable);
+        } else if (hasRole) {
+            return userRepository.findByOrganizationIdAndRole(orgId, roleEnum, pageable);
+        } else if (hasSearch) {
+            return userRepository.searchByOrganizationIdAndKeyword(orgId, search, pageable);
+        }
+        return userRepository.findByOrganizationId(orgId, pageable);
+    }
+
+    /**
+     * Issue #229: batch lookup org names cho 1 page user — tránh N+1 query
+     * khi convert per-row toResponse. Trả empty map nếu không user nào
+     * có organizationId (vd page chỉ có system ADMIN).
+     */
+    private Map<UUID, String> buildOrgNameMap(Collection<UserJpaEntity> users) {
+        Set<UUID> orgIds = users.stream()
+                .map(UserJpaEntity::getOrganizationId)
+                .filter(java.util.Objects::nonNull)
+                .collect(Collectors.toSet());
+        if (orgIds.isEmpty()) return Map.of();
+        return organizationRepository.findAllById(orgIds).stream()
+                .collect(Collectors.toMap(OrganizationJpaEntity::getId, OrganizationJpaEntity::getName));
     }
 
     @Operation(summary = "Get all users (capped at 1000)")
@@ -672,6 +712,18 @@ public class UserControllerV3 {
     }
 
     private UserResponse toResponse(UserJpaEntity user) {
+        return toResponse(user, Map.of());
+    }
+
+    /**
+     * Issue #229: overload accept pre-built `orgNameMap` để emit org info.
+     * System ADMIN có `organizationId=null` -> trả về null (FE hiển thị
+     * badge "Hệ thống" cho row không thuộc org). ORG_ADMIN/TEACHER/STUDENT
+     * thuộc org cụ thể -> orgName tra từ map (đã batch query 1 lần ở
+     * caller, tránh N+1).
+     */
+    private UserResponse toResponse(UserJpaEntity user, Map<UUID, String> orgNameMap) {
+        UUID orgId = user.getOrganizationId();
         return UserResponse.builder()
                 .id(user.getId().toString())
                 .username(user.getDisplayName())
@@ -687,10 +739,23 @@ public class UserControllerV3 {
                 .mustChangePassword(user.isMustChangePassword())
                 .createdAt(user.getCreatedAt() != null ? user.getCreatedAt().toString() : null)
                 .updatedAt(user.getUpdatedAt() != null ? user.getUpdatedAt().toString() : null)
+                .organizationId(orgId != null ? orgId.toString() : null)
+                .organizationName(orgId != null ? orgNameMap.get(orgId) : null)
                 .build();
     }
 
     private UserResponse toResponse(User user) {
+        // Issue #229: domain User overload — caller (single-user endpoint
+        // create/update) thường lookup org riêng nếu cần. Helper trả về
+        // organizationId dạng UUID string nhưng KHÔNG resolve org name
+        // (caller có thể gọi `organizationRepository.findById` nếu cần).
+        UUID orgId = user.getOrganizationId();
+        String orgName = null;
+        if (orgId != null) {
+            orgName = organizationRepository.findById(orgId)
+                    .map(OrganizationJpaEntity::getName)
+                    .orElse(null);
+        }
         return UserResponse.builder()
                 .id(user.getId().value().toString())
                 .username(user.getUsername())
@@ -702,6 +767,8 @@ public class UserControllerV3 {
                 .enabled(user.isEnabled())
                 .createdAt(user.getCreatedAt() != null ? user.getCreatedAt().toString() : null)
                 .updatedAt(user.getUpdatedAt() != null ? user.getUpdatedAt().toString() : null)
+                .organizationId(orgId != null ? orgId.toString() : null)
+                .organizationName(orgName)
                 .build();
     }
 
@@ -1033,6 +1100,12 @@ public class UserControllerV3 {
         private int loginCount;
         private int coursesCreated;
         private int coursesEnrolled;
+        /** Issue #229: organization scoping for multi-org admin management.
+         *  null cho system ADMIN (không thuộc org nào) — FE hiển thị "Hệ thống". */
+        private String organizationId;
+        /** Issue #229: tên tổ chức tra cứu batch (avoid N+1) tại UserControllerV3.
+         *  null đồng nghĩa với organizationId=null hoặc org đã bị xóa (orphan). */
+        private String organizationName;
     }
 
     @Data @NoArgsConstructor @AllArgsConstructor

--- a/backend/src/test/java/com/example/lms/identity/infrastructure/web/MultiTierAdminSecurityTest.java
+++ b/backend/src/test/java/com/example/lms/identity/infrastructure/web/MultiTierAdminSecurityTest.java
@@ -4,6 +4,8 @@ import com.example.lms.identity.application.usecase.UpdateUserUseCaseV3;
 import com.example.lms.identity.domain.model.User;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
+import com.example.lms.identity.infrastructure.persistence.OrganizationJpaRepository;
+import com.example.lms.identity.infrastructure.persistence.entity.OrganizationJpaEntity;
 import com.example.lms.course_authoring.infrastructure.persistence.JpaCourseRepository;
 import com.example.lms.learning_delivery.infrastructure.persistence.JpaEnrollmentRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +47,7 @@ class MultiTierAdminSecurityTest {
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private JpaEnrollmentRepository enrollmentRepository;
     @Mock private JpaCourseRepository courseRepository;
+    @Mock private OrganizationJpaRepository organizationRepository;
 
     @InjectMocks private UserControllerV3 controller;
 
@@ -623,6 +626,63 @@ class MultiTierAdminSecurityTest {
             ResponseEntity<?> response = controller.searchUsers("STUDENT", "student", 1, 10, teacher);
 
             assertThat(response.getStatusCode().value()).isEqualTo(403);
+        }
+    }
+
+    // =============================================
+    // Get Users — multi-org boundary tests (#229)
+    // =============================================
+
+    @Nested
+    @DisplayName("Get Users - ORG_ADMIN cross-org boundary (#229)")
+    class GetUsersOrgScopeTests {
+
+        @Test
+        @DisplayName("ORG_ADMIN gửi organizationId param khác org của họ -> param bị ignore, vẫn scope to own org")
+        void orgAdminCannotCrossOrgFilter() {
+            UUID otherOrgId = UUID.randomUUID();
+            // Mock UserJpaRepository.findByOrganizationId được gọi với own orgId,
+            // KHÔNG phải otherOrgId. Nếu logic sai, test sẽ fail vì stub không match.
+            org.springframework.data.domain.Page<UserJpaEntity> emptyPage =
+                    new org.springframework.data.domain.PageImpl<>(java.util.List.of());
+            when(userRepository.findByOrganizationId(eq(organizationId), any())).thenReturn(emptyPage);
+
+            // Act: ORG_ADMIN cố gắng filter sang org khác
+            controller.getUsers(1, 10, null, null, null, otherOrgId, orgAdmin);
+
+            // Assert: query was made with own organizationId, NOT otherOrgId
+            verify(userRepository).findByOrganizationId(eq(organizationId), any());
+            verify(userRepository, never()).findByOrganizationId(eq(otherOrgId), any());
+        }
+
+        @Test
+        @DisplayName("ADMIN system gửi organizationId param -> scope to that org")
+        void systemAdminCanFilterByOrg() {
+            UUID targetOrgId = UUID.randomUUID();
+            org.springframework.data.domain.Page<UserJpaEntity> emptyPage =
+                    new org.springframework.data.domain.PageImpl<>(java.util.List.of());
+            when(userRepository.findByOrganizationId(eq(targetOrgId), any())).thenReturn(emptyPage);
+
+            // Act: ADMIN filter to specific org
+            controller.getUsers(1, 10, null, null, null, targetOrgId, systemAdmin);
+
+            // Assert: query was made with targetOrgId
+            verify(userRepository).findByOrganizationId(eq(targetOrgId), any());
+        }
+
+        @Test
+        @DisplayName("ADMIN system không gửi organizationId -> findAll cross-org")
+        void systemAdminWithoutOrgFilterSeesAll() {
+            org.springframework.data.domain.Page<UserJpaEntity> emptyPage =
+                    new org.springframework.data.domain.PageImpl<>(java.util.List.of());
+            when(userRepository.findAll(any(org.springframework.data.domain.Pageable.class))).thenReturn(emptyPage);
+
+            // Act
+            controller.getUsers(1, 10, null, null, null, null, systemAdmin);
+
+            // Assert: cross-org findAll, không scope by orgId
+            verify(userRepository).findAll(any(org.springframework.data.domain.Pageable.class));
+            verify(userRepository, never()).findByOrganizationId(any(), any());
         }
     }
 

--- a/backend/src/test/java/com/example/lms/identity/infrastructure/web/UserControllerV3TeacherKpiTest.java
+++ b/backend/src/test/java/com/example/lms/identity/infrastructure/web/UserControllerV3TeacherKpiTest.java
@@ -81,7 +81,7 @@ class UserControllerV3TeacherKpiTest {
                 .thenReturn(teacherACountRow);
 
         ResponseEntity<ApiResponse<Page<UserControllerV3.UserResponse>>> response =
-                controller.getUsers(1, 10, null, null, null, admin);
+                controller.getUsers(1, 10, null, null, null, null, admin);
 
         @SuppressWarnings("ConstantConditions")
         List<UserControllerV3.UserResponse> rows = response.getBody().getData().getContent();
@@ -107,7 +107,7 @@ class UserControllerV3TeacherKpiTest {
                 .thenReturn(new PageImpl<>(users));
         when(courseRepository.countCoursesByTeacherIds(any())).thenReturn(List.of());
 
-        controller.getUsers(1, 10, null, null, null, admin);
+        controller.getUsers(1, 10, null, null, null, null, admin);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Collection<UUID>> captor = ArgumentCaptor.forClass(Collection.class);
@@ -124,7 +124,7 @@ class UserControllerV3TeacherKpiTest {
         when(userRepository.findAll(any(PageRequest.class)))
                 .thenReturn(new PageImpl<>(users));
 
-        controller.getUsers(1, 10, null, null, null, admin);
+        controller.getUsers(1, 10, null, null, null, null, admin);
 
         verify(courseRepository, never()).countCoursesByTeacherIds(any());
     }

--- a/fe/src/app/features/admin/infrastructure/services/admin.service.ts
+++ b/fe/src/app/features/admin/infrastructure/services/admin.service.ts
@@ -135,6 +135,10 @@ export interface AdminUser {
   coursesEnrolled?: number; // For STUDENT
   totalSpent?: number;
   permissions: string[];
+  // Issue #229: organization scoping multi-org admin management.
+  // null cho system ADMIN (không thuộc org nào — FE hiển thị "Hệ thống").
+  organizationId?: string;
+  organizationName?: string;
 }
 
 // Backend User interface - matches AdminUserDTO from backend
@@ -154,6 +158,10 @@ export interface BackendUser {
   coursesEnrolled?: number; // For STUDENT
   createdAt: string;
   updatedAt?: string;
+  // Issue #229: BE expose org info từ UserResponse#229.
+  // null cho system ADMIN không thuộc org.
+  organizationId?: string;
+  organizationName?: string;
 }
 
 // Create User Request
@@ -887,7 +895,10 @@ export class AdminService {
       coursesCreated: backendUser.coursesCreated ?? 0,
       coursesCooped: backendUser.coursesCooped ?? 0,
       coursesEnrolled: backendUser.coursesEnrolled ?? 0,
-      permissions: this.getPermissionsForRole(backendUser.role)
+      permissions: this.getPermissionsForRole(backendUser.role),
+      // Issue #229: forward org info từ BE (null cho system ADMIN)
+      organizationId: backendUser.organizationId,
+      organizationName: backendUser.organizationName
     };
   }
 

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
@@ -56,6 +56,16 @@
           <option value="BLOCKED">Bị khóa</option>
           <option value="RESTRICTED">Hạn chế</option>
         </select>
+        <!-- Issue #229: Filter theo tổ chức cho multi-org admin management.
+             'system' option lọc system ADMIN không thuộc org nào. -->
+        <select [value]="orgFilter()" (change)="onOrgFilterChange($any($event.target).value)"
+                class="filter-select" aria-label="Lọc theo tổ chức">
+          <option value="">Tất cả tổ chức</option>
+          <option value="system">Hệ thống (không thuộc tổ chức)</option>
+          @for (org of organizations(); track org.id) {
+            <option [value]="org.id">{{ org.name }}</option>
+          }
+        </select>
       </div>
       <div class="filter-summary">
         <p class="filter-summary-text">
@@ -94,6 +104,8 @@
                 </th>
                 <th>Quản trị viên</th>
                 <th>Vai trò</th>
+                <!-- Issue #229: column "Tổ chức" multi-org admin scoping. -->
+                <th>Tổ chức</th>
                 <th>Trạng thái</th>
                 <th>Hoạt động cuối</th>
                 <th>Đăng nhập</th>
@@ -130,6 +142,16 @@
                       <option value="TEACHER">Giảng viên</option>
                       <option value="ADMIN">Quản trị viên</option>
                     </select>
+                  </td>
+                  <!-- Issue #229: Tổ chức column — badge "Hệ thống" cho
+                       system ADMIN không thuộc org, badge org name cho
+                       ORG_ADMIN thuộc tổ chức cụ thể. -->
+                  <td>
+                    @if (admin.organizationName) {
+                      <span class="badge badge-org">{{ admin.organizationName }}</span>
+                    } @else {
+                      <span class="badge badge-system">Hệ thống</span>
+                    }
                   </td>
                   <!-- Status -->
                   <td>

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
@@ -143,12 +143,18 @@
                       <option value="ADMIN">Quản trị viên</option>
                     </select>
                   </td>
-                  <!-- Issue #229: Tổ chức column — badge "Hệ thống" cho
-                       system ADMIN không thuộc org, badge org name cho
-                       ORG_ADMIN thuộc tổ chức cụ thể. -->
+                  <!-- Issue #229: Tổ chức column — 3 trạng thái:
+                       - organizationName != null -> badge org name (blue)
+                       - organizationId != null nhưng organizationName null -> orphan
+                         (org đã bị xóa) -> badge "(Tổ chức bị xóa)" gray
+                       - cả 2 null -> system ADMIN -> badge "Hệ thống" gray.
+                       Phân biệt orphan vs system tránh confusion (sub-agent
+                       review P1b PR #230). -->
                   <td>
                     @if (admin.organizationName) {
                       <span class="badge badge-org">{{ admin.organizationName }}</span>
+                    } @else if (admin.organizationId) {
+                      <span class="badge badge-system">(Tổ chức bị xóa)</span>
                     } @else {
                       <span class="badge badge-system">Hệ thống</span>
                     }

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.scss
@@ -356,6 +356,17 @@ $orange-700: #9A3412;
 .badge-warning { background: $warning-light; color: $warning; }
 .badge-default { background: $gray-100; color: $gray-800; }
 
+/* Issue #229: org scoping badges — phân biệt visual giữa system ADMIN
+   ("Hệ thống" gray) và ORG_ADMIN thuộc tổ chức (org name blue tint). */
+.badge-system {
+  background: $gray-100;
+  color: $gray-700;
+}
+.badge-org {
+  background: rgba($blue-primary, 0.1);
+  color: $blue-hover;
+}
+
 .status-dot {
   width: 6px;
   height: 6px;

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
@@ -4,6 +4,8 @@ import { RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { forkJoin } from 'rxjs';
 import { AdminService, AdminUser, UserAccountStatus, UpdateUserStatusRequest } from '../../infrastructure/services/admin.service';
+import { OrganizationService } from '../../infrastructure/services/organization.service';
+import { Organization } from '../../../../shared/types/user.types';
 import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
 import { AuthService } from '../../../../core/services/auth.service';
@@ -25,6 +27,7 @@ import { formatRelativeTimeVN } from '../../../../shared/utils/relative-time.uti
 })
 export class AdminUserManagementComponent implements OnInit {
   private adminService = inject(AdminService);
+  private organizationService = inject(OrganizationService);
   private toast = inject(ToastService);
   private confirmDialog = inject(ConfirmDialogService);
   private authService = inject(AuthService);
@@ -32,9 +35,12 @@ export class AdminUserManagementComponent implements OnInit {
 
   // State
   allUsers = signal<AdminUser[]>([]);
+  organizations = signal<Organization[]>([]);  // #229: cho dropdown filter org
   isLoading = signal(false);
   searchQuery = signal('');
   statusFilter = signal('');
+  // Issue #229: '' = tất cả, 'system' = ADMIN không thuộc org, UUID = org cụ thể
+  orgFilter = signal('');
   showCreateModal = signal(false);
   newAdminName = signal('');
   newAdminEmail = signal('');
@@ -78,6 +84,7 @@ export class AdminUserManagementComponent implements OnInit {
     let admins = this.adminUsers();
     const query = this.searchQuery().toLowerCase();
     const status = this.statusFilter();
+    const org = this.orgFilter();
 
     if (query) {
       admins = admins.filter(a =>
@@ -88,6 +95,16 @@ export class AdminUserManagementComponent implements OnInit {
 
     if (status) {
       admins = admins.filter(a => a.accountStatus === status);
+    }
+
+    // Issue #229: org filter — 'system' = system ADMIN không có organizationId,
+    // UUID = scope tới org cụ thể. '' = không filter, hiển thị tất cả.
+    if (org) {
+      if (org === 'system') {
+        admins = admins.filter(a => !a.organizationId);
+      } else {
+        admins = admins.filter(a => a.organizationId === org);
+      }
     }
 
     return admins;
@@ -105,6 +122,7 @@ export class AdminUserManagementComponent implements OnInit {
 
   ngOnInit() {
     this.loadUsers();
+    this.loadOrganizations();
   }
 
   loadUsers() {
@@ -116,6 +134,15 @@ export class AdminUserManagementComponent implements OnInit {
         this.isLoading.set(false);
       },
       error: () => this.isLoading.set(false)
+    });
+  }
+
+  // Issue #229: load organizations cho filter dropdown. Silent fail nếu
+  // endpoint lỗi — page vẫn dùng được không có org filter.
+  private loadOrganizations() {
+    this.organizationService.listOrganizations().subscribe({
+      next: (orgs) => this.organizations.set(orgs),
+      error: () => this.organizations.set([])
     });
   }
 
@@ -293,6 +320,12 @@ export class AdminUserManagementComponent implements OnInit {
 
   onStatusFilterChange(value: string) {
     this.statusFilter.set(value);
+  }
+
+  // Issue #229: org filter handler — '' = tất cả, 'system' = ADMIN không
+  // thuộc org, UUID = scope tới org cụ thể.
+  onOrgFilterChange(value: string) {
+    this.orgFilter.set(value);
   }
 
   openCreateModal() {


### PR DESCRIPTION
## Summary

Cross-stack BE+FE — Wire org info vào `UserResponse` + filter admins page theo organization. Foundation cho multi-org admin management khi scale lên nhiều tổ chức maritime.

Closes #229

## Change type

- [x] Feature (multi-org scoping)
- [x] Bug fix (BE response missing org info)

## Scope

**Backend** (2 file):
- `UserControllerV3.java`: DTO + 2 helper + filter param
- `UserControllerV3TeacherKpiTest.java`: 3 test call sites add null arg

**Frontend** (4 file):
- `admin.service.ts`: AdminUser + BackendUser interface + mapper
- `admin-user-management.component.{ts,html,scss}`: state + filter + column

## What changed

### Backend

- **`UserResponse`** add `organizationId: String?`, `organizationName: String?`
- **`getUsers`** thêm `@RequestParam(required=false) UUID organizationId`
  - ORG_ADMIN: param ignored, auto-scope to own org (security)
  - ADMIN: optional filter scope tới org cụ thể
- **Helper `queryUsersInOrg`**: DRY 4-branch query (hasRole+hasSearch / hasRole / hasSearch / default) reuse cho ORG_ADMIN auto-scope + ADMIN explicit filter
- **Helper `buildOrgNameMap`**: batch lookup org names cho 1 page (avoid N+1 query)
- **`toResponse(UserJpaEntity, Map)` overload** accept pre-built map
- **`toResponse(User)` domain overload**: single-user lookup org name riêng

### Frontend

- `AdminUser` + `BackendUser` interface add 2 org fields
- `mapBackendUserToAdminUser` forward fields
- `admin-user-management`:
  - Inject `OrganizationService`, signals `organizations` + `orgFilter`
  - Load orgs trong `ngOnInit`
  - Filter computed: `''` = tất cả, `'system'` = không thuộc org, UUID = scope
  - Filter dropdown 3 option (Tất cả / Hệ thống / list orgs)
  - Column "Tổ chức" badge: `badge-org` blue cho user thuộc org, `badge-system` gray cho ADMIN không thuộc org

## Why

Hiện tại BE response thiếu `organizationId/Name` → FE không hiển thị org per row → ADMIN không phân biệt được ORG_ADMIN của org nào. Khi scale 10-50 tổ chức maritime, workflow overload.

**Industry SOTA pattern** (Auth0, Stripe Connect, GitHub Enterprise People, Linear Members): user row hiển thị org column + filter dropdown by org. Pattern hybrid cross-org flat search (giữ) + org filter (mới).

## Verified runtime smoke

```bash
GET /api/v3/users?role=ORG_ADMIN
→ orgId=a0000000-...01 | orgName=Wiii Org

GET /api/v3/users?organizationId=a0000000-...01
→ 4 users filter scope to Wiii Org
```

**Browser smoke** `/admin/users/admins`:
- Column "Tổ chức" badge "Wiii Org" rendered cho 4 admin (verified screenshot)
- Filter dropdown 3 option
- Sidebar "Quản trị viên" active blue

## Risk & rollback

- **Risk**: thấp.
  - BE: thêm 2 field optional vào response → JSON consumer ignore extra field (backward-compat). Filter param optional.
  - FE: AdminUser interface thêm field optional (`?:`) → mọi caller cũ vẫn type-safe.
  - N+1 query mitigated bằng batch lookup map.
- **Rollback**: `git revert <SHA>`. Không có DB migration.

## Out-of-scope (defer follow-up)

- Apply column "Tổ chức" cho `/admin/users/all`, `/admin/users/teachers`, `/admin/users/students` (consistency)
- `/admin/organizations/:id` detail page thêm tab Admins/Teachers/Students per-org (org-centric workflow Phase 2)

## Testing

- [x] Existing util tests pass
- [x] BE Maven compile success
- [x] BE Docker rebuild + restart + curl runtime smoke (org fields present, filter works)
- [x] FE production build pass (`npm run build`)
- [x] Browser eval verified column + filter render
- [x] CI: pending after push

## Checklist

- [x] Tuân thủ Conventional Commits
- [x] Không commit secret
- [x] Self-reviewed diff
- [x] Clean Architecture: BE inject repository qua DI, FE inject service qua DI

🤖 Generated with [Claude Code](https://claude.com/claude-code)