### PR TITLE
feat(teacher/students): đồng bộ UX/UI với pattern Khóa học của tôi

### DIFF
--- a/fe/src/app/features/teacher/students/student-management.component.html
+++ b/fe/src/app/features/teacher/students/student-management.component.html
@@ -1,176 +1,390 @@
-<div class="student-management-container">
-  <!-- Header -->
-  <div class="page-header">
-    <div class="header-left">
-      <h1 class="page-title">Quản lý học viên</h1>
-      <p class="page-subtitle">Theo dõi tiến độ và thành tích của học viên</p>
-    </div>
-  </div>
-
-  <!-- Search & Filters -->
-  <div class="filters-card">
-    <div class="search-wrapper">
-      <app-icon name="magnifying-glass" size="sm" class="search-icon" />
-      <input 
-        class="search-input" 
-        placeholder="Tìm kiếm theo tên hoặc email..."
-        [(ngModel)]="keyword"
-        (input)="applyFilters()" />
-    </div>
-
-    <div class="filters-row">
-      <select class="filter-select" [(ngModel)]="selectedCourse" (change)="applyFilters()">
-        <option value="">Tất cả khóa học</option>
-        @for (course of courses(); track course.id) {
-          <option [value]="course.id">{{ course.title }}</option>
-        }
-      </select>
-
-      <select class="filter-select" [(ngModel)]="status" (change)="applyFilters()">
-        <option value="">Tất cả trạng thái</option>
-        <option value="active">Đang học</option>
-        <option value="inactive">Không hoạt động</option>
-        <option value="suspended">Tạm khóa</option>
-      </select>
-
-      <div class="results-count">
-        <strong>{{ total() }}</strong> học viên
-      </div>
-    </div>
-  </div>
-
-  <!-- Students Table -->
-  <div class="table-card">
-    @if (loading()) {
-      <div class="loading-state">
-        <app-icon name="arrow-path" size="xl" class="spin" />
-        <p>Đang tải danh sách học viên...</p>
-      </div>
-    }
-
-    @if (error() && !loading()) {
-      <div class="error-state">
-        <app-icon name="exclamation-circle" size="xl" />
-        <p>{{ error() }}</p>
-        <app-button variant="ghost" (clicked)="onReload()">
-          <app-icon name="arrow-path" size="sm" />
-          Thử lại
-        </app-button>
-      </div>
-    }
-
-    @if (!loading() && !error() && paged().length === 0) {
-      <div class="empty-state">
-        <app-icon name="users" size="xl" />
-        <h3>Không tìm thấy học viên</h3>
-        <p>Thử điều chỉnh bộ lọc hoặc tìm kiếm với từ khóa khác</p>
-      </div>
-    }
-
-    @if (!loading() && !error() && paged().length > 0) {
-      <div class="table-container">
-        <table class="students-table">
-          <thead>
-            <tr>
-              <th>Học viên</th>
-              <th class="text-center">Tiến độ</th>
-              <th class="text-center">Điểm TB</th>
-              <th class="text-center">Trạng thái</th>
-              <th class="text-right">Thao tác</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (student of paged(); track student.id) {
-              <tr>
-                <td>
-                  <div class="student-info">
-                    <div class="student-avatar">
-                      {{ getInitials(student.name) }}
-                    </div>
-                    <div class="student-details">
-                      <div class="student-name">{{ student.name }}</div>
-                      <div class="student-email">{{ student.email }}</div>
-                    </div>
-                  </div>
-                </td>
-                <td class="text-center">
-                  <div class="progress-cell">
-                    <span class="progress-text">{{ student.progress }}%</span>
-                    <app-progress-bar 
-                      [progress]="student.progress" 
-                      [thin]="true" 
-                    />
-                  </div>
-                </td>
-                <td class="text-center">
-                  <span 
-                    class="grade-badge"
-                    [class.grade-excellent]="student.averageGrade >= 8"
-                    [class.grade-good]="student.averageGrade >= 6 && student.averageGrade < 8"
-                    [class.grade-poor]="student.averageGrade < 6">
-                    {{ student.averageGrade.toFixed(1) }}
-                  </span>
-                </td>
-                <td class="text-center">
-                  <app-badge 
-                    [variant]="getStatusVariant(student.status)" 
-                    size="sm">
-                    {{ getStatusLabel(student.status) }}
-                  </app-badge>
-                </td>
-                <td class="text-right">
-                  <div class="action-buttons">
-                    <app-button 
-                      variant="ghost" 
-                      size="sm"
-                      [routerLink]="['/teacher/students', student.id]">
-                      <app-icon name="document-text" size="xs" />
-                      Chi tiết
-                    </app-button>
-                    <app-button 
-                      variant="ghost" 
-                      size="sm"
-                      (clicked)="sendMessage(student.id)">
-                      <app-icon name="bell" size="xs" />
-                      Nhắn tin
-                    </app-button>
-                  </div>
-                </td>
-              </tr>
+<div class="students-container">
+  <div class="main-content">
+    <!-- ===== HEADER ===== -->
+    <div class="page-header">
+      <div class="header-content">
+        <div class="title-section">
+          @if (selectedCourse()) {
+            <button type="button" class="back-link" (click)="backToCourses()">
+              <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"/>
+              </svg>
+              Quay lại danh sách khóa học
+            </button>
+          }
+          <h1 class="page-title">
+            {{ selectedCourse() ? selectedCourse()!.title : 'Quản lý học viên' }}
+          </h1>
+          <p class="page-subtitle">
+            @if (selectedCourse()) {
+              {{ total() }} học viên đang ghi danh
+            } @else {
+              Theo dõi tiến độ học viên theo từng khóa học
             }
-          </tbody>
-        </table>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== COURSE PICKER VIEW ===== -->
+    @if (!selectedCourse()) {
+      <!-- Tabs + filters -->
+      <div class="section-header">
+        <div class="flex flex-wrap items-center gap-2" role="tablist" aria-label="Lọc khóa học theo trạng thái">
+          @for (tab of courseTabItems; track tab.key) {
+            <button
+              type="button"
+              role="tab"
+              [attr.aria-selected]="courseStatusFilter() === tab.key"
+              class="inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-sm font-medium transition-colors"
+              [class.bg-[#0056D2]]="courseStatusFilter() === tab.key"
+              [class.text-white]="courseStatusFilter() === tab.key"
+              [class.border-[#0056D2]]="courseStatusFilter() === tab.key"
+              [class.bg-white]="courseStatusFilter() !== tab.key"
+              [class.text-gray-700]="courseStatusFilter() !== tab.key"
+              [class.border-gray-200]="courseStatusFilter() !== tab.key"
+              [class.hover:border-gray-300]="courseStatusFilter() !== tab.key"
+              (click)="setCourseStatusFilter(tab.key)">
+              {{ tab.label }} ({{ getCourseTabCount(tab.key) }})
+            </button>
+          }
+        </div>
+        <div class="search-wrapper">
+          <svg class="search-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.2-5.2M17 11a6 6 0 11-12 0 6 6 0 0112 0z"/>
+          </svg>
+          <input
+            type="search"
+            class="search-input"
+            placeholder="Tìm tên hoặc mã khóa học..."
+            aria-label="Tìm khóa học"
+            [ngModel]="courseKeyword()"
+            (input)="onCourseSearchInput($event)" />
+        </div>
       </div>
 
-      <!-- Pagination -->
-      <div class="pagination-bar">
-        <div class="page-size-selector">
-          <span>Hiển thị</span>
-          <select [ngModel]="pageSize()" (ngModelChange)="onPageSizeChange($event)">
-            <option [ngValue]="5">5</option>
-            <option [ngValue]="10">10</option>
-            <option [ngValue]="20">20</option>
-          </select>
-          <span>mỗi trang</span>
+      <!-- Loading: skeleton -->
+      @if (loading()) {
+        <div class="courses-list">
+          @for (i of [1, 2, 3]; track i) {
+            <div class="course-card">
+              <div class="course-card-body">
+                <div class="course-thumbnail skeleton-thumb"></div>
+                <div class="course-metadata">
+                  <div class="skeleton-line w60"></div>
+                  <div class="skeleton-line w40"></div>
+                </div>
+              </div>
+            </div>
+          }
         </div>
-        
-        <div class="page-navigation">
-          <app-button 
-            variant="ghost" 
-            size="sm"
-            [disabled]="pageIndex() <= 1"
-            (clicked)="prevPage()">
-            Trước
-          </app-button>
-          <span class="page-info">Trang {{ pageIndex() }} / {{ totalPages() }}</span>
-          <app-button 
-            variant="ghost" 
-            size="sm"
-            [disabled]="pageIndex() >= totalPages()"
-            (clicked)="nextPage()">
-            Sau
-          </app-button>
+      }
+
+      <!-- Error -->
+      @if (!loading() && error()) {
+        <div class="empty-state">
+          <div class="empty-state-icon">
+            <svg width="32" height="32" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"/>
+            </svg>
+          </div>
+          <h3 class="empty-state-title">Không thể tải dữ liệu</h3>
+          <p class="empty-state-text">{{ error() }}</p>
+          <button type="button" class="retry-link" (click)="onReload()">Thử lại</button>
         </div>
+      }
+
+      <!-- Empty: chưa có khóa học -->
+      @if (!loading() && !error() && courses().length === 0) {
+        <div class="empty-state">
+          <div class="empty-state-icon">
+            <svg width="40" height="40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+            </svg>
+          </div>
+          <h3 class="empty-state-title">Chưa có khóa học</h3>
+          <p class="empty-state-text">Tạo khóa học đầu tiên để bắt đầu giảng dạy và quản lý học viên</p>
+          <a routerLink="/teacher/course-creation" class="retry-link">Tạo khóa học mới &rarr;</a>
+        </div>
+      }
+
+      <!-- Empty: filter không khớp -->
+      @if (!loading() && !error() && courses().length > 0 && filteredCourses().length === 0) {
+        <div class="empty-state">
+          <div class="empty-state-icon">
+            <svg width="32" height="32" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 21l-5.2-5.2M17 11a6 6 0 11-12 0 6 6 0 0112 0z"/>
+            </svg>
+          </div>
+          <h3 class="empty-state-title">Không tìm thấy khóa học phù hợp</h3>
+          <p class="empty-state-text">Thử bỏ bộ lọc hoặc tìm với từ khóa khác</p>
+          <button type="button" class="retry-link" (click)="clearCourseFilters()">Xóa bộ lọc</button>
+        </div>
+      }
+
+      <!-- Course cards -->
+      @if (!loading() && !error() && filteredCourses().length > 0) {
+        <div class="courses-list">
+          @for (course of pagedCourses(); track course.id) {
+            <button
+              type="button"
+              class="course-card"
+              [attr.aria-label]="'Xem học viên khóa: ' + course.title"
+              (click)="viewCourseStudents(course)">
+              <div class="course-card-body">
+                <!-- Thumbnail -->
+                <div class="course-thumbnail">
+                  @if (course.thumbnailUrl) {
+                    <img
+                      [ngSrc]="course.thumbnailUrl"
+                      width="160"
+                      height="90"
+                      [alt]="course.title"
+                      class="thumbnail-image"
+                      (error)="onThumbError($event)" />
+                  } @else {
+                    <div class="thumbnail-placeholder">
+                      <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/>
+                      </svg>
+                    </div>
+                  }
+                </div>
+
+                <!-- Metadata -->
+                <div class="course-metadata">
+                  <h3 class="course-title">{{ course.title }}</h3>
+                  <div class="course-meta">
+                    @if (course.code) {
+                      <span class="meta-code">{{ course.code }}</span>
+                      <span class="separator">&middot;</span>
+                    }
+                    <span>{{ course.enrolledCount || 0 }} học viên</span>
+                    @if (course.lessonCount) {
+                      <span class="separator">&middot;</span>
+                      <span>{{ course.lessonCount }} bài học</span>
+                    }
+                  </div>
+                </div>
+
+                <!-- Status + action -->
+                <div class="course-actions">
+                  <span
+                    class="status-badge"
+                    [class.badge-approved]="isApprovedStatus(course.status)"
+                    [class.badge-pending]="course.status === 'PENDING'"
+                    [class.badge-draft]="course.status === 'DRAFT'"
+                    [class.badge-rejected]="course.status === 'REJECTED'">
+                    {{ getStatusLabel(course.status) }}
+                  </span>
+                  <span class="course-date">{{ formatDate(course.updatedAt || course.createdAt) }}</span>
+                  <span class="card-arrow" aria-hidden="true">
+                    <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+                    </svg>
+                  </span>
+                </div>
+              </div>
+            </button>
+          }
+        </div>
+
+        <!-- Pagination -->
+        @if (courseTotal() > coursePageSize()) {
+          <div class="pagination-bar">
+            <div class="page-size-selector">
+              <span>Hiển thị</span>
+              <select [ngModel]="coursePageSize()" (ngModelChange)="onCoursePageSizeChange($event)" aria-label="Số khóa học mỗi trang">
+                <option [ngValue]="5">5</option>
+                <option [ngValue]="10">10</option>
+                <option [ngValue]="20">20</option>
+                <option [ngValue]="50">50</option>
+              </select>
+              <span>khóa học / trang</span>
+            </div>
+            <div class="page-navigation">
+              <button type="button" class="page-btn" [disabled]="coursePageIndex() <= 1" (click)="prevCoursePage()">Trước</button>
+              <span class="page-info">Trang {{ coursePageIndex() }} / {{ courseTotalPages() }}</span>
+              <button type="button" class="page-btn" [disabled]="coursePageIndex() >= courseTotalPages()" (click)="nextCoursePage()">Sau</button>
+            </div>
+          </div>
+        }
+      }
+    } @else {
+      <!-- ===== STUDENT LIST VIEW ===== -->
+      <div class="students-panel">
+        <div class="section-header">
+          <div class="flex flex-wrap items-center gap-2" role="tablist" aria-label="Lọc học viên theo trạng thái">
+            @for (tab of studentTabItems; track tab.key) {
+              <button
+                type="button"
+                role="tab"
+                [attr.aria-selected]="status === tab.key"
+                class="inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-sm font-medium transition-colors"
+                [class.bg-[#0056D2]]="status === tab.key"
+                [class.text-white]="status === tab.key"
+                [class.border-[#0056D2]]="status === tab.key"
+                [class.bg-white]="status !== tab.key"
+                [class.text-gray-700]="status !== tab.key"
+                [class.border-gray-200]="status !== tab.key"
+                [class.hover:border-gray-300]="status !== tab.key"
+                (click)="setStudentStatus(tab.key)">
+                {{ tab.label }}{{ tab.key === '' ? ' (' + total() + ')' : '' }}
+              </button>
+            }
+          </div>
+          <div class="search-wrapper">
+            <svg class="search-icon" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.2-5.2M17 11a6 6 0 11-12 0 6 6 0 0112 0z"/>
+            </svg>
+            <input
+              type="search"
+              class="search-input"
+              placeholder="Tìm tên hoặc email học viên..."
+              aria-label="Tìm học viên"
+              [(ngModel)]="keyword"
+              (keyup.enter)="applyFilters()"
+              (input)="onStudentSearchInput($event)" />
+          </div>
+        </div>
+
+        <!-- Loading: skeleton table rows -->
+        @if (loading()) {
+          <div class="table-card">
+            <table class="students-table">
+              <thead>
+                <tr>
+                  <th>Học viên</th>
+                  <th>Email</th>
+                  <th>Tiến độ</th>
+                  <th class="th-center">Khóa học</th>
+                  <th class="th-center">Trạng thái</th>
+                  <th class="th-right">Thao tác</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (i of [1, 2, 3]; track i) {
+                  <tr>
+                    <td colspan="6"><div class="skeleton-row"></div></td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        }
+
+        <!-- Error -->
+        @if (!loading() && error()) {
+          <div class="empty-state">
+            <div class="empty-state-icon">
+              <svg width="32" height="32" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"/>
+              </svg>
+            </div>
+            <h3 class="empty-state-title">Không thể tải danh sách học viên</h3>
+            <p class="empty-state-text">{{ error() }}</p>
+            <button type="button" class="retry-link" (click)="onReload()">Thử lại</button>
+          </div>
+        }
+
+        <!-- Empty -->
+        @if (!loading() && !error() && paged().length === 0) {
+          <div class="empty-state">
+            <div class="empty-state-icon">
+              <svg width="40" height="40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 014-4h4a4 4 0 014 4v2h-3m-5-9a4 4 0 100-8 4 4 0 000 8zm8 0a3 3 0 100-6 3 3 0 000 6z"/>
+              </svg>
+            </div>
+            <h3 class="empty-state-title">Không có học viên</h3>
+            <p class="empty-state-text">
+              @if (keyword || status) {
+                Thử bỏ bộ lọc hoặc tìm với từ khóa khác
+              } @else {
+                Khóa học này chưa có học viên ghi danh
+              }
+            </p>
+            @if (keyword || status) {
+              <button type="button" class="retry-link" (click)="clearStudentFilters()">Xóa bộ lọc</button>
+            }
+          </div>
+        }
+
+        <!-- Student table -->
+        @if (!loading() && !error() && paged().length > 0) {
+          <div class="table-card">
+            <table class="students-table">
+              <thead>
+                <tr>
+                  <th>Học viên</th>
+                  <th>Email</th>
+                  <th>Tiến độ</th>
+                  <th class="th-center">Khóa học</th>
+                  <th class="th-center">Trạng thái</th>
+                  <th class="th-right">Thao tác</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (s of paged(); track trackById($index, s)) {
+                  <tr>
+                    <td>
+                      <div class="student-cell">
+                        <div class="student-avatar" [attr.aria-hidden]="true">{{ getInitials(s.name) }}</div>
+                        <span class="student-name">{{ s.name }}</span>
+                      </div>
+                    </td>
+                    <td class="cell-muted">{{ s.email }}</td>
+                    <td>
+                      <div class="progress-cell">
+                        <div class="progress-track" [attr.aria-label]="'Tiến độ ' + s.progress + '%'" role="progressbar" [attr.aria-valuenow]="s.progress" aria-valuemin="0" aria-valuemax="100">
+                          <div class="progress-fill" [style.width.%]="s.progress"></div>
+                        </div>
+                        <span class="progress-text">{{ s.progress }}%</span>
+                      </div>
+                    </td>
+                    <td class="cell-center">{{ s.completedCourses }}/{{ s.totalCourses }}</td>
+                    <td class="cell-center">
+                      <span
+                        class="status-badge"
+                        [class.badge-active]="s.status === 'ACTIVE'"
+                        [class.badge-completed]="s.status === 'COMPLETED'"
+                        [class.badge-suspended]="s.status === 'SUSPENDED'"
+                        [class.badge-muted]="s.status === 'DROPPED' || s.status === 'EXPIRED'">
+                        {{ getStudentStatusLabel(s.status) }}
+                      </span>
+                    </td>
+                    <td class="cell-right">
+                      <div class="action-buttons">
+                        <a [routerLink]="['/teacher/students', s.id]" class="action-link">Chi tiết</a>
+                        <button type="button" class="action-btn" (click)="sendMessage(s.id)">Nhắn tin</button>
+                      </div>
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Pagination -->
+          @if (total() > pageSize()) {
+            <div class="pagination-bar">
+              <div class="page-size-selector">
+                <span>Hiển thị</span>
+                <select [ngModel]="pageSize()" (ngModelChange)="onStudentPageSizeChange($event)" aria-label="Số học viên mỗi trang">
+                  <option [ngValue]="5">5</option>
+                  <option [ngValue]="10">10</option>
+                  <option [ngValue]="20">20</option>
+                  <option [ngValue]="50">50</option>
+                </select>
+                <span>học viên / trang</span>
+              </div>
+              <div class="page-navigation">
+                <button type="button" class="page-btn" [disabled]="pageIndex() <= 1" (click)="prevPage()">Trước</button>
+                <span class="page-info">Trang {{ pageIndex() }} / {{ totalPages() }}</span>
+                <button type="button" class="page-btn" [disabled]="pageIndex() >= totalPages()" (click)="nextPage()">Sau</button>
+              </div>
+            </div>
+          }
+        }
       </div>
     }
   </div>

--- a/fe/src/app/features/teacher/students/student-management.component.scss
+++ b/fe/src/app/features/teacher/students/student-management.component.scss
@@ -1,78 +1,114 @@
-@import '../../../../styles/variables';
+@use '../../../../styles/variables' as *;
 
-.student-management-container {
-  padding: 40px 48px;
-  background: $bg-page;
+/* ===== CONTAINER ===== */
+.students-container {
+  display: block;
+  background: #FAFAFA;
   min-height: 100vh;
+  padding: 0;
+}
 
-  @include mobile {
-    padding: 24px 16px;
+.main-content {
+  max-width: 1400px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 24px;
+}
+
+/* ===== HEADER ===== */
+.page-header {
+  margin-bottom: $spacing-6;
+}
+
+.header-content {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-4;
+}
+
+.title-section {
+  flex: 1;
+  min-width: 0;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 0;
+  background: none;
+  color: $blue-primary;
+  padding: 0;
+  margin-bottom: $spacing-2;
+  font-size: $text-xs;
+  font-weight: $font-medium;
+  cursor: pointer;
+  transition: color $transition-normal;
+
+  @include focus-visible;
+
+  &:hover {
+    color: $blue-hover;
+    text-decoration: underline;
   }
 }
 
-/* Page Header */
-.page-header {
-  margin-bottom: 32px;
-}
-
-.header-left {
-  flex: 1;
-}
-
 .page-title {
-  font-size: 32px;
+  margin: 0 0 4px;
+  font-size: 28px;
   font-weight: $font-bold;
-  color: $text-primary;
-  margin: 0 0 8px 0;
-  letter-spacing: -0.8px;
+  color: #1F1F1F;
+  line-height: 1.2;
+  @include truncate;
 }
 
 .page-subtitle {
-  font-size: $text-base;
-  color: $text-secondary;
   margin: 0;
+  font-size: $text-sm;
+  color: #636363;
+  line-height: $leading-normal;
 }
 
-/* Filters Card */
-.filters-card {
-  background: $bg-surface;
-  border: 1px solid $border-default;
-  border-radius: $radius-lg;
-  padding: 24px;
-  margin-bottom: 24px;
-  box-shadow: $shadow-sm;
+/* ===== SECTION HEADER (tabs + search) ===== */
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: $spacing-3;
+  margin-bottom: $spacing-4;
+  padding-bottom: $spacing-3;
+  border-bottom: 1px solid $border-default;
+  flex-wrap: wrap;
 }
 
 .search-wrapper {
   position: relative;
-  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  flex: 0 1 280px;
+  min-width: 200px;
 }
 
 .search-icon {
   position: absolute;
-  left: 14px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: $text-muted;
+  left: 12px;
+  color: $gray-400;
   pointer-events: none;
 }
 
 .search-input {
   width: 100%;
-  padding: 12px 16px 12px 42px;
-  border: 2px solid $border-default;
-  border-radius: $radius-sm;
-  font-size: $text-base;
-  color: $text-primary;
+  height: 36px;
+  padding: 0 12px 0 32px;
+  border: 1px solid $border-default;
+  border-radius: $radius-md;
   background: white;
-  transition: all $transition-fast;
+  font-size: $text-sm;
+  color: $text-primary;
+  transition: border-color $transition-normal, box-shadow $transition-normal;
 
   &::placeholder {
-    color: $text-muted;
-  }
-
-  &:hover {
-    border-color: $gray-400;
+    color: $gray-400;
   }
 
   &:focus {
@@ -82,298 +118,567 @@
   }
 }
 
-.filters-row {
+/* ===== COURSE CARDS ===== */
+.courses-list {
   display: flex;
-  gap: 12px;
-  align-items: center;
-
-  @include mobile {
-    flex-direction: column;
-    align-items: stretch;
-  }
+  flex-direction: column;
+  gap: $spacing-3;
 }
 
-.filter-select {
-  padding: 10px 16px;
-  border: 1px solid $border-default;
-  border-radius: $radius-sm;
-  font-size: $text-sm;
-  color: $text-primary;
+.course-card {
+  width: 100%;
+  text-align: left;
   background: white;
+  border-radius: $radius-md;
+  border: 1px solid $border-default;
+  box-shadow: $shadow-sm;
+  transition: all $transition-normal;
+  overflow: hidden;
   cursor: pointer;
-  transition: all $transition-fast;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+
+  @include focus-visible;
 
   &:hover {
-    border-color: $gray-400;
-  }
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 
-  &:focus {
-    outline: none;
-    border-color: $blue-primary;
-    box-shadow: 0 0 0 3px rgba(0, 86, 210, 0.1);
-  }
+    .course-title {
+      color: $blue-primary;
+    }
 
-  @include mobile {
-    width: 100%;
-  }
-}
-
-.results-count {
-  margin-left: auto;
-  font-size: $text-sm;
-  color: $text-secondary;
-
-  strong {
-    color: $text-primary;
-    font-weight: $font-semibold;
-  }
-
-  @include mobile {
-    margin-left: 0;
+    .card-arrow {
+      color: $blue-primary;
+      transform: translateX(2px);
+    }
   }
 }
 
-/* Table Card */
+.course-card-body {
+  display: flex;
+  gap: $spacing-4;
+  padding: $spacing-2;
+  align-items: center;
+}
+
+.course-thumbnail {
+  width: 160px;
+  height: 90px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: $radius-md;
+  flex-shrink: 0;
+  overflow: hidden;
+  background: $gray-100;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.thumbnail-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.thumbnail-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(0, 86, 210, 0.35);
+  background: #E3F2FD;
+}
+
+.course-metadata {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.course-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: $font-semibold;
+  color: #1F1F1F;
+  line-height: 1.4;
+  transition: color $transition-normal;
+  @include truncate;
+}
+
+.course-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  font-size: $text-xs;
+  color: $text-muted;
+}
+
+.meta-code {
+  font-family: $font-family-mono;
+}
+
+.separator {
+  color: $border-dark;
+}
+
+.course-actions {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  min-width: 90px;
+}
+
+.card-arrow {
+  color: $gray-400;
+  transition: color $transition-normal, transform $transition-normal;
+}
+
+.course-date {
+  font-size: 11px;
+  color: $gray-400;
+}
+
+/* ===== STATUS BADGES ===== */
+.status-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: $font-medium;
+  padding: 3px 10px;
+  border-radius: $radius-full;
+  min-width: 72px;
+  text-align: center;
+
+  /* Course status */
+  &.badge-approved {
+    background: #ECFDF5;
+    color: #059669;
+  }
+
+  &.badge-pending {
+    background: #FFFBEB;
+    color: #D97706;
+  }
+
+  &.badge-draft {
+    background: $gray-100;
+    color: $gray-500;
+  }
+
+  &.badge-rejected {
+    background: #FEF2F2;
+    color: #DC2626;
+  }
+
+  /* Student enrollment status */
+  &.badge-active {
+    background: #ECFDF5;
+    color: #059669;
+  }
+
+  &.badge-completed {
+    background: $info-light;
+    color: $info;
+  }
+
+  &.badge-suspended {
+    background: #FEF2F2;
+    color: #DC2626;
+  }
+
+  &.badge-muted {
+    background: $gray-100;
+    color: $gray-500;
+  }
+}
+
+/* ===== STUDENT TABLE ===== */
+.students-panel {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-3;
+}
+
 .table-card {
-  background: $bg-surface;
+  background: white;
   border: 1px solid $border-default;
-  border-radius: $radius-lg;
+  border-radius: $radius-md;
   box-shadow: $shadow-sm;
   overflow: hidden;
-}
-
-.table-container {
-  overflow-x: auto;
 }
 
 .students-table {
   width: 100%;
   border-collapse: collapse;
 
-  thead {
+  th, td {
+    padding: 14px 20px;
+    border-bottom: 1px solid $border-default;
+    font-size: $text-sm;
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  th {
     background: $gray-50;
-    border-bottom: 2px solid $border-default;
+    color: $text-muted;
+    font-size: 11px;
+    font-weight: $font-bold;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
 
-    th {
-      padding: 16px 20px;
-      text-align: left;
-      font-size: $text-xs;
-      font-weight: $font-bold;
-      color: $text-secondary;
-      text-transform: uppercase;
-      letter-spacing: 0.8px;
-
-      &.text-center {
-        text-align: center;
-      }
-
-      &.text-right {
-        text-align: right;
-      }
-    }
+    &.th-center { text-align: center; }
+    &.th-right { text-align: right; }
   }
 
-  tbody {
-    tr {
-      border-bottom: 1px solid $border-light;
-      transition: background $transition-fast;
-
-      &:hover {
-        background: $gray-50;
-      }
-
-      &:last-child {
-        border-bottom: none;
-      }
-    }
-
-    td {
-      padding: 16px 20px;
-      font-size: $text-sm;
-
-      &.text-center {
-        text-align: center;
-      }
-
-      &.text-right {
-        text-align: right;
-      }
-    }
+  tbody tr:last-child td {
+    border-bottom: 0;
   }
+
+  tbody tr:hover {
+    background: $gray-50;
+  }
+
+  .cell-center { text-align: center; }
+  .cell-right { text-align: right; white-space: nowrap; }
+  .cell-muted { color: $text-secondary; }
 }
 
-.student-info {
+.student-cell {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: $spacing-3;
 }
 
 .student-avatar {
-  width: 40px;
-  height: 40px;
+  width: 36px;
+  height: 36px;
   border-radius: $radius-full;
-  background: linear-gradient(135deg, $blue-primary 0%, #0073E6 100%);
-  color: white;
-  display: flex;
+  background: $blue-light;
+  color: $blue-primary;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: $text-sm;
+  font-size: $text-xs;
   font-weight: $font-bold;
   flex-shrink: 0;
-}
-
-.student-details {
-  flex: 1;
-  min-width: 0;
 }
 
 .student-name {
   font-weight: $font-semibold;
   color: $text-primary;
-  margin-bottom: 2px;
 }
 
-.student-email {
-  font-size: $text-xs;
-  color: $text-muted;
-  @include truncate;
-}
-
+/* ===== PROGRESS ===== */
 .progress-cell {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: $spacing-2;
   min-width: 120px;
 }
 
-.progress-text {
-  font-weight: $font-semibold;
-  color: $text-primary;
-  font-size: $text-sm;
+.progress-track {
+  flex: 1;
+  max-width: 80px;
+  height: 6px;
+  background: $gray-200;
+  border-radius: $radius-full;
+  overflow: hidden;
 }
 
-.grade-badge {
+.progress-fill {
+  height: 100%;
+  background: $blue-primary;
+  border-radius: $radius-full;
+  transition: width $transition-slow;
+}
+
+.progress-text {
+  font-size: $text-xs;
+  font-weight: $font-medium;
+  color: $text-secondary;
+  min-width: 36px;
+  text-align: right;
+}
+
+/* ===== ACTIONS ===== */
+.action-buttons {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  padding: 6px 12px;
-  border-radius: $radius-full;
-  font-weight: $font-bold;
-  font-size: $text-sm;
-
-  &.grade-excellent {
-    background: rgba(5, 150, 105, 0.1);
-    color: $success;
-  }
-
-  &.grade-good {
-    background: rgba(217, 119, 6, 0.1);
-    color: $warning;
-  }
-
-  &.grade-poor {
-    background: rgba(220, 38, 38, 0.1);
-    color: $error;
-  }
-}
-
-.action-buttons {
-  display: flex;
-  gap: 8px;
+  gap: $spacing-3;
   justify-content: flex-end;
 }
 
-/* Pagination */
+.action-link {
+  font-size: $text-sm;
+  font-weight: $font-medium;
+  color: $blue-primary;
+  text-decoration: none;
+  transition: color $transition-normal;
+
+  @include focus-visible;
+
+  &:hover {
+    color: $blue-hover;
+    text-decoration: underline;
+  }
+}
+
+.action-btn {
+  padding: 4px 12px;
+  border: 1px solid $blue-primary;
+  border-radius: $radius-sm;
+  background: white;
+  color: $blue-primary;
+  font-size: $text-xs;
+  font-weight: $font-semibold;
+  cursor: pointer;
+  transition: all $transition-normal;
+
+  @include focus-visible;
+
+  &:hover {
+    background: $blue-primary;
+    color: white;
+  }
+}
+
+/* ===== EMPTY STATE ===== */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+  background: white;
+  border-radius: $radius-md;
+  border: 1px dashed $border-dark;
+  text-align: center;
+}
+
+.empty-state-icon {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: $gray-400;
+  margin-bottom: $spacing-3;
+}
+
+.empty-state-title {
+  font-size: 15px;
+  font-weight: $font-semibold;
+  color: $gray-700;
+  margin: 0 0 6px 0;
+}
+
+.empty-state-text {
+  font-size: 13px;
+  color: #636363;
+  margin: 0 0 $spacing-4 0;
+  max-width: 320px;
+}
+
+.retry-link {
+  font-size: $text-sm;
+  font-weight: $font-medium;
+  color: $blue-primary;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+
+  @include focus-visible;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+/* ===== SKELETON ===== */
+.skeleton-thumb {
+  background: $gray-100 !important;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.skeleton-line {
+  height: 14px;
+  background: $gray-100;
+  border-radius: $radius-sm;
+  animation: pulse 1.5s ease-in-out infinite;
+
+  &.w60 { width: 60%; margin-bottom: 8px; }
+  &.w40 { width: 40%; }
+}
+
+.skeleton-row {
+  height: 36px;
+  background: $gray-100;
+  border-radius: $radius-sm;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+/* ===== PAGINATION ===== */
 .pagination-bar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
-  border-top: 1px solid $border-light;
-
-  @include mobile {
-    flex-direction: column;
-    gap: 12px;
-  }
+  gap: $spacing-3;
+  margin-top: $spacing-3;
+  padding: $spacing-3 $spacing-4;
+  background: white;
+  border: 1px solid $border-default;
+  border-radius: $radius-md;
+  flex-wrap: wrap;
 }
 
-.page-size-selector {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: $text-sm;
-  color: $text-secondary;
-
-  select {
-    padding: 6px 12px;
-    border: 1px solid $border-default;
-    border-radius: $radius-sm;
-    font-size: $text-sm;
-    cursor: pointer;
-  }
-}
-
+.page-size-selector,
 .page-navigation {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: $spacing-2;
+  font-size: $text-xs;
+  color: $text-muted;
+
+  select {
+    border: 1px solid $border-default;
+    border-radius: $radius-sm;
+    padding: 4px 8px;
+    background: white;
+    font-size: $text-xs;
+    color: $text-primary;
+    cursor: pointer;
+
+    &:focus {
+      outline: 2px solid $blue-primary;
+      outline-offset: 1px;
+    }
+  }
 }
 
 .page-info {
-  font-size: $text-sm;
-  color: $text-primary;
+  color: $text-secondary;
   font-weight: $font-medium;
 }
 
-/* States */
-.loading-state,
-.error-state,
-.empty-state {
-  text-align: center;
-  padding: 60px 24px;
+.page-btn {
+  padding: 4px 12px;
+  border: 1px solid $border-default;
+  border-radius: $radius-sm;
+  background: white;
+  color: $text-secondary;
+  font-size: $text-xs;
+  font-weight: $font-medium;
+  cursor: pointer;
+  transition: all $transition-normal;
 
-  app-icon {
-    margin-bottom: 16px;
-    color: $text-muted;
+  @include focus-visible;
+
+  &:hover:not(:disabled) {
+    border-color: $blue-primary;
+    color: $blue-primary;
   }
 
-  h3 {
-    font-size: $text-xl;
-    font-weight: $font-semibold;
-    color: $text-primary;
-    margin: 0 0 8px 0;
-  }
-
-  p {
-    margin: 0 0 16px 0;
-    color: $text-secondary;
-  }
-}
-
-.loading-state app-icon {
-  color: $blue-primary;
-}
-
-.error-state {
-  app-icon {
-    color: $error;
-  }
-
-  p {
-    color: $error;
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 }
 
-.spin {
-  animation: spin 1s linear infinite;
+/* ===== RESPONSIVE ===== */
+@media (max-width: $breakpoint-md) {
+  .main-content {
+    padding: 24px 16px;
+  }
+
+  .course-thumbnail {
+    width: 120px;
+    height: 72px;
+  }
+
+  .students-table {
+    th, td {
+      padding: 12px 14px;
+    }
+  }
 }
 
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
+@media (max-width: $breakpoint-sm) {
+  .main-content {
+    padding: 16px 12px;
   }
-  to {
-    transform: rotate(360deg);
+
+  .page-title {
+    font-size: 20px;
+    white-space: normal;
+  }
+
+  .page-subtitle {
+    font-size: 13px;
+  }
+
+  .section-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-wrapper {
+    flex: 1 1 100%;
+    width: 100%;
+  }
+
+  .course-card-body {
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px;
+    align-items: stretch;
+  }
+
+  .course-thumbnail {
+    width: 100%;
+    height: 140px;
+  }
+
+  .course-title {
+    white-space: normal;
+    @include line-clamp(2);
+  }
+
+  .course-actions {
+    flex-direction: row;
+    align-items: center;
+    align-self: stretch;
+    justify-content: space-between;
+    min-width: 0;
+  }
+
+  .card-arrow {
+    display: none;
+  }
+
+  .table-card {
+    overflow-x: auto;
+  }
+
+  .students-table {
+    min-width: 640px;
+  }
+
+  .pagination-bar {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/fe/src/app/features/teacher/students/student-management.component.ts
+++ b/fe/src/app/features/teacher/students/student-management.component.ts
@@ -6,275 +6,14 @@ import { CourseApi } from '../../../api/client/course.api';
 import { StudentApi, StudentEnrollmentStatus, StudentSummary } from '../../../api/client/student.api';
 import { CourseSummary } from '../../../api/types/course.types';
 
+type CourseTabKey = '' | 'APPROVED' | 'PENDING' | 'DRAFT';
+type StudentTabKey = '' | StudentEnrollmentStatus;
+
 @Component({
   selector: 'app-student-management',
   imports: [RouterModule, FormsModule, CommonModule, NgOptimizedImage],
-  template: `
-    <div class="students-page">
-      <div class="page-inner">
-        <div class="page-header">
-          <div>
-            @if (selectedCourse()) {
-              <button class="back-btn" (click)="backToCourses()">Quay lại danh sách khóa học</button>
-            }
-            <h1 class="page-title">{{ selectedCourse() ? selectedCourse()!.title : 'Quản lý học viên' }}</h1>
-            <p class="page-subtitle">
-              {{ selectedCourse() ? ('Học viên đang ghi danh · ' + total() + ' người') : 'Theo dõi học viên theo từng khóa học' }}
-            </p>
-          </div>
-        </div>
-
-        @if (!selectedCourse()) {
-          <div class="toolbar">
-            <div class="tabs-container" role="tablist">
-              <button class="tab-chip" [class.active]="courseStatusFilter() === ''" (click)="setCourseStatusFilter('')">Tất cả ({{ courseTotal() }})</button>
-              <button class="tab-chip" [class.active]="courseStatusFilter() === 'APPROVED'" (click)="setCourseStatusFilter('APPROVED')">Đã duyệt</button>
-              <button class="tab-chip" [class.active]="courseStatusFilter() === 'PENDING'" (click)="setCourseStatusFilter('PENDING')">Chờ duyệt</button>
-              <button class="tab-chip" [class.active]="courseStatusFilter() === 'DRAFT'" (click)="setCourseStatusFilter('DRAFT')">Nháp</button>
-            </div>
-            <input class="search-input" placeholder="Tìm tên hoặc mã khóa học..." [ngModel]="courseKeyword()" (input)="onCourseSearchInput($event)" />
-          </div>
-
-          @if (loading()) {
-            <div class="panel muted">Đang tải danh sách khóa học...</div>
-          }
-
-          @if (!loading() && error()) {
-            <div class="panel error-state">
-              <p>{{ error() }}</p>
-              <button class="primary-btn" (click)="onReload()">Thử lại</button>
-            </div>
-          }
-
-          @if (!loading() && !error() && courses().length === 0) {
-            <div class="panel muted">Bạn chưa có khóa học nào.</div>
-          }
-
-          @if (!loading() && !error() && courses().length > 0) {
-            @if (filteredCourses().length === 0) {
-              <div class="panel muted">
-                <p>Không tìm thấy khóa học phù hợp.</p>
-                <button class="secondary-btn" (click)="clearCourseFilters()">Xóa bộ lọc</button>
-              </div>
-            } @else {
-              <div class="courses-list">
-                @for (course of pagedCourses(); track course.id) {
-                  <div class="course-card" (click)="viewCourseStudents(course)">
-                    <div class="course-thumb">
-                      @if (course.thumbnailUrl) {
-                        <img [ngSrc]="course.thumbnailUrl" width="160" height="90" [alt]="course.title" class="course-thumb-img" (error)="onThumbError($event)" />
-                      } @else {
-                        <div class="course-thumb-placeholder">Kh\u00f3a h\u1ecdc</div>
-                      }
-                    </div>
-                    <div class="course-main">
-                      <h3 class="course-title">{{ course.title }}</h3>
-                      <p class="course-meta">
-                        @if (course.code) {
-                          <span>{{ course.code }}</span>
-                          <span>·</span>
-                        }
-                        <span>{{ course.enrolledCount || 0 }} học viên</span>
-                        @if (course.lessonCount) {
-                          <span>·</span>
-                          <span>{{ course.lessonCount }} bài học</span>
-                        }
-                      </p>
-                      <span class="status-badge">{{ getStatusLabel(course.status) }}</span>
-                    </div>
-                    <div class="course-side">
-                      <span class="course-date">{{ formatDate(course.updatedAt || course.createdAt) }}</span>
-                      <button class="secondary-btn" (click)="viewCourseStudents(course); $event.stopPropagation()">Xem học viên</button>
-                    </div>
-                  </div>
-                }
-              </div>
-
-              @if (courseTotal() > 0) {
-                <div class="footer-bar">
-                  <div class="footer-group">
-                    <span>Hiển thị</span>
-                    <select [ngModel]="coursePageSize()" (ngModelChange)="onCoursePageSizeChange($event)">
-                      <option [ngValue]="5">5</option>
-                      <option [ngValue]="10">10</option>
-                      <option [ngValue]="20">20</option>
-                      <option [ngValue]="50">50</option>
-                    </select>
-                    <span>dòng / trang</span>
-                  </div>
-                  <div class="footer-group">
-                    <button class="secondary-btn" [disabled]="coursePageIndex() <= 1" (click)="prevCoursePage()">Trước</button>
-                    <span>Trang {{ coursePageIndex() }} / {{ courseTotalPages() }}</span>
-                    <button class="secondary-btn" [disabled]="coursePageIndex() >= courseTotalPages()" (click)="nextCoursePage()">Sau</button>
-                  </div>
-                  <div class="footer-group">Tổng số {{ courseTotal() }} khóa học</div>
-                </div>
-              }
-            }
-          }
-        } @else {
-          <div class="panel table-panel">
-            <div class="toolbar compact-toolbar">
-              <div class="tabs-container" role="tablist">
-                <button class="tab-chip" [class.active]="status === ''" (click)="setStudentStatus('')">Tất cả ({{ total() }})</button>
-                <button class="tab-chip" [class.active]="status === 'ACTIVE'" (click)="setStudentStatus('ACTIVE')">Đang học</button>
-                <button class="tab-chip" [class.active]="status === 'COMPLETED'" (click)="setStudentStatus('COMPLETED')">Hoàn thành</button>
-                <button class="tab-chip" [class.active]="status === 'SUSPENDED'" (click)="setStudentStatus('SUSPENDED')">Tạm khóa</button>
-              </div>
-              <input class="search-input" placeholder="Tìm tên hoặc email học viên..." [(ngModel)]="keyword" (keyup.enter)="applyFilters()" (input)="onStudentSearchInput($event)" />
-            </div>
-
-            <div class="overflow-x-auto">
-              <table class="students-table">
-                <thead>
-                  <tr>
-                    <th>Tên</th>
-                    <th>Email</th>
-                    <th>Tiến độ</th>
-                    <th>Khóa học</th>
-                    <th>Trạng thái</th>
-                    <th></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  @if (loading()) {
-                    <tr>
-                      <td colspan="6" class="muted center">Đang tải danh sách học viên...</td>
-                    </tr>
-                  }
-
-                  @if (!loading() && error()) {
-                    <tr>
-                      <td colspan="6" class="center error-text">
-                        {{ error() }}
-                        <button class="inline-link" (click)="onReload()">Tải lại</button>
-                      </td>
-                    </tr>
-                  }
-
-                  @if (!loading() && !error() && paged().length === 0) {
-                    <tr>
-                      <td colspan="6" class="muted center">Không tìm thấy học viên nào.</td>
-                    </tr>
-                  }
-
-                  @for (s of paged(); track trackById($index, s)) {
-                    <tr>
-                      <td class="strong">{{ s.name }}</td>
-                      <td>{{ s.email }}</td>
-                      <td>
-                        <div class="progress-cell">
-                          <div class="progress-track"><div class="progress-fill" [style.width.%]="s.progress"></div></div>
-                          <span>{{ s.progress }}%</span>
-                        </div>
-                      </td>
-                      <td class="center">{{ s.completedCourses }}/{{ s.totalCourses }}</td>
-                      <td>
-                        <span class="status-pill" [class.pill-active]="s.status === 'ACTIVE'" [class.pill-completed]="s.status === 'COMPLETED'" [class.pill-suspended]="s.status === 'SUSPENDED'" [class.pill-muted]="s.status === 'DROPPED' || s.status === 'EXPIRED'">
-                          {{ getStudentStatusLabel(s.status) }}
-                        </span>
-                      </td>
-                      <td class="actions-cell">
-                        <a [routerLink]="['/teacher/students', s.id]" class="secondary-link">Chi tiết</a>
-                        <button class="secondary-btn" (click)="sendMessage(s.id)">Nhắn tin</button>
-                      </td>
-                    </tr>
-                  }
-                </tbody>
-              </table>
-            </div>
-          </div>
-
-          @if (total() > 0) {
-            <div class="footer-bar">
-              <div class="footer-group">
-                <span>Hiển thị</span>
-                <select [ngModel]="pageSize()" (ngModelChange)="onStudentPageSizeChange($event)">
-                  <option [ngValue]="5">5</option>
-                  <option [ngValue]="10">10</option>
-                  <option [ngValue]="20">20</option>
-                  <option [ngValue]="50">50</option>
-                </select>
-                <span>dòng / trang</span>
-              </div>
-              <div class="footer-group">
-                <button class="secondary-btn" [disabled]="pageIndex() <= 1" (click)="prevPage()">Trước</button>
-                <span>Trang {{ pageIndex() }} / {{ totalPages() }}</span>
-                <button class="secondary-btn" [disabled]="pageIndex() >= totalPages()" (click)="nextPage()">Sau</button>
-              </div>
-              <div class="footer-group">Tổng: {{ total() }}</div>
-            </div>
-          }
-        }
-      </div>
-    </div>
-  `,
-  styles: [
-    `
-      .students-page { min-height: 100vh; background: #fafafa; }
-      .page-inner { max-width: 1280px; margin: 0 auto; padding: 32px; }
-      .page-header { margin-bottom: 24px; }
-      .page-title { margin: 0; font-size: 28px; font-weight: 700; color: #111827; }
-      .page-subtitle { margin: 6px 0 0; color: #6b7280; font-size: 14px; }
-      .back-btn { border: 0; background: none; color: #0056d2; padding: 0; margin-bottom: 8px; font-size: 13px; cursor: pointer; }
-      .toolbar { display: flex; justify-content: space-between; gap: 12px; align-items: center; margin-bottom: 16px; flex-wrap: wrap; }
-      .compact-toolbar { margin-bottom: 0; padding-bottom: 0; }
-      .tabs-container { display: flex; gap: 8px; flex-wrap: wrap; }
-      .tab-chip { border: 1px solid #d1d5db; background: white; color: #374151; border-radius: 999px; padding: 8px 14px; font-size: 13px; font-weight: 600; cursor: pointer; }
-      .tab-chip.active { background: #0056d2; border-color: #0056d2; color: white; }
-      .search-input { height: 40px; min-width: 260px; padding: 0 14px; border: 1px solid #e5e7eb; border-radius: 10px; background: white; }
-      .search-input:focus { outline: none; border-color: #0056d2; box-shadow: 0 0 0 3px rgba(0, 86, 210, 0.1); }
-      .panel { background: white; border: 1px solid #e5e7eb; border-radius: 16px; padding: 20px; }
-      .table-panel { padding: 0; overflow: hidden; }
-      .muted { color: #6b7280; }
-      .center { text-align: center; }
-      .error-state { display: flex; flex-direction: column; gap: 12px; align-items: center; }
-      .error-text { color: #dc2626; }
-      .courses-list { display: flex; flex-direction: column; gap: 12px; }
-      .course-card { display: flex; gap: 16px; align-items: center; padding: 14px; border: 1px solid #e5e7eb; border-radius: 14px; background: white; cursor: pointer; }
-      .course-card:hover { border-color: #c7d2fe; box-shadow: 0 6px 20px rgba(15, 23, 42, 0.06); }
-      .course-thumb { width: 160px; height: 90px; border-radius: 10px; overflow: hidden; background: #eff6ff; flex-shrink: 0; }
-      .course-thumb-img { width: 100%; height: 100%; object-fit: cover; display: block; }
-      .course-thumb-placeholder { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; color: #0056d2; font-size: 12px; font-weight: 700; }
-      .course-main { flex: 1; min-width: 0; }
-      .course-title { margin: 0 0 4px; font-size: 16px; font-weight: 700; color: #111827; }
-      .course-meta { display: flex; gap: 6px; flex-wrap: wrap; margin: 0 0 8px; color: #6b7280; font-size: 13px; }
-      .course-side { display: flex; flex-direction: column; gap: 10px; align-items: flex-end; }
-      .course-date { color: #9ca3af; font-size: 12px; }
-      .status-badge, .status-pill { display: inline-flex; align-items: center; border-radius: 999px; padding: 4px 10px; font-size: 12px; font-weight: 700; }
-      .status-badge { background: #eff6ff; color: #0056d2; }
-      .status-pill { background: #f3f4f6; color: #4b5563; }
-      .pill-active { background: #dcfce7; color: #166534; }
-      .pill-completed { background: #dbeafe; color: #1d4ed8; }
-      .pill-suspended { background: #fee2e2; color: #b91c1c; }
-      .pill-muted { background: #f3f4f6; color: #4b5563; }
-      .students-table { width: 100%; border-collapse: collapse; }
-      .students-table th, .students-table td { padding: 16px 20px; border-bottom: 1px solid #e5e7eb; font-size: 14px; text-align: left; }
-      .students-table th { background: #f9fafb; color: #6b7280; font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; }
-      .students-table tbody tr:last-child td { border-bottom: 0; }
-      .strong { font-weight: 700; color: #111827; }
-      .actions-cell { text-align: right; white-space: nowrap; }
-      .secondary-link { color: #0056d2; font-weight: 600; margin-right: 12px; text-decoration: none; }
-      .secondary-btn, .primary-btn { border-radius: 10px; padding: 8px 14px; font-size: 13px; font-weight: 600; cursor: pointer; }
-      .secondary-btn { border: 1px solid #d1d5db; background: white; color: #374151; }
-      .secondary-btn:disabled { opacity: 0.4; cursor: default; }
-      .primary-btn { border: 1px solid #0056d2; background: #0056d2; color: white; }
-      .inline-link { margin-left: 8px; border: 0; background: none; color: #0056d2; cursor: pointer; }
-      .progress-cell { display: flex; align-items: center; gap: 10px; }
-      .progress-track { width: 72px; height: 8px; background: #e5e7eb; border-radius: 999px; overflow: hidden; }
-      .progress-fill { height: 100%; background: #0056d2; border-radius: 999px; }
-      .footer-bar { margin-top: 16px; display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; padding: 16px 20px; background: white; border: 1px solid #e5e7eb; border-radius: 14px; }
-      .footer-group { display: flex; align-items: center; gap: 10px; color: #6b7280; font-size: 13px; }
-      select { border: 1px solid #d1d5db; border-radius: 8px; padding: 6px 10px; background: white; }
-      @media (max-width: 768px) {
-        .page-inner { padding: 20px 16px; }
-        .course-card { flex-direction: column; align-items: stretch; }
-        .course-thumb { width: 100%; }
-        .course-side { align-items: flex-start; }
-        .search-input { min-width: 100%; width: 100%; }
-      }
-    `
-  ],
+  templateUrl: './student-management.component.html',
+  styleUrls: ['./student-management.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class StudentManagementComponent {
@@ -282,10 +21,11 @@ export class StudentManagementComponent {
   private courseApi = inject(CourseApi);
   private router = inject(Router);
 
+  // ===== STATE =====
   keyword = '';
-  status: '' | StudentEnrollmentStatus = '';
+  status: StudentTabKey = '';
   courseKeyword = signal('');
-  courseStatusFilter = signal<'' | 'APPROVED' | 'PENDING' | 'DRAFT' | 'PUBLISHED'>('');
+  courseStatusFilter = signal<CourseTabKey>('');
   students = signal<StudentSummary[]>([]);
   courses = signal<CourseSummary[]>([]);
   error = signal('');
@@ -297,12 +37,32 @@ export class StudentManagementComponent {
   coursePageIndex = signal(1);
   coursePageSize = signal(10);
 
+  private studentSearchTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // ===== TAB CONFIG =====
+  readonly courseTabItems: { key: CourseTabKey; label: string }[] = [
+    { key: '', label: 'Tất cả' },
+    { key: 'APPROVED', label: 'Đã duyệt' },
+    { key: 'PENDING', label: 'Chờ duyệt' },
+    { key: 'DRAFT', label: 'Nháp' }
+  ];
+
+  readonly studentTabItems: { key: StudentTabKey; label: string }[] = [
+    { key: '', label: 'Tất cả' },
+    { key: 'ACTIVE', label: 'Đang học' },
+    { key: 'COMPLETED', label: 'Hoàn thành' },
+    { key: 'SUSPENDED', label: 'Tạm khóa' }
+  ];
+
+  // ===== COMPUTED =====
   filteredCourses = computed(() => {
     const kw = this.courseKeyword().trim().toLowerCase();
     const filter = this.courseStatusFilter();
     return this.courses().filter((course) => {
-      const matchesKeyword = !kw || course.title.toLowerCase().includes(kw) || (course.code || '').toLowerCase().includes(kw);
-      const matchesStatus = !filter || course.status === filter || (filter === 'APPROVED' && course.status === 'PUBLISHED');
+      const matchesKeyword =
+        !kw || course.title.toLowerCase().includes(kw) || (course.code || '').toLowerCase().includes(kw);
+      const matchesStatus =
+        !filter || course.status === filter || (filter === 'APPROVED' && course.status === 'PUBLISHED');
       return matchesKeyword && matchesStatus;
     });
   });
@@ -317,31 +77,41 @@ export class StudentManagementComponent {
   paged = computed(() => this.students());
   total = computed(() => this.totalElements());
   totalPages = computed(() => Math.max(1, Math.ceil(this.total() / this.pageSize())));
-  private studentSearchTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     this.loadData();
   }
 
-  setCourseStatusFilter(status: '' | 'APPROVED' | 'PENDING' | 'DRAFT' | 'PUBLISHED') {
+  // ===== TAB HELPERS =====
+  getCourseTabCount(key: CourseTabKey): number {
+    if (!key) return this.courses().length;
+    return this.courses().filter((c) => {
+      if (key === 'APPROVED') return c.status === 'APPROVED' || c.status === 'PUBLISHED';
+      return c.status === key;
+    }).length;
+  }
+
+  setCourseStatusFilter(status: CourseTabKey) {
     this.courseStatusFilter.set(status);
     this.coursePageIndex.set(1);
   }
 
-  setStudentStatus(status: '' | StudentEnrollmentStatus) {
+  setStudentStatus(status: StudentTabKey) {
     this.status = status;
     this.applyFilters();
   }
 
+  // ===== FILTER ACTIONS =====
   clearCourseFilters() {
     this.courseKeyword.set('');
     this.courseStatusFilter.set('');
     this.coursePageIndex.set(1);
   }
 
-  clearCourseKeyword() {
-    this.courseKeyword.set('');
-    this.coursePageIndex.set(1);
+  clearStudentFilters() {
+    this.keyword = '';
+    this.status = '';
+    this.applyFilters();
   }
 
   onCourseSearchInput(event: Event) {
@@ -355,6 +125,7 @@ export class StudentManagementComponent {
     this.studentSearchTimer = setTimeout(() => this.applyFilters(), 400);
   }
 
+  // ===== DATA LOADING =====
   private loadData() {
     this.error.set('');
     this.loading.set(true);
@@ -403,13 +174,18 @@ export class StudentManagementComponent {
     });
   }
 
+  // ===== STATUS HELPERS =====
+  isApprovedStatus(status?: string): boolean {
+    return status === 'APPROVED' || status === 'PUBLISHED';
+  }
+
   getStatusLabel(status?: string): string {
     const labels: Record<string, string> = {
-      PUBLISHED: 'Đã xuất bản',
+      PUBLISHED: 'Đã duyệt',
       APPROVED: 'Đã duyệt',
       PENDING: 'Chờ duyệt',
       DRAFT: 'Nháp',
-      REJECTED: 'Từ chối',
+      REJECTED: 'Bị từ chối',
       ARCHIVED: 'Lưu trữ'
     };
     return labels[status || ''] || status || 'Không xác định';
@@ -426,16 +202,31 @@ export class StudentManagementComponent {
     return labels[status] || status;
   }
 
+  // ===== FORMATTING =====
   formatDate(dateStr?: string): string {
     if (!dateStr) return '';
-    const date = new Date(dateStr);
-    return Number.isNaN(date.getTime()) ? '' : date.toLocaleDateString('vi-VN');
+    const d = new Date(dateStr);
+    if (Number.isNaN(d.getTime())) return '';
+    const now = new Date();
+    const days = Math.floor((now.getTime() - d.getTime()) / 86400000);
+    if (days === 0) return 'Hôm nay';
+    if (days === 1) return 'Hôm qua';
+    if (days < 7) return `${days} ngày trước`;
+    return d.toLocaleDateString('vi-VN');
+  }
+
+  getInitials(name: string): string {
+    if (!name) return '?';
+    const parts = name.trim().split(/\s+/);
+    if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
+    return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
   }
 
   onThumbError(event: Event) {
     (event.target as HTMLImageElement).src = '/icons/icon-192x192.png';
   }
 
+  // ===== NAVIGATION =====
   viewCourseStudents(course: CourseSummary) {
     this.selectedCourse.set(course);
     this.pageIndex.set(1);
@@ -456,6 +247,7 @@ export class StudentManagementComponent {
     this.loadStudents();
   }
 
+  // ===== PAGINATION =====
   goToPage(page: number) {
     this.pageIndex.set(Math.min(Math.max(1, page), this.totalPages()));
     this.loadStudents();


### PR DESCRIPTION
## Tại sao

Sau khi bảo vệ TTTN xong, mở wave cải thiện UX/UI từng trang giảng viên cho nhất quán với chuẩn Coursera tokens đã thiết lập ở các page đã đồng bộ trước đó (`/teacher/courses` — "Khóa học của tôi"). Trang `/teacher/students` là trang đầu tiên trong wave này.

Closes #298

## Vấn đề hiện trạng

| Khía cạnh | Hiện trạng | Reference (`teacher-dashboard`) |
|-----------|-----------|-------------------------------|
| Architecture | Inline template + inline styles dồn 500 LOC vào `.ts` | 3 files split (`.ts`/`.html`/`.scss`) |
| HTML file | 177 LOC stale, KHÔNG được wire | Templated qua `templateUrl` |
| Design tokens | Hardcoded `#0056d2`, `#fafafa`; border-radius 16/14/10px lung tung | `@use 'variables'`: `$blue-primary`, `$radius-md`, `$spacing-*` |
| Status badge | `pill-active/completed/suspended` (#dcfce7/#166534) | `badge-approved/pending/draft/rejected` (#ECFDF5/#059669) |
| Loading | Plain text "Đang tải..." | Skeleton 3 cards với shimmer |
| Empty state | Plain text trong `.panel.muted` | Icon + title + text + retry-link |
| Tab chips | Custom `tab-chip` filled solid blue | rounded-full Tailwind utilities |
| Card click | `(click)` trên `<div>` — không keyboard accessible | `<button>` với `aria-label` + `focus-visible` |

## Thay đổi (tóm tắt)

### 1. Restructure 3 files
- `.ts`: 110 LOC logic thuần (giảm từ 500 LOC), `templateUrl` + `styleUrls` thay vì inline
- `.html`: Angular 20 control flow (`@if`/`@for`), 3 view: course picker / student table / empty states
- `.scss`: `@use '../../../../styles/variables' as *`, full design token adoption

### 2. Header
- Title 28px bold `#1F1F1F`, subtitle `text-sm` `#636363`
- Back link với SVG arrow (drill-down: course → students)
- Truncate dài tên course

### 3. Course cards (matching reference)
- 160x90 thumbnail (mobile: 100% width × 140px)
- `$spacing-2` padding, `$radius-md`, `$shadow-sm`
- 15px semibold title, hover → blue + arrow → `translate(2px)`
- `<button>` thay `<div>` với `aria-label="Xem học viên khóa: ..."`
- `[ngSrc]` Angular optimized image directive preserved

### 4. Status badges
- Course: `badge-approved` (#ECFDF5/#059669), `badge-pending` (#FFFBEB/#D97706), `badge-draft`, `badge-rejected`
- Student: `badge-active`, `badge-completed`, `badge-suspended`, `badge-muted`
- Helper `isApprovedStatus()` map APPROVED + PUBLISHED → green

### 5. Tab chips
- `rounded-full px-3.5 py-1.5 text-sm font-medium` Tailwind utilities
- `bg-[#0056D2] text-white` khi active, `bg-white text-gray-700 border-gray-200` khi không
- `role="tablist"` + `aria-selected` + `aria-label` mô tả filter

### 6. Skeleton loading
- Course view: 3 card skeletons với shimmer animation
- Student view: 3 row skeletons trong table giữ structure

### 7. Empty states (3 variants)
- No courses → CTA "Tạo khóa học mới →" tới `/teacher/course-creation`
- No filter match → button "Xóa bộ lọc" reset filters
- No students in course → contextual ("chưa có học viên ghi danh" vs "thử bỏ bộ lọc")

### 8. A11y
- `role="tablist"` + `aria-selected` + `aria-label` trên tabs
- `<button>` thay `<div>` cho clickable cards với `aria-label`
- `role="progressbar"` với `aria-valuenow/min/max` trên progress bar
- `@include focus-visible` mixin trên TẤT CẢ interactive elements (back link, search, cards, tabs, retry, action buttons, pagination)

### 9. Mobile responsive (<640px)
- Section header stack vertical (tabs above search)
- Card body column layout, thumbnail full-width
- Table horizontal scroll với `min-width: 640px`
- Pagination stack vertical
- `card-arrow` ẩn (chiếm space không cần thiết)

### 10. Microcopy polish
- Subtitle khi chưa chọn course: "Theo dõi tiến độ học viên theo từng khóa học"
- Subtitle khi chọn course: "X học viên đang ghi danh"
- Empty contextual: "Khóa học này chưa có học viên ghi danh" vs "Thử bỏ bộ lọc hoặc tìm với từ khóa khác"

## Out of scope (không đụng)

- `StudentApi` — không touch
- `student-detail`, `student-assignments`, `messages-tab` — không touch  
- Drill-down logic (course picker → student list) — preserved
- Không thêm feature mới (avatar API, bulk actions, export)

## Verification

- [x] `npm run build` clean (chỉ warnings về SCSS @import deprecation ở files khác — không liên quan)
- [x] `templateUrl` wire đúng file `.html` mới
- [x] `styleUrls` wire đúng file `.scss` mới
- [x] CourseSummary fields verified: `thumbnailUrl`, `enrolledCount`, `lessonCount`, `code`, `status`, `updatedAt`, `createdAt` đều exist
- [x] StudentEnrollmentStatus type đầy đủ: ACTIVE/COMPLETED/DROPPED/EXPIRED/SUSPENDED
- [ ] Manual smoke trên dev: drill-down course → students vẫn load
- [ ] Mobile responsive < 640px

## Test plan

- [ ] Browse `/teacher/students` → course picker render đúng
- [ ] Filter tab "Đã duyệt" → chỉ hiện courses APPROVED/PUBLISHED  
- [ ] Search "khóa" → debounced filter
- [ ] Click vào course card → navigate vào student list view
- [ ] Back button → quay về course picker
- [ ] Drill-down vào course có students → table render đúng
- [ ] Filter student status "Đang học" → hiện ACTIVE only
- [ ] Click "Chi tiết" → navigate `/teacher/students/:id`
- [ ] Click "Nhắn tin" → navigate với queryParams `tab=messages`
- [ ] Pagination prev/next + page size change
- [ ] Mobile < 640px: stack vertical, table horizontal scroll
- [ ] Keyboard: Tab through cards, Enter để mở, focus visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)