### PR TITLE
fix(section-save): dùng BE response làm source of truth cho local store

### DIFF
--- a/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
+++ b/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
@@ -237,18 +237,24 @@ export class CurriculumEditorService {
           });
         }
       } else {
-        await firstValueFrom(this.sectionApi.updateSection(lessonId, this.editingSectionId()!, formData));
+        const res: any = await firstValueFrom(this.sectionApi.updateSection(lessonId, this.editingSectionId()!, formData));
+        // BE trả ApiResponse<ContentBlock> = { data: { id, type, data: {...flat fields...} } }.
+        // Trước đây updateSectionLocal dùng FE payload — local sẽ drift nếu BE merge
+        // thay đổi fields (e.g., partial-update merge giữ lại stale fields). Giờ dùng
+        // BE response làm source of truth, fallback FE payload khi BE không trả field.
+        const block = res?.data ?? res;
+        const beData = (block?.data && typeof block.data === 'object') ? block.data : {};
         this.store.updateSectionLocal(lessonId, this.editingSectionId()!, {
-          title: payload['title'] || '',
-          type: type,
-          content: payload['content'],
-          videoAssetId: payload['videoAssetId'],
-          videoUrl: payload['videoUrl'],
-          videoType: payload['videoType'],
-          streamVideoUid: payload['streamVideoUid'],
-          isRequired: payload['isRequired'] ?? false,
-          completionThreshold: payload['completionThreshold'],
-          quizData: payload['quizData'],
+          title: (beData['title'] as string) ?? payload['title'] ?? '',
+          type: (block?.type ? String(block.type).toUpperCase() : type),
+          content: (beData['content'] as string) ?? payload['content'],
+          videoAssetId: (beData['videoAssetId'] as string) ?? payload['videoAssetId'],
+          videoUrl: (beData['videoUrl'] as string) ?? payload['videoUrl'],
+          videoType: (beData['videoType'] as string) ?? payload['videoType'],
+          streamVideoUid: (beData['streamVideoUid'] as string) ?? payload['streamVideoUid'],
+          isRequired: (beData['isRequired'] as boolean) ?? payload['isRequired'] ?? false,
+          completionThreshold: (beData['completionThreshold'] as number) ?? payload['completionThreshold'],
+          quizData: beData['quizData'] ?? payload['quizData'],
         } as any);
       }
 


### PR DESCRIPTION
## 🎯 Mục tiêu
Phòng tránh drift giữa local store và BE truth sau khi save section. Defensive fix cho bug user report \"không cập nhật được nội dung TEXT có sẵn\".

## 📝 Thay đổi
- \`curriculum-editor.service.ts:240-261\` — parse BE response ContentBlock structure (\`{id, type, data: {...}}\`) → map về flat SectionDraftDTO. FE payload là fallback khi BE không trả field cụ thể.

## 🔍 Root cause analysis

Trace static code FE→BE→DB→FE → không tìm bug rõ ràng. Pipeline về logic là đúng. Hypothesis của bug user report:

1. **Local-vs-BE drift**: \`updateSectionLocal\` dùng FE payload (\`payload.content\`), KHÔNG đọc BE response. Nếu BE merge thay đổi gì (e.g., normalize HTML, giữ stale field từ existing data), local sẽ drift. User thấy local OK nhưng F5 reload load BE truth → \"đã mất sửa\".

2. **BE response chưa parse**: BE trả \`ApiResponse<ContentBlock>\` với nested \`{data: {...flat fields...}}\` structure. FE typed là SectionDetail flat — mismatch silent.

Fix sync local với BE response dù bug có hay không, sẽ giúp catch mọi drift trong tương lai.

## 🧪 Test plan
- [x] FE typecheck clean
- [x] Logic preserved: nếu BE không trả field, dùng FE payload (no regression)
- [ ] Manual test: open existing TEXT section, edit, save, reload F5 → verify content sync

## 🏛️ SOTA pattern
- **Notion / Linear**: server response is canonical, client mirrors after every mutation
- **Optimistic UI** với reconciliation từ server: cập nhật local optimistically, reconcile với server response
- **Karpathy**: trust source of truth (server), không trust derived state (client expectation)

## ⚠️ Risks
- Nếu BE trả null cho field hợp lệ, FE fallback FE payload → safe
- Nếu BE trả undefined cho field, ?? operator pass through correctly

## 🔄 Rollback
- Revert commit; quay về FE-payload-only behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code) following the AI Pipeline Workflow.