### PR TITLE
feat: Phase 3 PR 3 — breadcrumb + animation transitions + polish

### DIFF
--- a/fe/src/app/features/admin/presentation/components/organization-detail.component.html
+++ b/fe/src/app/features/admin/presentation/components/organization-detail.component.html
@@ -6,6 +6,28 @@
         <p class="loading-text">Đang tải thông tin tổ chức...</p>
       </div>
     } @else if (org()) {
+      <!-- Phase 3 PR 3 (#241): breadcrumb — Linear/Stripe/GitHub pattern.
+           3 levels: Tổ chức (admin) hoặc Trang chủ (org-admin) → Org Name
+           (current, no link) → active tab. Click level 1 = back to list. -->
+      <nav class="breadcrumb" aria-label="Đường dẫn">
+        <ol class="breadcrumb-list">
+          <li class="breadcrumb-item">
+            <a [routerLink]="backRoute()" class="breadcrumb-link">{{ breadcrumbRootLabel() }}</a>
+          </li>
+          <li class="breadcrumb-item breadcrumb-separator" aria-hidden="true">/</li>
+          <li class="breadcrumb-item">
+            <span class="breadcrumb-current"
+                  [attr.aria-current]="activeTabLabel() ? null : 'page'">{{ org()!.name }}</span>
+          </li>
+          @if (activeTabLabel()) {
+            <li class="breadcrumb-item breadcrumb-separator" aria-hidden="true">/</li>
+            <li class="breadcrumb-item">
+              <span class="breadcrumb-current breadcrumb-tab" aria-current="page">{{ activeTabLabel() }}</span>
+            </li>
+          }
+        </ol>
+      </nav>
+
       <!--
         F-OA-4: Page header — back link now binds to backRoute() computed
         signal (was hardcoded /admin/organizations, broke for ORG_ADMIN

--- a/fe/src/app/features/admin/presentation/components/organization-detail.component.scss
+++ b/fe/src/app/features/admin/presentation/components/organization-detail.component.scss
@@ -1150,6 +1150,76 @@
 }
 
 /* =====================================================================
+   Phase 3 PR 3 (#241): breadcrumb (Linear/Stripe/GitHub pattern)
+   ===================================================================== */
+.breadcrumb {
+  margin-bottom: $spacing-3;
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.breadcrumb-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.breadcrumb-item {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.breadcrumb-separator {
+  color: #d1d5db;
+  font-weight: 400;
+  user-select: none;
+}
+
+.breadcrumb-link {
+  color: #6b7280;
+  text-decoration: none;
+  padding: 2px 6px;
+  margin: 0 -6px;
+  border-radius: 4px;
+  transition: all 0.15s ease;
+
+  &:hover {
+    color: #0056D2;
+    background: rgba(0, 86, 210, 0.06);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #0056D2;
+    outline-offset: 1px;
+  }
+}
+
+.breadcrumb-current {
+  color: #111827;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 280px;
+}
+
+.breadcrumb-tab {
+  color: #4b5563;
+  font-weight: 400;
+}
+
+@media (max-width: 640px) {
+  .breadcrumb-current {
+    max-width: 160px;
+  }
+}
+
+/* =====================================================================
    Phase 2 (#235): multi-tenant signals + Overview + Stats
    ===================================================================== */
 
@@ -1181,11 +1251,25 @@
   border-color: #e5e7eb;
 }
 
-/* Default org indicator next to title — surface HoLiLiHu Org */
+/* Default org indicator next to title — surface HoLiLiHu Org.
+   Phase 3 PR 3 (#241): subtle pulse animation cho visual delight. */
 .default-star {
   font-size: 0.85em;
   margin-left: 6px;
   cursor: help;
+  display: inline-block;
+  animation: default-star-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes default-star-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.12); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .default-star {
+    animation: none;
+  }
 }
 
 /* Overview tab — landing layout (info card + quick actions card) */
@@ -1406,6 +1490,7 @@
   .btn-icon-xs,
   .btn-token-display,
   .btn-link,
+  .breadcrumb,
   .header-actions,
   .invite-actions,
   .new-code-banner,

--- a/fe/src/app/features/admin/presentation/components/organization-detail.component.ts
+++ b/fe/src/app/features/admin/presentation/components/organization-detail.component.ts
@@ -93,6 +93,14 @@ export class OrganizationDetailComponent implements OnInit {
     { key: 'settings' as Tab, label: 'Cài đặt' }
   ];
 
+  // Phase 3 PR 3 (#241): breadcrumb derive — Tổ chức/Trang chủ → Org Name → Tab.
+  activeTabLabel = computed(() =>
+    this.tabs.find(t => t.key === this.activeTab())?.label ?? ''
+  );
+  breadcrumbRootLabel = computed(() =>
+    this.authService.userRole() === 'admin' ? 'Tổ chức' : 'Trang chủ'
+  );
+
   // Phase 2 (#235): multi-tenant signals — type badge variant + label + isDefault.
   // Fallback dùng khi BE corruption / legacy data trả type=null hoặc value không
   // map (BE đã có parseType warn fallback PARTNER, FE phản ánh chung).

--- a/fe/src/app/shared/components/navigation/sidebar.component.css
+++ b/fe/src/app/shared/components/navigation/sidebar.component.css
@@ -726,3 +726,67 @@
 .sidebar-nav--org-scoped {
   position: relative;
 }
+
+/* =====================================================================
+   Phase 3 PR 3 (#241): animation + polish
+   Sidebar nav switch fade transition — runs khi @if(inOrgScopedMode)
+   flips, new <nav> element mounts → animation triggers từ initial state.
+   Skip for users prefer-reduced-motion. */
+.sidebar-nav {
+  animation: sidebar-nav-fade-in 200ms ease-out;
+}
+
+@keyframes sidebar-nav-fade-in {
+  from {
+    opacity: 0;
+    transform: translateX(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-nav {
+    animation: none;
+  }
+  .sidebar-org-default-star {
+    animation: none !important;
+  }
+}
+
+/* Active org-scoped item — left border indicator (subtle accent) */
+.sidebar-nav--org-scoped .nav-item.active {
+  position: relative;
+}
+.sidebar-nav--org-scoped .nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 6px;
+  bottom: 6px;
+  width: 3px;
+  background: #0056D2;
+  border-radius: 0 3px 3px 0;
+}
+
+/* Org context block hover elevation — subtle interactive feel */
+.sidebar-org-context {
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+.sidebar-org-context:hover {
+  border-color: rgba(0, 86, 210, 0.25);
+  box-shadow: 0 1px 3px rgba(0, 86, 210, 0.06);
+}
+
+/* Default star subtle pulse — dùng cho HoLiLiHu Org indicator */
+.sidebar-org-default-star {
+  display: inline-block;
+  animation: default-star-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes default-star-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.12); }
+}


### PR DESCRIPTION
Closes #241

Phase 3 PR 3 (final của 3-PR series). PR 1 #238 + PR 2 #240 đã ship sidebar shell + mode switch. PR 3 hoàn thiện: breadcrumb + animation + polish.

## A. Breadcrumb (Linear/Stripe/GitHub pattern)

Render top of org-detail page, 3 levels:
- **Tổ chức** (admin) / **Trang chủ** (org-admin) → click → back to list/dashboard
- **Org Name** (current, no link) — \`aria-current\` khi không có tab
- **Active Tab Name** — \`aria-current=\"page\"\`

Semantic ol+li, aria-label \"Đường dẫn\". Mobile ellipsis 280→160px. Hide trong print.

## B. Animation transitions

- Sidebar nav switch (\`@if(inOrgScopedMode)\` flip): fade-in 200ms ease-out
- \`prefers-reduced-motion: reduce\` → skip animation (a11y)

## C. Polish micro-interactions

- Active org-scoped item: left border indicator 3px #0056D2
- Sidebar context block hover: elevation + border accent transition
- Default star ⭐ pulse 2.4s infinite (HoLiLiHu Org indicator)
- Apply cả sidebar context + org-detail header default star

## Self-review fix
- Bỏ \`.default-star-pulse\` selector sai trong prefers-reduced-motion (đó là keyframe name, không phải CSS class)
- Thêm \`aria-current=\"page\"\` cho final breadcrumb item

## Verified
- npx tsc --noEmit: EXIT=0
- npm run build: success, fix-ngsw clean
- 4 files changed, +180/-1

## Test plan
- [ ] Navigate /admin/organizations/HOLILIHU_ORG_ID → breadcrumb \"Tổ chức / HoLiLiHu Org / Tổng quan\"
- [ ] Click \"Tổ chức\" → /admin/organizations
- [ ] Switch tabs → breadcrumb level 3 update tự động
- [ ] Sidebar nav switch animate fade smooth
- [ ] Active item left border visible
- [ ] Default star pulse subtle
- [ ] prefers-reduced-motion → animation skip
- [ ] Mobile breadcrumb ellipsis
- [ ] org-admin login → /org-admin/organization → breadcrumb \"Trang chủ / ...\"

## Multi-org track complete

5 PRs Phase 1+2+3 multi-org foundation đến UX polish:
- #232 Phase 1 foundation (V119, domain, repos)
- #234 Phase 1 bootstrap fix (V120 + public endpoint)
- #236 Phase 2 org detail tabs (Overview + Stats + multi-tenant signals)
- #238 Phase 3 PR 1 sidebar context block
- #240 Phase 3 PR 2 org-scoped nav mode switch
- **#PR_THIS Phase 3 PR 3 breadcrumb + animation + polish**

🤖 Generated with [Claude Code](https://claude.com/claude-code)