### PR TITLE
fix(teacher-editor): cô lập state editor và chặn crash PDF iframe

### DIFF
--- a/fe/src/app/features/teacher/course-editor/course-editor.routes.ts
+++ b/fe/src/app/features/teacher/course-editor/course-editor.routes.ts
@@ -3,6 +3,8 @@ import { CanActivateFn, Router, Routes } from '@angular/router';
 import { of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { CourseAuthoringService } from './services/course-authoring.service';
+import { CurriculumEditorService } from './services/curriculum-editor.service';
+import { CurriculumSelectionService } from './services/curriculum-selection.service';
 import { CourseEditorStore } from './store/course-editor.store';
 
 const instructorLedClassesGuard: CanActivateFn = (route) => {
@@ -34,6 +36,11 @@ const instructorLedClassesGuard: CanActivateFn = (route) => {
 export const courseEditorRoutes: Routes = [
     {
         path: '',
+        providers: [
+            CourseEditorStore,
+            CurriculumSelectionService,
+            CurriculumEditorService
+        ],
         loadComponent: () => import('./layouts/course-editor-layout/course-editor-layout.component')
             .then(m => m.CourseEditorLayoutComponent),
         children: [

--- a/fe/src/app/features/teacher/course-editor/layouts/course-editor-layout/course-editor-layout.component.ts
+++ b/fe/src/app/features/teacher/course-editor/layouts/course-editor-layout/course-editor-layout.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, OnInit, computed, signal, effect, untracked, ChangeDetectionStrategy, DestroyRef } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 
 import { RouterOutlet, RouterModule, ActivatedRoute, Router, NavigationEnd } from '@angular/router';
 import { CourseEditorSidebarComponent } from '../../components/sidebar/sidebar.component';
@@ -8,7 +8,7 @@ import { CourseRejectionBannerComponent } from '../../components/rejection-banne
 import { CourseEditorStore } from '../../store/course-editor.store';
 import { CurriculumSelectionService } from '../../services/curriculum-selection.service';
 import { AuthService } from '../../../../../core/services/auth.service';
-import { filter, take, map } from 'rxjs/operators';
+import { distinctUntilChanged, filter, take, map } from 'rxjs/operators';
 
 
 @Component({
@@ -180,7 +180,8 @@ export class CourseEditorLayoutComponent implements OnInit {
   constructor() {
     // Auto-collapse/expand sidebar based on active route
     this.router.events.pipe(
-      filter((e): e is NavigationEnd => e instanceof NavigationEnd)
+      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+      takeUntilDestroyed(this.destroyRef)
     ).subscribe(e => {
       const url = e.urlAfterRedirects;
       this.updateSidebarForRoute(url);
@@ -284,10 +285,12 @@ export class CourseEditorLayoutComponent implements OnInit {
     this.updateActiveTab(this.router.url);
 
     this.getRouteId().pipe(
-      take(1),
-      filter((id): id is string => !!id)
+      filter((id): id is string => !!id),
+      distinctUntilChanged(),
+      takeUntilDestroyed(this.destroyRef)
     ).subscribe(id => {
-      this.store.loadCourse(id);
+      this.resetRouteScopedEditorState();
+      this.store.loadCourse(id, true);
     });
   }
 
@@ -320,6 +323,12 @@ export class CourseEditorLayoutComponent implements OnInit {
 
   private getCurrentQueryParams(url: string): URLSearchParams {
     return new URLSearchParams(this.router.parseUrl(url).queryParams as Record<string, string>);
+  }
+
+  private resetRouteScopedEditorState(): void {
+    this.lastSyncedCurriculumSelectionKey = null;
+    this.selectionService.clearSelection();
+    this.store.resetEditorState();
   }
 
 }

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
@@ -649,6 +649,13 @@ type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
                 </div>
               }
 
+              @if (svc.sectionFileUrl() && getFileExtension(svc.sectionFileUrl()!) === 'pdf' && !svc.safePdfUrl() && svc.sectionPreviewStatus() !== 'PROCESSING' && svc.sectionPreviewStatus() !== 'FAILED') {
+                <div class="flex items-start gap-2.5 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5">
+                  <lucide-icon name="info" [size]="16" class="mt-0.5 shrink-0 text-slate-500"></lucide-icon>
+                  <p class="text-xs text-slate-600">TÃ i liá»‡u PDF gá»‘c khÃ´ng tá»± má»Ÿ trong khung chá»‰nh sá»­a Ä‘á»ƒ trÃ¡nh crash Chrome PDF viewer. DÃ¹ng nÃºt táº£i xuá»‘ng/má»Ÿ á»Ÿ trÃªn náº¿u cáº§n xem tÃ i liá»‡u.</p>
+                </div>
+              }
+
               <!-- PDF preview iframe (READY) -->
               @if (svc.safePdfUrl()) {
                 <div>

--- a/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
+++ b/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
@@ -38,7 +38,8 @@ export type SectionQuizAssessmentType = 'PRACTICE' | 'ASSESSMENT' | 'EXAM';
  * All editor sub-components inject this service to read/write
  * the active editing context without direct parent-child coupling.
  *
- * Scoped to the course-editor route via `providedIn: 'root'`.
+ * Scoped to the course-editor route by `courseEditorRoutes.providers`.
+ * The root provider remains only as a compatibility fallback for tests/legacy callers.
  * Selection hierarchy delegates to CurriculumSelectionService.
  */
 @Injectable({ providedIn: 'root' })
@@ -667,10 +668,9 @@ export class CurriculumEditorService {
     if (section.type === 'FILE') {
       this.sectionPreviewStatus.set(section.previewStatus ?? null);
       const previewUrl = section.previewPdfUrl ?? null;
-      const fileUrl = section.fileUrl ?? null;
-      const urlToPreview = previewUrl ?? (fileUrl?.toLowerCase().endsWith('.pdf') ? fileUrl : null);
-      if (urlToPreview) {
-        this.safePdfUrl.set(this.sanitizer.bypassSecurityTrustResourceUrl(urlToPreview));
+      const canEmbedPreview = !!previewUrl && (!section.previewStatus || section.previewStatus === 'READY');
+      if (canEmbedPreview) {
+        this.safePdfUrl.set(this.sanitizer.bypassSecurityTrustResourceUrl(previewUrl));
       } else {
         this.safePdfUrl.set(null);
       }

--- a/fe/src/app/features/teacher/course-editor/store/course-editor.store.spec.ts
+++ b/fe/src/app/features/teacher/course-editor/store/course-editor.store.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+import { ToastService } from '../../../../core/services/toast.service';
+import { CourseAuthoringService, CourseDraftDTO } from '../services/course-authoring.service';
+import { CourseEditorStore } from './course-editor.store';
+
+describe('CourseEditorStore', () => {
+  let store: CourseEditorStore;
+  let authoringService: jasmine.SpyObj<CourseAuthoringService>;
+
+  const draft = (id: string): CourseDraftDTO => ({
+    id,
+    code: id.toUpperCase(),
+    title: `Course ${id}`,
+    description: '',
+    deliveryMode: 'SELF_PACED',
+    chapters: [],
+  });
+
+  beforeEach(() => {
+    authoringService = jasmine.createSpyObj<CourseAuthoringService>('CourseAuthoringService', [
+      'getCourseDraft',
+      'updateCourseInfo',
+    ]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        CourseEditorStore,
+        { provide: CourseAuthoringService, useValue: authoringService },
+        { provide: ToastService, useValue: jasmine.createSpyObj<ToastService>('ToastService', ['error']) },
+      ],
+    });
+
+    store = TestBed.inject(CourseEditorStore);
+  });
+
+  it('clears editor state and ignores a stale load after reset', () => {
+    const staleLoad$ = new Subject<CourseDraftDTO>();
+    authoringService.getCourseDraft.and.returnValue(staleLoad$.asObservable());
+
+    store.loadCourse('course-a', true);
+    expect(store.isLoading()).toBeTrue();
+
+    store.resetEditorState();
+
+    expect(store.courseTree()).toBeNull();
+    expect(store.isLoading()).toBeFalse();
+    expect(store.saveStatus()).toBe('saved');
+
+    staleLoad$.next(draft('course-a'));
+    staleLoad$.complete();
+
+    expect(store.courseTree()).toBeNull();
+  });
+
+  it('keeps the latest course when an earlier request resolves late', () => {
+    const firstLoad$ = new Subject<CourseDraftDTO>();
+    const secondLoad$ = new Subject<CourseDraftDTO>();
+    authoringService.getCourseDraft.and.returnValues(
+      firstLoad$.asObservable(),
+      secondLoad$.asObservable(),
+    );
+
+    store.loadCourse('course-a', true);
+    store.loadCourse('course-b', true);
+
+    firstLoad$.next(draft('course-a'));
+    expect(store.courseTree()).toBeNull();
+
+    secondLoad$.next(draft('course-b'));
+    expect(store.courseTree()?.id).toBe('course-b');
+  });
+});

--- a/fe/src/app/features/teacher/course-editor/store/course-editor.store.ts
+++ b/fe/src/app/features/teacher/course-editor/store/course-editor.store.ts
@@ -24,6 +24,7 @@ export class CourseEditorStore {
     // Auto-save status
     readonly saveStatus = signal<SaveStatus>('saved');
     private autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
+    private activeLoadToken = 0;
 
     // Selectors
     readonly chapters = computed(() => this.courseTree()?.chapters || []);
@@ -105,6 +106,8 @@ export class CourseEditorStore {
     }
 
     loadCourse(courseId: string, forceRefresh = false) {
+        const loadToken = ++this.activeLoadToken;
+
         // Check cache first - return immediately if valid AND not forced
         if (!forceRefresh) {
             const cached = this.courseCache.get(courseId);
@@ -118,12 +121,18 @@ export class CourseEditorStore {
         this.isLoading.set(true);
         this.error.set(null);
         this.service.getCourseDraft(courseId)
-            .pipe(finalize(() => this.isLoading.set(false)))
+            .pipe(finalize(() => {
+                if (loadToken === this.activeLoadToken) {
+                    this.isLoading.set(false);
+                }
+            }))
             .subscribe({
                 next: (data) => {
+                    if (loadToken !== this.activeLoadToken) return;
                     this.setCourseTreeState(data);
                 },
                 error: (err: any) => {
+                    if (loadToken !== this.activeLoadToken) return;
                     const message = err?.error?.message || err?.message || 'Không thể tải khóa học';
                     this.error.set(message);
                     this.toast.error(message);
@@ -453,5 +462,16 @@ export class CourseEditorStore {
             clearTimeout(this.autoSaveTimer);
             this.autoSaveTimer = null;
         }
+    }
+
+    resetEditorState() {
+        this.activeLoadToken++;
+        this.cancelAutoSave();
+        this.courseTree.set(null);
+        this.error.set(null);
+        this.isLoading.set(false);
+        this.isSaving.set(false);
+        this.saveStatus.set('saved');
+        this.courseCache.clear();
     }
 }


### PR DESCRIPTION
﻿## Problem

Teacher editor có 3 triệu chứng liên quan cùng một vùng rủi ro:

- Khi mở course editor vào section `b1bc674e-3434-40ef-9850-5ea1fe130c76` trong Bài 2 / Mục 2, Chrome có thể crash `Aw, Snap! STATUS_BREAKPOINT`.
- Sau khi đổi tài khoản teacher, main content editor có thể còn giữ nội dung của teacher/course trước.
- Khi state bị stale, thao tác save/publish/refresh có rủi ro ghi đè nội dung rỗng hoặc sai context.

Prod read-only verification với `vudinhthang@maritime.edu` xác nhận target section là `FILE`, `contentLength=0`, `previewPdfUrl=null`, `previewStatus=null`, file gốc là PDF `https://holilihu.online/uploads/sections/ed09ad30-e9ae-4029-8b75-b24da18cc0f4.pdf` khoảng 7.19 MB. Luồng FE hiện tại tự iframe file PDF gốc khi `previewPdfUrl` không có, khớp điểm crash Chrome PDF viewer.

## Root Cause

- `CourseEditorStore`, `CurriculumSelectionService`, `CurriculumEditorService` đang là singleton root, nên state editor/cache/selection có thể sống qua nhiều route/session teacher.
- `CourseEditorLayoutComponent` chỉ `take(1)` route id và `loadCourse()` không force refresh, nên cùng component instance hoặc cache 60s có thể render draft cũ.
- `loadCourse()` không có request token, request cũ về muộn có thể ghi đè state mới.
- FILE section fallback từ `previewPdfUrl` sang `fileUrl.endsWith('.pdf')`, khiến editor tự nhúng PDF gốc trong iframe.

## Fix

- Scope 3 service editor theo `courseEditorRoutes.providers`, để mỗi route editor có store/selection/editor context riêng.
- Layout theo dõi `courseId` bằng `distinctUntilChanged()` + `takeUntilDestroyed()`, reset selection/store và force reload draft khi vào course.
- Thêm `activeLoadToken` + `resetEditorState()` trong `CourseEditorStore` để response cũ không thể ghi đè course mới.
- Không tự iframe PDF gốc nữa; chỉ iframe khi backend có `previewPdfUrl` sẵn sàng. Nếu chỉ có PDF gốc, UI hiện info callout và giữ nút mở/tải tệp.
- Thêm unit test cho store để khóa regression stale response/reset editor.

## Verified

- [x] Prod API read-only: target section là FILE PDF gốc, không có preview snapshot.
- [x] `npx ng test --watch=false --browsers=ChromeHeadless --include=src/app/features/teacher/course-editor/store/course-editor.store.spec.ts` → 2/2 SUCCESS.
- [x] `npx ng build --configuration development` → PASS.
- [x] `git diff --check` → PASS.

## Notes

- `browser-use` trong Codex app khởi tạo được nhưng navigation bị blocker app-server path trên máy local, nên phần browser trực tiếp được thay bằng prod API + compile/test local.
- `npm run build` production hiện dừng ở baseline SSR route extraction `localStorage.getItem is not a function` sau khi bundle build xong; issue này nằm ngoài scope PR này và nên tách nếu team muốn xử lý SSR production build path riêng.
