### PR TITLE
feat(ai-chat): integrate Wiii Pointy V1 read-only tutor primitives

### DIFF
--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
@@ -387,4 +387,117 @@ describe('WiiiContextService - operator preview/apply flows', () => {
       button.remove();
     }
   });
+
+  // ── Wiii Pointy V1 — read-only tutor primitives ──
+
+  describe('Wiii Pointy actions', () => {
+    afterEach(() => {
+      // Clean up any cursor / overlay nodes injected by handlers.
+      for (const id of [
+        'wiii-pointy-cursor',
+        'wiii-pointy-overlay',
+        'wiii-pointy-tooltip',
+      ]) {
+        const node = document.getElementById(id);
+        node?.remove();
+      }
+      document.querySelectorAll('[data-wiii-test]').forEach((el) => el.remove());
+    });
+
+    it('ui.highlight succeeds when the selector resolves and reports describeTarget', async () => {
+      const target = document.createElement('button');
+      target.setAttribute('data-wiii-id', 'continue-lesson');
+      target.setAttribute('data-wiii-test', 'pointy');
+      target.textContent = 'Tiếp tục học';
+      document.body.appendChild(target);
+
+      const result = await (service as any).handleActionRequest('ui.highlight', {
+        selector: '[data-wiii-id="continue-lesson"]',
+        message: 'Đây là nút tiếp tục.',
+        duration_ms: 1500,
+      });
+
+      expect(result.success).toBeTrue();
+      expect(result.data?.summary).toContain('continue-lesson');
+      // The cursor SVG must have been mounted by the handler.
+      expect(document.getElementById('wiii-pointy-cursor')).not.toBeNull();
+      expect(document.getElementById('wiii-pointy-overlay')).not.toBeNull();
+    });
+
+    it('ui.highlight fails closed when the selector is missing', async () => {
+      const result = await (service as any).handleActionRequest('ui.highlight', {
+        selector: '[data-wiii-id="nope"]',
+      });
+      expect(result.success).toBeFalse();
+      expect(result.error).toContain('selector_not_found');
+    });
+
+    it('ui.scroll_to invokes scrollIntoView on the resolved target', async () => {
+      const target = document.createElement('section');
+      target.setAttribute('data-wiii-id', 'profile-card');
+      target.setAttribute('data-wiii-test', 'pointy');
+      document.body.appendChild(target);
+      const spy = spyOn(target, 'scrollIntoView');
+
+      const result = await (service as any).handleActionRequest('ui.scroll_to', {
+        selector: '[data-wiii-id="profile-card"]',
+        block: 'center',
+      });
+
+      expect(result.success).toBeTrue();
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('ui.show_tour completes all steps with present selectors and reports counters', async () => {
+      const a = document.createElement('div');
+      a.setAttribute('data-wiii-id', 'tour-a');
+      a.setAttribute('data-wiii-test', 'pointy');
+      a.style.height = '20px';
+      const b = document.createElement('div');
+      b.setAttribute('data-wiii-id', 'tour-b');
+      b.setAttribute('data-wiii-test', 'pointy');
+      b.style.height = '20px';
+      document.body.appendChild(a);
+      document.body.appendChild(b);
+
+      const result = await (service as any).handleActionRequest('ui.show_tour', {
+        steps: [
+          { selector: '[data-wiii-id="tour-a"]', message: 'A', duration_ms: 5 },
+          { selector: '[data-wiii-id="tour-b"]', message: 'B', duration_ms: 5 },
+        ],
+      });
+
+      expect(result.success).toBeTrue();
+      expect(result.data?.completed_steps).toBe(2);
+      expect(result.data?.total_steps).toBe(2);
+      expect(result.data?.cancelled).toBeFalse();
+      expect(result.data?.missing_selectors).toEqual([]);
+    });
+
+    it('ui.show_tour collects missing selectors without aborting', async () => {
+      const present = document.createElement('div');
+      present.setAttribute('data-wiii-id', 'tour-present');
+      present.setAttribute('data-wiii-test', 'pointy');
+      document.body.appendChild(present);
+
+      const result = await (service as any).handleActionRequest('ui.show_tour', {
+        steps: [
+          { selector: '[data-wiii-id="tour-present"]', message: 'p', duration_ms: 5 },
+          { selector: '[data-wiii-id="tour-missing"]', message: 'm', duration_ms: 5 },
+        ],
+      });
+
+      expect(result.success).toBeTrue();
+      expect(result.data?.completed_steps).toBe(1);
+      expect(result.data?.missing_selectors).toEqual(['[data-wiii-id="tour-missing"]']);
+    });
+
+    it('ui.show_tour rejects an empty / malformed steps array', async () => {
+      const result = await (service as any).handleActionRequest('ui.show_tour', {
+        steps: [],
+      });
+      expect(result.success).toBeFalse();
+      expect(result.error).toBe('invalid_tour_steps');
+    });
+  });
 });

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -23,6 +23,22 @@ import { AuthService } from '../../../../core/services/auth.service';
 import { LessonApi } from '../../../../api/client/lesson.api';
 import { QuizApi } from '../../../../api/endpoints/quiz.api';
 import { CurriculumSelectionService } from '../../../teacher/course-editor/services/curriculum-selection.service';
