### PR TITLE
feat(sidebar): Phase 3 PR 1 — org context awareness

### DIFF
--- a/fe/src/app/core/services/organization-context.service.ts
+++ b/fe/src/app/core/services/organization-context.service.ts
@@ -1,0 +1,25 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { ApiClient } from '../../api/client/api-client';
+import { ORGANIZATION_ENDPOINTS } from '../../api/endpoints/organization.endpoints';
+import { ApiResponse } from '../../api/types/common.types';
+import { Organization } from '../../shared/types/user.types';
+
+/**
+ * Issue #237 (Phase 3 PR 1): minimal shared org accessor cho shared components
+ * (sidebar, header). Tách khỏi features/admin/OrganizationService để tránh
+ * shared → features layer violation. Chỉ expose read methods cần cho context
+ * surface — không CRUD/invite/payment.
+ */
+@Injectable({ providedIn: 'root' })
+export class OrganizationContextService {
+  private api = inject(ApiClient);
+
+  /** Fetch single organization detail by id. Used for sidebar context block. */
+  getOrganization(id: string): Observable<Organization> {
+    return this.api.get<ApiResponse<Organization>>(ORGANIZATION_ENDPOINTS.BY_ID(id)).pipe(
+      map(res => res.data)
+    );
+  }
+}

--- a/fe/src/app/shared/components/navigation/sidebar.component.css
+++ b/fe/src/app/shared/components/navigation/sidebar.component.css
@@ -592,3 +592,128 @@
 .nav-item.force-active .nav-icon {
   color: #0056D2;
 }
