### PR TITLE
feat(multi-org-phase-1): foundation — default org HoLiLiHu + type field + NOT NULL constraint

### DIFF
--- a/backend/src/main/java/com/example/lms/identity/application/dto/OrganizationResponse.java
+++ b/backend/src/main/java/com/example/lms/identity/application/dto/OrganizationResponse.java
@@ -1,12 +1,16 @@
 package com.example.lms.identity.application.dto;
 
 import com.example.lms.identity.domain.model.Organization;
+import com.example.lms.identity.domain.model.OrganizationType;
 
 import java.time.Instant;
 import java.util.UUID;
 
 /**
  * Response DTO for organization data.
+ *
+ * Issue #231 (Phase 1): expose `type` (PLATFORM/PARTNER/INTERNAL) +
+ * `isDefault` flag để FE phân biệt org nền tảng vs đối tác.
  */
 public record OrganizationResponse(
     UUID id,
@@ -15,6 +19,8 @@ public record OrganizationResponse(
     String description,
     boolean enabled,
     int tokenExpiryDays,
+    OrganizationType type,
+    boolean isDefault,
     Instant createdAt,
     Instant updatedAt
 ) {
@@ -22,6 +28,7 @@ public record OrganizationResponse(
         return new OrganizationResponse(
             org.getId(), org.getName(), org.getCode(), org.getDescription(),
             org.isEnabled(), org.getTokenExpiryDays(),
+            org.getType(), org.isDefault(),
             org.getCreatedAt(), org.getUpdatedAt()
         );
     }

--- a/backend/src/main/java/com/example/lms/identity/application/usecase/AuthenticateWithGoogleUseCase.java
+++ b/backend/src/main/java/com/example/lms/identity/application/usecase/AuthenticateWithGoogleUseCase.java
@@ -7,6 +7,7 @@ import com.example.lms.identity.application.dto.VerifiedGoogleIdentity;
 import com.example.lms.identity.application.port.GoogleIdentityVerifierPort;
 import com.example.lms.identity.application.port.TokenService;
 import com.example.lms.identity.domain.model.ExternalIdentityProvider;
+import com.example.lms.identity.domain.model.Organization;
 import com.example.lms.identity.domain.model.Role;
 import com.example.lms.identity.domain.model.User;
 import com.example.lms.identity.domain.model.UserExternalIdentity;
@@ -133,9 +134,16 @@ public class AuthenticateWithGoogleUseCase {
                 throw new DomainException("INVITE_INVALID", e.getMessage());
             }
         } else {
-            organizationRepository.findByCode("WIII")
-                    .filter(org -> org.isEnabled())
-                    .ifPresent(org -> user.assignToOrganization(org.getId()));
+            // Issue #231 (Phase 1): default to platform org via findDefault()
+            // (HoLiLiHu Org PLATFORM type). Throw nếu không tìm thấy — Phase 1
+            // enforce mọi user phải thuộc 1 org, không silent fail.
+            Organization defaultOrg = organizationRepository.findDefault()
+                    .filter(Organization::isEnabled)
+                    .or(() -> organizationRepository.findByCode("HOLILIHU")
+                            .filter(Organization::isEnabled))
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Không tìm thấy tổ chức nền tảng mặc định — V119 migration phải được apply"));
+            user.assignToOrganization(defaultOrg.getId());
         }
 
         return user;

--- a/backend/src/main/java/com/example/lms/identity/application/usecase/RegisterUserUseCaseV2.java
+++ b/backend/src/main/java/com/example/lms/identity/application/usecase/RegisterUserUseCaseV2.java
@@ -41,7 +41,10 @@ public class RegisterUserUseCaseV2 {
     private final AcceptInviteUseCase acceptInviteUseCase;
     private final OrganizationRepository organizationRepository;
 
-    private static final String DEFAULT_ORG_CODE = "WIII";
+    // Issue #231 (Phase 1): default org code đã đổi WIII -> HOLILIHU (V119
+    // migration). Dùng `findDefault()` thay hardcode để tránh fragility nếu
+    // sau này admin rename code lần nữa.
+    private static final String LEGACY_DEFAULT_ORG_CODE = "HOLILIHU";
 
     @Transactional
     public AuthResponse execute(RegisterUserCommand command) {
@@ -86,16 +89,18 @@ public class RegisterUserUseCaseV2 {
                 throw new ValidationException("inviteCode", e.getMessage());
             }
         } else {
-            // Default: assign to Wiii Org — log warning if not found
-            Organization defaultOrg = organizationRepository.findByCode(DEFAULT_ORG_CODE)
+            // Issue #231 (Phase 1): default to platform org via findDefault()
+            // (PLATFORM type + is_default=true). Fallback findByCode cho
+            // legacy compat nếu migration chưa apply (dev/staging old).
+            // Phase 1 enforce mọi user thuộc 1 org -> throw nếu không tìm
+            // thấy default org (data inconsistency, không cho silent fail).
+            Organization defaultOrg = organizationRepository.findDefault()
                     .filter(Organization::isEnabled)
-                    .orElse(null);
-            if (defaultOrg != null) {
-                user.assignToOrganization(defaultOrg.getId());
-            } else {
-                log.warn("Default organization '{}' not found or disabled — user {} will have no org",
-                        DEFAULT_ORG_CODE, command.email());
-            }
+                    .or(() -> organizationRepository.findByCode(LEGACY_DEFAULT_ORG_CODE)
+                            .filter(Organization::isEnabled))
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Không tìm thấy tổ chức nền tảng mặc định — V119 migration phải được apply"));
+            user.assignToOrganization(defaultOrg.getId());
         }
 
         // Save using domain repository

--- a/backend/src/main/java/com/example/lms/identity/domain/model/Organization.java
+++ b/backend/src/main/java/com/example/lms/identity/domain/model/Organization.java
@@ -16,6 +16,8 @@ public class Organization {
     private String description;
     private boolean enabled;
     private int tokenExpiryDays;
+    private OrganizationType type;
+    private boolean isDefault;
     private Instant createdAt;
     private Instant updatedAt;
 
@@ -23,6 +25,7 @@ public class Organization {
 
     public Organization(UUID id, String name, String code, String description,
                         boolean enabled, int tokenExpiryDays,
+                        OrganizationType type, boolean isDefault,
                         Instant createdAt, Instant updatedAt) {
         this.id = Objects.requireNonNull(id);
         this.name = Objects.requireNonNull(name, "Tên tổ chức không được null");
@@ -30,8 +33,21 @@ public class Organization {
         this.description = description;
         this.enabled = enabled;
         this.tokenExpiryDays = tokenExpiryDays;
+        this.type = type != null ? type : OrganizationType.PARTNER;
+        this.isDefault = isDefault;
         this.createdAt = createdAt != null ? createdAt : Instant.now();
         this.updatedAt = updatedAt;
+    }
+
+    /**
+     * Issue #231: backward-compat constructor cho call sites cũ chưa biết
+     * về OrganizationType. Defaults type=PARTNER, isDefault=false.
+     */
+    public Organization(UUID id, String name, String code, String description,
+                        boolean enabled, int tokenExpiryDays,
+                        Instant createdAt, Instant updatedAt) {
+        this(id, name, code, description, enabled, tokenExpiryDays,
+             OrganizationType.PARTNER, false, createdAt, updatedAt);
     }
 
     public static Organization create(String name, String code, String description, int tokenExpiryDays) {
@@ -40,7 +56,9 @@ public class Organization {
         }
         return new Organization(
             UUID.randomUUID(), name, code.toUpperCase(), description,
-            true, tokenExpiryDays, Instant.now(), null
+            true, tokenExpiryDays,
+            OrganizationType.PARTNER, false,
+            Instant.now(), null
         );
     }
 
@@ -71,6 +89,11 @@ public class Organization {
         }
     }
 
+    /** Issue #231: phân biệt PLATFORM org (system) vs PARTNER (external). */
+    public boolean isPlatform() {
+        return type == OrganizationType.PLATFORM;
+    }
+
     // Getters
     public UUID getId() { return id; }
     public String getName() { return name; }
@@ -78,6 +101,8 @@ public class Organization {
     public String getDescription() { return description; }
     public boolean isEnabled() { return enabled; }
     public int getTokenExpiryDays() { return tokenExpiryDays; }
+    public OrganizationType getType() { return type; }
+    public boolean isDefault() { return isDefault; }
     public Instant getCreatedAt() { return createdAt; }
     public Instant getUpdatedAt() { return updatedAt; }
 

--- a/backend/src/main/java/com/example/lms/identity/domain/model/OrganizationType.java
+++ b/backend/src/main/java/com/example/lms/identity/domain/model/OrganizationType.java
@@ -1,0 +1,21 @@
+package com.example.lms.identity.domain.model;
+
+/**
+ * Issue #231 (Phase 1): Organization type enum cho multi-tenant model.
+ *
+ * <ul>
+ *   <li>{@link #PLATFORM} — tổ chức nền tảng (HoLiLiHu Org). Là home org
+ *   của system ADMIN và người dùng đăng ký cá nhân. Chỉ có 1 row PLATFORM
+ *   duy nhất (enforced bằng `is_default` partial unique index ở DB).</li>
+ *   <li>{@link #PARTNER} — tổ chức đối tác (trường hàng hải khác, công ty
+ *   đào tạo thuyền viên, đơn vị kiểm định). ORG_ADMIN scoped tại đây.</li>
+ *   <li>{@link #INTERNAL} — tổ chức nội bộ thuộc cùng tổ chức quản lý
+ *   platform nhưng tách phòng ban (vd Phòng Đào tạo vs Khoa Hàng hải).
+ *   Phase 2+, hiện default fallback PARTNER.</li>
+ * </ul>
+ */
+public enum OrganizationType {
+    PLATFORM,
+    PARTNER,
+    INTERNAL
+}

--- a/backend/src/main/java/com/example/lms/identity/domain/repository/OrganizationRepository.java
+++ b/backend/src/main/java/com/example/lms/identity/domain/repository/OrganizationRepository.java
@@ -23,4 +23,11 @@ public interface OrganizationRepository {
     boolean existsByCode(String code);
 
     long count();
+
+    /**
+     * Issue #231 (Phase 1): tìm tổ chức nền tảng mặc định (PLATFORM type
+     * + is_default=true). Chỉ có 1 row trong DB (partial unique index).
+     * Là home org cho system ADMIN + người dùng đăng ký cá nhân.
+     */
+    Optional<Organization> findDefault();
 }

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/OrganizationJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/OrganizationJpaRepository.java
@@ -16,4 +16,7 @@ public interface OrganizationJpaRepository extends JpaRepository<OrganizationJpa
 
     /** Count organizations with {@code enabled = true} (issue #200, F-ORG-1). */
     long countByEnabledTrue();
+
+    /** Issue #231 (Phase 1): tìm default platform org. */
+    Optional<OrganizationJpaEntity> findByIsDefaultTrue();
 }

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/OrganizationRepositoryAdapter.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/OrganizationRepositoryAdapter.java
@@ -48,4 +48,9 @@ public class OrganizationRepositoryAdapter implements OrganizationRepository {
     public long count() {
         return jpaRepo.count();
     }
+
+    @Override
+    public Optional<Organization> findDefault() {
+        return jpaRepo.findByIsDefaultTrue().map(mapper::toDomain);
+    }
 }

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/entity/OrganizationJpaEntity.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/entity/OrganizationJpaEntity.java
@@ -27,6 +27,16 @@ public class OrganizationJpaEntity {
     @Column(name = "token_expiry_days", nullable = false)
     private Integer tokenExpiryDays = 30;
 
+    /** Issue #231 (V119): PLATFORM | PARTNER | INTERNAL — phân biệt
+     *  org nền tảng vs đối tác cho multi-tenant scoping. */
+    @Column(name = "type", nullable = false, length = 32)
+    private String type = "PARTNER";
+
+    /** Issue #231 (V119): chỉ 1 org có is_default=true (partial unique
+     *  index ở DB). Default org là home cho user đăng ký cá nhân. */
+    @Column(name = "is_default", nullable = false)
+    private Boolean isDefault = false;
+
     @Column(name = "created_at", nullable = false)
     private Instant createdAt = Instant.now();
 
@@ -53,6 +63,12 @@ public class OrganizationJpaEntity {
 
     public Integer getTokenExpiryDays() { return tokenExpiryDays; }
     public void setTokenExpiryDays(Integer tokenExpiryDays) { this.tokenExpiryDays = tokenExpiryDays; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public Boolean getIsDefault() { return isDefault; }
+    public void setIsDefault(Boolean isDefault) { this.isDefault = isDefault; }
 
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/mapper/OrganizationEntityMapper.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/mapper/OrganizationEntityMapper.java
@@ -1,6 +1,7 @@
 package com.example.lms.identity.infrastructure.persistence.mapper;
 
 import com.example.lms.identity.domain.model.Organization;
+import com.example.lms.identity.domain.model.OrganizationType;
 import com.example.lms.identity.infrastructure.persistence.entity.OrganizationJpaEntity;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,8 @@ public class OrganizationEntityMapper {
             entity.getDescription(),
             entity.getEnabled() != null && entity.getEnabled(),
             entity.getTokenExpiryDays() != null ? entity.getTokenExpiryDays() : 30,
+            parseType(entity.getType()),
+            entity.getIsDefault() != null && entity.getIsDefault(),
             entity.getCreatedAt(),
             entity.getUpdatedAt()
         );
@@ -30,8 +33,20 @@ public class OrganizationEntityMapper {
         entity.setDescription(domain.getDescription());
         entity.setEnabled(domain.isEnabled());
         entity.setTokenExpiryDays(domain.getTokenExpiryDays());
+        entity.setType(domain.getType() != null ? domain.getType().name() : OrganizationType.PARTNER.name());
+        entity.setIsDefault(domain.isDefault());
         entity.setCreatedAt(domain.getCreatedAt());
         entity.setUpdatedAt(domain.getUpdatedAt());
         return entity;
+    }
+
+    /** Issue #231: tolerant parse — bad data fallback PARTNER thay vì throw. */
+    private OrganizationType parseType(String raw) {
+        if (raw == null || raw.isBlank()) return OrganizationType.PARTNER;
+        try {
+            return OrganizationType.valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            return OrganizationType.PARTNER;
+        }
     }
 }

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/mapper/OrganizationEntityMapper.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/mapper/OrganizationEntityMapper.java
@@ -3,8 +3,10 @@ package com.example.lms.identity.infrastructure.persistence.mapper;
 import com.example.lms.identity.domain.model.Organization;
 import com.example.lms.identity.domain.model.OrganizationType;
 import com.example.lms.identity.infrastructure.persistence.entity.OrganizationJpaEntity;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class OrganizationEntityMapper {
 
@@ -40,12 +42,14 @@ public class OrganizationEntityMapper {
         return entity;
     }
 
-    /** Issue #231: tolerant parse — bad data fallback PARTNER thay vì throw. */
+    /** Issue #231: tolerant parse — bad data fallback PARTNER thay vì throw.
+     *  Log warn để DBA biết có corruption (sub-agent review #232 P1). */
     private OrganizationType parseType(String raw) {
         if (raw == null || raw.isBlank()) return OrganizationType.PARTNER;
         try {
             return OrganizationType.valueOf(raw.trim().toUpperCase());
         } catch (IllegalArgumentException ex) {
+            log.warn("Organization type corruption: invalid value='{}', fallback PARTNER", raw);
             return OrganizationType.PARTNER;
         }
     }

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/web/OrganizationControllerV3.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/web/OrganizationControllerV3.java
@@ -72,6 +72,20 @@ public class OrganizationControllerV3 {
         return ResponseEntity.ok(ApiResponse.success(listOrganizationsUseCase.execute()));
     }
 
+    /**
+     * Issue #231 (Phase 1): trả về org nền tảng default (HoLiLiHu Org).
+     * Public endpoint (không cần auth) — dùng cho registration flow để
+     * client biết home org của user đăng ký cá nhân + branding header.
+     */
+    @GetMapping("/default")
+    @Operation(summary = "Tổ chức mặc định (PLATFORM)")
+    public ResponseEntity<ApiResponse<OrganizationResponse>> getDefaultOrganization() {
+        return orgRepo.findDefault()
+                .map(org -> ResponseEntity.ok(ApiResponse.success(OrganizationResponse.from(org))))
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(ApiResponse.error("Không tìm thấy tổ chức mặc định")));
+    }
+
     @GetMapping("/stats")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Thống kê tổ chức (ADMIN only)")

--- a/backend/src/main/resources/db/migration/V119__multi_org_foundation.sql
+++ b/backend/src/main/resources/db/migration/V119__multi_org_foundation.sql
@@ -1,0 +1,65 @@
+-- V119: Multi-org foundation (issue #231 — Phase 1).
+--
+-- Goal: enforce mọi user thuộc 1 organization. Default platform org
+-- "HoLiLiHu Org" (renamed từ "Wiii Org" V64) cho system ADMIN +
+-- người dùng đăng ký cá nhân.
+--
+-- Architecture: Option B Hybrid (sub-agent research 12 SOTA platforms).
+-- - PLATFORM org: nơi vận hành platform, ADMIN home org
+-- - PARTNER org: tổ chức đối tác (trường khác, công ty đào tạo)
+-- - INTERNAL org: tổ chức nội bộ (Phase 2+)
+--
+-- Backward compat: V64 đã backfill users.organization_id IS NULL ->
+-- default org. Migration này incremental, idempotent.
+
+-- ============================================================
+-- 1. Add organizations.type + is_default columns
+-- ============================================================
+ALTER TABLE organizations
+    ADD COLUMN IF NOT EXISTS type VARCHAR(32) NOT NULL DEFAULT 'PARTNER';
+
+ALTER TABLE organizations
+    ADD COLUMN IF NOT EXISTS is_default BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Type enum constraint (PLATFORM | PARTNER | INTERNAL)
+ALTER TABLE organizations
+    DROP CONSTRAINT IF EXISTS chk_organizations_type;
+ALTER TABLE organizations
+    ADD CONSTRAINT chk_organizations_type
+        CHECK (type IN ('PLATFORM', 'PARTNER', 'INTERNAL'));
+
+-- Partial unique index: chỉ 1 row có is_default = TRUE
+CREATE UNIQUE INDEX IF NOT EXISTS uq_organizations_default
+    ON organizations (is_default) WHERE is_default = TRUE;
+
+-- ============================================================
+-- 2. Promote default org seed (Wiii Org -> HoLiLiHu Org PLATFORM)
+--
+-- V64 seed UUID 'a0000000-0000-0000-0000-000000000001'. Rename name
+-- + code, set type=PLATFORM, is_default=TRUE. Idempotent qua WHERE.
+-- ============================================================
+UPDATE organizations
+SET name = 'HoLiLiHu Org',
+    code = 'HOLILIHU',
+    description = 'Tổ chức nền tảng — vận hành LMS Maritime + người dùng đăng ký cá nhân',
+    type = 'PLATFORM',
+    is_default = TRUE,
+    updated_at = NOW()
+WHERE id = 'a0000000-0000-0000-0000-000000000001';
+
+-- ============================================================
+-- 3. Backfill any user còn null organization_id sau V64 (idempotent
+-- guard cho dữ liệu mới insert giữa V64 -> V119 nếu có)
+-- ============================================================
+UPDATE users
+SET organization_id = 'a0000000-0000-0000-0000-000000000001'
+WHERE organization_id IS NULL;
+
+-- ============================================================
+-- 4. Enforce NOT NULL constraint trên users.organization_id
+--
+-- Sau backfill bước 3, không còn null nào. Nếu vẫn còn (data
+-- inconsistency), ALTER sẽ fail và Flyway rollback migration.
+-- ============================================================
+ALTER TABLE users
+    ALTER COLUMN organization_id SET NOT NULL;

--- a/backend/src/main/resources/db/migration/V119__multi_org_foundation.sql
+++ b/backend/src/main/resources/db/migration/V119__multi_org_foundation.sql
@@ -60,6 +60,20 @@ WHERE organization_id IS NULL;
 --
 -- Sau backfill bước 3, không còn null nào. Nếu vẫn còn (data
 -- inconsistency), ALTER sẽ fail và Flyway rollback migration.
+--
+-- Idempotent guard: nếu cột đã NOT NULL (rerun migration), skip
+-- ALTER để tránh confusion log. PG ALTER SET NOT NULL bản thân
+-- là idempotent runtime, nhưng DO $$ block document intent rõ.
 -- ============================================================
-ALTER TABLE users
-    ALTER COLUMN organization_id SET NOT NULL;
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'users'
+          AND column_name = 'organization_id'
+          AND is_nullable = 'YES'
+    ) THEN
+        ALTER TABLE users ALTER COLUMN organization_id SET NOT NULL;
+    END IF;
+END $$;

--- a/backend/src/test/java/com/example/lms/identity/application/usecase/AuthenticateWithGoogleUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/identity/application/usecase/AuthenticateWithGoogleUseCaseTest.java
@@ -7,6 +7,7 @@ import com.example.lms.identity.application.port.GoogleIdentityVerifierPort;
 import com.example.lms.identity.application.port.TokenService;
 import com.example.lms.identity.domain.model.ExternalIdentityProvider;
 import com.example.lms.identity.domain.model.Organization;
+import com.example.lms.identity.domain.model.OrganizationType;
 import com.example.lms.identity.domain.model.Role;
 import com.example.lms.identity.domain.model.User;
 import com.example.lms.identity.domain.model.UserExternalIdentity;
@@ -134,11 +135,13 @@ class AuthenticateWithGoogleUseCaseTest {
         UUID orgId = UUID.randomUUID();
         Organization defaultOrg = new Organization(
                 orgId,
-                "WIII",
-                "WIII",
-                "Default organization",
+                "HoLiLiHu Org",
+                "HOLILIHU",
+                "Tổ chức nền tảng",
                 true,
                 30,
+                OrganizationType.PLATFORM,
+                true,
                 Instant.now(),
                 null
         );
@@ -150,7 +153,7 @@ class AuthenticateWithGoogleUseCaseTest {
         when(userRepository.findByEmail("cadet@example.com")).thenReturn(Optional.empty());
         when(userRepository.existsByUsername("cadet@example.com")).thenReturn(false);
         when(passwordEncoder.encode(anyString())).thenReturn("encoded-google-only-password");
-        when(organizationRepository.findByCode("WIII")).thenReturn(Optional.of(defaultOrg));
+        when(organizationRepository.findDefault()).thenReturn(Optional.of(defaultOrg));
         when(organizationRepository.findById(orgId)).thenReturn(Optional.of(defaultOrg));
         when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(tokenService.generateAccessToken(any(UUID.class), anyString(), anyString(), eq(orgId)))
@@ -252,6 +255,6 @@ class AuthenticateWithGoogleUseCaseTest {
         assertThat(savedUser.getOrganizationId()).isEqualTo(invitedOrgId);
         assertThat(response.user().organizationId()).isEqualTo(invitedOrgId);
         verify(acceptInviteUseCase).acceptForNewUser("INVITE-2026");
-        verify(organizationRepository, never()).findByCode("WIII");
+        verify(organizationRepository, never()).findDefault();
     }
 }

--- a/backend/src/test/java/com/example/lms/identity/application/usecase/RegisterUserUseCaseV2Test.java
+++ b/backend/src/test/java/com/example/lms/identity/application/usecase/RegisterUserUseCaseV2Test.java
@@ -3,6 +3,8 @@ package com.example.lms.identity.application.usecase;
 import com.example.lms.identity.application.dto.AuthResponse;
 import com.example.lms.identity.application.dto.RegisterUserCommand;
 import com.example.lms.identity.application.port.TokenService;
+import com.example.lms.identity.domain.model.Organization;
+import com.example.lms.identity.domain.model.OrganizationType;
 import com.example.lms.identity.domain.model.Role;
 import com.example.lms.identity.domain.model.User;
 import com.example.lms.identity.domain.repository.UserRepository;
@@ -21,6 +23,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;
@@ -84,6 +88,24 @@ class RegisterUserUseCaseV2Test {
         );
     }
 
+    /** Issue #231 Phase 1: helper tạo PLATFORM default org cho test mock.
+     *  Mọi test register-without-invite dùng `findDefault()` → cần stub
+     *  để useCase không throw IllegalStateException. */
+    private Organization platformDefaultOrg() {
+        return new Organization(
+            UUID.randomUUID(),
+            "HoLiLiHu Org",
+            "HOLILIHU",
+            "Tổ chức nền tảng",
+            true,
+            30,
+            OrganizationType.PLATFORM,
+            true,
+            Instant.now(),
+            null
+        );
+    }
+
     @Nested
     @DisplayName("Happy Path Tests")
     class HappyPathTests {
@@ -94,6 +116,7 @@ class RegisterUserUseCaseV2Test {
             // Given
             when(userRepository.existsByUsername(anyString())).thenReturn(false);
             when(userRepository.existsByEmail(anyString())).thenReturn(false);
+            when(organizationRepository.findDefault()).thenReturn(Optional.of(platformDefaultOrg()));
             when(passwordEncoder.encode(anyString())).thenReturn(ENCODED_PASSWORD);
             when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
             when(tokenService.generateAccessToken(any(UUID.class), anyString(), anyString(), any())).thenReturn(ACCESS_TOKEN);
@@ -116,6 +139,7 @@ class RegisterUserUseCaseV2Test {
             // Given
             when(userRepository.existsByUsername(anyString())).thenReturn(false);
             when(userRepository.existsByEmail(anyString())).thenReturn(false);
+            when(organizationRepository.findDefault()).thenReturn(Optional.of(platformDefaultOrg()));
             when(passwordEncoder.encode("Password123!")).thenReturn(ENCODED_PASSWORD);
             when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
             when(tokenService.generateAccessToken(any(UUID.class), anyString(), anyString(), any())).thenReturn(ACCESS_TOKEN);
@@ -138,6 +162,7 @@ class RegisterUserUseCaseV2Test {
             // Given
             when(userRepository.existsByUsername(anyString())).thenReturn(false);
             when(userRepository.existsByEmail(anyString())).thenReturn(false);
+            when(organizationRepository.findDefault()).thenReturn(Optional.of(platformDefaultOrg()));
             when(passwordEncoder.encode(anyString())).thenReturn(ENCODED_PASSWORD);
             when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
             when(tokenService.generateAccessToken(any(UUID.class), anyString(), anyString(), any())).thenReturn(ACCESS_TOKEN);
@@ -165,6 +190,7 @@ class RegisterUserUseCaseV2Test {
 
             when(userRepository.existsByUsername("hacker")).thenReturn(false);
             when(userRepository.existsByEmail("hacker@test.com")).thenReturn(false);
+            when(organizationRepository.findDefault()).thenReturn(Optional.of(platformDefaultOrg()));
             when(passwordEncoder.encode("securePass99")).thenReturn("encoded-pw");
 
             User savedUser = User.createNew(
@@ -197,6 +223,7 @@ class RegisterUserUseCaseV2Test {
 
             when(userRepository.existsByUsername("orguser")).thenReturn(false);
             when(userRepository.existsByEmail("orguser@test.com")).thenReturn(false);
+            when(organizationRepository.findDefault()).thenReturn(Optional.of(platformDefaultOrg()));
             when(passwordEncoder.encode("securePass99")).thenReturn("encoded-pw");
 
             User savedUser = User.createNew(
@@ -229,6 +256,7 @@ class RegisterUserUseCaseV2Test {
 
             when(userRepository.existsByUsername("newuser")).thenReturn(false);
             when(userRepository.existsByEmail("newuser@test.com")).thenReturn(false);
+            when(organizationRepository.findDefault()).thenReturn(Optional.of(platformDefaultOrg()));
             when(passwordEncoder.encode("securePass99")).thenReturn("encoded-pw");
 
             User savedUser = User.createNew(
@@ -324,6 +352,7 @@ class RegisterUserUseCaseV2Test {
             // Given
             when(userRepository.existsByUsername(anyString())).thenReturn(false);
             when(userRepository.existsByEmail(anyString())).thenReturn(false);
+            when(organizationRepository.findDefault()).thenReturn(Optional.of(platformDefaultOrg()));
             when(passwordEncoder.encode("Password123!")).thenReturn(ENCODED_PASSWORD);
             when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
             when(tokenService.generateAccessToken(any(UUID.class), anyString(), anyString(), any())).thenReturn(ACCESS_TOKEN);
@@ -342,6 +371,7 @@ class RegisterUserUseCaseV2Test {
             // Given
             when(userRepository.existsByUsername(anyString())).thenReturn(false);
             when(userRepository.existsByEmail(anyString())).thenReturn(false);
+            when(organizationRepository.findDefault()).thenReturn(Optional.of(platformDefaultOrg()));
             when(passwordEncoder.encode(anyString())).thenReturn(ENCODED_PASSWORD);
             when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
             when(tokenService.generateAccessToken(any(UUID.class), anyString(), anyString(), any())).thenReturn(ACCESS_TOKEN);

--- a/fe/src/app/features/admin/infrastructure/services/organization.service.ts
+++ b/fe/src/app/features/admin/infrastructure/services/organization.service.ts
@@ -18,6 +18,16 @@ export class OrganizationService {
   }
 
   /**
+   * Issue #231 (Phase 1): trả về org nền tảng default (HoLiLiHu Org).
+   * Dùng cho registration flow + branding header.
+   */
+  getDefault(): Observable<Organization> {
+    return this.api.get<ApiResponse<Organization>>(`${ORGANIZATION_ENDPOINTS.BASE}/default`).pipe(
+      map(res => res.data)
+    );
+  }
+
+  /**
    * Aggregate stats over all organizations — KPI strip on /admin/organizations
    * (issue #200, F-ORG-1). ADMIN role only.
    */

--- a/fe/src/app/shared/types/user.types.ts
+++ b/fe/src/app/shared/types/user.types.ts
@@ -42,6 +42,10 @@ export interface RegisterRequest {
 }
 
 // Organization types
+// Issue #231 (Phase 1): type + isDefault cho multi-tenant scoping.
+// PLATFORM = HoLiLiHu Org nền tảng, PARTNER = đối tác, INTERNAL = nội bộ.
+export type OrganizationType = 'PLATFORM' | 'PARTNER' | 'INTERNAL';
+
 export interface Organization {
   id: string;
   name: string;
@@ -49,6 +53,8 @@ export interface Organization {
   description: string | null;
   enabled: boolean;
   tokenExpiryDays: number;
+  type: OrganizationType;
+  isDefault: boolean;
   createdAt: string;
   updatedAt: string | null;
 }


### PR DESCRIPTION
## Summary

Phase 1 multi-org foundation: enforce mọi user thuộc 1 tổ chức + default platform org "HoLiLiHu Org" + organization type enum.

Closes #231

## Architecture

Sub-agent research 12 SOTA platforms (GitHub Enterprise, Auth0, Stripe, Azure AD, Google Workspace, AWS Org, Atlassian, Notion, Slack, Salesforce, Canvas, Moodle Workplace) → **Option B Hybrid org-centric**.

- ADMIN home org = HoLiLiHu Org (PLATFORM)
- ORG_ADMIN home org = PARTNER org
- TEACHER/STUDENT thuộc home org (mặc định HoLiLiHu Org)

## Change type

- [x] Feature (multi-tenant foundation)
- [x] Migration (V119 schema enforcement)

## What changed

### V119 migration `multi_org_foundation.sql`
- `organizations.type VARCHAR(32) NOT NULL DEFAULT 'PARTNER'` + CHECK constraint enum (PLATFORM/PARTNER/INTERNAL)
- `organizations.is_default BOOLEAN NOT NULL DEFAULT FALSE` + partial unique index (chỉ 1 row default)
- Promote Wiii Org seed → "HoLiLiHu Org" (rename + code "HOLILIHU" + type=PLATFORM + is_default=TRUE)
- Backfill any null `users.organization_id` → default org id (idempotent guard)
- ALTER `users.organization_id` SET NOT NULL

### BE domain + JPA
- `OrganizationType` enum (PLATFORM | PARTNER | INTERNAL)
- `Organization` domain add `type`, `isDefault` + `isPlatform()` helper
- Backward-compat constructor cho call sites cũ chưa biết về OrganizationType
- `OrganizationJpaEntity` add columns + getters
- `OrganizationEntityMapper` tolerant parseType (bad data → PARTNER fallback)

### BE repository
- `OrganizationRepository` port + `findDefault()` method
- `OrganizationJpaRepository` Spring Data `findByIsDefaultTrue()`
- `OrganizationRepositoryAdapter` implementation

### BE controller
- `OrganizationResponse` DTO add `type` + `isDefault` fields
- New endpoint `GET /api/v3/organizations/default` → trả default org info

### BE registration use cases — enforce
- `RegisterUserUseCaseV2` + `AuthenticateWithGoogleUseCase`: dùng `findDefault()` thay hardcoded "WIII" code, throw nếu không tìm thấy (Phase 1 enforce, no silent fail)

### FE
- `Organization` interface add `type: OrganizationType`, `isDefault: boolean`
- `OrganizationType` type alias
- `OrganizationService.getDefault()` method

## Verified runtime smoke

```
Flyway: "Successfully applied 1 migration to schema public, now at version v119 (execution time 00:00.074s)"

GET /api/v3/organizations/default →
{
  "id": "a0000000-0000-0000-0000-000000000001",
  "name": "HoLiLiHu Org",
  "code": "HOLILIHU",
  "type": "PLATFORM",
  "isDefault": true,
  ...
}
```

## Risk + rollback

- **Risk**: medium (DB migration ALTER NOT NULL + rename existing org).
- **Idempotent**: V64 đã backfill, V119 chỉ ALTER constraint + rename. Migration script idempotent qua `IF NOT EXISTS` + `WHERE` clause.
- **Rollback**: revert commit + V120 reverse migration (ALTER COLUMN DROP NOT NULL + restore Wiii Org name nếu cần).
- **Test fixture impact**: User factory không thay đổi signature, nhưng caller use cases enforce orgId via repository lookup. Existing test `MultiTierAdminSecurityTest` mock UserJpaEntity trực tiếp → không ảnh hưởng.

## Phase 2-4 defer follow-up

- Phase 2: Org detail page tabs (`/admin/orgs/:id/users|courses|analytics`)
- Phase 3: Sidebar restructure 2-mode (cross-org + org-scoped drill-down)
- Phase 4: Cross-org views polish + invite partner org flow + branding per-org

## Testing

- [x] BE Maven compile success
- [x] BE Docker rebuild + V119 migration applied successfully
- [x] BE Smoke `/default` endpoint returns HoLiLiHu Org PLATFORM
- [x] FE production build pass
- [x] CI pending after push

## Checklist

- [x] Conventional Commits
- [x] Không commit secret
- [x] Self-reviewed diff
- [x] Clean Architecture: domain pure POJO, mapper layer, repository port-adapter
- [x] DDD: aggregate Organization với invariants validate ở constructor

🤖 Generated with [Claude Code](https://claude.com/claude-code)