### PR TITLE
fix(storage): bug entity link thumbnail/avatar/submission + harden cleanup scheduler

### DIFF
--- a/backend/src/main/java/com/example/lms/assessment/infrastructure/web/StudentAssignmentControllerV3.java
+++ b/backend/src/main/java/com/example/lms/assessment/infrastructure/web/StudentAssignmentControllerV3.java
@@ -10,6 +10,7 @@ import com.example.lms.assessment.infrastructure.persistence.repository.Assignme
 import com.example.lms.assessment.infrastructure.persistence.repository.AssignmentJpaRepository;
 import com.example.lms.assessment.infrastructure.persistence.repository.AssignmentSubmissionJpaRepository;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
+import com.example.lms.shared.application.port.FileManagementPort;
 import com.example.lms.shared.infrastructure.web.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,6 +42,7 @@ public class StudentAssignmentControllerV3 {
     private final AssignmentSubmissionJpaRepository submissionRepository;
     private final AssignmentJpaRepository assignmentRepository;
     private final AssignmentAttachmentJpaRepository attachmentRepository;
+    private final FileManagementPort fileManagementPort;
 
     @Operation(summary = "Danh sach bai tap cua hoc vien")
     @GetMapping
@@ -149,9 +151,16 @@ public class StudentAssignmentControllerV3 {
                         .fileType(att.mimeType())
                         .uploadedBy(user.getId())
                         .build());
+                // Link each attachment so cleanup scheduler doesn't delete it.
+                fileManagementPort.linkFileByUrl(att.fileUrl(), submission.getId(), "SUBMISSION");
             }
             log.info("Saved {} attachments for submission {} (assignment {})",
                     request.attachments().size(), submission.getId(), id);
