### PR TITLE
feat(admin-org): Phase 4 PR 1 — type-aware create + list filter + search

### DIFF
--- a/backend/src/main/java/com/example/lms/identity/application/usecase/CreateOrganizationUseCase.java
+++ b/backend/src/main/java/com/example/lms/identity/application/usecase/CreateOrganizationUseCase.java
@@ -2,6 +2,7 @@ package com.example.lms.identity.application.usecase;
 
 import com.example.lms.identity.application.dto.OrganizationResponse;
 import com.example.lms.identity.domain.model.Organization;
+import com.example.lms.identity.domain.model.OrganizationType;
 import com.example.lms.identity.domain.repository.OrganizationRepository;
 import com.example.lms.shared.exception.ValidationException;
 import lombok.RequiredArgsConstructor;
@@ -18,13 +19,40 @@ public class CreateOrganizationUseCase {
 
     @Transactional
     public OrganizationResponse execute(String name, String code, String description, int tokenExpiryDays) {
+        return execute(name, code, description, tokenExpiryDays, null);
+    }
+
+    /**
+     * Issue #254 (Phase 4): create với type field optional. PLATFORM bị reject
+     * — V119 partial unique constraint chỉ cho phép 1 PLATFORM (HoLiLiHu Org).
+     * Null/empty/invalid → fallback PARTNER (consistent OrganizationEntityMapper).
+     */
+    @Transactional
+    public OrganizationResponse execute(String name, String code, String description,
+                                        int tokenExpiryDays, String typeRaw) {
         if (orgRepo.existsByCode(code.toUpperCase())) {
             throw new ValidationException("code", "Mã tổ chức đã tồn tại");
         }
 
-        Organization org = Organization.create(name, code, description, tokenExpiryDays);
+        OrganizationType type = parseType(typeRaw);
+        if (type == OrganizationType.PLATFORM) {
+            throw new ValidationException("type",
+                "Không thể tạo tổ chức loại PLATFORM — chỉ tổ chức nền tảng mặc định (HoLiLiHu Org) được phép.");
+        }
+
+        Organization org = Organization.create(name, code, description, tokenExpiryDays, type);
         Organization saved = orgRepo.save(org);
-        log.info("Organization created: id={} code={}", saved.getId(), saved.getCode());
+        log.info("Organization created: id={} code={} type={}", saved.getId(), saved.getCode(), saved.getType());
         return OrganizationResponse.from(saved);
+    }
+
+    private OrganizationType parseType(String raw) {
+        if (raw == null || raw.isBlank()) return OrganizationType.PARTNER;
+        try {
+            return OrganizationType.valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            log.warn("Invalid organization type '{}', fallback PARTNER", raw);
+            return OrganizationType.PARTNER;
+        }
     }
 }

--- a/backend/src/main/java/com/example/lms/identity/application/usecase/ListOrganizationsUseCase.java
+++ b/backend/src/main/java/com/example/lms/identity/application/usecase/ListOrganizationsUseCase.java
@@ -1,8 +1,10 @@
 package com.example.lms.identity.application.usecase;
 
 import com.example.lms.identity.application.dto.OrganizationResponse;
