### PR TITLE
fix(section-editor): applyTemplate append thay vì replace — chống wipe content

### DIFF
--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
@@ -1718,12 +1718,30 @@ export class SectionEditorComponent {
     return cat === 'format' || cat === 'transcode' || cat == null;
   }
 
+  /**
+   * Apply lesson template — append at cursor (Notion/Google Docs UX) thay vì
+   * replace toàn bộ. Trước đây silent-replace gây silent data loss (section
+   * dc5675f0 bị wipe nhiều lần). Closes #280.
+   *
+   * Branch:
+   *  - Editor empty → set content (initial scaffolding usage)
+   *  - Editor has content → insertContent at cursor (append, preserve existing)
+   */
   applyTemplate(tpl: LessonTemplate): void {
     this.showTemplatePicker.set(false);
-    if (tpl.content) {
+    if (!tpl.content) return;
+
+    const editorRef = this.tiptapEditor();
+    const editor = editorRef?.editor;
+
+    if (editor && !editor.isEmpty) {
+      // Append at cursor — match Notion/Tiptap default UX, no destructive replace.
+      editor.commands.insertContent(tpl.content);
+    } else {
+      // Empty editor: full set is fine (initial scaffolding).
       this.svc.sectionContent.set(tpl.content);
-      this.svc.markDirty();
     }
+    this.svc.markDirty();
   }
 
   onTitleChange(value: string): void {


### PR DESCRIPTION
## 🎯 Mục tiêu

Closes #280.

## 📌 Severity

**P1 HIGH** — recurring data loss. Section dc5675f0 đã bị wipe ≥ 3 lần.

## 🔍 Root cause

\`section-editor.component.ts:1721\` \`applyTemplate()\` silent-replaces editor content. User curious click template button → existing rich content nuked → save → DB overwrite.

## 📝 Thay đổi

| File | Change |
|---|---|
| \`section-editor.component.ts\` | \`applyTemplate\` branch: empty→set, non-empty→insertContent (append at cursor) |

## 🏛️ SOTA pattern

- **Notion** templates: insert at cursor, không replace
- **Google Docs**: "Insert template" appends
- **Tiptap**: \`insertContent()\` vs \`setContent()\` — đúng API

## 🧪 Test plan

- [x] Compile clean
- [ ] Manual E2E (after merge + deploy):
  - Open section dc5675f0 với rich content
  - Click template button "Case study"
  - Expect: template appended at cursor, original 3226 chars preserved
- [ ] No regression với empty editor flow (initial scaffolding still works)

## ⚠️ Trade-off

User click template 2 lần → 2 templates inserted (double scaffolding). Acceptable: **visible cost vs silent data loss**. User can ctrl+Z undo.

## 🔄 Rollback

Revert commit. Old destructive behavior restored.

## 🔗 Related

- #277 UTF-8 (closed via #278) — different layer
- #279 Quiz orphan IDs + 504 cold start — open
- #280 này — root cause của recurring section dc5675f0 wipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)