### PR TITLE
fix(multi-org): repair default org bootstrap

### DIFF
--- a/backend/src/main/java/com/example/lms/config/PublicApiEndpointMatcher.java
+++ b/backend/src/main/java/com/example/lms/config/PublicApiEndpointMatcher.java
@@ -34,6 +34,7 @@ public class PublicApiEndpointMatcher {
             "/api/v3/course-categories",
             "/api/v3/course-categories/**",
             "/api/v3/course-tags",
+            "/api/v3/organizations/default",
             "/uploads/**",
             "/api/v3/student/certificates/*/verify",
             "/api/v3/certificates/verify/*",

--- a/backend/src/main/resources/db/migration/V120__repair_default_platform_org.sql
+++ b/backend/src/main/resources/db/migration/V120__repair_default_platform_org.sql
@@ -1,0 +1,73 @@
+-- V120: Repair default platform organization after Phase 1 multi-org rollout.
+--
+-- PR #232 introduced V119 and the HoLiLiHu PLATFORM default org contract.
+-- Do not edit V119 after merge because environments may have already recorded
+-- its Flyway checksum. This forward-only migration repairs drift safely:
+-- - ensures the default org row exists before any user backfill
+-- - guarantees only that row is marked is_default=true
+-- - backfills any remaining users with organization_id IS NULL
+
+DO $$
+DECLARE
+    v_default_org_id UUID := 'a0000000-0000-0000-0000-000000000001';
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM organizations
+        WHERE code = 'HOLILIHU'
+          AND id <> v_default_org_id
+    ) THEN
+        RAISE EXCEPTION
+            'Cannot repair default organization: code HOLILIHU belongs to a different id';
+    END IF;
+
+    INSERT INTO organizations (
+        id,
+        name,
+        code,
+        description,
+        enabled,
+        token_expiry_days,
+        created_at,
+        updated_at,
+        type,
+        is_default
+    )
+    VALUES (
+        v_default_org_id,
+        'HoLiLiHu Org',
+        'HOLILIHU',
+        'Default platform organization for LMS Maritime and individual registrations',
+        TRUE,
+        30,
+        NOW(),
+        NOW(),
+        'PLATFORM',
+        FALSE
+    )
+    ON CONFLICT (id) DO NOTHING;
+
+    UPDATE organizations
+    SET is_default = FALSE,
+        updated_at = NOW()
+    WHERE is_default = TRUE
+      AND id <> v_default_org_id;
+
+    UPDATE organizations
+    SET name = 'HoLiLiHu Org',
+        code = 'HOLILIHU',
+        enabled = TRUE,
+        type = 'PLATFORM',
+        is_default = TRUE,
+        updated_at = CASE
+            WHEN (name, code, enabled, type, is_default)
+                 IS DISTINCT FROM ('HoLiLiHu Org', 'HOLILIHU', TRUE, 'PLATFORM', TRUE)
+            THEN NOW()
+            ELSE updated_at
+        END
+    WHERE id = v_default_org_id;
+
+    UPDATE users
+    SET organization_id = v_default_org_id
+    WHERE organization_id IS NULL;
+END $$;

--- a/backend/src/test/java/com/example/lms/config/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/example/lms/config/JwtAuthenticationFilterTest.java
@@ -101,6 +101,35 @@ class JwtAuthenticationFilterTest {
     }
 
     @Test
+    @DisplayName("default organization endpoint is public for registration bootstrap")
+    void defaultOrganizationEndpointIsPublic() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(
+                jwtService,
+                userDetailsService,
+                new PublicApiEndpointMatcher(),
+                testObjectMapper()
+        );
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v3/organizations/default");
+        request.addHeader("Authorization", "Bearer invalid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+        FilterChain chain = (req, res) -> {
+            chainCalled.set(true);
+            ((MockHttpServletResponse) res).setStatus(200);
+        };
+
+        given(jwtService.extractUsername("invalid-token"))
+                .willThrow(new SignatureException("JWT signature does not match locally computed signature."));
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(chainCalled.get()).isTrue();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
     @DisplayName("valid bearer token still authenticates optional-auth public routes")
     void validBearerStillAuthenticatesPublicRoute() throws Exception {
         JwtAuthenticationFilter filter = new JwtAuthenticationFilter(


### PR DESCRIPTION
﻿## Problem

Closes #233.

Independent review of Phase 1 Multi-Org Foundation after PR #232 found two P0 blockers:

1. `GET /api/v3/organizations/default` was documented as public for registration bootstrap, but it was missing from the shared public endpoint registry. Unauthenticated requests returned `403`.
2. V119 promoted the default org with an `UPDATE` against the expected seed UUID, so drifted databases without that seed could end up without a default org or fail user backfill.

## Root Cause

- `OrganizationControllerV3#getDefaultOrganization()` was added without updating `PublicApiEndpointMatcher`, which is the shared source of truth for `SecurityConfig` and optional-auth JWT behavior.
- V119 assumed V64's default organization seed always exists. Since V119 has already been merged/applied in some environments, this PR avoids changing the V119 checksum and repairs state with a forward-only migration.

## Fix

- Add `/api/v3/organizations/default` to `PublicApiEndpointMatcher`.
- Add a regression test proving the default organization endpoint behaves as a public route.
- Add `V120__repair_default_platform_org.sql` to:
  - create the HoLiLiHu PLATFORM default org if missing,
  - ensure only that org is marked `is_default=true`,
  - backfill any remaining `users.organization_id IS NULL` rows after the default org exists.

## Verified

- [x] `mvn test "-Dtest=JwtAuthenticationFilterTest,*Organization*,RegisterUserUseCaseV2Test,AuthenticateWithGoogleUseCaseTest"` -> 19 tests, 0 failures.
- [x] V120 probe on schema with no default org + one null user -> creates HoLiLiHu Org and leaves `0` null users.
- [x] `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build backend` -> Flyway migrated local DB from v119 to v120.
- [x] `curl -i http://localhost:8088/api/v3/organizations/default` without auth -> HTTP 200, `type=PLATFORM`, `isDefault=true`.
- [x] `git diff --check` -> clean.

## Notes for reviewers

This PR intentionally does not edit V119 to avoid Flyway checksum drift on environments that already applied PR #232. V120 is forward-only and idempotent for existing v119 databases.
