### PR TITLE
chore(section-editor): gỡ [DIAG-onSave] console.warn — root cause đã fix

### DIFF
--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
@@ -1765,19 +1765,6 @@ export class SectionEditorComponent {
     const editor = this.tiptapEditor();
     const editorType = this.svc.sectionEditorType();
 
-    // DIAGNOSTIC (2026-04-27 — remove sau root cause identified): capture
-    // exact state at save time để debug data loss.
-    console.warn('[DIAG-onSave]', {
-      editorType,
-      hasEditorRef: !!editor,
-      editorEmpty: editor?.editor?.isEmpty,
-      editorHTML_preview: editor?.editor?.getHTML?.()?.substring(0, 100),
-      sectionTitle: this.svc.sectionTitle(),
-      sectionContentLen: this.svc.sectionContent()?.length ?? 0,
-      sectionContentPreview: this.svc.sectionContent()?.substring(0, 100),
-      editingSectionId: this.svc.editingSectionId(),
-    });
-
     if (editor && editorType === 'TEXT') {
       const freshHtml = editor.getCurrentHTML();
       const currentSignal = this.svc.sectionContent();


### PR DESCRIPTION
## 🎯 Mục tiêu
Gỡ console.warn DIAG đã hết giá trị diagnostic.

## 📝 Thay đổi
- \`section-editor.component.ts:1768-1779\` — gỡ \`console.warn('[DIAG-onSave]', {...})\` block (13 dòng)

## 🔍 Lý do
DIAG-onSave được thêm 2026-04-27 trong commit \`f3cd1ecf\` để debug section dc5675f0 data-loss. Root cause đã identified (template applyTemplate replace silently) và đã có 2 layer fix:
1. \`applyTemplate\` đổi sang insertContent (append, không replace)
2. \`onSave\` FORWARD-ONLY flush guard chống editor-empty wipe signal

Log đã hết giá trị, gây nhiễu console mỗi lần teacher save section + làm user lo lắng "có lỗi à?". Thuộc dead-code cleanup.

## 🧪 Test plan
- [x] FE typecheck clean
- [x] Save flow vẫn hoạt động (không thay đổi logic, chỉ gỡ log)
- Trade-off: nếu data-loss bug tái xuất, sẽ cần re-instrument (chấp nhận)

🤖 Generated with [Claude Code](https://claude.com/claude-code) following the AI Pipeline Workflow.