+import {
+  POINTY_ACTION_HIGHLIGHT,
+  POINTY_ACTION_SCROLL_TO,
+  POINTY_ACTION_SHOW_TOUR,
+  describeTarget,
+  hideCursor,
+  hideSpotlight,
+  moveCursorToRect,
+  resolvePointySelector,
+  runTour,
+  showSpotlight,
+  type HighlightParams,
+  type ScrollToParams,
+  type ShowTourParams,
+  type TourStep,
+} from '../pointy';
 
 /** AI course generation progress event (from Wiii → LMS) */
 export interface CourseProgressEvent {
@@ -507,6 +523,71 @@ export class WiiiContextService implements OnDestroy {
         roles: ['student', 'teacher', 'admin'],
         surface: 'host_page',
         result_schema: { type: 'object', properties: { image: { type: 'string' } } },
+      },
+      // Wiii Pointy V1 — read-only tutor primitives. No auto-click, no auto-fill.
+      // Vendored handlers in `../pointy/`. Quiz answer options must NOT be highlighted
+      // (pedagogical guardrail enforced server-side via `lms-pointy-tutor` skill).
+      {
+        name: POINTY_ACTION_HIGHLIGHT,
+        input_schema: {
+          type: 'object',
+          properties: {
+            selector: { type: 'string' },
+            message: { type: 'string' },
+            duration_ms: { type: 'number' },
+          },
+          required: ['selector'],
+        },
+        requires_confirmation: false,
+        mutates_state: false,
+        permission: 'use:tools',
+        description:
+          'Trỏ và làm nổi bật một phần tử trên trang để hướng dẫn người dùng. Không tự click — chỉ chỉ đường.',
+        roles: ['student', 'teacher', 'admin'],
+        surface: 'host_page',
+        result_schema: { type: 'object', properties: { summary: { type: 'string' } } },
+      },
+      {
+        name: POINTY_ACTION_SCROLL_TO,
+        input_schema: {
+          type: 'object',
+          properties: {
+            selector: { type: 'string' },
+            block: { type: 'string' },
+          },
+          required: ['selector'],
+        },
+        requires_confirmation: false,
+        mutates_state: false,
+        permission: 'use:tools',
+        description: 'Cuộn trang đến một phần tử cụ thể.',
+        roles: ['student', 'teacher', 'admin'],
+        surface: 'host_page',
+        result_schema: { type: 'object', properties: { summary: { type: 'string' } } },
+      },
+      {
+        name: POINTY_ACTION_SHOW_TOUR,
+        input_schema: {
+          type: 'object',
+          properties: {
+            steps: { type: 'array' },
+            start_at: { type: 'number' },
+          },
+          required: ['steps'],
+        },
+        requires_confirmation: false,
+        mutates_state: false,
+        permission: 'use:tools',
+        description: 'Chạy hướng dẫn nhiều bước; mỗi bước trỏ + highlight một element kèm tooltip.',
+        roles: ['student', 'teacher', 'admin'],
+        surface: 'host_page',
+        result_schema: {
+          type: 'object',
+          properties: {
+            completed_steps: { type: 'number' },
+            total_steps: { type: 'number' },
+          },
+        },
       },
     ];
 
