### PR TITLE
feat(admin-org): Phase 4 PR 3 — promote/demote ORG_ADMIN workflow

### DIFF
--- a/backend/src/main/java/com/example/lms/identity/application/usecase/PromoteOrgAdminUseCase.java
+++ b/backend/src/main/java/com/example/lms/identity/application/usecase/PromoteOrgAdminUseCase.java
@@ -1,11 +1,14 @@
 package com.example.lms.identity.application.usecase;
 
-import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
-import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
+import com.example.lms.identity.domain.model.Role;
+import com.example.lms.identity.domain.model.User;
+import com.example.lms.identity.domain.repository.UserRepository;
+import com.example.lms.shared.domain.valueobject.UserId;
 import com.example.lms.shared.exception.EntityNotFoundException;
 import com.example.lms.shared.exception.ValidationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,30 +24,35 @@ import java.util.UUID;
  *  - Không demote chính mình (caller != target)
  *  - Demote về TEACHER mặc định (nếu cần STUDENT, ADMIN có thể edit
  *    qua user role CRUD generic sau)
+ *
+ * Clean architecture: dùng domain UserRepository (port), không phụ thuộc
+ * UserJpaRepository (infrastructure adapter) — pass ArchUnit
+ * useCasesShouldNotDependOnInfrastructure.
  */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class PromoteOrgAdminUseCase {
 
-    private final UserJpaRepository userRepo;
+    @Qualifier("newUserRepositoryAdapter")
+    private final UserRepository userRepo;
 
     @Transactional
     public void promote(UUID orgId, UUID userId, UUID actorId) {
-        UserJpaEntity user = findMember(orgId, userId);
+        User user = findMember(orgId, userId);
 
-        if (user.getRole() == UserJpaEntity.UserRole.ADMIN) {
+        if (user.getRole() == Role.ADMIN) {
             throw new ValidationException("role",
                 "Không thể bổ nhiệm Quản trị viên hệ thống thành ORG_ADMIN — vai trò ADMIN bảo toàn ngoài org scope");
         }
 
-        if (user.getRole() == UserJpaEntity.UserRole.ORG_ADMIN) {
+        if (user.getRole() == Role.ORG_ADMIN) {
             // Idempotent — already ORG_ADMIN, không thay đổi
             log.info("Promote no-op: user={} already ORG_ADMIN of org={}", userId, orgId);
             return;
         }
 
-        user.setRole(UserJpaEntity.UserRole.ORG_ADMIN);
+        user.changeRole(Role.ORG_ADMIN);
         userRepo.save(user);
         log.info("Promoted user={} → ORG_ADMIN of org={} by actor={}", userId, orgId, actorId);
     }
@@ -56,20 +64,20 @@ public class PromoteOrgAdminUseCase {
                 "Không thể hạ cấp chính mình. Hãy nhờ Quản trị viên hệ thống thực hiện nếu cần.");
         }
 
-        UserJpaEntity user = findMember(orgId, userId);
+        User user = findMember(orgId, userId);
 
-        if (user.getRole() != UserJpaEntity.UserRole.ORG_ADMIN) {
+        if (user.getRole() != Role.ORG_ADMIN) {
             throw new ValidationException("role",
                 "Người dùng không phải ORG_ADMIN của tổ chức này — không thể hạ cấp");
         }
 
-        user.setRole(UserJpaEntity.UserRole.TEACHER);
+        user.changeRole(Role.TEACHER);
         userRepo.save(user);
         log.info("Demoted user={} ORG_ADMIN → TEACHER of org={} by actor={}", userId, orgId, actorId);
     }
 
-    private UserJpaEntity findMember(UUID orgId, UUID userId) {
-        UserJpaEntity user = userRepo.findById(userId)
+    private User findMember(UUID orgId, UUID userId) {
+        User user = userRepo.findById(UserId.of(userId))
                 .orElseThrow(() -> new EntityNotFoundException("Người dùng", userId));
         if (!orgId.equals(user.getOrganizationId())) {
             throw new EntityNotFoundException("Thành viên trong tổ chức", userId);

--- a/backend/src/main/java/com/example/lms/identity/application/usecase/PromoteOrgAdminUseCase.java
+++ b/backend/src/main/java/com/example/lms/identity/application/usecase/PromoteOrgAdminUseCase.java
@@ -1,0 +1,79 @@
+package com.example.lms.identity.application.usecase;
+
+import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
+import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
+import com.example.lms.shared.exception.EntityNotFoundException;
+import com.example.lms.shared.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Issue #258 (Phase 4 PR 3): bổ nhiệm member trở thành ORG_ADMIN của 1 tổ
+ * chức + hạ cấp ngược lại. ADMIN-only operation.
+ *
+ * Validation rules:
+ *  - User phải đã là member của org (organization_id = orgId)
+ *  - Không promote user role=ADMIN (system role bảo toàn)
+ *  - Không demote chính mình (caller != target)
+ *  - Demote về TEACHER mặc định (nếu cần STUDENT, ADMIN có thể edit
+ *    qua user role CRUD generic sau)
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PromoteOrgAdminUseCase {
+
+    private final UserJpaRepository userRepo;
+
+    @Transactional
+    public void promote(UUID orgId, UUID userId, UUID actorId) {
+        UserJpaEntity user = findMember(orgId, userId);
+
+        if (user.getRole() == UserJpaEntity.UserRole.ADMIN) {
+            throw new ValidationException("role",
+                "Không thể bổ nhiệm Quản trị viên hệ thống thành ORG_ADMIN — vai trò ADMIN bảo toàn ngoài org scope");
+        }
+
+        if (user.getRole() == UserJpaEntity.UserRole.ORG_ADMIN) {
+            // Idempotent — already ORG_ADMIN, không thay đổi
+            log.info("Promote no-op: user={} already ORG_ADMIN of org={}", userId, orgId);
+            return;
+        }
+
+        user.setRole(UserJpaEntity.UserRole.ORG_ADMIN);
+        userRepo.save(user);
+        log.info("Promoted user={} → ORG_ADMIN of org={} by actor={}", userId, orgId, actorId);
+    }
+
+    @Transactional
+    public void demote(UUID orgId, UUID userId, UUID actorId) {
+        if (userId.equals(actorId)) {
+            throw new ValidationException("self",
+                "Không thể hạ cấp chính mình. Hãy nhờ Quản trị viên hệ thống thực hiện nếu cần.");
+        }
+
+        UserJpaEntity user = findMember(orgId, userId);
+
+        if (user.getRole() != UserJpaEntity.UserRole.ORG_ADMIN) {
+            throw new ValidationException("role",
+                "Người dùng không phải ORG_ADMIN của tổ chức này — không thể hạ cấp");
+        }
+
+        user.setRole(UserJpaEntity.UserRole.TEACHER);
+        userRepo.save(user);
+        log.info("Demoted user={} ORG_ADMIN → TEACHER of org={} by actor={}", userId, orgId, actorId);
+    }
+
+    private UserJpaEntity findMember(UUID orgId, UUID userId) {
+        UserJpaEntity user = userRepo.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("Người dùng", userId));
+        if (!orgId.equals(user.getOrganizationId())) {
+            throw new EntityNotFoundException("Thành viên trong tổ chức", userId);
+        }
+        return user;
+    }
+}

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/web/OrganizationControllerV3.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/web/OrganizationControllerV3.java
@@ -48,6 +48,7 @@ public class OrganizationControllerV3 {
     private final SendEmailInviteUseCase sendEmailInviteUseCase;
     private final ListInvitesUseCase listInvitesUseCase;
     private final RevokeInviteUseCase revokeInviteUseCase;
+    private final PromoteOrgAdminUseCase promoteOrgAdminUseCase;
     private final UserJpaRepository userJpaRepo;
     private final OrganizationJpaRepository orgJpaRepo;
     private final OrganizationInviteJpaRepository inviteJpaRepo;
@@ -271,6 +272,33 @@ public class OrganizationControllerV3 {
         result.put("effectiveExpiryDays", request.tokenExpiryDays() != null ? request.tokenExpiryDays() : org.getTokenExpiryDays());
         log.info("Token config updated: userId={} orgId={} days={} by={}", userId, id, request.tokenExpiryDays(), currentUser.getId());
         return ResponseEntity.ok(ApiResponse.success(result, "Đã cập nhật cấu hình token"));
+    }
+
+    // ==================== Org Admin Promote/Demote (Phase 4 #258) ====================
+
+    /** Issue #258: bổ nhiệm member thành ORG_ADMIN. ADMIN-only — ORG_ADMIN
+     *  KHÔNG có quyền promote member khác (security boundary). */
+    @PostMapping("/{id}/admins/{userId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Bổ nhiệm thành viên làm ORG_ADMIN (ADMIN only)")
+    public ResponseEntity<ApiResponse<String>> promoteOrgAdmin(
+            @PathVariable UUID id,
+            @PathVariable UUID userId,
+            @AuthenticationPrincipal UserJpaEntity currentUser) {
+        promoteOrgAdminUseCase.promote(id, userId, currentUser.getId());
+        return ResponseEntity.ok(ApiResponse.success("Đã bổ nhiệm Quản trị viên tổ chức"));
+    }
+
+    /** Issue #258: hạ cấp ORG_ADMIN xuống TEACHER. ADMIN-only. */
+    @DeleteMapping("/{id}/admins/{userId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Hạ cấp ORG_ADMIN xuống Giảng viên (ADMIN only)")
+    public ResponseEntity<ApiResponse<String>> demoteOrgAdmin(
+            @PathVariable UUID id,
+            @PathVariable UUID userId,
+            @AuthenticationPrincipal UserJpaEntity currentUser) {
+        promoteOrgAdminUseCase.demote(id, userId, currentUser.getId());
+        return ResponseEntity.ok(ApiResponse.success("Đã hạ cấp xuống Giảng viên"));
     }
 
     // ==================== Invite Management ====================

--- a/backend/src/test/java/com/example/lms/identity/application/usecase/PromoteOrgAdminUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/identity/application/usecase/PromoteOrgAdminUseCaseTest.java
@@ -1,7 +1,10 @@
 package com.example.lms.identity.application.usecase;
 
-import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
-import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
+import com.example.lms.identity.domain.model.Role;
+import com.example.lms.identity.domain.model.User;
+import com.example.lms.identity.domain.repository.UserRepository;
+import com.example.lms.shared.domain.valueobject.Email;
+import com.example.lms.shared.domain.valueobject.UserId;
 import com.example.lms.shared.exception.EntityNotFoundException;
 import com.example.lms.shared.exception.ValidationException;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,123 +22,144 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Issue #258 (Phase 4 PR 3): Promote/demote ORG_ADMIN workflow tests.
+ * Sử dụng domain UserRepository + User domain model (clean architecture).
  */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PromoteOrgAdminUseCase Tests")
 class PromoteOrgAdminUseCaseTest {
 
     @Mock
-    private UserJpaRepository userRepo;
+    private UserRepository userRepo;
 
     @InjectMocks
     private PromoteOrgAdminUseCase useCase;
 
     @Captor
-    private ArgumentCaptor<UserJpaEntity> userCaptor;
+    private ArgumentCaptor<User> userCaptor;
 
     private UUID orgId;
-    private UUID userId;
+    private UUID userIdRaw;
+    private UserId userId;
     private UUID actorId;
 
     @BeforeEach
     void setUp() {
         orgId = UUID.randomUUID();
-        userId = UUID.randomUUID();
+        userIdRaw = UUID.randomUUID();
+        userId = UserId.of(userIdRaw);
         actorId = UUID.randomUUID();
     }
 
-    private UserJpaEntity memberWithRole(UserJpaEntity.UserRole role) {
-        UserJpaEntity user = new UserJpaEntity();
-        user.setId(userId);
-        user.setOrganizationId(orgId);
-        user.setRole(role);
+    private User memberWithRole(Role role) {
+        User user = User.builder()
+                .id(userId)
+                .username("testuser")
+                .email(Email.of("test@example.com"))
+                .password("encoded")
+                .fullName("Test User")
+                .role(role)
+                .enabled(true)
+                .organizationId(orgId)
+                .build();
         return user;
     }
 
     @Test
     @DisplayName("Promote STUDENT → ORG_ADMIN")
     void shouldPromoteStudentToOrgAdmin() {
-        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.STUDENT);
+        User user = memberWithRole(Role.STUDENT);
         when(userRepo.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepo.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        useCase.promote(orgId, userId, actorId);
+        useCase.promote(orgId, userIdRaw, actorId);
 
         verify(userRepo).save(userCaptor.capture());
-        assertThat(userCaptor.getValue().getRole()).isEqualTo(UserJpaEntity.UserRole.ORG_ADMIN);
+        assertThat(userCaptor.getValue().getRole()).isEqualTo(Role.ORG_ADMIN);
     }
 
     @Test
     @DisplayName("Promote TEACHER → ORG_ADMIN")
     void shouldPromoteTeacherToOrgAdmin() {
-        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.TEACHER);
+        User user = memberWithRole(Role.TEACHER);
         when(userRepo.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepo.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        useCase.promote(orgId, userId, actorId);
+        useCase.promote(orgId, userIdRaw, actorId);
 
         verify(userRepo).save(userCaptor.capture());
-        assertThat(userCaptor.getValue().getRole()).isEqualTo(UserJpaEntity.UserRole.ORG_ADMIN);
+        assertThat(userCaptor.getValue().getRole()).isEqualTo(Role.ORG_ADMIN);
     }
 
     @Test
     @DisplayName("Promote user role=ADMIN → ValidationException (system role bảo toàn)")
     void shouldRejectPromotingSystemAdmin() {
-        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.ADMIN);
+        User user = memberWithRole(Role.ADMIN);
         when(userRepo.findById(userId)).thenReturn(Optional.of(user));
 
-        assertThatThrownBy(() -> useCase.promote(orgId, userId, actorId))
+        assertThatThrownBy(() -> useCase.promote(orgId, userIdRaw, actorId))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("ADMIN");
 
-        verify(userRepo, never()).save(user);
+        verify(userRepo, never()).save(any(User.class));
     }
 
     @Test
     @DisplayName("Promote user not in org → EntityNotFoundException")
     void shouldRejectPromotingNonMember() {
-        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.STUDENT);
-        user.setOrganizationId(UUID.randomUUID()); // different org
+        User user = User.builder()
+                .id(userId)
+                .username("testuser")
+                .email(Email.of("test@example.com"))
+                .password("encoded")
+                .fullName("Test User")
+                .role(Role.STUDENT)
+                .enabled(true)
+                .organizationId(UUID.randomUUID()) // different org
+                .build();
         when(userRepo.findById(userId)).thenReturn(Optional.of(user));
 
-        assertThatThrownBy(() -> useCase.promote(orgId, userId, actorId))
+        assertThatThrownBy(() -> useCase.promote(orgId, userIdRaw, actorId))
                 .isInstanceOf(EntityNotFoundException.class);
 
-        verify(userRepo, never()).save(user);
+        verify(userRepo, never()).save(any(User.class));
     }
 
     @Test
     @DisplayName("Promote already ORG_ADMIN → idempotent no-op")
     void shouldBeIdempotentPromote() {
-        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.ORG_ADMIN);
+        User user = memberWithRole(Role.ORG_ADMIN);
         when(userRepo.findById(userId)).thenReturn(Optional.of(user));
 
-        useCase.promote(orgId, userId, actorId);
+        useCase.promote(orgId, userIdRaw, actorId);
 
-        verify(userRepo, never()).save(user);
+        verify(userRepo, never()).save(any(User.class));
     }
 
     @Test
     @DisplayName("Demote ORG_ADMIN → TEACHER")
     void shouldDemoteOrgAdminToTeacher() {
-        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.ORG_ADMIN);
+        User user = memberWithRole(Role.ORG_ADMIN);
         when(userRepo.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepo.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        useCase.demote(orgId, userId, actorId);
+        useCase.demote(orgId, userIdRaw, actorId);
 
         verify(userRepo).save(userCaptor.capture());
-        assertThat(userCaptor.getValue().getRole()).isEqualTo(UserJpaEntity.UserRole.TEACHER);
+        assertThat(userCaptor.getValue().getRole()).isEqualTo(Role.TEACHER);
     }
 
     @Test
     @DisplayName("Demote chính mình → ValidationException")
     void shouldRejectDemotingSelf() {
-        // userId == actorId
-        assertThatThrownBy(() -> useCase.demote(orgId, userId, userId))
+        // userIdRaw == actorId
+        assertThatThrownBy(() -> useCase.demote(orgId, userIdRaw, userIdRaw))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("chính mình");
 
@@ -145,26 +169,34 @@ class PromoteOrgAdminUseCaseTest {
     @Test
     @DisplayName("Demote user không phải ORG_ADMIN → ValidationException")
     void shouldRejectDemotingNonOrgAdmin() {
-        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.TEACHER);
+        User user = memberWithRole(Role.TEACHER);
         when(userRepo.findById(userId)).thenReturn(Optional.of(user));
 
-        assertThatThrownBy(() -> useCase.demote(orgId, userId, actorId))
+        assertThatThrownBy(() -> useCase.demote(orgId, userIdRaw, actorId))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("không phải ORG_ADMIN");
 
-        verify(userRepo, never()).save(user);
+        verify(userRepo, never()).save(any(User.class));
     }
 
     @Test
     @DisplayName("Demote user not in org → EntityNotFoundException")
     void shouldRejectDemotingNonMember() {
-        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.ORG_ADMIN);
-        user.setOrganizationId(UUID.randomUUID()); // different org
+        User user = User.builder()
+                .id(userId)
+                .username("testuser")
+                .email(Email.of("test@example.com"))
+                .password("encoded")
+                .fullName("Test User")
+                .role(Role.ORG_ADMIN)
+                .enabled(true)
+                .organizationId(UUID.randomUUID()) // different org
+                .build();
         when(userRepo.findById(userId)).thenReturn(Optional.of(user));
 
-        assertThatThrownBy(() -> useCase.demote(orgId, userId, actorId))
+        assertThatThrownBy(() -> useCase.demote(orgId, userIdRaw, actorId))
                 .isInstanceOf(EntityNotFoundException.class);
 
-        verify(userRepo, never()).save(user);
+        verify(userRepo, never()).save(any(User.class));
     }
 }

--- a/backend/src/test/java/com/example/lms/identity/application/usecase/PromoteOrgAdminUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/identity/application/usecase/PromoteOrgAdminUseCaseTest.java
@@ -1,0 +1,170 @@
+package com.example.lms.identity.application.usecase;
+
+import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
+import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
+import com.example.lms.shared.exception.EntityNotFoundException;
+import com.example.lms.shared.exception.ValidationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #258 (Phase 4 PR 3): Promote/demote ORG_ADMIN workflow tests.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PromoteOrgAdminUseCase Tests")
+class PromoteOrgAdminUseCaseTest {
+
+    @Mock
+    private UserJpaRepository userRepo;
+
+    @InjectMocks
+    private PromoteOrgAdminUseCase useCase;
+
+    @Captor
+    private ArgumentCaptor<UserJpaEntity> userCaptor;
+
+    private UUID orgId;
+    private UUID userId;
+    private UUID actorId;
+
+    @BeforeEach
+    void setUp() {
+        orgId = UUID.randomUUID();
+        userId = UUID.randomUUID();
+        actorId = UUID.randomUUID();
+    }
+
+    private UserJpaEntity memberWithRole(UserJpaEntity.UserRole role) {
+        UserJpaEntity user = new UserJpaEntity();
+        user.setId(userId);
+        user.setOrganizationId(orgId);
+        user.setRole(role);
+        return user;
+    }
+
+    @Test
+    @DisplayName("Promote STUDENT → ORG_ADMIN")
+    void shouldPromoteStudentToOrgAdmin() {
+        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.STUDENT);
+        when(userRepo.findById(userId)).thenReturn(Optional.of(user));
+
+        useCase.promote(orgId, userId, actorId);
+
+        verify(userRepo).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getRole()).isEqualTo(UserJpaEntity.UserRole.ORG_ADMIN);
+    }
+
+    @Test
+    @DisplayName("Promote TEACHER → ORG_ADMIN")
+    void shouldPromoteTeacherToOrgAdmin() {
+        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.TEACHER);
+        when(userRepo.findById(userId)).thenReturn(Optional.of(user));
+
+        useCase.promote(orgId, userId, actorId);
+
+        verify(userRepo).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getRole()).isEqualTo(UserJpaEntity.UserRole.ORG_ADMIN);
+    }
+
+    @Test
+    @DisplayName("Promote user role=ADMIN → ValidationException (system role bảo toàn)")
+    void shouldRejectPromotingSystemAdmin() {
+        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.ADMIN);
+        when(userRepo.findById(userId)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> useCase.promote(orgId, userId, actorId))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("ADMIN");
+
+        verify(userRepo, never()).save(user);
+    }
+
+    @Test
+    @DisplayName("Promote user not in org → EntityNotFoundException")
+    void shouldRejectPromotingNonMember() {
+        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.STUDENT);
+        user.setOrganizationId(UUID.randomUUID()); // different org
+        when(userRepo.findById(userId)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> useCase.promote(orgId, userId, actorId))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        verify(userRepo, never()).save(user);
+    }
+
+    @Test
+    @DisplayName("Promote already ORG_ADMIN → idempotent no-op")
+    void shouldBeIdempotentPromote() {
+        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.ORG_ADMIN);
+        when(userRepo.findById(userId)).thenReturn(Optional.of(user));
+
+        useCase.promote(orgId, userId, actorId);
+
+        verify(userRepo, never()).save(user);
+    }
+
+    @Test
+    @DisplayName("Demote ORG_ADMIN → TEACHER")
+    void shouldDemoteOrgAdminToTeacher() {
+        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.ORG_ADMIN);
+        when(userRepo.findById(userId)).thenReturn(Optional.of(user));
+
+        useCase.demote(orgId, userId, actorId);
+
+        verify(userRepo).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getRole()).isEqualTo(UserJpaEntity.UserRole.TEACHER);
+    }
+
+    @Test
+    @DisplayName("Demote chính mình → ValidationException")
+    void shouldRejectDemotingSelf() {
+        // userId == actorId
+        assertThatThrownBy(() -> useCase.demote(orgId, userId, userId))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("chính mình");
+
+        verify(userRepo, never()).findById(userId);
+    }
+
+    @Test
+    @DisplayName("Demote user không phải ORG_ADMIN → ValidationException")
+    void shouldRejectDemotingNonOrgAdmin() {
+        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.TEACHER);
+        when(userRepo.findById(userId)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> useCase.demote(orgId, userId, actorId))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("không phải ORG_ADMIN");
+
+        verify(userRepo, never()).save(user);
+    }
+
+    @Test
+    @DisplayName("Demote user not in org → EntityNotFoundException")
+    void shouldRejectDemotingNonMember() {
+        UserJpaEntity user = memberWithRole(UserJpaEntity.UserRole.ORG_ADMIN);
+        user.setOrganizationId(UUID.randomUUID()); // different org
+        when(userRepo.findById(userId)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> useCase.demote(orgId, userId, actorId))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        verify(userRepo, never()).save(user);
+    }
+}