+
+/* =====================================================================
+   Phase 3 PR 1 (#237): sidebar org context block
+   Pattern: GitHub org context bar, Linear workspace switcher
+   ===================================================================== */
+.sidebar-org-context {
+  margin: 0 12px 12px 12px;
+  padding: 12px;
+  background: linear-gradient(180deg, rgba(0, 86, 210, 0.04), rgba(0, 86, 210, 0.01));
+  border: 1px solid rgba(0, 86, 210, 0.12);
+  border-radius: 10px;
+}
+
+.sidebar-org-context-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.sidebar-org-avatar {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: white;
+  background: #0056D2;
+}
+.sidebar-org-avatar--platform { background: #0056D2; }
+.sidebar-org-avatar--partner  { background: #6D28D9; }
+.sidebar-org-avatar--internal { background: #6b7280; }
+
+.sidebar-org-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.sidebar-org-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: #111827;
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 4px;
+}
+
+.sidebar-org-default-star {
+  font-size: 0.85em;
+  margin-left: 2px;
+  cursor: help;
+}
+
+.sidebar-org-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.sidebar-org-type {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border: 1px solid transparent;
+  line-height: 1.4;
+}
+.sidebar-org-type--platform {
+  background: rgba(0, 86, 210, 0.1);
+  color: #0056D2;
+  border-color: rgba(0, 86, 210, 0.25);
+}
+.sidebar-org-type--partner {
+  background: rgba(124, 58, 237, 0.1);
+  color: #6D28D9;
+  border-color: rgba(124, 58, 237, 0.25);
+}
+.sidebar-org-type--internal {
+  background: #f3f4f6;
+  color: #4b5563;
+  border-color: #e5e7eb;
+}
+
+.sidebar-org-code {
+  font-size: 10px;
+  color: #6b7280;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  background: rgba(0, 0, 0, 0.04);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.sidebar-org-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: #6b7280;
+  text-decoration: none;
+  padding: 4px 6px;
+  margin: 0 -6px -4px -6px;
+  border-radius: 6px;
+  transition: all 0.15s ease;
+}
+
+.sidebar-org-back:hover {
+  background: rgba(0, 86, 210, 0.06);
+  color: #0056D2;
+}
+
+.sidebar-org-back:focus-visible {
+  outline: 2px solid #0056D2;
+  outline-offset: 1px;
+}

--- a/fe/src/app/shared/components/navigation/sidebar.component.html
+++ b/fe/src/app/shared/components/navigation/sidebar.component.html
@@ -19,6 +19,40 @@
         </button>
     </div>
 
+    <!-- Phase 3 PR 1 (#237): Org context block — auto-render khi user trong
+         org detail page. Pattern: GitHub org context bar, Linear workspace
+         switcher. Ẩn khi sidebar collapsed để tiết kiệm space. -->
+    @if (inOrgContext() && !collapsed()) {
+        <div class="sidebar-org-context" role="complementary" aria-label="Đang xem tổ chức">
+            <div class="sidebar-org-context-header">
+                <div class="sidebar-org-avatar"
+                     [class.sidebar-org-avatar--platform]="currentOrg()!.type === 'PLATFORM'"
+                     [class.sidebar-org-avatar--partner]="currentOrg()!.type === 'PARTNER'"
+                     [class.sidebar-org-avatar--internal]="currentOrg()!.type === 'INTERNAL'">
+                    {{ orgAvatarLabel() }}
+                </div>
+                <div class="sidebar-org-info">
+                    <div class="sidebar-org-name" [title]="currentOrg()!.name">
+                        {{ currentOrg()!.name }}
+                        @if (currentOrg()!.isDefault) {
+                            <span class="sidebar-org-default-star" aria-label="Tổ chức nền tảng" title="Tổ chức nền tảng">⭐</span>
+                        }
+                    </div>
+                    <div class="sidebar-org-meta">
+                        <span [class]="orgTypeBadge().cssClass">{{ orgTypeBadge().label }}</span>
+                        <span class="sidebar-org-code">{{ currentOrg()!.code }}</span>
+                    </div>
+                </div>
+            </div>
+            @if (orgListBackRoute()) {
+                <a [routerLink]="orgListBackRoute()" class="sidebar-org-back">
+                    <app-icon name="chevron-left" size="xs"/>
+                    <span>Danh sách tổ chức</span>
+                </a>
+            }
+        </div>
+    }
+
     <!-- Navigation Menu -->
     <nav class="sidebar-nav">
         @for (item of config().menuItems; track item.route; let i = $index) {

--- a/fe/src/app/shared/components/navigation/sidebar.component.ts
+++ b/fe/src/app/shared/components/navigation/sidebar.component.ts
@@ -1,9 +1,11 @@
-import { Component, input, output, signal, computed, inject, ChangeDetectionStrategy, ViewEncapsulation, OnInit, OnDestroy } from '@angular/core';
+import { Component, input, output, signal, computed, inject, ChangeDetectionStrategy, ViewEncapsulation, OnInit, OnDestroy, effect, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { RouterModule, Router, RouterLinkActive, NavigationEnd } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { AuthService } from '../../../core/services/auth.service';
-import { UserRole } from '../../../shared/types/user.types';
+import { Organization, OrganizationType, UserRole } from '../../../shared/types/user.types';
+import { OrganizationService } from '../../../features/admin/infrastructure/services/organization.service';
 import { IconComponent, IconName } from '../icon/icon.component';
 import { getPortalLandingRoute } from '../../../core/utils/portal-route.util';
 
@@ -37,6 +39,8 @@ export interface SidebarConfig {
 export class SidebarComponent implements OnInit, OnDestroy {
   protected authService = inject(AuthService);
   private router = inject(Router);
+  private orgService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
 
   config = input.required<SidebarConfig>();
   collapsed = input(false);
@@ -45,6 +49,78 @@ export class SidebarComponent implements OnInit, OnDestroy {
   // Reactive URL tracking — for alsoActiveFor matching (OnPush safe)
   private currentUrl = signal(this.router.url.split('?')[0]);
   private routerSub?: Subscription;
+
+  // ---------------------------------------------------------------------
+  // Phase 3 PR 1 (#237): org context awareness — auto-detect khi user trong
+  // org detail page (/admin/organizations/:id hoặc /org-admin/organization)
+  // và fetch org info để render compact context block ở top sidebar.
+  // Pattern: GitHub org context bar, Linear workspace switcher.
+  // ---------------------------------------------------------------------
+  private readonly orgIdFromUrl = computed<string | null>(() => {
+    const url = this.currentUrl();
+    // Admin org detail: /admin/organizations/{uuid}/...
+    const adminMatch = url.match(/^\/admin\/organizations\/([0-9a-f-]{8,})/i);
+    if (adminMatch) return adminMatch[1];
+    // Org-admin route /org-admin/organization — orgId implicit từ JWT
+    if (url.startsWith('/org-admin/organization')) {
+      return this.authService.currentUserSignal()?.organizationId ?? null;
+    }
+    return null;
+  });
+
+  protected currentOrg = signal<Organization | null>(null);
+  protected isLoadingOrg = signal(false);
+  protected inOrgContext = computed(() => !!this.currentOrg() && this.orgIdFromUrl() === this.currentOrg()!.id);
+
+  /** Null-safe type meta (consistent với org-detail Phase 2). */
+  private readonly orgTypeFallback = { label: 'Đối tác', cssClass: 'sidebar-org-type sidebar-org-type--partner' };
+  private readonly orgTypeMeta: Record<OrganizationType, { label: string; cssClass: string }> = {
+    PLATFORM: { label: 'Nền tảng', cssClass: 'sidebar-org-type sidebar-org-type--platform' },
+    PARTNER:  { label: 'Đối tác',  cssClass: 'sidebar-org-type sidebar-org-type--partner' },
+    INTERNAL: { label: 'Nội bộ',   cssClass: 'sidebar-org-type sidebar-org-type--internal' }
+  };
+  protected orgTypeBadge = computed(() => {
+    const type = this.currentOrg()?.type;
+    return (type && this.orgTypeMeta[type]) || this.orgTypeFallback;
+  });
+
+  /** 2-letter avatar từ org code (consistent với org-detail header). */
+  protected orgAvatarLabel = computed(() => {
+    const code = this.currentOrg()?.code ?? '';
+    return code.substring(0, 2).toUpperCase();
+  });
+
+  protected orgListBackRoute = computed(() => {
+    return this.config().role === 'admin' ? '/admin/organizations' : null;
+  });
+
+  constructor() {
+    // Khi orgId từ URL thay đổi → fetch org info (skip nếu đã cache đúng id).
+    effect((onCleanup) => {
+      const orgId = this.orgIdFromUrl();
+      if (!orgId) {
+        this.currentOrg.set(null);
+        this.isLoadingOrg.set(false);
+        return;
+      }
+      if (this.currentOrg()?.id === orgId) return;
+      this.isLoadingOrg.set(true);
+      const sub = this.orgService.getOrganization(orgId)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (org) => {
+            this.currentOrg.set(org);
+            this.isLoadingOrg.set(false);
+          },
+          error: () => {
+            // Silent fail — block ẩn nếu fetch lỗi (404/403/network).
+            this.currentOrg.set(null);
+            this.isLoadingOrg.set(false);
+          }
+        });
+      onCleanup(() => sub.unsubscribe());
+    });
+  }
 
   ngOnInit(): void {
     this.routerSub = this.router.events.pipe(

--- a/fe/src/app/shared/components/navigation/sidebar.component.ts
+++ b/fe/src/app/shared/components/navigation/sidebar.component.ts
@@ -1,11 +1,10 @@
-import { Component, input, output, signal, computed, inject, ChangeDetectionStrategy, ViewEncapsulation, OnInit, OnDestroy, effect, DestroyRef } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, input, output, signal, computed, inject, ChangeDetectionStrategy, ViewEncapsulation, OnInit, OnDestroy, effect } from '@angular/core';
 
 import { RouterModule, Router, RouterLinkActive, NavigationEnd } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { AuthService } from '../../../core/services/auth.service';
+import { OrganizationContextService } from '../../../core/services/organization-context.service';
 import { Organization, OrganizationType, UserRole } from '../../../shared/types/user.types';
-import { OrganizationService } from '../../../features/admin/infrastructure/services/organization.service';
 import { IconComponent, IconName } from '../icon/icon.component';
 import { getPortalLandingRoute } from '../../../core/utils/portal-route.util';
 
@@ -39,8 +38,7 @@ export interface SidebarConfig {
 export class SidebarComponent implements OnInit, OnDestroy {
   protected authService = inject(AuthService);
   private router = inject(Router);
-  private orgService = inject(OrganizationService);
-  private destroyRef = inject(DestroyRef);
+  private orgContextService = inject(OrganizationContextService);
 
   config = input.required<SidebarConfig>();
   collapsed = input(false);
@@ -61,8 +59,10 @@ export class SidebarComponent implements OnInit, OnDestroy {
     // Admin org detail: /admin/organizations/{uuid}/...
     const adminMatch = url.match(/^\/admin\/organizations\/([0-9a-f-]{8,})/i);
     if (adminMatch) return adminMatch[1];
-    // Org-admin route /org-admin/organization — orgId implicit từ JWT
-    if (url.startsWith('/org-admin/organization')) {
+    // Org-admin route /org-admin/organization — exact match để tránh false-
+    // positive với bất kỳ route nào prefix `/org-admin/organization*` future
+    // (e.g., /org-admin/organization-policies). orgId implicit từ JWT.
+    if (url === '/org-admin/organization') {
       return this.authService.currentUserSignal()?.organizationId ?? null;
     }
     return null;
@@ -96,6 +96,8 @@ export class SidebarComponent implements OnInit, OnDestroy {
 
   constructor() {
     // Khi orgId từ URL thay đổi → fetch org info (skip nếu đã cache đúng id).
+    // Cleanup: onCleanup() unsubscribe khi effect re-run (URL thay đổi nhanh)
+    // hoặc component destroy. Không cần takeUntilDestroyed vì effect tự dispose.
     effect((onCleanup) => {
       const orgId = this.orgIdFromUrl();
       if (!orgId) {
@@ -105,19 +107,18 @@ export class SidebarComponent implements OnInit, OnDestroy {
       }
       if (this.currentOrg()?.id === orgId) return;
       this.isLoadingOrg.set(true);
-      const sub = this.orgService.getOrganization(orgId)
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe({
-          next: (org) => {
-            this.currentOrg.set(org);
-            this.isLoadingOrg.set(false);
-          },
-          error: () => {
-            // Silent fail — block ẩn nếu fetch lỗi (404/403/network).
-            this.currentOrg.set(null);
-            this.isLoadingOrg.set(false);
-          }
-        });
+      const sub = this.orgContextService.getOrganization(orgId).subscribe({
+        next: (org) => {
+          this.currentOrg.set(org);
+          this.isLoadingOrg.set(false);
+        },
+        error: (err) => {
+          // Silent fail UI (block ẩn) nhưng log để debug fetch error.
+          console.warn('[sidebar] org context fetch failed', orgId, err);
+          this.currentOrg.set(null);
+          this.isLoadingOrg.set(false);
+        }
+      });
       onCleanup(() => sub.unsubscribe());
     });
   }


### PR DESCRIPTION
Closes #237

Phase 3 multi-org follow-up to Phase 1 (#232 #234) + Phase 2 (#236). Tách Phase 3 thành 3 PR nhỏ để Codex review từng phần dễ + ít risk. Đây là PR đầu tiên — pure FE, không cần BE change.

## Behavior

**Auto-detect org context** từ URL pattern:
- `/admin/organizations/{uuid}` (admin) → fetch + render
- `/org-admin/organization` (org-admin) → fetch + render (orgId implicit từ JWT)
- Other URLs → block ẩn, sidebar bình thường

**Block content** (compact card top of sidebar):
- Avatar 2-letter (background theo type: PLATFORM xanh / PARTNER tím / INTERNAL xám)
- Org name (truncate nếu dài)
- ⭐ default org indicator (HoLiLiHu Org)
- Type badge: Nền tảng / Đối tác / Nội bộ — null-safe fallback PARTNER
- Org code monospace pill
- Admin only: "← Danh sách tổ chức" back link

## Implementation note
- `orgIdFromUrl` computed từ currentUrl signal (regex admin + JWT fallback org-admin)
- `effect()` fetch OrganizationService.getOrganization() khi orgId change, skip nếu cache match
- `takeUntilDestroyed(DestroyRef)` cleanup
- Silent fail (404/403/network) → block ẩn, không toast spam
- Auto-hide khi sidebar collapsed

## Out of scope (defer PR 2, PR 3)
- **PR 2**: full mode toggle UI + role-aware org-scoped nav items
- **PR 3**: breadcrumb, animation, polish

## Verified
- npx tsc --noEmit: EXIT=0
- npm run build: success, fix-ngsw clean
- 3 files changed, +237/-2

## Pattern reference
- GitHub: org context bar (sticky top sidebar khi trong org)
- Linear: workspace switcher đầu sidebar
- Stripe: account header trong sidebar

## Test plan
- [ ] Navigate `/admin/organizations/HOLILIHU_ORG_ID` → sidebar context block hiện (HoLiLiHu Org + ⭐ + Nền tảng)
- [ ] Click "← Danh sách tổ chức" → back to /admin/organizations
- [ ] Navigate `/admin/dashboard` → block ẩn
- [ ] org-admin login → /org-admin/organization → block hiện cho org của họ
- [ ] Sidebar collapsed → block ẩn
- [ ] Toggle giữa nhiều org URLs → fetch không leak (DevTools Network: 1 request per orgId)
- [ ] Browser memory: navigate away → no lingering subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)