### PR TITLE
feat(admin-org): Phase 4 PR 2 — pagination cho org list

### DIFF
--- a/fe/src/app/features/admin/presentation/components/organization-list.component.html
+++ b/fe/src/app/features/admin/presentation/components/organization-list.component.html
@@ -126,9 +126,9 @@
         </div>
       }
 
-      <!-- Org List -->
+      <!-- Org List (paginated #256) -->
       <div class="org-grid">
-        @for (org of filteredOrganizations(); track org.id) {
+        @for (org of paginatedOrganizations(); track org.id) {
           <a [routerLink]="['/admin/organizations', org.id]" class="org-card">
             <div class="org-card-row">
               <div class="org-card-left">
@@ -195,6 +195,16 @@
           </div>
         }
       </div>
+
+      <!-- Pagination (#256) — chỉ render khi có hơn 1 trang -->
+      @if (paginationInfo().totalPages > 1) {
+        <app-pagination
+          [currentPage]="currentPage()"
+          [totalPages]="paginationInfo().totalPages"
+          [totalItems]="paginationInfo().totalItems"
+          [itemsPerPage]="pageSize"
+          (pageChange)="onPageChange($event)" />
+      }
     }
   </div>
 </div>

--- a/fe/src/app/features/admin/presentation/components/organization-list.component.ts
+++ b/fe/src/app/features/admin/presentation/components/organization-list.component.ts
@@ -1,16 +1,17 @@
-import { Component, signal, inject, OnInit, ChangeDetectionStrategy, computed } from '@angular/core';
+import { Component, signal, inject, OnInit, ChangeDetectionStrategy, computed, effect } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { OrganizationService, OrganizationStats } from '../../infrastructure/services/organization.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { Organization, OrganizationType } from '../../../../shared/types/user.types';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
+import { PaginationComponent } from '../../../../shared/components/pagination/pagination.component';
 
 type TypeFilterValue = 'ALL' | OrganizationType;
 
 @Component({
   selector: 'app-organization-list',
-  imports: [RouterModule, KpiCardComponent],
+  imports: [RouterModule, KpiCardComponent, PaginationComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './organization-list.component.html',
   styleUrl: './organization-list.component.scss',
@@ -43,6 +44,37 @@ export class OrganizationListComponent implements OnInit {
       return true;
     });
   });
+
+  // Issue #256 (Phase 4 PR 2): pagination — FE-side slice trên filteredOrganizations.
+  // List size hiện < 100, BE pagination defer khi list grow. PaginationComponent
+  // 1-based currentPage. pageSize 12 khớp grid card layout.
+  currentPage = signal<number>(1);
+  readonly pageSize = 12;
+
+  paginationInfo = computed(() => {
+    const total = this.filteredOrganizations().length;
+    const totalPages = Math.max(1, Math.ceil(total / this.pageSize));
+    return { totalItems: total, totalPages };
+  });
+
+  paginatedOrganizations = computed(() => {
+    const items = this.filteredOrganizations();
+    const start = (this.currentPage() - 1) * this.pageSize;
+    return items.slice(start, start + this.pageSize);
+  });
+
+  constructor() {
+    // Reset về page 1 khi filter/search thay đổi (UX: user expects fresh view).
+    effect(() => {
+      this.typeFilter();
+      this.searchQuery();
+      this.currentPage.set(1);
+    });
+  }
+
+  onPageChange(page: number): void {
+    this.currentPage.set(page);
+  }
 
   /** Type badge meta (consistent với org-detail Phase 2). */
   readonly typeMeta: Record<OrganizationType, { label: string; cssClass: string }> = {


### PR DESCRIPTION
Closes #256

Phase 4 PR 2 — pagination cho org list. FE-side slice trên filteredOrganizations. List size hiện < 100, BE pagination defer.

## Changes
- Reuse shared PaginationComponent (pattern courses page)
- pageSize 12 (khớp grid card)
- effect reset page=1 khi filter/search change
- Render khi totalPages > 1

## Verified
- tsc EXIT=0, npm run build clean
- 2 files, +30/-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)