### PR TITLE
feat(admin-org): Phase 4 PR 4 — cross-org revenue dashboard

### DIFF
--- a/backend/src/main/java/com/example/lms/identity/application/dto/CrossOrgRevenueResponse.java
+++ b/backend/src/main/java/com/example/lms/identity/application/dto/CrossOrgRevenueResponse.java
@@ -1,0 +1,28 @@
+package com.example.lms.identity.application.dto;
+
+import com.example.lms.identity.domain.model.OrganizationType;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Issue #260 (Phase 4 PR 4): cross-org revenue aggregate response cho admin
+ * dashboard. Tổng hợp metrics all-time + top N orgs by revenue.
+ */
+public record CrossOrgRevenueResponse(
+        BigDecimal totalGrossRevenue,
+        BigDecimal totalPlatformFees,
+        BigDecimal totalTeacherPayouts,
+        BigDecimal totalOrgPayouts,
+        List<TopOrgRevenue> topOrgs
+) {
+    public record TopOrgRevenue(
+            UUID orgId,
+            String name,
+            String code,
+            OrganizationType type,
+            boolean isDefault,
+            BigDecimal totalRevenue
+    ) {}
+}

--- a/backend/src/main/java/com/example/lms/identity/application/usecase/GetCrossOrgRevenueUseCase.java
+++ b/backend/src/main/java/com/example/lms/identity/application/usecase/GetCrossOrgRevenueUseCase.java
@@ -1,0 +1,67 @@
+package com.example.lms.identity.application.usecase;
+
+import com.example.lms.identity.application.dto.CrossOrgRevenueResponse;
+import com.example.lms.identity.application.dto.CrossOrgRevenueResponse.TopOrgRevenue;
+import com.example.lms.identity.domain.model.Organization;
+import com.example.lms.identity.domain.repository.OrganizationRepository;
+import com.example.lms.shared.domain.model.OrgRevenueAggregate;
+import com.example.lms.shared.domain.repository.RevenueSplitRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Issue #260 (Phase 4 PR 4): aggregate cross-org revenue cho admin dashboard.
+ * ADMIN-only — surface high-level metrics + top orgs ranking.
+ *
+ * Clean architecture: dùng cả 2 domain ports (RevenueSplitRepository +
+ * OrganizationRepository), không phụ thuộc infrastructure.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GetCrossOrgRevenueUseCase {
+
+    private static final int TOP_N = 5;
+
+    private final RevenueSplitRepository revenueRepo;
+    private final OrganizationRepository orgRepo;
+
+    @Transactional(readOnly = true)
+    public CrossOrgRevenueResponse execute() {
+        BigDecimal totalGross = revenueRepo.sumGrossRevenueAll();
+        BigDecimal totalPlatform = revenueRepo.sumPlatformAmountAll();
+        BigDecimal totalTeacher = revenueRepo.sumTeacherAmountAll();
+        BigDecimal totalOrg = revenueRepo.sumOrgAmountAll();
+
+        List<OrgRevenueAggregate> topAggregates = revenueRepo.findTopOrgsByRevenue(TOP_N);
+        List<TopOrgRevenue> topOrgs = topAggregates.stream()
+                .map(this::resolveOrgMetadata)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+
+        return new CrossOrgRevenueResponse(
+                totalGross, totalPlatform, totalTeacher, totalOrg, topOrgs);
+    }
+
+    /** Resolve org id → name/code/type. Trả null nếu org bị xóa (orphan
+     *  revenue split) — filter out ở caller. */
+    private TopOrgRevenue resolveOrgMetadata(OrgRevenueAggregate agg) {
+        UUID orgId = agg.orgId();
+        Organization org = orgRepo.findById(orgId).orElse(null);
+        if (org == null) {
+            log.warn("Cross-org revenue: org {} not found (orphan revenue split)", orgId);
+            return null;
+        }
+        return new TopOrgRevenue(
+                org.getId(), org.getName(), org.getCode(),
+                org.getType(), org.isDefault(),
+                agg.totalRevenue()
+        );
+    }
+}

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/web/OrganizationControllerV3.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/web/OrganizationControllerV3.java
@@ -49,6 +49,7 @@ public class OrganizationControllerV3 {
     private final ListInvitesUseCase listInvitesUseCase;
     private final RevokeInviteUseCase revokeInviteUseCase;
     private final PromoteOrgAdminUseCase promoteOrgAdminUseCase;
+    private final GetCrossOrgRevenueUseCase getCrossOrgRevenueUseCase;
     private final UserJpaRepository userJpaRepo;
     private final OrganizationJpaRepository orgJpaRepo;
     private final OrganizationInviteJpaRepository inviteJpaRepo;
@@ -101,6 +102,14 @@ public class OrganizationControllerV3 {
                 inviteJpaRepo.countActiveInvites(Instant.now())
         );
         return ResponseEntity.ok(ApiResponse.success(stats));
+    }
+
+    /** Issue #260 (Phase 4 PR 4): cross-org revenue aggregate cho admin dashboard. */
+    @GetMapping("/stats/revenue")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Cross-org revenue dashboard (ADMIN only)")
+    public ResponseEntity<ApiResponse<com.example.lms.identity.application.dto.CrossOrgRevenueResponse>> getCrossOrgRevenue() {
+        return ResponseEntity.ok(ApiResponse.success(getCrossOrgRevenueUseCase.execute()));
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/example/lms/shared/domain/model/OrgRevenueAggregate.java
+++ b/backend/src/main/java/com/example/lms/shared/domain/model/OrgRevenueAggregate.java
@@ -1,0 +1,12 @@
+package com.example.lms.shared.domain.model;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Issue #260 (Phase 4 PR 4): aggregate row trả về từ findTopOrgsByRevenue.
+ * Pure domain value object — không phụ thuộc Organization để tránh coupling
+ * giữa shared (revenue) và identity (org). Use case resolve org metadata
+ * sau bằng OrganizationRepository.
+ */
+public record OrgRevenueAggregate(UUID orgId, BigDecimal totalRevenue) {}

--- a/backend/src/main/java/com/example/lms/shared/domain/repository/RevenueSplitRepository.java
+++ b/backend/src/main/java/com/example/lms/shared/domain/repository/RevenueSplitRepository.java
@@ -1,10 +1,12 @@
 package com.example.lms.shared.domain.repository;
 
+import com.example.lms.shared.domain.model.OrgRevenueAggregate;
 import com.example.lms.shared.domain.model.RevenueSplit;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -17,4 +19,17 @@ public interface RevenueSplitRepository {
     BigDecimal sumTeacherAmountThisMonth(UUID teacherId);
     BigDecimal sumTeacherAmountLastMonth(UUID teacherId);
     long countDistinctCoursesByTeacherId(UUID teacherId);
+
+    // ==================== Issue #260 (Phase 4 PR 4): cross-org aggregates ====================
+
+    /** Tổng doanh thu gross all-time (mọi payment đã complete). */
+    BigDecimal sumGrossRevenueAll();
+    /** Tổng phí nền tảng all-time. */
+    BigDecimal sumPlatformAmountAll();
+    /** Tổng teacher payouts all-time. */
+    BigDecimal sumTeacherAmountAll();
+    /** Tổng org payouts all-time. */
+    BigDecimal sumOrgAmountAll();
+    /** Top N orgs theo gross revenue (skip null org_id). */
+    List<OrgRevenueAggregate> findTopOrgsByRevenue(int limit);
 }

--- a/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/RevenueSplitRepositoryAdapter.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/RevenueSplitRepositoryAdapter.java
@@ -1,5 +1,6 @@
 package com.example.lms.shared.infrastructure.persistence;
 
+import com.example.lms.shared.domain.model.OrgRevenueAggregate;
 import com.example.lms.shared.domain.model.RevenueSplit;
 import com.example.lms.shared.domain.repository.RevenueSplitRepository;
 import com.example.lms.shared.infrastructure.persistence.entity.RevenueSplitJpaEntity;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -52,6 +54,38 @@ public class RevenueSplitRepositoryAdapter implements RevenueSplitRepository {
     @Override
     public long countDistinctCoursesByTeacherId(UUID teacherId) {
         return jpaRepo.countDistinctCoursesByTeacherId(teacherId);
+    }
+
+    // ==================== Issue #260 (Phase 4 PR 4): cross-org aggregates ====================
+
+    @Override
+    public BigDecimal sumGrossRevenueAll() {
+        return jpaRepo.sumGrossRevenueAll();
+    }
+
+    @Override
+    public BigDecimal sumPlatformAmountAll() {
+        return jpaRepo.sumPlatformAmountAll();
+    }
+
+    @Override
+    public BigDecimal sumTeacherAmountAll() {
+        return jpaRepo.sumTeacherAmountAll();
+    }
+
+    @Override
+    public BigDecimal sumOrgAmountAll() {
+        return jpaRepo.sumOrgAmountAll();
+    }
+
+    @Override
+    public List<OrgRevenueAggregate> findTopOrgsByRevenue(int limit) {
+        return jpaRepo.findTopOrgsByRevenue(limit).stream()
+                .map(row -> new OrgRevenueAggregate(
+                        (UUID) row[0],
+                        (BigDecimal) row[1]
+                ))
+                .toList();
     }
 
     private RevenueSplitJpaEntity toEntity(RevenueSplit s) {

--- a/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/repository/RevenueSplitJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/repository/RevenueSplitJpaRepository.java
@@ -41,4 +41,30 @@ public interface RevenueSplitJpaRepository
 
     @Query("SELECT COUNT(DISTINCT r.courseId) FROM RevenueSplitJpaEntity r WHERE r.teacherId = :teacherId")
     long countDistinctCoursesByTeacherId(@Param("teacherId") UUID teacherId);
+
+    // ==================== Issue #260 (Phase 4 PR 4): cross-org aggregates ====================
+
+    @Query("SELECT COALESCE(SUM(r.grossAmount), 0) FROM RevenueSplitJpaEntity r")
+    BigDecimal sumGrossRevenueAll();
+
+    @Query("SELECT COALESCE(SUM(r.platformAmount), 0) FROM RevenueSplitJpaEntity r")
+    BigDecimal sumPlatformAmountAll();
+
+    @Query("SELECT COALESCE(SUM(r.teacherAmount), 0) FROM RevenueSplitJpaEntity r")
+    BigDecimal sumTeacherAmountAll();
+
+    @Query("SELECT COALESCE(SUM(r.orgAmount), 0) FROM RevenueSplitJpaEntity r")
+    BigDecimal sumOrgAmountAll();
+
+    /** Top N orgs by gross revenue. Returns Object[] {orgId UUID, total BigDecimal}.
+     *  Skip rows where org_id IS NULL (individual users / default org gross). */
+    @Query(value = """
+        SELECT r.org_id AS orgId, SUM(r.gross_amount) AS total
+        FROM revenue_splits r
+        WHERE r.org_id IS NOT NULL
+        GROUP BY r.org_id
+        ORDER BY total DESC
+        LIMIT :limit
+        """, nativeQuery = true)
+    java.util.List<Object[]> findTopOrgsByRevenue(@Param("limit") int limit);
 }

--- a/fe/src/app/features/admin/infrastructure/services/organization.service.ts
+++ b/fe/src/app/features/admin/infrastructure/services/organization.service.ts
@@ -40,6 +40,13 @@ export class OrganizationService {
     );
   }
 
+  /** Issue #260 (Phase 4 PR 4): cross-org revenue dashboard. ADMIN only. */
+  getCrossOrgRevenue(): Observable<CrossOrgRevenueResponse> {
+    return this.api.get<ApiResponse<CrossOrgRevenueResponse>>('/api/v3/organizations/stats/revenue').pipe(
+      map(res => res.data)
+    );
+  }
+
   getOrganization(id: string): Observable<Organization> {
     return this.api.get<ApiResponse<Organization>>(ORGANIZATION_ENDPOINTS.BY_ID(id)).pipe(
       map(res => res.data)
@@ -172,4 +179,22 @@ export interface OrganizationStats {
   activeOrgs: number;
   totalMembers: number;
   activeInvites: number;
+}
+
+/** Issue #260 (Phase 4 PR 4): cross-org revenue aggregate. */
+export interface TopOrgRevenue {
+  orgId: string;
+  name: string;
+  code: string;
+  type: OrganizationType;
+  isDefault: boolean;
+  totalRevenue: number;
+}
+
+export interface CrossOrgRevenueResponse {
+  totalGrossRevenue: number;
+  totalPlatformFees: number;
+  totalTeacherPayouts: number;
+  totalOrgPayouts: number;
+  topOrgs: TopOrgRevenue[];
 }

--- a/fe/src/app/features/admin/presentation/components/organization-list.component.html
+++ b/fe/src/app/features/admin/presentation/components/organization-list.component.html
@@ -26,6 +26,61 @@
       </div>
     }
 
+    <!-- Issue #260 (Phase 4 PR 4): Cross-org revenue dashboard (ADMIN only) -->
+    @if (revenueStats(); as rev) {
+      <section class="revenue-section" aria-labelledby="revenue-heading">
+        <div class="revenue-header">
+          <h2 id="revenue-heading" class="revenue-title">Tổng quan doanh thu (toàn nền tảng)</h2>
+          <p class="revenue-subtitle">Aggregate doanh thu từ V83 revenue_splits ledger — all-time</p>
+        </div>
+        <div class="revenue-cards">
+          <div class="revenue-card revenue-card--gross">
+            <div class="revenue-card-label">Tổng doanh thu (gross)</div>
+            <div class="revenue-card-value">{{ formatVnd(rev.totalGrossRevenue) }}</div>
+          </div>
+          <div class="revenue-card">
+            <div class="revenue-card-label">Phí nền tảng</div>
+            <div class="revenue-card-value">{{ formatVnd(rev.totalPlatformFees) }}</div>
+          </div>
+          <div class="revenue-card">
+            <div class="revenue-card-label">Trả giảng viên</div>
+            <div class="revenue-card-value">{{ formatVnd(rev.totalTeacherPayouts) }}</div>
+          </div>
+          <div class="revenue-card">
+            <div class="revenue-card-label">Trả tổ chức</div>
+            <div class="revenue-card-value">{{ formatVnd(rev.totalOrgPayouts) }}</div>
+          </div>
+        </div>
+
+        @if (rev.topOrgs.length > 0) {
+          <div class="top-orgs-card">
+            <h3 class="top-orgs-title">Top {{ rev.topOrgs.length }} tổ chức theo doanh thu</h3>
+            <div class="top-orgs-list">
+              @for (org of rev.topOrgs; track org.orgId; let i = $index) {
+                <a [routerLink]="['/admin/organizations', org.orgId]" class="top-org-row">
+                  <span class="top-org-rank">#{{ i + 1 }}</span>
+                  <div class="top-org-info">
+                    <div class="top-org-name">
+                      {{ org.name }}
+                      @if (org.isDefault) {
+                        <span class="default-star" title="Tổ chức nền tảng" aria-label="Tổ chức nền tảng">⭐</span>
+                      }
+                    </div>
+                    <div class="top-org-meta">
+                      <span [class]="typeMetaFor(org.type).cssClass">{{ typeMetaFor(org.type).label }}</span>
+                      <span class="dot-separator">&middot;</span>
+                      <span class="top-org-code">{{ org.code }}</span>
+                    </div>
+                  </div>
+                  <span class="top-org-revenue">{{ formatVnd(org.totalRevenue) }}</span>
+                </a>
+              }
+            </div>
+          </div>
+        }
+      </section>
+    }
+
     <!-- Create Form (inline card) -->
     @if (canCreateOrganizations() && showCreateForm()) {
       <div class="create-form-card">

--- a/fe/src/app/features/admin/presentation/components/organization-list.component.scss
+++ b/fe/src/app/features/admin/presentation/components/organization-list.component.scss
@@ -675,6 +675,176 @@
   .filter-type-select { width: 100%; }
 }
 
+/* =====================================================================
+   Issue #260 (Phase 4 PR 4): cross-org revenue dashboard
+   ===================================================================== */
+.revenue-section {
+  margin-bottom: $spacing-6;
+  padding: $spacing-5;
+  background: white;
+  border: 1px solid $border-default;
+  border-radius: $radius-xl;
+  box-shadow: $shadow-sm;
+}
+
+.revenue-header {
+  margin-bottom: $spacing-4;
+}
+
+.revenue-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #111827;
+  margin: 0 0 4px 0;
+}
+
+.revenue-subtitle {
+  font-size: 13px;
+  color: #6b7280;
+  margin: 0;
+}
+
+.revenue-cards {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: $spacing-3;
+  margin-bottom: $spacing-5;
+
+  @media (max-width: 1024px) { grid-template-columns: repeat(2, 1fr); }
+  @media (max-width: 640px) { grid-template-columns: 1fr; }
+}
+
+.revenue-card {
+  padding: $spacing-3 $spacing-4;
+  background: #f9fafb;
+  border: 1px solid $border-default;
+  border-radius: $radius-lg;
+  transition: border-color 0.15s ease;
+
+  &:hover {
+    border-color: rgba(0, 86, 210, 0.25);
+  }
+}
+
+.revenue-card--gross {
+  background: linear-gradient(135deg, rgba(0, 86, 210, 0.04), rgba(0, 86, 210, 0.01));
+  border-color: rgba(0, 86, 210, 0.2);
+}
+
+.revenue-card-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #6b7280;
+  margin-bottom: 6px;
+}
+
+.revenue-card-value {
+  font-size: 18px;
+  font-weight: 700;
+  color: #111827;
+  font-variant-numeric: tabular-nums;
+}
+
+.revenue-card--gross .revenue-card-value {
+  color: #0056D2;
+}
+
+/* Top orgs ranking */
+.top-orgs-card {
+  background: #fafafa;
+  border: 1px solid $border-default;
+  border-radius: $radius-lg;
+  padding: $spacing-4;
+}
+
+.top-orgs-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+  margin: 0 0 $spacing-3 0;
+}
+
+.top-orgs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.top-org-row {
+  display: flex;
+  align-items: center;
+  gap: $spacing-3;
+  padding: $spacing-3;
+  background: white;
+  border: 1px solid transparent;
+  border-radius: $radius-md;
+  text-decoration: none;
+  transition: all 0.15s ease;
+
+  &:hover {
+    border-color: rgba(0, 86, 210, 0.25);
+    background: rgba(0, 86, 210, 0.02);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #0056D2;
+    outline-offset: 2px;
+  }
+}
+
+.top-org-rank {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 28px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: rgba(0, 86, 210, 0.08);
+  color: #0056D2;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.top-org-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.top-org-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.top-org-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.top-org-code {
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  background: rgba(0, 0, 0, 0.04);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.top-org-revenue {
+  font-size: 14px;
+  font-weight: 700;
+  color: #0056D2;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
 /* ===== PRINT ===== */
 @media print {
   .org-list-page {

--- a/fe/src/app/features/admin/presentation/components/organization-list.component.ts
+++ b/fe/src/app/features/admin/presentation/components/organization-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, signal, inject, OnInit, ChangeDetectionStrategy, computed, effect } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { OrganizationService, OrganizationStats } from '../../infrastructure/services/organization.service';
+import { OrganizationService, OrganizationStats, CrossOrgRevenueResponse } from '../../infrastructure/services/organization.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { Organization, OrganizationType } from '../../../../shared/types/user.types';
@@ -23,6 +23,8 @@ export class OrganizationListComponent implements OnInit {
 
   organizations = signal<Organization[]>([]);
   stats = signal<OrganizationStats | null>(null);
+  // Issue #260 (Phase 4 PR 4): cross-org revenue aggregate (ADMIN only).
+  revenueStats = signal<CrossOrgRevenueResponse | null>(null);
   isLoading = signal(true);
   showCreateForm = signal(false);
   isCreating = signal(false);
@@ -105,7 +107,24 @@ export class OrganizationListComponent implements OnInit {
     this.loadOrganizations();
     if (this.canCreateOrganizations()) {
       this.loadStats();
+      this.loadRevenueStats();
     }
+  }
+
+  /** Issue #260 (Phase 4 PR 4): load cross-org revenue. Silent fail nếu 403. */
+  private loadRevenueStats(): void {
+    this.orgService.getCrossOrgRevenue().subscribe({
+      next: (revenue) => this.revenueStats.set(revenue),
+      error: () => {
+        // Silent fail — section ẩn nếu endpoint không authorized hoặc lỗi
+      }
+    });
+  }
+
+  /** Format VND currency cho revenue cards. Vietnamese locale. */
+  formatVnd(amount: number | undefined | null): string {
+    if (amount === null || amount === undefined) return '0 ₫';
+    return new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND', maximumFractionDigits: 0 }).format(amount);
   }
 
   loadOrganizations(): void {


### PR DESCRIPTION
Closes #260

Phase 4 PR 4 (final) — cross-org revenue overview cho ADMIN. Tận dụng V83 revenue_splits ledger immutable. Surface aggregate metrics + top 5 orgs ranking trên admin/organizations page.

## BE — Clean architecture compliant
- \`OrgRevenueAggregate\` value object (shared/domain/model)
- \`RevenueSplitRepository\` (domain port) thêm 5 methods aggregate
- \`RevenueSplitJpaRepository\` impl với @Query + native query top orgs
- Adapter map Object[] → domain value object
- \`CrossOrgRevenueResponse\` DTO (record + nested TopOrgRevenue)
- \`GetCrossOrgRevenueUseCase\` orchestrate 2 domain ports + orphan-org fallback
- \`GET /api/v3/organizations/stats/revenue\` — @PreAuthorize ADMIN

## FE
- \`OrganizationService.getCrossOrgRevenue()\` + DTO interfaces
- Revenue section trên \`/admin/organizations\`:
  - 4 KPI cards: Gross (gradient blue) / Platform / Teacher / Org
  - Top 5 orgs ranking với rank badge, type badge, code, revenue VND
  - Click row → org detail page
- formatVnd() Intl.NumberFormat vi-VN locale
- Responsive 4→2→1 cols, mobile stack

## Verified
- tsc EXIT=0, npm run build clean
- BE compile SUCCESS
- CleanArchitectureTest 7/7 PASS (use case không leak infrastructure)
- 11 files, +461/-1

## Phase 4 complete (4 PRs)
1. #255 type-aware create + filter + search
2. #257 pagination
3. #259 promote/demote ORG_ADMIN workflow
4. **#260 cross-org revenue dashboard** ← this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)