### PR TITLE
feat(org-detail): Phase 2 — Overview + Stats tabs + multi-tenant signals

### DIFF
--- a/fe/src/app/features/admin/presentation/components/organization-detail.component.html
+++ b/fe/src/app/features/admin/presentation/components/organization-detail.component.html
@@ -34,8 +34,9 @@
           <div class="header-meta">
             <span class="org-code">{{ org()!.code }}</span>
             <span class="dot-separator">&middot;</span>
-            <!-- Phase 2 (#235): type badge multi-tenant signal (PLATFORM/PARTNER/INTERNAL) -->
-            <span [ngClass]="orgTypeMeta[org()!.type].cssClass">{{ orgTypeMeta[org()!.type].label }}</span>
+            <!-- Phase 2 (#235): type badge multi-tenant signal (PLATFORM/PARTNER/INTERNAL).
+                 orgTypeBadge() null-safe fallback PARTNER cho legacy/corrupt data. -->
+            <span [ngClass]="orgTypeBadge().cssClass">{{ orgTypeBadge().label }}</span>
             <span class="dot-separator">&middot;</span>
             @if (org()!.enabled) {
               <span class="badge badge--active">Hoạt động</span>
@@ -126,7 +127,7 @@
               <div class="overview-info-row">
                 <dt>Loại tổ chức</dt>
                 <dd>
-                  <span [ngClass]="orgTypeMeta[org()!.type].cssClass">{{ orgTypeMeta[org()!.type].label }}</span>
+                  <span [ngClass]="orgTypeBadge().cssClass">{{ orgTypeBadge().label }}</span>
                   @if (org()!.isDefault) {
                     <span class="overview-info-note">— tổ chức nền tảng mặc định</span>
                   }

--- a/fe/src/app/features/admin/presentation/components/organization-detail.component.html
+++ b/fe/src/app/features/admin/presentation/components/organization-detail.component.html
@@ -23,9 +23,19 @@
           {{ org()!.code.substring(0, 2) }}
         </div>
         <div class="header-info">
-          <h1 class="header-title">{{ org()!.name }}</h1>
+          <h1 class="header-title">
+            {{ org()!.name }}
+            <!-- Phase 2 (#235): default org indicator — surfaces HoLiLiHu Org sau khi
+                 Phase 1 split type/isDefault. Title attribute giải thích cho user. -->
+            @if (org()!.isDefault) {
+              <span class="default-star" title="Tổ chức nền tảng — không thể xóa" aria-label="Tổ chức nền tảng">⭐</span>
+            }
+          </h1>
           <div class="header-meta">
             <span class="org-code">{{ org()!.code }}</span>
+            <span class="dot-separator">&middot;</span>
+            <!-- Phase 2 (#235): type badge multi-tenant signal (PLATFORM/PARTNER/INTERNAL) -->
+            <span [ngClass]="orgTypeMeta[org()!.type].cssClass">{{ orgTypeMeta[org()!.type].label }}</span>
             <span class="dot-separator">&middot;</span>
             @if (org()!.enabled) {
               <span class="badge badge--active">Hoạt động</span>
@@ -37,7 +47,7 @@
           </div>
         </div>
         <div class="header-actions">
-          <button type="button" class="btn-primary" (click)="activeTab.set('invites')">
+          <button type="button" class="btn-primary" (click)="selectTab('invites')">
             <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
             </svg>
@@ -75,11 +85,15 @@
 
       <!-- Tabs -->
       <div class="tab-bar">
-        <nav class="tab-nav">
+        <nav class="tab-nav" role="tablist" aria-label="Phần quản lý tổ chức">
           @for (tab of tabs; track tab.key) {
-            <button (click)="activeTab.set(tab.key)"
+            <button (click)="selectTab(tab.key)"
                     class="tab-btn"
-                    [class.tab-btn--active]="activeTab() === tab.key">
+                    [class.tab-btn--active]="activeTab() === tab.key"
+                    role="tab"
+                    [attr.aria-selected]="activeTab() === tab.key"
+                    [attr.aria-controls]="'panel-' + tab.key"
+                    [id]="'tab-' + tab.key">
               {{ tab.label }}
               @if (tab.key === 'members' && members().length > 0) {
                 <span class="tab-count" [class.tab-count--active]="activeTab() === 'members'" [class.tab-count--default]="activeTab() !== 'members'">
@@ -96,9 +110,101 @@
         </nav>
       </div>
 
+      <!-- ==================== OVERVIEW TAB (Phase 2 #235) ==================== -->
+      @if (activeTab() === 'overview') {
+        <div role="tabpanel" id="panel-overview" aria-labelledby="tab-overview" class="overview-grid">
+          <!-- Org info card — surfaces multi-tenant metadata (type, isDefault, code).
+               SOTA: Linear / Stripe org settings landing pattern. -->
+          <div class="card card-body overview-info-card">
+            <div class="overview-info-header">
+              <h3>Thông tin tổ chức</h3>
+              <button type="button" class="btn-link" (click)="selectTab('settings')">
+                Chỉnh sửa
+              </button>
+            </div>
+            <dl class="overview-info-list">
+              <div class="overview-info-row">
+                <dt>Loại tổ chức</dt>
+                <dd>
+                  <span [ngClass]="orgTypeMeta[org()!.type].cssClass">{{ orgTypeMeta[org()!.type].label }}</span>
+                  @if (org()!.isDefault) {
+                    <span class="overview-info-note">— tổ chức nền tảng mặc định</span>
+                  }
+                </dd>
+              </div>
+              <div class="overview-info-row">
+                <dt>Mã định danh</dt>
+                <dd><code class="overview-info-code">{{ org()!.code }}</code></dd>
+              </div>
+              <div class="overview-info-row">
+                <dt>Trạng thái</dt>
+                <dd>
+                  @if (org()!.enabled) {
+                    <span class="badge badge--active">Hoạt động</span>
+                  } @else {
+                    <span class="badge badge--disabled">Vô hiệu</span>
+                  }
+                </dd>
+              </div>
+              <div class="overview-info-row">
+                <dt>Token mặc định</dt>
+                <dd>{{ org()!.tokenExpiryDays }} ngày</dd>
+              </div>
+              <div class="overview-info-row">
+                <dt>Mô tả</dt>
+                <dd>{{ org()!.description || '—' }}</dd>
+              </div>
+              <div class="overview-info-row">
+                <dt>Tạo lúc</dt>
+                <dd>{{ org()!.createdAt | date:'dd/MM/yyyy HH:mm' }}</dd>
+              </div>
+              @if (org()!.updatedAt) {
+                <div class="overview-info-row">
+                  <dt>Cập nhật gần nhất</dt>
+                  <dd>{{ org()!.updatedAt | date:'dd/MM/yyyy HH:mm' }}</dd>
+                </div>
+              }
+            </dl>
+          </div>
+
+          <!-- Quick actions card — primary CTAs cho landing tab -->
+          <div class="card card-body overview-actions-card">
+            <h3>Hành động nhanh</h3>
+            <button type="button" class="overview-action-btn" (click)="selectTab('invites')">
+              <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"/>
+              </svg>
+              <div>
+                <div class="overview-action-title">Mời thành viên</div>
+                <div class="overview-action-sub">Tạo mã mời hoặc gửi email</div>
+              </div>
+            </button>
+            <button type="button" class="overview-action-btn" (click)="selectTab('payment-config')">
+              <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+              </svg>
+              <div>
+                <div class="overview-action-title">Cấu hình doanh thu</div>
+                <div class="overview-action-sub">Tỷ lệ chia nền tảng / giảng viên / tổ chức</div>
+              </div>
+            </button>
+            <button type="button" class="overview-action-btn" (click)="selectTab('settings')">
+              <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+              </svg>
+              <div>
+                <div class="overview-action-title">Cài đặt tổ chức</div>
+                <div class="overview-action-sub">Tên, mô tả, thời hạn token</div>
+              </div>
+            </button>
+          </div>
+        </div>
+      }
+
       <!-- ==================== MEMBERS TAB ==================== -->
       @if (activeTab() === 'members') {
-        <div class="card card-overflow">
+        <div role="tabpanel" id="panel-members" aria-labelledby="tab-members" class="card card-overflow">
           <div class="table-scroll">
             <table class="data-table">
               <thead>
@@ -221,6 +327,7 @@
 
       <!-- ==================== INVITES TAB ==================== -->
       @if (activeTab() === 'invites') {
+        <div role="tabpanel" id="panel-invites" aria-labelledby="tab-invites">
         <!-- Create Invite Actions -->
         <div class="card invite-actions">
           <h3>Tạo lời mời mới</h3>
@@ -381,11 +488,42 @@
             </table>
           </div>
         </div>
+        </div>
+      }
+
+      <!-- ==================== STATS TAB (Phase 2 #235) ==================== -->
+      @if (activeTab() === 'stats') {
+        <div role="tabpanel" id="panel-stats" aria-labelledby="tab-stats" class="card card-body stats-empty">
+          <div class="stats-empty-icon">
+            <svg class="icon-lg" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+            </svg>
+          </div>
+          <h3 class="stats-empty-title">Bảng điều khiển thống kê đang phát triển</h3>
+          <p class="stats-empty-desc">
+            Phase tiếp theo sẽ trực quan hóa: tăng trưởng thành viên, tỷ lệ sử dụng lời mời,
+            doanh thu khóa học, hoạt động đăng ký theo tuần.
+          </p>
+          <div class="stats-placeholder-grid">
+            <div class="stats-placeholder-card">
+              <div class="stats-placeholder-label">Tăng trưởng thành viên</div>
+              <div class="stats-placeholder-bar"></div>
+            </div>
+            <div class="stats-placeholder-card">
+              <div class="stats-placeholder-label">Sử dụng lời mời</div>
+              <div class="stats-placeholder-bar"></div>
+            </div>
+            <div class="stats-placeholder-card">
+              <div class="stats-placeholder-label">Doanh thu khóa học</div>
+              <div class="stats-placeholder-bar"></div>
+            </div>
+          </div>
+        </div>
       }
 
       <!-- ==================== PAYMENT CONFIG TAB ==================== -->
       @if (activeTab() === 'payment-config') {
-        <div class="config-section">
+        <div role="tabpanel" id="panel-payment-config" aria-labelledby="tab-payment-config" class="config-section">
           @if (isLoadingConfig()) {
             <div class="loading-center">
               <div class="loading-spinner-sm"></div>
@@ -518,7 +656,7 @@
 
       <!-- ==================== SETTINGS TAB ==================== -->
       @if (activeTab() === 'settings') {
-        <div class="card card-body settings-card">
+        <div role="tabpanel" id="panel-settings" aria-labelledby="tab-settings" class="card card-body settings-card">
           <h3>Cài đặt tổ chức</h3>
           <div class="settings-fields">
             <div>

--- a/fe/src/app/features/admin/presentation/components/organization-detail.component.scss
+++ b/fe/src/app/features/admin/presentation/components/organization-detail.component.scss
@@ -1149,6 +1149,248 @@
   }
 }
 
+/* =====================================================================
+   Phase 2 (#235): multi-tenant signals + Overview + Stats
+   ===================================================================== */
+
+/* Type badge (PLATFORM / PARTNER / INTERNAL) — sits cùng row với status
+   badge ở header, dùng cùng visual contract (rounded pill, 11/13px text). */
+.badge-org-type {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border: 1px solid transparent;
+}
+.badge-org-type--platform {
+  background: rgba(0, 86, 210, 0.08);
+  color: #0056D2;
+  border-color: rgba(0, 86, 210, 0.2);
+}
+.badge-org-type--partner {
+  background: rgba(124, 58, 237, 0.08);
+  color: #6D28D9;
+  border-color: rgba(124, 58, 237, 0.2);
+}
+.badge-org-type--internal {
+  background: #f3f4f6;
+  color: #4b5563;
+  border-color: #e5e7eb;
+}
+
+/* Default org indicator next to title — surface HoLiLiHu Org */
+.default-star {
+  font-size: 0.85em;
+  margin-left: 6px;
+  cursor: help;
+}
+
+/* Overview tab — landing layout (info card + quick actions card) */
+.overview-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: $spacing-6;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.overview-info-card {
+  .overview-info-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: $spacing-4;
+
+    h3 {
+      margin: 0;
+      font-size: 16px;
+      font-weight: 600;
+      color: #111827;
+    }
+  }
+
+  .btn-link {
+    background: none;
+    border: none;
+    color: #0056D2;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 6px;
+
+    &:hover { background: rgba(0, 86, 210, 0.06); }
+    &:focus-visible { outline: 2px solid #0056D2; outline-offset: 2px; }
+  }
+}
+
+.overview-info-list {
+  margin: 0;
+  display: grid;
+  grid-template-columns: minmax(140px, max-content) 1fr;
+  gap: $spacing-3 $spacing-4;
+}
+
+.overview-info-row {
+  display: contents;
+
+  dt {
+    color: #6b7280;
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  dd {
+    margin: 0;
+    color: #111827;
+    font-size: 14px;
+    word-break: break-word;
+  }
+}
+
+.overview-info-code {
+  background: #f3f4f6;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+
+.overview-info-note {
+  color: #6b7280;
+  font-size: 12px;
+  margin-left: 6px;
+}
+
+.overview-actions-card {
+  h3 {
+    margin: 0 0 $spacing-4 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: #111827;
+  }
+}
+
+.overview-action-btn {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-3;
+  width: 100%;
+  padding: $spacing-3;
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: $radius-lg;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  margin-bottom: $spacing-2;
+
+  &:hover {
+    border-color: #0056D2;
+    background: rgba(0, 86, 210, 0.02);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #0056D2;
+    outline-offset: 2px;
+  }
+
+  .icon {
+    width: 20px;
+    height: 20px;
+    color: #0056D2;
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+
+  &:last-child { margin-bottom: 0; }
+}
+
+.overview-action-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 2px;
+}
+
+.overview-action-sub {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+/* Stats tab — empty/coming-soon SOTA pattern (Linear/Stripe placeholder) */
+.stats-empty {
+  text-align: center;
+  padding: $spacing-8 $spacing-6;
+}
+
+.stats-empty-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: rgba(0, 86, 210, 0.08);
+  color: #0056D2;
+  margin-bottom: $spacing-4;
+
+  .icon-lg { width: 28px; height: 28px; }
+}
+
+.stats-empty-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #111827;
+  margin: 0 0 $spacing-2 0;
+}
+
+.stats-empty-desc {
+  font-size: 14px;
+  color: #6b7280;
+  margin: 0 auto $spacing-6 auto;
+  max-width: 540px;
+  line-height: 1.6;
+}
+
+.stats-placeholder-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: $spacing-3;
+  max-width: 720px;
+  margin: 0 auto;
+
+  @media (max-width: 640px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.stats-placeholder-card {
+  background: #f9fafb;
+  border: 1px dashed #d1d5db;
+  border-radius: $radius-lg;
+  padding: $spacing-4;
+  text-align: left;
+}
+
+.stats-placeholder-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #6b7280;
+  margin-bottom: $spacing-2;
+}
+
+.stats-placeholder-bar {
+  height: 48px;
+  background: linear-gradient(90deg, rgba(0, 86, 210, 0.08), rgba(0, 86, 210, 0.03));
+  border-radius: 6px;
+}
+
 /* ===== PRINT ===== */
 @media print {
   .org-detail-page {
@@ -1163,12 +1405,14 @@
   .btn-danger-text,
   .btn-icon-xs,
   .btn-token-display,
+  .btn-link,
   .header-actions,
   .invite-actions,
   .new-code-banner,
   .tab-bar,
   .config-actions,
   .settings-actions,
+  .overview-actions-card,
   app-kebab-menu {
     display: none !important;
   }

--- a/fe/src/app/features/admin/presentation/components/organization-detail.component.ts
+++ b/fe/src/app/features/admin/presentation/components/organization-detail.component.ts
@@ -1,4 +1,5 @@
-import { Component, signal, inject, OnInit, ChangeDetectionStrategy, computed } from '@angular/core';
+import { Component, signal, inject, OnInit, ChangeDetectionStrategy, computed, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { RouterModule, ActivatedRoute, Router } from '@angular/router';
 import { OrganizationService, OrgPaymentConfig } from '../../infrastructure/services/organization.service';
@@ -25,6 +26,7 @@ const VALID_TABS: ReadonlySet<Tab> = new Set([
 export class OrganizationDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
   private orgService = inject(OrganizationService);
   private toast = inject(ToastService);
   private confirmDialog = inject(ConfirmDialogService);
@@ -92,11 +94,19 @@ export class OrganizationDetailComponent implements OnInit {
   ];
 
   // Phase 2 (#235): multi-tenant signals — type badge variant + label + isDefault.
+  // Fallback dùng khi BE corruption / legacy data trả type=null hoặc value không
+  // map (BE đã có parseType warn fallback PARTNER, FE phản ánh chung).
+  private readonly orgTypeFallback = { label: 'Đối tác', cssClass: 'badge-org-type badge-org-type--partner' };
   readonly orgTypeMeta: Record<OrganizationType, { label: string; cssClass: string }> = {
     PLATFORM: { label: 'Nền tảng', cssClass: 'badge-org-type badge-org-type--platform' },
     PARTNER:  { label: 'Đối tác',  cssClass: 'badge-org-type badge-org-type--partner' },
     INTERNAL: { label: 'Nội bộ',   cssClass: 'badge-org-type badge-org-type--internal' }
   };
+  /** Phase 2 (#235): null-safe lookup cho header + overview info card. */
+  orgTypeBadge = computed(() => {
+    const type = this.org()?.type;
+    return (type && this.orgTypeMeta[type]) || this.orgTypeFallback;
+  });
 
   private orgId = '';
 
@@ -107,14 +117,17 @@ export class OrganizationDetailComponent implements OnInit {
       this.toast.error('Không tìm thấy tổ chức để quản lý');
       return;
     }
-    // Phase 2 (#235): deep-link tab restore từ query param. Sub Subscribe để
-    // pick up cả navigation trong cùng route (back/forward, share link).
-    this.route.queryParamMap.subscribe(params => {
-      const requested = params.get('tab') as Tab | null;
-      if (requested && VALID_TABS.has(requested)) {
-        this.activeTab.set(requested);
-      }
-    });
+    // Phase 2 (#235): deep-link tab restore từ query param. takeUntilDestroyed
+    // giải phóng subscription khi component destroy — tránh leak trên admin
+    // route navigation. Pick up cả back/forward + share link.
+    this.route.queryParamMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(params => {
+        const requested = params.get('tab') as Tab | null;
+        if (requested && VALID_TABS.has(requested)) {
+          this.activeTab.set(requested);
+        }
+      });
     this.loadAll();
     this.loadPaymentConfig();
   }

--- a/fe/src/app/features/admin/presentation/components/organization-detail.component.ts
+++ b/fe/src/app/features/admin/presentation/components/organization-detail.component.ts
@@ -1,15 +1,19 @@
 import { Component, signal, inject, OnInit, ChangeDetectionStrategy, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule, ActivatedRoute } from '@angular/router';
+import { RouterModule, ActivatedRoute, Router } from '@angular/router';
 import { OrganizationService, OrgPaymentConfig } from '../../infrastructure/services/organization.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
 import { AuthService } from '../../../../core/services/auth.service';
-import { Organization, OrganizationInvite, OrgMember } from '../../../../shared/types/user.types';
+import { Organization, OrganizationInvite, OrgMember, OrganizationType } from '../../../../shared/types/user.types';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 import { KebabMenuComponent, KebabAction } from '../../../../shared/components/admin/kebab-menu/kebab-menu.component';
 
-type Tab = 'members' | 'invites' | 'settings' | 'payment-config';
+type Tab = 'overview' | 'members' | 'invites' | 'settings' | 'payment-config' | 'stats';
+
+const VALID_TABS: ReadonlySet<Tab> = new Set([
+  'overview', 'members', 'invites', 'settings', 'payment-config', 'stats'
+]);
 
 @Component({
   selector: 'app-organization-detail',
@@ -20,6 +24,7 @@ type Tab = 'members' | 'invites' | 'settings' | 'payment-config';
 })
 export class OrganizationDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private router = inject(Router);
   private orgService = inject(OrganizationService);
   private toast = inject(ToastService);
   private confirmDialog = inject(ConfirmDialogService);
@@ -30,7 +35,9 @@ export class OrganizationDetailComponent implements OnInit {
   members = signal<OrgMember[]>([]);
   invites = signal<OrganizationInvite[]>([]);
   isLoading = signal(true);
-  activeTab = signal<Tab>('members');
+  // Phase 2 (#235): default 'overview' — landing card cho org info + multi-tenant
+  // signals (type, isDefault). Deep-link via query param ?tab=members|invites...
+  activeTab = signal<Tab>('overview');
 
   isCreatingInvite = signal(false);
   isSendingEmail = signal(false);
@@ -76,11 +83,20 @@ export class OrganizationDetailComponent implements OnInit {
   );
 
   readonly tabs = [
+    { key: 'overview' as Tab, label: 'Tổng quan' },
     { key: 'members' as Tab, label: 'Thành viên' },
     { key: 'invites' as Tab, label: 'Lời mời' },
-    { key: 'settings' as Tab, label: 'Cài đặt' },
-    { key: 'payment-config' as Tab, label: 'Cấu hình doanh thu' }
+    { key: 'stats' as Tab, label: 'Thống kê' },
+    { key: 'payment-config' as Tab, label: 'Cấu hình doanh thu' },
+    { key: 'settings' as Tab, label: 'Cài đặt' }
   ];
+
+  // Phase 2 (#235): multi-tenant signals — type badge variant + label + isDefault.
+  readonly orgTypeMeta: Record<OrganizationType, { label: string; cssClass: string }> = {
+    PLATFORM: { label: 'Nền tảng', cssClass: 'badge-org-type badge-org-type--platform' },
+    PARTNER:  { label: 'Đối tác',  cssClass: 'badge-org-type badge-org-type--partner' },
+    INTERNAL: { label: 'Nội bộ',   cssClass: 'badge-org-type badge-org-type--internal' }
+  };
 
   private orgId = '';
 
@@ -91,8 +107,27 @@ export class OrganizationDetailComponent implements OnInit {
       this.toast.error('Không tìm thấy tổ chức để quản lý');
       return;
     }
+    // Phase 2 (#235): deep-link tab restore từ query param. Sub Subscribe để
+    // pick up cả navigation trong cùng route (back/forward, share link).
+    this.route.queryParamMap.subscribe(params => {
+      const requested = params.get('tab') as Tab | null;
+      if (requested && VALID_TABS.has(requested)) {
+        this.activeTab.set(requested);
+      }
+    });
     this.loadAll();
     this.loadPaymentConfig();
+  }
+
+  /** Phase 2 (#235): chuyển tab + sync URL query param để deep-link / share. */
+  selectTab(tab: Tab): void {
+    this.activeTab.set(tab);
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { tab },
+      queryParamsHandling: 'merge',
+      replaceUrl: true
+    });
   }
 
   private loadAll(): void {


### PR DESCRIPTION
Closes #235

Phase 2 multi-org follow-up to PR #232 (Phase 1 foundation) + #234 (bootstrap fix). Surface metadata mới (type, isDefault) ở UI + thêm landing tab tổng hợp. Pure FE — không cần BE change.

## Scope

### A. Tab "Tổng quan" (Overview) — NEW default landing
- Org info card: type, mã, trạng thái, token mặc định, mô tả, tạo lúc, cập nhật lúc
- Quick actions: Mời thành viên / Cấu hình doanh thu / Cài đặt
- 2-column grid (info 2fr + actions 1fr), stack mobile <768px

### B. Tab "Thống kê" (Stats) — NEW placeholder
- SOTA empty state (Linear/Stripe coming-soon pattern)
- 3 chart placeholder cards: tăng trưởng thành viên / sử dụng lời mời / doanh thu

### C. Multi-tenant signals visible
- Header type badge: **PLATFORM** (xanh #0056D2) / **PARTNER** (tím #6D28D9) / **INTERNAL** (xám)
- Default org indicator ⭐ trên title nếu isDefault=true (HoLiLiHu Org)

### D. UX polish
- Deep-link query param `?tab=overview|members|invites|settings|payment-config|stats` — sync state ↔ URL via Router.navigate replaceUrl
- ARIA: tablist / tab / tabpanel / aria-controls / aria-labelledby / aria-selected
- selectTab() helper thay cho activeTab.set() rải rác
- Tab order: Overview → Members → Invites → Stats → Payment-config → Settings

## Verified
- npx tsc --noEmit: EXIT=0
- npm run build: success, fix-ngsw clean
- 3 files changed, +431/-14
- Apply cho cả admin (/admin/organizations/:id) lẫn org-admin (/org-admin/organization)

## Out of scope (defer Phase 3+)
- Sidebar 2-mode (Hệ thống / Tổ chức context-aware)
- Real chart components trong Stats — chỉ placeholder
- Cross-org views, invite partner org workflow

## Test plan
- [ ] Navigate /admin/organizations/HOLILIHU_ORG_ID → land trên Overview tab
- [ ] HoLiLiHu Org hiển thị ⭐ + type badge "Nền tảng" xanh
- [ ] Click tab khác → URL update với ?tab=X
- [ ] Refresh trang với ?tab=invites → land trực tiếp Invites
- [ ] Quick actions cards → click chuyển đúng tab tương ứng
- [ ] Stats tab hiển thị empty state đẹp
- [ ] org-admin landing /org-admin/organization → cùng pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)