--- a/fe/src/app/features/admin/infrastructure/services/organization.service.ts
+++ b/fe/src/app/features/admin/infrastructure/services/organization.service.ts
@@ -79,6 +79,20 @@ export class OrganizationService {
     );
   }
 
+  /** Issue #258 (Phase 4 PR 3): bổ nhiệm member thành ORG_ADMIN. ADMIN-only. */
+  promoteOrgAdmin(orgId: string, userId: string): Observable<string> {
+    return this.api.post<ApiResponse<string>>(`/api/v3/organizations/${orgId}/admins/${userId}`, {}).pipe(
+      map(res => res.data)
+    );
+  }
+
+  /** Issue #258 (Phase 4 PR 3): hạ cấp ORG_ADMIN xuống Giảng viên. ADMIN-only. */
+  demoteOrgAdmin(orgId: string, userId: string): Observable<string> {
+    return this.api.delete<ApiResponse<string>>(`/api/v3/organizations/${orgId}/admins/${userId}`).pipe(
+      map(res => res.data)
+    );
+  }
+
   // Invites
   createInviteCode(orgId: string, data: { maxUses?: number; expiryDays?: number }): Observable<OrganizationInvite> {
     return this.api.post<ApiResponse<OrganizationInvite>>(ORGANIZATION_ENDPOINTS.INVITE_CODE(orgId), data).pipe(

--- a/fe/src/app/features/admin/presentation/components/organization-detail.component.ts
+++ b/fe/src/app/features/admin/presentation/components/organization-detail.component.ts
@@ -390,9 +390,13 @@ export class OrganizationDetailComponent implements OnInit {
   // text buttons that were the only row action. Mirrors admin-shared kebab
   // pattern (PR #219) — every admin table now uses the same overflow
   // surface.
+  // Phase 4 PR 3 (#258): thêm promote/demote ORG_ADMIN actions (ADMIN-only).
   // ---------------------------------------------------------------------
   memberRowActions(member: OrgMember): KebabAction[] {
     const actions: KebabAction[] = [];
+    const role = member.role?.toUpperCase();
+    const isAdmin = this.authService.userRole() === 'admin';
+    const currentUserId = this.authService.currentUser()?.id;
 
     if (this.canEditMember(member)) {
       actions.push({
@@ -402,6 +406,27 @@ export class OrganizationDetailComponent implements OnInit {
         // pencil
         icon: 'M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z',
       });
+    }
+
+    // Issue #258: Promote/demote ORG_ADMIN — ADMIN role only (boundary)
+    if (isAdmin && role !== 'ADMIN') {
+      if (role === 'ORG_ADMIN' && member.id !== currentUserId) {
+        actions.push({
+          key: 'demote-org-admin',
+          label: 'Hạ cấp xuống Giảng viên',
+          ariaLabel: `Hạ cấp ${member.fullName} xuống Giảng viên`,
+          // arrow-down
+          icon: 'M16 17l-4 4-4-4m8-5l-4 4-4-4m8-5l-4 4-4-4',
+        });
+      } else if (role !== 'ORG_ADMIN') {
+        actions.push({
+          key: 'promote-org-admin',
+          label: 'Bổ nhiệm Quản trị viên tổ chức',
+          ariaLabel: `Bổ nhiệm ${member.fullName} làm Quản trị viên tổ chức`,
+          // shield
+          icon: 'M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z',
+        });
+      }
     }
 
     if (this.canRemoveMember(member)) {
@@ -423,10 +448,56 @@ export class OrganizationDetailComponent implements OnInit {
       case 'edit-token':
         this.editingTokenMemberId.set(member.id);
         break;
+      case 'promote-org-admin':
+        this.promoteOrgAdmin(member);
+        break;
+      case 'demote-org-admin':
+        this.demoteOrgAdmin(member);
+        break;
       case 'remove':
         this.removeMember(member);
         break;
     }
+  }
+
+  /** Issue #258 (Phase 4 PR 3): bổ nhiệm thành ORG_ADMIN sau confirm. */
+  async promoteOrgAdmin(member: OrgMember): Promise<void> {
+    const confirmed = await this.confirmDialog.confirm({
+      title: 'Bổ nhiệm Quản trị viên tổ chức',
+      message: `Bổ nhiệm "${member.fullName}" làm Quản trị viên của tổ chức này? Họ sẽ có quyền quản lý thành viên + lời mời.`,
+      variant: 'info',
+      confirmText: 'Bổ nhiệm',
+      cancelText: 'Hủy'
+    });
+    if (!confirmed) return;
+
+    this.orgService.promoteOrgAdmin(this.orgId, member.id).subscribe({
+      next: () => {
+        this.toast.success('Đã bổ nhiệm Quản trị viên tổ chức', `"${member.fullName}" giờ là ORG_ADMIN`);
+        this.loadMembers();
+      },
+      error: (err) => this.toast.error(err.error?.message || 'Không thể bổ nhiệm')
+    });
+  }
+
+  /** Issue #258 (Phase 4 PR 3): hạ cấp ORG_ADMIN xuống Giảng viên sau confirm. */
+  async demoteOrgAdmin(member: OrgMember): Promise<void> {
+    const confirmed = await this.confirmDialog.confirm({
+      title: 'Hạ cấp Quản trị viên',
+      message: `Hạ cấp "${member.fullName}" xuống Giảng viên? Họ sẽ mất quyền quản lý tổ chức.`,
+      variant: 'warning',
+      confirmText: 'Hạ cấp',
+      cancelText: 'Hủy'
+    });
+    if (!confirmed) return;
+
+    this.orgService.demoteOrgAdmin(this.orgId, member.id).subscribe({
+      next: () => {
+        this.toast.success('Đã hạ cấp', `"${member.fullName}" giờ là Giảng viên`);
+        this.loadMembers();
+      },
+      error: (err) => this.toast.error(err.error?.message || 'Không thể hạ cấp')
+    });
   }
 
   inviteRowActions(invite: OrganizationInvite): KebabAction[] {


### PR DESCRIPTION
Closes #258

Phase 4 PR 3 — workflow promote member trở thành ORG_ADMIN của 1 tổ chức. ADMIN-only operation.

## BE
- \`PromoteOrgAdminUseCase\` (promote + demote methods)
- \`POST /api/v3/organizations/:id/admins/:userId\` — promote → ORG_ADMIN
- \`DELETE /api/v3/organizations/:id/admins/:userId\` — demote → TEACHER
- Both @PreAuthorize hasRole('ADMIN')

**Validation rules:**
- User phải là member của org (\`organization_id\` match)
- Promote ADMIN role rejected (bảo toàn system role)
- Demote không phải ORG_ADMIN rejected
- Demote chính mình rejected
- Promote already ORG_ADMIN → idempotent no-op

**Tests 9/9 PASS:**
- Promote STUDENT/TEACHER → ORG_ADMIN
- Promote ADMIN/non-member reject
- Promote idempotent
- Demote ORG_ADMIN → TEACHER
- Demote self/non-ORG_ADMIN/non-member reject

## FE
- \`OrganizationService.promoteOrgAdmin\` / \`demoteOrgAdmin\`
- Member kebab actions thêm:
  - \"Bổ nhiệm Quản trị viên tổ chức\" (ADMIN role thấy cho member non-ADMIN/non-ORG_ADMIN)
  - \"Hạ cấp xuống Giảng viên\" (ADMIN role thấy cho ORG_ADMIN ngoài self)
- Confirm dialog + auto-refresh + toast

## Verified
- tsc EXIT=0, npm run build clean
- BE tests 9/9 PASS
- 5 files, +362/-0

🤖 Generated with [Claude Code](https://claude.com/claude-code)