+import com.example.lms.identity.domain.model.OrganizationType;
 import com.example.lms.identity.domain.repository.OrganizationRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,14 +12,38 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ListOrganizationsUseCase {
 
     private final OrganizationRepository orgRepo;
 
     @Transactional(readOnly = true)
     public List<OrganizationResponse> execute() {
-        return orgRepo.findAll().stream()
-                .map(OrganizationResponse::from)
-                .toList();
+        return execute(null);
+    }
+
+    /**
+     * Issue #254 (Phase 4): optional type filter. Invalid/blank → no filter
+     * (return all). Filter ở memory level vì repo không expose findByType yet
+     * — list size hiện tại nhỏ (< 100 orgs typical), chấp nhận trade-off.
+     */
+    @Transactional(readOnly = true)
+    public List<OrganizationResponse> execute(String typeFilter) {
+        OrganizationType filter = parseType(typeFilter);
+        var stream = orgRepo.findAll().stream();
+        if (filter != null) {
+            stream = stream.filter(org -> org.getType() == filter);
+        }
+        return stream.map(OrganizationResponse::from).toList();
+    }
+
+    private OrganizationType parseType(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        try {
+            return OrganizationType.valueOf(raw.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            log.warn("Invalid type filter '{}', ignoring filter", raw);
+            return null;
+        }
     }
 }

--- a/backend/src/main/java/com/example/lms/identity/domain/model/Organization.java
+++ b/backend/src/main/java/com/example/lms/identity/domain/model/Organization.java
@@ -51,13 +51,19 @@ public class Organization {
     }
 
     public static Organization create(String name, String code, String description, int tokenExpiryDays) {
+        return create(name, code, description, tokenExpiryDays, OrganizationType.PARTNER);
+    }
+
+    /** Issue #254 (Phase 4): factory với type explicit cho admin create flow. */
+    public static Organization create(String name, String code, String description,
+                                       int tokenExpiryDays, OrganizationType type) {
         if (tokenExpiryDays < 7 || tokenExpiryDays > 1095) {
             throw new IllegalArgumentException("Token expiry days phải từ 7 đến 1095");
         }
         return new Organization(
             UUID.randomUUID(), name, code.toUpperCase(), description,
             true, tokenExpiryDays,
-            OrganizationType.PARTNER, false,
+            type != null ? type : OrganizationType.PARTNER, false,
             Instant.now(), null
         );
     }

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/web/OrganizationControllerV3.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/web/OrganizationControllerV3.java
@@ -58,9 +58,12 @@ public class OrganizationControllerV3 {
     @PreAuthorize("hasAnyRole('ADMIN', 'ORG_ADMIN')")
     @Operation(summary = "Danh sách tổ chức")
     public ResponseEntity<ApiResponse<List<OrganizationResponse>>> listOrganizations(
-            @AuthenticationPrincipal UserJpaEntity currentUser) {
+            @AuthenticationPrincipal UserJpaEntity currentUser,
+            /** Issue #254 (Phase 4): optional type filter (PLATFORM/PARTNER/INTERNAL).
+             *  ADMIN dùng cho org list, ORG_ADMIN bypass — chỉ thấy 1 org của mình. */
+            @RequestParam(required = false) String type) {
         if (isOrgAdmin(currentUser)) {
-            // ORG_ADMIN: only sees own org
+            // ORG_ADMIN: only sees own org (type filter bỏ qua — chỉ 1 org)
             if (currentUser.getOrganizationId() == null) {
                 return ResponseEntity.ok(ApiResponse.success(List.of()));
             }
@@ -69,7 +72,7 @@ public class OrganizationControllerV3 {
                             List.of(OrganizationResponse.from(org)))))
                     .orElse(ResponseEntity.ok(ApiResponse.success(List.of())));
         }
-        return ResponseEntity.ok(ApiResponse.success(listOrganizationsUseCase.execute()));
+        return ResponseEntity.ok(ApiResponse.success(listOrganizationsUseCase.execute(type)));
     }
 
     /**
@@ -117,7 +120,8 @@ public class OrganizationControllerV3 {
     public ResponseEntity<ApiResponse<OrganizationResponse>> createOrganization(
             @Valid @RequestBody CreateOrgRequest request) {
         OrganizationResponse response = createOrganizationUseCase.execute(
-                request.name(), request.code(), request.description(), request.tokenExpiryDays());
+                request.name(), request.code(), request.description(),
+                request.tokenExpiryDays(), request.type());
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response, "Tạo tổ chức thành công"));
     }
 
@@ -348,7 +352,10 @@ public class OrganizationControllerV3 {
         @NotBlank String name,
         @NotBlank @Size(min = 2, max = 50) String code,
         String description,
-        @Min(7) @Max(1095) int tokenExpiryDays
+        @Min(7) @Max(1095) int tokenExpiryDays,
+        /** Issue #254 (Phase 4): optional type — null/empty fallback PARTNER.
+         *  PLATFORM rejected ở use case (V119 partial unique HoLiLiHu only). */
+        String type
     ) {
         public CreateOrgRequest {
             if (tokenExpiryDays == 0) tokenExpiryDays = 30;

--- a/backend/src/test/java/com/example/lms/identity/application/usecase/CreateOrganizationUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/identity/application/usecase/CreateOrganizationUseCaseTest.java
@@ -1,0 +1,127 @@
+package com.example.lms.identity.application.usecase;
+
+import com.example.lms.identity.application.dto.OrganizationResponse;
+import com.example.lms.identity.domain.model.Organization;
+import com.example.lms.identity.domain.model.OrganizationType;
+import com.example.lms.identity.domain.repository.OrganizationRepository;
+import com.example.lms.shared.exception.ValidationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #254 (Phase 4 PR 1): contract test cho CreateOrganizationUseCase
+ * type-aware overload. Verify PARTNER/INTERNAL accept, PLATFORM reject,
+ * fallback PARTNER cho null/invalid type.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CreateOrganizationUseCase Tests")
+class CreateOrganizationUseCaseTest {
+
+    @Mock
+    private OrganizationRepository orgRepo;
+
+    @InjectMocks
+    private CreateOrganizationUseCase useCase;
+
+    @Captor
+    private ArgumentCaptor<Organization> orgCaptor;
+
+    @Test
+    @DisplayName("Tạo org với type=PARTNER → lưu PARTNER")
+    void shouldCreatePartnerOrg() {
+        when(orgRepo.existsByCode(anyString())).thenReturn(false);
+        when(orgRepo.save(any(Organization.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        OrganizationResponse response = useCase.execute("Đối tác A", "PARTNERA", "desc", 30, "PARTNER");
+
+        verify(orgRepo).save(orgCaptor.capture());
+        assertThat(orgCaptor.getValue().getType()).isEqualTo(OrganizationType.PARTNER);
+        assertThat(response.code()).isEqualTo("PARTNERA");
+    }
+
+    @Test
+    @DisplayName("Tạo org với type=INTERNAL → lưu INTERNAL")
+    void shouldCreateInternalOrg() {
+        when(orgRepo.existsByCode(anyString())).thenReturn(false);
+        when(orgRepo.save(any(Organization.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        useCase.execute("Phòng đào tạo", "INTERNAL1", "desc", 30, "INTERNAL");
+
+        verify(orgRepo).save(orgCaptor.capture());
+        assertThat(orgCaptor.getValue().getType()).isEqualTo(OrganizationType.INTERNAL);
+    }
+
+    @Test
+    @DisplayName("Tạo org với type=PLATFORM → ném ValidationException (V119 partial unique)")
+    void shouldRejectPlatformType() {
+        when(orgRepo.existsByCode(anyString())).thenReturn(false);
+
+        assertThatThrownBy(() -> useCase.execute("Sham platform", "FAKE", "desc", 30, "PLATFORM"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("PLATFORM");
+
+        verify(orgRepo, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Tạo org với type=null → fallback PARTNER")
+    void shouldFallbackPartnerWhenTypeNull() {
+        when(orgRepo.existsByCode(anyString())).thenReturn(false);
+        when(orgRepo.save(any(Organization.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        useCase.execute("Default org", "DEFAULT1", "desc", 30, null);
+
+        verify(orgRepo).save(orgCaptor.capture());
+        assertThat(orgCaptor.getValue().getType()).isEqualTo(OrganizationType.PARTNER);
+    }
+
+    @Test
+    @DisplayName("Tạo org với type='UNKNOWN' → fallback PARTNER (tolerant)")
+    void shouldFallbackPartnerWhenTypeInvalid() {
+        when(orgRepo.existsByCode(anyString())).thenReturn(false);
+        when(orgRepo.save(any(Organization.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        useCase.execute("Bad type", "BAD1", "desc", 30, "UNKNOWN_GIBBERISH");
+
+        verify(orgRepo).save(orgCaptor.capture());
+        assertThat(orgCaptor.getValue().getType()).isEqualTo(OrganizationType.PARTNER);
+    }
+
+    @Test
+    @DisplayName("Backward-compat 4-arg overload → fallback PARTNER")
+    void shouldFallbackPartnerOnLegacyOverload() {
+        when(orgRepo.existsByCode(anyString())).thenReturn(false);
+        when(orgRepo.save(any(Organization.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        useCase.execute("Legacy call", "LEGACY1", "desc", 30);
+
+        verify(orgRepo).save(orgCaptor.capture());
+        assertThat(orgCaptor.getValue().getType()).isEqualTo(OrganizationType.PARTNER);
+    }
+
+    @Test
+    @DisplayName("Code đã tồn tại → ném ValidationException")
+    void shouldRejectDuplicateCode() {
+        when(orgRepo.existsByCode("DUPE")).thenReturn(true);
+
+        assertThatThrownBy(() -> useCase.execute("Dupe org", "DUPE", "desc", 30, "PARTNER"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("đã tồn tại");
+
+        verify(orgRepo, never()).save(any());
+    }
+}

--- a/backend/src/test/java/com/example/lms/identity/application/usecase/ListOrganizationsUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/identity/application/usecase/ListOrganizationsUseCaseTest.java
@@ -1,0 +1,115 @@
+package com.example.lms.identity.application.usecase;
+
+import com.example.lms.identity.application.dto.OrganizationResponse;
+import com.example.lms.identity.domain.model.Organization;
+import com.example.lms.identity.domain.model.OrganizationType;
+import com.example.lms.identity.domain.repository.OrganizationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #254 (Phase 4 PR 1): contract test cho ListOrganizationsUseCase
+ * type filter overload. No filter → all. Valid type → filtered. Invalid →
+ * tolerant (no filter, return all).
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ListOrganizationsUseCase Tests")
+class ListOrganizationsUseCaseTest {
+
+    @Mock
+    private OrganizationRepository orgRepo;
+
+    @InjectMocks
+    private ListOrganizationsUseCase useCase;
+
+    private Organization platformOrg() {
+        return new Organization(UUID.randomUUID(), "HoLiLiHu", "HOLILIHU", null, true, 30,
+                OrganizationType.PLATFORM, true, Instant.now(), null);
+    }
+
+    private Organization partnerOrg(String code) {
+        return new Organization(UUID.randomUUID(), code, code, null, true, 30,
+                OrganizationType.PARTNER, false, Instant.now(), null);
+    }
+
+    private Organization internalOrg(String code) {
+        return new Organization(UUID.randomUUID(), code, code, null, true, 30,
+                OrganizationType.INTERNAL, false, Instant.now(), null);
+    }
+
+    @Test
+    @DisplayName("execute() không filter → trả tất cả org")
+    void shouldReturnAllWhenNoFilter() {
+        when(orgRepo.findAll()).thenReturn(List.of(platformOrg(), partnerOrg("P1"), internalOrg("I1")));
+
+        List<OrganizationResponse> result = useCase.execute();
+
+        assertThat(result).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("execute('PARTNER') → chỉ trả PARTNER orgs")
+    void shouldFilterByPartner() {
+        when(orgRepo.findAll()).thenReturn(List.of(
+                platformOrg(), partnerOrg("P1"), partnerOrg("P2"), internalOrg("I1")));
+
+        List<OrganizationResponse> result = useCase.execute("PARTNER");
+
+        assertThat(result).hasSize(2);
+        assertThat(result).allMatch(r -> r.type() == OrganizationType.PARTNER);
+    }
+
+    @Test
+    @DisplayName("execute('PLATFORM') → chỉ trả PLATFORM org (HoLiLiHu)")
+    void shouldFilterByPlatform() {
+        when(orgRepo.findAll()).thenReturn(List.of(
+                platformOrg(), partnerOrg("P1"), internalOrg("I1")));
+
+        List<OrganizationResponse> result = useCase.execute("PLATFORM");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).type()).isEqualTo(OrganizationType.PLATFORM);
+    }
+
+    @Test
+    @DisplayName("execute('INVALID_TYPE') → tolerant, trả tất cả (không filter)")
+    void shouldReturnAllWhenInvalidFilter() {
+        when(orgRepo.findAll()).thenReturn(List.of(platformOrg(), partnerOrg("P1")));
+
+        List<OrganizationResponse> result = useCase.execute("INVALID_GIBBERISH");
+
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("execute(null) → trả tất cả")
+    void shouldReturnAllWhenFilterNull() {
+        when(orgRepo.findAll()).thenReturn(List.of(platformOrg(), partnerOrg("P1")));
+
+        List<OrganizationResponse> result = useCase.execute((String) null);
+
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("execute('  partner  ') → case-insensitive + trim")
+    void shouldFilterCaseInsensitive() {
+        when(orgRepo.findAll()).thenReturn(List.of(partnerOrg("P1"), internalOrg("I1")));
+
+        List<OrganizationResponse> result = useCase.execute("  partner  ");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).type()).isEqualTo(OrganizationType.PARTNER);
+    }
+}

--- a/fe/src/app/features/admin/infrastructure/services/organization.service.ts
+++ b/fe/src/app/features/admin/infrastructure/services/organization.service.ts
@@ -4,15 +4,18 @@ import { map } from 'rxjs/operators';
 import { ApiClient } from '../../../../api/client/api-client';
 import { ORGANIZATION_ENDPOINTS, INVITE_ENDPOINTS } from '../../../../api/endpoints/organization.endpoints';
 import { ApiResponse } from '../../../../api/types/common.types';
-import { Organization, OrganizationInvite, OrgMember } from '../../../../shared/types/user.types';
+import { Organization, OrganizationInvite, OrganizationType, OrgMember } from '../../../../shared/types/user.types';
 
 @Injectable({ providedIn: 'root' })
 export class OrganizationService {
   private api = inject(ApiClient);
 
   // Organization CRUD
-  listOrganizations(): Observable<Organization[]> {
-    return this.api.get<ApiResponse<Organization[]>>(ORGANIZATION_ENDPOINTS.BASE).pipe(
+  /** Issue #254 (Phase 4): optional type filter (PLATFORM/PARTNER/INTERNAL).
+   *  ADMIN only — ORG_ADMIN bypass server-side, chỉ thấy org của mình. */
+  listOrganizations(typeFilter?: OrganizationType): Observable<Organization[]> {
+    const options = typeFilter ? { params: { type: typeFilter } } : {};
+    return this.api.get<ApiResponse<Organization[]>>(ORGANIZATION_ENDPOINTS.BASE, options).pipe(
       map(res => res.data)
     );
   }
@@ -43,7 +46,9 @@ export class OrganizationService {
     );
   }
 
-  createOrganization(data: { name: string; code: string; description?: string; tokenExpiryDays?: number }): Observable<Organization> {
+  /** Issue #254 (Phase 4): type field optional (default PARTNER server-side).
+   *  PLATFORM bị reject — chỉ HoLiLiHu Org được phép. */
+  createOrganization(data: { name: string; code: string; description?: string; tokenExpiryDays?: number; type?: OrganizationType }): Observable<Organization> {
     return this.api.post<ApiResponse<Organization>>(ORGANIZATION_ENDPOINTS.BASE, data).pipe(
       map(res => res.data)
     );

--- a/fe/src/app/features/admin/presentation/components/organization-list.component.html
+++ b/fe/src/app/features/admin/presentation/components/organization-list.component.html
@@ -108,16 +108,18 @@
             </svg>
             <input #searchInput type="search" placeholder="Tìm theo tên hoặc mã tổ chức..."
                    class="filter-search-input"
+                   [value]="searchQuery()"
                    (input)="setSearchQuery(searchInput.value)">
           </div>
           <select #typeSelect class="filter-type-select"
+                  [value]="typeFilter()"
                   (change)="setTypeFilter(typeSelect.value)">
             @for (opt of typeFilterOptions; track opt.value) {
-              <option [value]="opt.value" [selected]="opt.value === typeFilter()">{{ opt.label }}</option>
+              <option [value]="opt.value">{{ opt.label }}</option>
             }
           </select>
           @if (hasActiveFilters()) {
-            <button type="button" class="filter-clear" (click)="clearFilters(); searchInput.value=''; typeSelect.value='ALL'">
+            <button type="button" class="filter-clear" (click)="clearFilters()">
               Xóa bộ lọc
             </button>
           }

--- a/fe/src/app/features/admin/presentation/components/organization-list.component.html
+++ b/fe/src/app/features/admin/presentation/components/organization-list.component.html
@@ -60,9 +60,18 @@
                    class="form-input">
             <p class="form-hint">7 - 730 ngày. Thời gian token đăng nhập hợp lệ</p>
           </div>
+          <div>
+            <label for="create-type" class="form-label">Loại tổ chức</label>
+            <select #orgType id="create-type" class="form-input">
+              @for (opt of typeCreateOptions; track opt.value) {
+                <option [value]="opt.value">{{ opt.label }}</option>
+              }
+            </select>
+            <p class="form-hint">Đối tác cho tổ chức bên ngoài, Nội bộ cho đơn vị thuộc nền tảng</p>
+          </div>
         </div>
         <div class="form-actions">
-          <button (click)="createOrg(orgName.value, orgCode.value, orgDesc.value, +orgExpiry.value)"
+          <button (click)="createOrg(orgName.value, orgCode.value, orgDesc.value, +orgExpiry.value, orgType.value)"
                   [disabled]="isCreating()"
                   class="btn-primary">
             @if (isCreating()) {
@@ -89,9 +98,35 @@
         <p class="loading-text">Đang tải danh sách tổ chức...</p>
       </div>
     } @else {
+      <!-- Issue #254 (Phase 4): Type filter + search bar (ADMIN only — vì
+           ORG_ADMIN chỉ có 1 org, filter vô nghĩa) -->
+      @if (canCreateOrganizations() && organizations().length > 0) {
+        <div class="filter-bar">
+          <div class="filter-search">
+            <svg class="filter-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+            </svg>
+            <input #searchInput type="search" placeholder="Tìm theo tên hoặc mã tổ chức..."
+                   class="filter-search-input"
+                   (input)="setSearchQuery(searchInput.value)">
+          </div>
+          <select #typeSelect class="filter-type-select"
+                  (change)="setTypeFilter(typeSelect.value)">
+            @for (opt of typeFilterOptions; track opt.value) {
+              <option [value]="opt.value" [selected]="opt.value === typeFilter()">{{ opt.label }}</option>
+            }
+          </select>
+          @if (hasActiveFilters()) {
+            <button type="button" class="filter-clear" (click)="clearFilters(); searchInput.value=''; typeSelect.value='ALL'">
+              Xóa bộ lọc
+            </button>
+          }
+        </div>
+      }
+
       <!-- Org List -->
       <div class="org-grid">
-        @for (org of organizations(); track org.id) {
+        @for (org of filteredOrganizations(); track org.id) {
           <a [routerLink]="['/admin/organizations', org.id]" class="org-card">
             <div class="org-card-row">
               <div class="org-card-left">
@@ -99,8 +134,15 @@
                   {{ org.code.substring(0, 2) }}
                 </div>
                 <div class="org-info">
-                  <div class="org-name">{{ org.name }}</div>
+                  <div class="org-name">
+                    {{ org.name }}
+                    @if (org.isDefault) {
+                      <span class="default-star" title="Tổ chức nền tảng — không thể xóa" aria-label="Tổ chức nền tảng">⭐</span>
+                    }
+                  </div>
                   <div class="org-meta">
+                    <span [class]="typeMetaFor(org.type).cssClass">{{ typeMetaFor(org.type).label }}</span>
+                    <span class="dot-separator">&middot;</span>
                     <span class="org-code">{{ org.code }}</span>
                     <span class="dot-separator">&middot;</span>
                     <span title="Thời hạn token đăng nhập của thành viên trong tổ chức">
@@ -125,22 +167,28 @@
             }
           </a>
         } @empty {
-          <!-- Empty State -->
+          <!-- Empty State — phân biệt no results filter vs truly empty list -->
           <div class="empty-state">
             <div class="empty-icon-wrapper">
               <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
               </svg>
             </div>
-            <h3 class="empty-title">Chưa có tổ chức nào</h3>
-            <p class="empty-desc">Tạo tổ chức đầu tiên để bắt đầu quản lý thành viên</p>
-            @if (canCreateOrganizations()) {
-              <button (click)="showCreateForm.set(true)" class="btn-primary">
-                <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
-                </svg>
-                Tạo tổ chức đầu tiên
-              </button>
+            @if (hasActiveFilters()) {
+              <h3 class="empty-title">Không tìm thấy tổ chức phù hợp</h3>
+              <p class="empty-desc">Thử thay đổi bộ lọc hoặc từ khóa tìm kiếm</p>
+              <button type="button" (click)="clearFilters()" class="btn-ghost">Xóa bộ lọc</button>
+            } @else {
+              <h3 class="empty-title">Chưa có tổ chức nào</h3>
+              <p class="empty-desc">Tạo tổ chức đầu tiên để bắt đầu quản lý thành viên</p>
+              @if (canCreateOrganizations()) {
+                <button (click)="showCreateForm.set(true)" class="btn-primary">
+                  <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+                  </svg>
+                  Tạo tổ chức đầu tiên
+                </button>
+              }
             }
           </div>
         }

--- a/fe/src/app/features/admin/presentation/components/organization-list.component.scss
+++ b/fe/src/app/features/admin/presentation/components/organization-list.component.scss
@@ -531,6 +531,150 @@
   }
 }
 
+/* =====================================================================
+   Issue #254 (Phase 4): filter bar + type badge + default star
+   ===================================================================== */
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+  margin-bottom: $spacing-4;
+  flex-wrap: wrap;
+}
+
+.filter-search {
+  flex: 1;
+  min-width: 240px;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.filter-icon {
+  position: absolute;
+  left: 12px;
+  width: 16px;
+  height: 16px;
+  color: #6b7280;
+  pointer-events: none;
+}
+
+.filter-search-input {
+  flex: 1;
+  height: 38px;
+  padding: 0 12px 0 36px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: white;
+  font-size: 14px;
+  color: #111827;
+  transition: border-color 0.15s ease;
+
+  &:focus {
+    outline: none;
+    border-color: #0056D2;
+    box-shadow: 0 0 0 3px rgba(0, 86, 210, 0.1);
+  }
+
+  &::placeholder { color: #9ca3af; }
+}
+
+.filter-type-select {
+  height: 38px;
+  padding: 0 32px 0 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: white;
+  font-size: 14px;
+  color: #111827;
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  min-width: 160px;
+
+  &:focus {
+    outline: none;
+    border-color: #0056D2;
+    box-shadow: 0 0 0 3px rgba(0, 86, 210, 0.1);
+  }
+}
+
+.filter-clear {
+  background: none;
+  border: 1px solid #e5e7eb;
+  color: #6b7280;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    border-color: #0056D2;
+    color: #0056D2;
+    background: rgba(0, 86, 210, 0.04);
+  }
+}
+
+/* Type badges — consistent với Phase 2 org-detail. Inline trong org-meta. */
+.badge-org-type {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border: 1px solid transparent;
+  line-height: 1.4;
+}
+.badge-org-type--platform {
+  background: rgba(0, 86, 210, 0.08);
+  color: #0056D2;
+  border-color: rgba(0, 86, 210, 0.2);
+}
+.badge-org-type--partner {
+  background: rgba(124, 58, 237, 0.08);
+  color: #6D28D9;
+  border-color: rgba(124, 58, 237, 0.2);
+}
+.badge-org-type--internal {
+  background: #f3f4f6;
+  color: #4b5563;
+  border-color: #e5e7eb;
+}
+
+/* Default org indicator pulse — reuse Phase 3 keyframe */
+.default-star {
+  font-size: 0.85em;
+  margin-left: 4px;
+  cursor: help;
+  display: inline-block;
+  animation: default-star-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes default-star-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.12); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .default-star {
+    animation: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .filter-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .filter-search { min-width: 0; }
+  .filter-type-select { width: 100%; }
+}
+
 /* ===== PRINT ===== */
 @media print {
   .org-list-page {
@@ -540,6 +684,7 @@
   .page-header .btn-primary,
   .create-form-card,
   .btn-close,
+  .filter-bar,
   .chevron-icon {
     display: none !important;
   }

--- a/fe/src/app/features/admin/presentation/components/organization-list.component.ts
+++ b/fe/src/app/features/admin/presentation/components/organization-list.component.ts
@@ -3,8 +3,10 @@ import { RouterModule } from '@angular/router';
 import { OrganizationService, OrganizationStats } from '../../infrastructure/services/organization.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { AuthService } from '../../../../core/services/auth.service';
-import { Organization } from '../../../../shared/types/user.types';
+import { Organization, OrganizationType } from '../../../../shared/types/user.types';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
+
+type TypeFilterValue = 'ALL' | OrganizationType;
 
 @Component({
   selector: 'app-organization-list',
@@ -24,6 +26,48 @@ export class OrganizationListComponent implements OnInit {
   showCreateForm = signal(false);
   isCreating = signal(false);
   canCreateOrganizations = computed(() => this.authService.userRole() === 'admin');
+
+  // Issue #254 (Phase 4): client-side filter + search.
+  typeFilter = signal<TypeFilterValue>('ALL');
+  searchQuery = signal<string>('');
+
+  /** Filter + search applied trên list đã load. */
+  filteredOrganizations = computed(() => {
+    const filter = this.typeFilter();
+    const query = this.searchQuery().trim().toLowerCase();
+    return this.organizations().filter(org => {
+      if (filter !== 'ALL' && org.type !== filter) return false;
+      if (query && !org.name.toLowerCase().includes(query) && !org.code.toLowerCase().includes(query)) {
+        return false;
+      }
+      return true;
+    });
+  });
+
+  /** Type badge meta (consistent với org-detail Phase 2). */
+  readonly typeMeta: Record<OrganizationType, { label: string; cssClass: string }> = {
+    PLATFORM: { label: 'Nền tảng', cssClass: 'badge-org-type badge-org-type--platform' },
+    PARTNER:  { label: 'Đối tác',  cssClass: 'badge-org-type badge-org-type--partner' },
+    INTERNAL: { label: 'Nội bộ',   cssClass: 'badge-org-type badge-org-type--internal' }
+  };
+  private readonly typeFallback = { label: 'Đối tác', cssClass: 'badge-org-type badge-org-type--partner' };
+  typeMetaFor(type: OrganizationType | undefined): { label: string; cssClass: string } {
+    return (type && this.typeMeta[type]) || this.typeFallback;
+  }
+
+  /** Type options cho filter dropdown — All + 3 enum values. */
+  readonly typeFilterOptions: Array<{ value: TypeFilterValue; label: string }> = [
+    { value: 'ALL', label: 'Tất cả loại' },
+    { value: 'PLATFORM', label: 'Nền tảng' },
+    { value: 'PARTNER', label: 'Đối tác' },
+    { value: 'INTERNAL', label: 'Nội bộ' }
+  ];
+
+  /** Type options cho create form — PLATFORM bị ẩn (reserved cho HoLiLiHu). */
+  readonly typeCreateOptions: Array<{ value: OrganizationType; label: string }> = [
+    { value: 'PARTNER',  label: 'Đối tác — tổ chức ngoài' },
+    { value: 'INTERNAL', label: 'Nội bộ — đơn vị nội bộ' }
+  ];
 
   ngOnInit(): void {
     this.loadOrganizations();
@@ -60,7 +104,22 @@ export class OrganizationListComponent implements OnInit {
     });
   }
 
-  createOrg(name: string, code: string, description: string, tokenExpiryDays: number): void {
+  setTypeFilter(value: string): void {
+    this.typeFilter.set(value as TypeFilterValue);
+  }
+
+  setSearchQuery(value: string): void {
+    this.searchQuery.set(value);
+  }
+
+  clearFilters(): void {
+    this.typeFilter.set('ALL');
+    this.searchQuery.set('');
+  }
+
+  hasActiveFilters = computed(() => this.typeFilter() !== 'ALL' || this.searchQuery().trim().length > 0);
+
+  createOrg(name: string, code: string, description: string, tokenExpiryDays: number, type: string): void {
     if (!this.canCreateOrganizations()) {
       this.showCreateForm.set(false);
       this.toast.warning('ORG_ADMIN chỉ có thể quản lý tổ chức hiện tại, không thể tạo tổ chức mới');
@@ -77,7 +136,8 @@ export class OrganizationListComponent implements OnInit {
       name: name.trim(),
       code: code.trim().toUpperCase(),
       description: description.trim() || undefined,
-      tokenExpiryDays: tokenExpiryDays || 30
+      tokenExpiryDays: tokenExpiryDays || 30,
+      type: (type as OrganizationType) || 'PARTNER'
     }).subscribe({
       next: (org) => {
         this.showCreateForm.set(false);


### PR DESCRIPTION
Closes #254

Phase 4 PR 1 — surface multi-tenant type signal ở admin org management end-to-end. Phase 1 thêm OrganizationType enum, Phase 2-3 surface ở org detail + sidebar context. Nay create flow + list view cũng support type.

## Goals

### A. BE — Type field trong DTOs + filter
- \`CreateOrgRequest\` thêm field \`type\` (optional, fallback PARTNER)
- \`CreateOrganizationUseCase\` overload với typeRaw param + PLATFORM reject
- \`Organization.create()\` factory overload accept type explicit
- \`ListOrganizationsUseCase\` overload với typeFilter (in-memory)
- \`GET /api/v3/organizations?type=X\` query param

### B. FE — Form create org type dropdown
- Dropdown options: PARTNER (Đối tác) / INTERNAL (Nội bộ)
- PLATFORM ẩn (reserved cho HoLiLiHu Org default)

### C. FE — List view enhancements
- Filter dropdown \"Loại tổ chức\" + search input by name/code
- Type badge cột trong card meta (PLATFORM xanh / PARTNER tím / INTERNAL xám)
- ⭐ default star indicator nếu \`isDefault\`
- Empty state phân biệt: no-results filter vs truly-empty list

## Verified
- npx tsc --noEmit: EXIT=0
- npm run build: success, fix-ngsw clean
- BE compile: SUCCESS
- BE tests RegisterUserUseCaseV2Test + AuthenticateWithGoogleUseCaseTest: 15/15 PASS (no regression — overload không break signatures cũ)
- 8 files changed, +356/-31

## Out of scope (defer Phase 4 PR 2/3/4)
- Pagination cho org list
- Promote ORG_ADMIN workflow
- Cross-org revenue dashboard

## Test plan
- [ ] BE: POST /api/v3/organizations với type=PARTNER → tạo PARTNER org
- [ ] BE: POST với type=PLATFORM → 400 ValidationException
- [ ] BE: POST không có type → fallback PARTNER
- [ ] BE: GET /api/v3/organizations?type=PARTNER → chỉ PARTNER orgs
- [ ] FE: form create có Type dropdown, default Đối tác
- [ ] FE: card có type badge + ⭐ default
- [ ] FE: filter dropdown lọc đúng theo type
- [ ] FE: search filter client-side theo name/code
- [ ] FE: empty state phân biệt khi filter no-match
- [ ] FE: mobile responsive filter bar stack vertical

🤖 Generated with [Claude Code](https://claude.com/claude-code)