@@ -1359,6 +1440,85 @@ export class WiiiContextService implements OnDestroy {
     return { success: true, data: { opened: true, action } };
   }
 
+  // ── Wiii Pointy V1 handlers (vendored — see fe/src/app/features/ai-chat/infrastructure/pointy) ──
+
+  private handlePointyHighlight(
+    params: HighlightParams,
+  ): { success: boolean; data?: Record<string, unknown>; error?: string } {
+    const selector = String(params?.selector || '').trim();
+    if (!selector) {
+      return { success: false, error: 'missing_selector' };
+    }
+    const target = resolvePointySelector(selector);
+    if (!target) {
+      return { success: false, error: `selector_not_found:${selector}` };
+    }
+    if (typeof (target as HTMLElement).scrollIntoView === 'function') {
+      (target as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+    moveCursorToRect(target.getBoundingClientRect(), { duration_ms: 600 });
+    showSpotlight(target, {
+      message: params.message,
+      duration_ms: params.duration_ms,
+    });
+    return {
+      success: true,
+      data: { summary: `Đã trỏ vào ${describeTarget(target)}` },
+    };
+  }
+
+  private handlePointyScrollTo(
+    params: ScrollToParams,
+  ): { success: boolean; data?: Record<string, unknown>; error?: string } {
+    const selector = String(params?.selector || '').trim();
+    if (!selector) {
+      return { success: false, error: 'missing_selector' };
+    }
+    const target = resolvePointySelector(selector);
+    if (!target) {
+      return { success: false, error: `selector_not_found:${selector}` };
+    }
+    if (typeof (target as HTMLElement).scrollIntoView === 'function') {
+      (target as HTMLElement).scrollIntoView({
+        behavior: 'smooth',
+        block: params.block || 'center',
+      });
+    }
+    return {
+      success: true,
+      data: { summary: `Đã cuộn tới ${describeTarget(target)}` },
+    };
+  }
+
+  private async handlePointyShowTour(
+    params: ShowTourParams,
+  ): Promise<{ success: boolean; data?: Record<string, unknown>; error?: string }> {
+    const rawSteps = Array.isArray(params?.steps) ? params.steps : [];
+    const steps: TourStep[] = rawSteps.filter(
+      (step): step is TourStep =>
+        !!step && typeof step.selector === 'string' && typeof step.message === 'string',
+    );
+    if (steps.length === 0) {
+      return { success: false, error: 'invalid_tour_steps' };
+    }
+    const result = await runTour(steps, { startAt: params.start_at });
+    // Defensive cleanup if the tour completed without a follow-up call.
+    if (result.completed_steps === result.total_steps && !result.cancelled) {
+      hideSpotlight();
+      hideCursor();
+    }
+    return {
+      success: true,
+      data: {
+        summary: `Tour ${result.completed_steps}/${result.total_steps} bước.`,
+        completed_steps: result.completed_steps,
+        total_steps: result.total_steps,
+        missing_selectors: result.missing_selectors,
+        cancelled: result.cancelled,
+      },
+    };
+  }
+
   private async handleActionRequest(
     action: string,
     params: Record<string, unknown>,
@@ -1366,6 +1526,12 @@ export class WiiiContextService implements OnDestroy {
     switch (action) {
       case 'capture_screenshot':
         return this.captureScreenshot(String(params['selector'] || 'main'));
+      case POINTY_ACTION_HIGHLIGHT:
+        return this.handlePointyHighlight(params as unknown as HighlightParams);
+      case POINTY_ACTION_SCROLL_TO:
+        return this.handlePointyScrollTo(params as unknown as ScrollToParams);
+      case POINTY_ACTION_SHOW_TOUR:
+        return this.handlePointyShowTour(params as unknown as ShowTourParams);
       case 'navigation.go_to': {
         const target = String(params['target'] || '').trim();
         const route = String(params['route'] || '').trim();

--- a/fe/src/app/features/ai-chat/infrastructure/pointy/cursor.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/pointy/cursor.ts
@@ -1,0 +1,117 @@
+/**
+ * Wiii Pointy — animated cursor overlay.
+ *
+ * Vendored from `meiiie/wiii` PR #188. Renders a single SVG circle with
+ * a "W" letter (Wiii brand orange #F97316 — kept intentionally so the
+ * student recognises this is Wiii pointing, not the LMS itself) that
+ * animates from its current position to the target element's bounding
+ * rect via the Web Animations API.
+ *
+ * Pure DOM. No React, no framework deps. SSR-safe — every public function
+ * no-ops gracefully when `document` is undefined (call sites in
+ * `WiiiContextService` are already gated by `isPlatformBrowser`).
+ */
+
+const CURSOR_ID = 'wiii-pointy-cursor';
+const CURSOR_SIZE = 36;
+const BRAND_ORANGE = '#F97316';
+const BRAND_CREAM = '#FAF5EE';
+
+let cursorEl: SVGSVGElement | null = null;
+let lastPos: { x: number; y: number } | null = null;
+
+function createCursor(): SVGSVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('id', CURSOR_ID);
+  svg.setAttribute('width', String(CURSOR_SIZE));
+  svg.setAttribute('height', String(CURSOR_SIZE));
+  svg.setAttribute('viewBox', '0 0 36 36');
+  svg.setAttribute('aria-hidden', 'true');
+  svg.setAttribute('data-wiii-pointy', 'cursor');
+
+  const css = svg.style;
+  css.position = 'fixed';
+  css.left = '0px';
+  css.top = '0px';
+  css.zIndex = '2147483646';
+  css.pointerEvents = 'none';
+  css.transformOrigin = 'center';
+  css.filter = 'drop-shadow(0 4px 8px rgba(0,0,0,0.25))';
+  css.opacity = '0';
+  css.transition = 'opacity 200ms ease-out';
+
+  svg.innerHTML = `
+    <circle cx="18" cy="18" r="16" fill="${BRAND_ORANGE}" stroke="${BRAND_CREAM}" stroke-width="2"/>
+    <text x="18" y="23" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="16" font-weight="700" fill="${BRAND_CREAM}">W</text>
+  `;
+  return svg;
+}
+
+function ensureCursor(): SVGSVGElement {
+  if (cursorEl && cursorEl.isConnected) return cursorEl;
+  cursorEl = createCursor();
+  document.body.appendChild(cursorEl);
+  return cursorEl;
+}
+
+export function computeTargetPoint(rect: DOMRect): { x: number; y: number } {
+  return {
+    x: rect.left + rect.width / 2 + 8,
+    y: rect.top + rect.height / 2 - 8,
+  };
+}
+
+export function computeOriginPoint(): { x: number; y: number } {
+  const w = typeof window !== 'undefined' ? window.innerWidth : 1024;
+  const h = typeof window !== 'undefined' ? window.innerHeight : 768;
+  return { x: w - CURSOR_SIZE, y: h / 2 };
+}
+
+export interface MoveCursorOptions {
+  duration_ms?: number;
+  onComplete?: () => void;
+}
+
+export function moveCursorToRect(rect: DOMRect, opts: MoveCursorOptions = {}): Animation | null {
+  if (typeof document === 'undefined') return null;
+  const cursor = ensureCursor();
+  const target = computeTargetPoint(rect);
+  const start = lastPos ?? computeOriginPoint();
+  lastPos = target;
+
+  cursor.style.opacity = '1';
+  const duration = Math.max(200, Math.min(opts.duration_ms ?? 600, 2000));
+
+  if (typeof cursor.animate !== 'function') {
+    cursor.style.transform = `translate(${target.x}px, ${target.y}px)`;
+    opts.onComplete?.();
+    return null;
+  }
+
+  const animation = cursor.animate(
+    [
+      { transform: `translate(${start.x}px, ${start.y}px) scale(0.9)` },
+      { transform: `translate(${target.x}px, ${target.y}px) scale(1.05)`, offset: 0.85 },
+      { transform: `translate(${target.x}px, ${target.y}px) scale(1.0)` },
+    ],
+    {
+      duration,
+      easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
+      fill: 'forwards',
+    },
+  );
+  animation.onfinish = () => opts.onComplete?.();
+  return animation;
+}
+
+export function hideCursor(): void {
+  if (cursorEl) cursorEl.style.opacity = '0';
+}
+
+export function destroyCursor(): void {
+  if (cursorEl && cursorEl.parentNode) {
+    cursorEl.parentNode.removeChild(cursorEl);
+  }
+  cursorEl = null;
+  lastPos = null;
+}

--- a/fe/src/app/features/ai-chat/infrastructure/pointy/helpers.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/pointy/helpers.ts
@@ -1,0 +1,31 @@
+/**
+ * Wiii Pointy — small helpers shared between handler call sites.
+ *
+ * Vendored from `meiiie/wiii` PR #188.
+ */
+
+export function describeTarget(el: Element): string {
+  const labels: string[] = [];
+  const id = el.getAttribute('data-wiii-id') || el.id;
+  if (id) labels.push(`#${id}`);
+  const aria = el.getAttribute('aria-label');
+  if (aria) labels.push(`"${aria}"`);
+  if (!labels.length) {
+    const text = (el.textContent || '').trim();
+    if (text) labels.push(`"${text.slice(0, 40)}"`);
+  }
+  if (!labels.length) labels.push(el.tagName.toLowerCase());
+  return labels.join(' ');
+}
+
+export function resolvePointySelector(selector: unknown): Element | null {
+  if (typeof selector !== 'string') return null;
+  const trimmed = selector.trim();
+  if (!trimmed) return null;
+  if (typeof document === 'undefined') return null;
+  try {
+    return document.querySelector(trimmed);
+  } catch {
+    return null;
+  }
+}

--- a/fe/src/app/features/ai-chat/infrastructure/pointy/index.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/pointy/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Wiii Pointy — barrel for the LMS-side integration.
+ * Vendored from `meiiie/wiii` PR #188 — keep in sync when upstream bumps.
+ */
+export * from './types';
+export {
+  computeOriginPoint,
+  computeTargetPoint,
+  destroyCursor,
+  hideCursor,
+  moveCursorToRect,
+} from './cursor';
+export {
+  computeTooltipPosition,
+  destroySpotlight,
+  hideSpotlight,
+  showSpotlight,
+} from './spotlight';
+export { cancelActiveTour, runTour, type TourResult } from './tour';
+export { describeTarget, resolvePointySelector } from './helpers';

--- a/fe/src/app/features/ai-chat/infrastructure/pointy/spotlight.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/pointy/spotlight.ts
@@ -1,0 +1,162 @@
+/**
+ * Wiii Pointy — spotlight overlay with tooltip.
+ *
+ * Vendored from `meiiie/wiii` PR #188. Dims the page (radial-gradient
+ * hole around the target) and shows a small Vietnamese-first tooltip near
+ * the element. Pure DOM, no Driver.js dep.
+ */
+
+const OVERLAY_ID = 'wiii-pointy-overlay';
+const TOOLTIP_ID = 'wiii-pointy-tooltip';
+const BRAND_ORANGE = '#F97316';
+const BRAND_CREAM = '#FAF5EE';
+const PADDING = 8;
+
+let overlayEl: HTMLDivElement | null = null;
+let tooltipEl: HTMLDivElement | null = null;
+let activeTimer: ReturnType<typeof setTimeout> | null = null;
+
+function createOverlay(): HTMLDivElement {
+  const el = document.createElement('div');
+  el.id = OVERLAY_ID;
+  el.setAttribute('data-wiii-pointy', 'overlay');
+  el.setAttribute('aria-hidden', 'true');
+  Object.assign(el.style, {
+    position: 'fixed',
+    inset: '0',
+    zIndex: '2147483645',
+    pointerEvents: 'none',
+    background: 'transparent',
+    transition: 'background 250ms ease-out',
+  });
+  return el;
+}
+
+function createTooltip(): HTMLDivElement {
+  const el = document.createElement('div');
+  el.id = TOOLTIP_ID;
+  el.setAttribute('data-wiii-pointy', 'tooltip');
+  el.setAttribute('role', 'status');
+  el.setAttribute('aria-live', 'polite');
+  Object.assign(el.style, {
+    position: 'fixed',
+    zIndex: '2147483647',
+    pointerEvents: 'none',
+    background: BRAND_CREAM,
+    color: '#1F2937',
+    border: `2px solid ${BRAND_ORANGE}`,
+    borderRadius: '12px',
+    padding: '8px 12px',
+    fontFamily: 'system-ui, -apple-system, sans-serif',
+    fontSize: '14px',
+    fontWeight: '500',
+    maxWidth: '280px',
+    boxShadow: '0 8px 24px rgba(0,0,0,0.18)',
+    opacity: '0',
+    transform: 'translateY(4px)',
+    transition: 'opacity 180ms ease-out, transform 180ms ease-out',
+  });
+  return el;
+}
+
+function ensureElements(): { overlay: HTMLDivElement; tooltip: HTMLDivElement } {
+  if (!overlayEl || !overlayEl.isConnected) {
+    overlayEl = createOverlay();
+    document.body.appendChild(overlayEl);
+  }
+  if (!tooltipEl || !tooltipEl.isConnected) {
+    tooltipEl = createTooltip();
+    document.body.appendChild(tooltipEl);
+  }
+  return { overlay: overlayEl, tooltip: tooltipEl };
+}
+
+export function computeTooltipPosition(
+  targetRect: DOMRect,
+  tooltipRect: { width: number; height: number },
+  viewport: { width: number; height: number },
+): { left: number; top: number } {
+  const desiredLeft = Math.max(
+    8,
+    Math.min(
+      targetRect.left + targetRect.width / 2 - tooltipRect.width / 2,
+      viewport.width - tooltipRect.width - 8,
+    ),
+  );
+  const wantsBelow = targetRect.bottom + tooltipRect.height + 12 <= viewport.height;
+  const top = wantsBelow
+    ? targetRect.bottom + 12
+    : Math.max(8, targetRect.top - tooltipRect.height - 12);
+  return { left: desiredLeft, top };
+}
+
+export interface SpotlightOptions {
+  message?: string;
+  duration_ms?: number;
+  onClose?: () => void;
+}
+
+export function showSpotlight(target: Element, opts: SpotlightOptions = {}): void {
+  if (typeof document === 'undefined') return;
+  const { overlay, tooltip } = ensureElements();
+  const rect = target.getBoundingClientRect();
+
+  const cx = rect.left + rect.width / 2;
+  const cy = rect.top + rect.height / 2;
+  const r = Math.max(rect.width, rect.height) / 2 + PADDING;
+  overlay.style.background = `radial-gradient(circle at ${cx}px ${cy}px, transparent 0px, transparent ${r}px, rgba(15,23,42,0.45) ${r + 24}px)`;
+
+  if (opts.message) {
+    tooltip.textContent = opts.message;
+    tooltip.style.opacity = '0';
+    tooltip.style.transform = 'translateY(4px)';
+    const tRect = tooltip.getBoundingClientRect();
+    const viewport = {
+      width: window.innerWidth || document.documentElement.clientWidth,
+      height: window.innerHeight || document.documentElement.clientHeight,
+    };
+    const { left, top } = computeTooltipPosition(rect, tRect, viewport);
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
+    requestAnimationFrame(() => {
+      tooltip.style.opacity = '1';
+      tooltip.style.transform = 'translateY(0)';
+    });
+  } else {
+    tooltip.style.opacity = '0';
+  }
+
+  if (activeTimer) {
+    clearTimeout(activeTimer);
+    activeTimer = null;
+  }
+  const ms = Math.max(800, Math.min(opts.duration_ms ?? 2200, 8000));
+  activeTimer = setTimeout(() => {
+    hideSpotlight();
+    opts.onClose?.();
+  }, ms);
+}
+
+export function hideSpotlight(): void {
+  if (activeTimer) {
+    clearTimeout(activeTimer);
+    activeTimer = null;
+  }
+  if (overlayEl) overlayEl.style.background = 'transparent';
+  if (tooltipEl) {
+    tooltipEl.style.opacity = '0';
+    tooltipEl.style.transform = 'translateY(4px)';
+  }
+}
+
+export function destroySpotlight(): void {
+  if (activeTimer) {
+    clearTimeout(activeTimer);
+    activeTimer = null;
+  }
+  for (const el of [overlayEl, tooltipEl]) {
+    if (el && el.parentNode) el.parentNode.removeChild(el);
+  }
+  overlayEl = null;
+  tooltipEl = null;
+}

--- a/fe/src/app/features/ai-chat/infrastructure/pointy/tour.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/pointy/tour.ts
@@ -1,0 +1,106 @@
+/**
+ * Wiii Pointy — multi-step tour sequencer.
+ *
+ * Vendored from `meiiie/wiii` PR #188. Walks through TourStep[] one at a
+ * time, scrolling, moving the cursor, and showing the spotlight + tooltip
+ * for each step. A new tour cancels any tour in progress so the AI can
+ * interrupt itself cleanly.
+ */
+import type { TourStep } from './types';
+import { hideCursor, moveCursorToRect } from './cursor';
+import { hideSpotlight, showSpotlight } from './spotlight';
+
+let activeTour: { cancelled: boolean } | null = null;
+
+export interface RunTourOptions {
+  resolveSelector?: (selector: string) => Element | null;
+  startAt?: number;
+}
+
+const DEFAULT_RESOLVE = (sel: string) =>
+  typeof document !== 'undefined' ? document.querySelector(sel) : null;
+
+export interface TourResult {
+  completed_steps: number;
+  total_steps: number;
+  cancelled: boolean;
+  missing_selectors: string[];
+}
+
+export async function runTour(
+  steps: TourStep[],
+  opts: RunTourOptions = {},
+): Promise<TourResult> {
+  if (activeTour) activeTour.cancelled = true;
+  const handle = { cancelled: false };
+  activeTour = handle;
+
+  const resolve = opts.resolveSelector ?? DEFAULT_RESOLVE;
+  const startAt = Math.max(0, Math.min(opts.startAt ?? 0, steps.length));
+  const result: TourResult = {
+    completed_steps: 0,
+    total_steps: steps.length,
+    cancelled: false,
+    missing_selectors: [],
+  };
+
+  for (let i = startAt; i < steps.length; i++) {
+    if (handle.cancelled) break;
+    const step = steps[i];
+    const target = resolve(step.selector);
+    if (!target) {
+      result.missing_selectors.push(step.selector);
+      continue;
+    }
+
+    if ('scrollIntoView' in target && typeof (target as HTMLElement).scrollIntoView === 'function') {
+      (target as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
+    const rect = target.getBoundingClientRect();
+    moveCursorToRect(rect, { duration_ms: 500 });
+
+    showSpotlight(target, {
+      message: step.message,
+      duration_ms: step.duration_ms ?? 2400,
+    });
+
+    await interruptibleWait(step.duration_ms ?? 2400, handle);
+    if (handle.cancelled) break;
+    result.completed_steps += 1;
+  }
+
+  result.cancelled = handle.cancelled;
+
+  if (activeTour === handle) {
+    hideSpotlight();
+    hideCursor();
+    activeTour = null;
+  }
+  return result;
+}
+
+export function cancelActiveTour(): void {
+  if (activeTour) activeTour.cancelled = true;
+  hideSpotlight();
+  hideCursor();
+}
+
+function interruptibleWait(ms: number, handle: { cancelled: boolean }): Promise<void> {
+  return new Promise((resolve) => {
+    const end = Date.now() + Math.max(0, ms);
+    const tick = () => {
+      if (handle.cancelled) {
+        resolve();
+        return;
+      }
+      const remaining = end - Date.now();
+      if (remaining <= 0) {
+        resolve();
+        return;
+      }
+      setTimeout(tick, Math.min(20, remaining));
+    };
+    tick();
+  });
+}

--- a/fe/src/app/features/ai-chat/infrastructure/pointy/types.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/pointy/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Wiii Pointy — type contracts for the LMS host integration.
+ *
+ * Vendored from `meiiie/wiii` PR #188 (Wiii Pointy V1, 2026-04-29).
+ * Re-sync this folder when the upstream Pointy package bumps its version.
+ *
+ * V1 is read-only: highlight, scroll_to, show_tour. No auto-click, no
+ * auto-fill. All actions are `mutates_state: false, requires_confirmation: false`.
+ *
+ * Note: `ui.navigate` is intentionally NOT shipped here — LMS already
+ * exposes `navigation.go_to` (with semantic targets + clickButtonByText)
+ * which covers the same surface and is integrated with Angular Router.
+ */
+
+export const POINTY_ACTION_HIGHLIGHT = 'ui.highlight';
+export const POINTY_ACTION_SCROLL_TO = 'ui.scroll_to';
+export const POINTY_ACTION_SHOW_TOUR = 'ui.show_tour';
+
+export const POINTY_ACTIONS = [
+  POINTY_ACTION_HIGHLIGHT,
+  POINTY_ACTION_SCROLL_TO,
+  POINTY_ACTION_SHOW_TOUR,
+] as const;
+
+export type PointyAction = (typeof POINTY_ACTIONS)[number];
+
+export interface HighlightParams {
+  selector: string;
+  message?: string;
+  duration_ms?: number;
+}
+
+export interface ScrollToParams {
+  selector: string;
+  block?: ScrollLogicalPosition;
+}
+
+export interface TourStep {
+  selector: string;
+  message: string;
+  duration_ms?: number;
+}
+
+export interface ShowTourParams {
+  steps: TourStep[];
+  start_at?: number;
+}


### PR DESCRIPTION
## Summary

- Add 3 new `ui.*` host actions that let Wiii (in-iframe) **point at** LMS UI elements, **scroll to** them, and run **multi-step tours** — without ever clicking or filling on the student's behalf.
- V1 is intentionally **read-only** (`mutates_state=false`, `requires_confirmation=false` on every Pointy tool) so the student stays in control. Auto-click + auto-fill are reserved for V2 with explicit per-tool gates.
- The matching host bundle ships in `meiiie/wiii` PR [#188](https://github.com/meiiie/wiii/pull/188) (Wiii Pointy V1, merged 2026-04-29). LMS owns its own integration so it stays under our deploy + i18n control.

## What ships

| Path | Purpose |
|---|---|
| `fe/src/app/features/ai-chat/infrastructure/pointy/{types,cursor,spotlight,tour,helpers,index}.ts` | 6 vendored pure-TS modules (~400 LOC). No React, no external deps, SSR-safe. |
| `fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts` | +3 tool definitions in `buildCapabilities()`, +3 case handlers in `handleActionRequest()` switch (private methods). |
| `fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts` | +6 Karma/Jasmine specs. |

### Deliberately NOT shipped

- **`ui.navigate`** — `navigation.go_to` already covers this surface (semantic targets + Angular Router + `clickButtonByText` fallback). Adding a duplicate would just confuse the AI.
- No `chat-panel.component.ts` / `environment.ts` / iframe lifecycle changes. No dependency bumps. No migrations.

## Risk & rollback

**Risk: low.** Pointy tools are additive — when the Wiii backend has `enable_host_actions=False` (default), the AI never sees the new tools and the existing UX is identical. The new private handlers are only reachable via the existing `wiii:action-request` PostMessage path that this service has owned since Sprint 221.

**Pedagogical guardrail preserved.** Pointy V1 is read-only and the matching server-side skill (`lms-pointy-tutor` in Wiii repo) explicitly forbids `ui.highlight` on quiz answer options.

**Rollback:** `git revert` this commit. The `pointy/` folder + service edits are self-contained — no migrations, no asset changes, no dependency bumps.

## Verification

- `npx tsc --noEmit -p tsconfig.json` → clean
- `npx ng test --include='**/wiii-context.service.spec.ts' --watch=false --browsers=ChromeHeadless` → **17/17 pass** (11 existing + 6 new Pointy specs)

Visual QA after CI:

1. Backend in dev: set `enable_host_actions=True` in Wiii config and ship the matching skill.
2. Open any LMS page that hosts the Wiii iframe.
3. In chat: *"Wiii ơi chỉ tôi nút Bắt đầu khóa học."* → expect orange "W" cursor flying to the button + spotlight + Vietnamese tooltip.

## Roadmap

- **V2** — `ui.click`, `ui.fill_field` gated `mutates_state=true, requires_confirmation=true`. Quiz answer options remain read-only.
- **V3** — push-to-talk voice + Agent-Mode dashboard panel (re-uses existing `OperatorSessionV1`).
- **Long-term** — migrate the capability declaration to WebMCP once the W3C draft stabilises (rename, not rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)