+        }
+
+        // Also link the primary file (legacy single-file submission flow).
+        if (primaryFileUrl != null) {
+            fileManagementPort.linkFileByUrl(primaryFileUrl, submission.getId(), "SUBMISSION");
         }
 
         return ResponseEntity.ok(ApiResponse.success(

--- a/backend/src/main/java/com/example/lms/course_authoring/application/usecase/UpdateCourseUseCase.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/application/usecase/UpdateCourseUseCase.java
@@ -5,6 +5,7 @@ import com.example.lms.course_authoring.application.dto.CourseResponse;
 import com.example.lms.course_authoring.domain.model.Course;
 import com.example.lms.course_authoring.domain.repository.CourseRepository;
 import com.example.lms.learning_delivery.domain.repository.EnrollmentRepositoryPort;
+import com.example.lms.shared.application.port.FileManagementPort;
 import com.example.lms.shared.exception.BusinessRuleException;
 import com.example.lms.shared.exception.EntityNotFoundException;
 import com.example.lms.shared.exception.UnauthorizedException;
@@ -22,6 +23,7 @@ public class UpdateCourseUseCase {
     private final CourseRepository courseRepository;
     private final EnrollmentRepositoryPort enrollmentRepository;
     private final CourseDraftMutationUseCase courseDraftMutationUseCase;
+    private final FileManagementPort fileManagementPort;
 
     @Transactional
     public CourseResponse execute(UpdateCourseCommand command) {
@@ -112,6 +114,15 @@ public class UpdateCourseUseCase {
 
         // Save course
         course = courseRepository.save(course);
+
+        // Link uploaded files to this course so cleanup scheduler doesn't treat them as orphans.
+        // No-op for external URLs (e.g. YouTube intro video) — port silently skips when no file_attachment matches.
+        if (command.thumbnailUrl() != null) {
+            fileManagementPort.linkFileByUrl(command.thumbnailUrl(), course.getId(), "COURSE");
+        }
+        if (command.introVideoUrl() != null) {
+            fileManagementPort.linkFileByUrl(command.introVideoUrl(), course.getId(), "COURSE");
+        }
 
         return CourseResponse.from(course);
     }

--- a/backend/src/main/java/com/example/lms/identity/application/usecase/UpdateProfileUseCaseV2.java
+++ b/backend/src/main/java/com/example/lms/identity/application/usecase/UpdateProfileUseCaseV2.java
@@ -4,6 +4,7 @@ import com.example.lms.identity.application.dto.UpdateProfileCommand;
 import com.example.lms.identity.application.dto.UserResponse;
 import com.example.lms.identity.domain.model.User;
 import com.example.lms.identity.domain.repository.UserRepository;
+import com.example.lms.shared.application.port.FileManagementPort;
 import com.example.lms.shared.domain.valueobject.Email;
 import com.example.lms.shared.domain.valueobject.UserId;
 import com.example.lms.shared.exception.EntityNotFoundException;
@@ -26,6 +27,7 @@ public class UpdateProfileUseCaseV2 {
 
     @Qualifier("newUserRepositoryAdapter")
     private final UserRepository userRepository;
+    private final FileManagementPort fileManagementPort;
 
     @Transactional
     public UserResponse execute(UUID userId, UpdateProfileCommand command) {
@@ -53,6 +55,12 @@ public class UpdateProfileUseCaseV2 {
 
         // Save updated user
         User updatedUser = userRepository.save(user);
+
+        // Link uploaded avatar so cleanup scheduler doesn't treat it as orphan.
+        // No-op for external avatars (Google profile picture etc.).
+        if (command.avatarUrl() != null) {
+            fileManagementPort.linkFileByUrl(command.avatarUrl(), userId, "USER");
+        }
 
         log.info("Profile updated successfully (V2) for user: {}", userId);
 

--- a/backend/src/main/java/com/example/lms/shared/application/port/FileManagementPort.java
+++ b/backend/src/main/java/com/example/lms/shared/application/port/FileManagementPort.java
@@ -15,4 +15,13 @@ public interface FileManagementPort {
      * Scans content blocks for file URLs and links them to the entity.
      */
     void linkFilesToEntity(List<ContentBlock> blocks, UUID entityId, String entityType);
+
+    /**
+     * Links a single file (looked up by its public URL) to an entity.
+     * Required for entities that store a single URL column instead of EditorJS content
+     * (course thumbnails, course intro videos, user avatars, assignment submissions, etc.).
+     * Without this link, {@code file_attachments.entity_id} stays NULL and
+     * {@code UploadCleanupScheduler} treats the file as orphan and deletes it after 7 days.
+     */
+    void linkFileByUrl(String url, UUID entityId, String entityType);
 }

--- a/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/repository/FileAttachmentJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/repository/FileAttachmentJpaRepository.java
@@ -17,6 +17,18 @@ public interface FileAttachmentJpaRepository extends JpaRepository<FileAttachmen
 
     Optional<FileAttachmentJpaEntity> findByFileName(String fileName);
 
-    @Query("SELECT f FROM FileAttachmentJpaEntity f WHERE f.entityId IS NULL AND f.uploadedAt < :cutoff")
+    /**
+     * Find true orphan attachments — entity_id NULL and old enough to be eligible for cleanup.
+     *
+     * Records tagged with {@code entity_type = 'PENDING_LINK_REVIEW'} are explicitly excluded
+     * via the {@code entity_id IS NULL} predicate (the tactical backfill sets entity_id to the
+     * uploader id alongside the sentinel type, so they no longer match here).
+     * This is defensive: even if a future change repopulates entity_id back to NULL on those
+     * rows, the additional {@code entity_type} filter below keeps them protected.
+     */
+    @Query("SELECT f FROM FileAttachmentJpaEntity f " +
+           "WHERE f.entityId IS NULL " +
+           "AND (f.entityType IS NULL OR f.entityType <> 'PENDING_LINK_REVIEW') " +
+           "AND f.uploadedAt < :cutoff")
     List<FileAttachmentJpaEntity> findOrphanedBefore(@Param("cutoff") Instant cutoff);
 }

--- a/backend/src/main/java/com/example/lms/shared/infrastructure/service/FileManagementService.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/service/FileManagementService.java
@@ -126,14 +126,21 @@ public class FileManagementService implements FileManagementPort {
         };
     }
 
+    @Override
     @Transactional
     public void linkFileByUrl(String url, UUID entityId, String entityType) {
-        fileRepository.findByFileUrl(url).ifPresent(file -> {
-            file.setEntityId(entityId);
-            file.setEntityType(entityType);
-            fileRepository.save(file);
-            log.info("Linked file {} to {} {}", file.getId(), entityType, entityId);
-        });
+        if (url == null || url.isBlank() || entityId == null || entityType == null) {
+            return;
+        }
+        fileRepository.findByFileUrl(url).ifPresentOrElse(
+            file -> {
+                file.setEntityId(entityId);
+                file.setEntityType(entityType);
+                fileRepository.save(file);
+                log.info("Linked file {} to {} {}", file.getId(), entityType, entityId);
+            },
+            () -> log.debug("No file_attachment found for url={} (external URL or already deleted)", url)
+        );
     }
 
     private boolean isVideoFolder(String folder) {

--- a/backend/src/main/java/com/example/lms/shared/infrastructure/service/UploadCleanupScheduler.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/service/UploadCleanupScheduler.java
@@ -5,6 +5,7 @@ import com.example.lms.shared.infrastructure.persistence.repository.FileAttachme
 import com.example.lms.shared.infrastructure.persistence.repository.UploadSessionJpaRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,22 @@ public class UploadCleanupScheduler {
     private final java.util.Optional<R2StorageService> r2StorageService;
     private final java.util.Optional<R2VideoStorageService> r2VideoStorageService;
     private final java.util.Optional<LocalStorageService> localStorageService;
+
+    /**
+     * Operations toggle for orphan attachment cleanup. Default true to preserve dev behaviour.
+     * In production, set {@code APP_CLEANUP_ORPHAN_ATTACHMENTS_ENABLED=false} as a kill switch
+     * if the cleanup query is suspected of deleting referenced files.
+     */
+    @Value("${app.cleanup.orphan-attachments.enabled:true}")
+    private boolean orphanCleanupEnabled;
+
+    /**
+     * Retention window for orphan attachments before they are eligible for deletion.
+     * Increased from the legacy 7 days to 30 days to give downstream entity-link flows
+     * sufficient time to mark attachments as referenced.
+     */
+    @Value("${app.cleanup.orphan-attachments.retention-days:30}")
+    private int orphanRetentionDays;
 
     @Autowired
     public UploadCleanupScheduler(
@@ -67,15 +84,40 @@ public class UploadCleanupScheduler {
     }
 
     /**
-     * Daily 3AM: clean orphaned file_attachments where entityId IS NULL and age > 7 days.
+     * Daily 3AM: clean orphaned file_attachments where entity_id IS NULL and age > retention window.
+     *
+     * Defense in depth — three layers:
+     *   1. {@code orphanCleanupEnabled} env kill-switch.
+     *   2. Retention window default 30 days (was 7 — too aggressive).
+     *   3. Repository query excludes the {@code PENDING_LINK_REVIEW} sentinel which protects
+     *      attachments that are awaiting proper entity linkage (set by tactical SQL backfill
+     *      when the original entity-link bug was discovered).
+     *
+     * Each candidate is logged BEFORE deletion so the action can be audited / reverted from logs.
      */
     @Scheduled(cron = "0 0 3 * * *")
     @Transactional
     public void cleanOrphanedAttachments() {
-        Instant cutoff = Instant.now().minus(7, ChronoUnit.DAYS);
+        if (!orphanCleanupEnabled) {
+            log.info("[Cleanup] Orphan attachment cleanup disabled via app.cleanup.orphan-attachments.enabled=false");
+            return;
+        }
+
+        Instant cutoff = Instant.now().minus(orphanRetentionDays, ChronoUnit.DAYS);
         var orphans = fileAttachmentRepository.findOrphanedBefore(cutoff);
 
-        if (orphans.isEmpty()) return;
+        if (orphans.isEmpty()) {
+            log.info("[Cleanup] No orphaned attachments older than {} days", orphanRetentionDays);
+            return;
+        }
+
+        log.warn("[Cleanup] About to delete {} orphan attachments (cutoff={}). Listing each for audit:",
+                orphans.size(), cutoff);
+        for (var a : orphans) {
+            log.warn("[Cleanup]   - id={} category={} fileName={} url={} uploadedBy={} uploadedAt={}",
+                    a.getId(), a.getFileCategory(), a.getFileName(), a.getFileUrl(),
+                    a.getUploadedBy(), a.getUploadedAt());
+        }
 
         int count = 0;
         for (var attachment : orphans) {

--- a/backend/src/test/java/com/example/lms/course_authoring/application/usecase/UpdateCourseUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/application/usecase/UpdateCourseUseCaseTest.java
@@ -5,6 +5,7 @@ import com.example.lms.course_authoring.application.dto.UpdateCourseCommand;
 import com.example.lms.course_authoring.domain.model.Course;
 import com.example.lms.course_authoring.domain.repository.CourseRepository;
 import com.example.lms.learning_delivery.domain.repository.EnrollmentRepositoryPort;
+import com.example.lms.shared.application.port.FileManagementPort;
 import com.example.lms.shared.domain.valueobject.CourseCode;
 import com.example.lms.shared.exception.BusinessRuleException;
 import com.example.lms.shared.exception.EntityNotFoundException;
@@ -50,6 +51,9 @@ class UpdateCourseUseCaseTest {
 
     @Mock
     private CourseDraftMutationUseCase courseDraftMutationUseCase;
+
+    @Mock
+    private FileManagementPort fileManagementPort;
 
     @InjectMocks
     private UpdateCourseUseCase useCase;


### PR DESCRIPTION
## Summary

Sửa root cause của bug **thumbnail course mất** trên production (course "An Toàn Hàng Hải v2"). Bug lan rộng hơn dự đoán — ảnh hưởng cả **avatar upload**, **assignment submission**, **course intro video**.

### Root cause
Khi upload thumbnail/avatar/submission file, backend tạo `file_attachments` với `entity_id=NULL`. Code **KHÔNG** gọi `linkFileByUrl()` để gán `entity_id = courseId/userId/submissionId` sau khi save entity. Cleanup scheduler 3 AM mỗi ngày tìm orphan `entity_id IS NULL > 7 ngày` → xóa file vật lý + DB row.

DB vẫn giữ URL absolute → **403 Forbidden** khi browser load (file đã mất khỏi disk).

Video file SỐNG SÓT vì có FK `video_assets.source_attachment_id ON DELETE RESTRICT`.

## Changes

**Port + adapter** (the fix):
- `FileManagementPort` — thêm `linkFileByUrl(url, entityId, entityType)` vào contract
- `FileManagementService` — `@Override` + null-safety + debug log khi URL không match
- `UpdateCourseUseCase` — link thumbnail + intro_video sau save
- `UpdateProfileUseCaseV2` — link avatar sau save
- `StudentAssignmentControllerV3` — link primary file + mọi attachment sau submit

**Cleanup hardening** (defense in depth, 3 lớp):
- `@Value app.cleanup.orphan-attachments.enabled` — kill switch (default true; production set false sau khi PR merge)
- Retention 7 → 30 ngày configurable (`app.cleanup.orphan-attachments.retention-days`)
- Repository query exclude `entity_type='PENDING_LINK_REVIEW'` sentinel — protect các orphan đã backfill tactical hôm nay
- Log mỗi candidate trước khi xóa cho audit trail

## Test plan

- [x] `mvn test -Dtest=UpdateCourseUseCaseTest` — 5/5 PASS
- [x] `mvn test -Dtest=UploadCleanupSchedulerTest` — 1/1 PASS
- [x] Full shared package — 127/127 PASS
- [x] Full identity + course_authoring + assessment — 695/695 PASS
- [x] Compile clean (Maven offline)
- [ ] CI 4/4 sau khi push
- [ ] Sau merge: deploy → set env `APP_CLEANUP_ORPHAN_ATTACHMENTS_ENABLED=false` trên VM tới Phase 5 hoàn tất → set lại true

## Related

- Production diagnose 2026-04-30: file `e7f512fa-fa18-4d7c-a215-7c8c28a906d7.png` đã mất khỏi disk khi cleanup 3 AM chạy. 1 course "An Toàn Hàng Hải v2" có thumbnail = NULL hiện thời (UI placeholder).
- Tactical backfill SQL đã chạy trên prod: 6 file_attachments đã link entity_id, 63 còn lại tag `PENDING_LINK_REVIEW` để protect.
- Phase 2 (schema FK) + Phase 3 (R2 migration) sẽ follow up trong các PR sau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)