### PR TITLE
fix(video): support HEAD on /object endpoint (no redirect to presigned-GET)

### DIFF
--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackCacheService.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackCacheService.java
@@ -31,4 +31,13 @@ public class AdaptiveVideoPlaybackCacheService {
     public String createObjectRedirect(String storageKey, Duration ttl) {
         return videoBinaryStorageService.createReadUrl(storageKey, ttl);
     }
+
+    /**
+     * Probe object metadata (size + content-type) without transferring body.
+     * Not cached — HEAD response varies per request and is cheap on R2.
+     */
+    public com.example.lms.shared.infrastructure.service.R2VideoStorageService.ObjectMetadata
+            headObject(String storageKey) throws IOException {
+        return videoBinaryStorageService.head(storageKey);
+    }
 }

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackService.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackService.java
@@ -98,6 +98,18 @@ public class AdaptiveVideoPlaybackService {
         return redirectUrl;
     }
 
+    /**
+     * Probe object size + content-type for HEAD requests.
+     * Avoids redirecting HEAD to a presigned-GET URL (R2 rejects with 403 because
+     * AWS SigV4 binds the signature to the HTTP method).
+     */
+    public com.example.lms.shared.infrastructure.service.R2VideoStorageService.ObjectMetadata
+            headObject(UUID assetId, String token, String storageKey) throws IOException {
+        validateClaims(token, assetId, null);
+        ensureStorageKeyAllowed(assetId, storageKey);
+        return adaptiveVideoPlaybackCacheService.headObject(storageKey);
+    }
+
     private VideoPlaybackTokenService.PlaybackClaims validateClaims(String token, UUID assetId, String expectedFormat) {
         VideoPlaybackTokenService.PlaybackClaims claims = videoPlaybackTokenService.parseAndValidate(token);
         if (!assetId.equals(claims.assetId())) {

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/VideoBinaryStorageService.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/VideoBinaryStorageService.java
@@ -129,6 +129,34 @@ public class VideoBinaryStorageService {
         return localStorageService.map(service -> service.exists(storageKey)).orElse(false);
     }
 
+    /**
+     * Return object size + content-type (HEAD without body transfer).
+     * Falls back through R2 video bucket → R2 general bucket → local FS.
+     */
+    public R2VideoStorageService.ObjectMetadata head(String storageKey) throws IOException {
+        if (r2VideoStorageService.isPresent()) {
+            return r2VideoStorageService.get().head(storageKey);
+        }
+        if (r2StorageService.isPresent()) {
+            // Fallback: probe via getObject HEAD-like call (R2StorageService doesn't expose head)
+            // For minimal change, materialise to temp file and read length.
+            Path tempFile = Files.createTempFile("video-head-", suffixFromStorageKey(storageKey));
+            try {
+                r2StorageService.get().downloadToFile(storageKey, tempFile);
+                return new R2VideoStorageService.ObjectMetadata(Files.size(tempFile), Files.probeContentType(tempFile));
+            } finally {
+                Files.deleteIfExists(tempFile);
+            }
+        }
+        if (localStorageService.isPresent()) {
+            Path local = Path.of("uploads").resolve(storageKey);
+            if (Files.exists(local)) {
+                return new R2VideoStorageService.ObjectMetadata(Files.size(local), Files.probeContentType(local));
+            }
+        }
+        throw new IOException("No storage backend configured to head object");
+    }
+
     public void delete(String storageKey) {
         if (r2VideoStorageService.isPresent()) {
             r2VideoStorageService.get().delete(storageKey);

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackController.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -64,5 +65,32 @@ public class AdaptiveVideoPlaybackController {
         return ResponseEntity.status(HttpStatus.FOUND)
                 .header(HttpHeaders.LOCATION, URI.create(redirectUrl).toString())
                 .build();
+    }
+
+    /**
+     * Handle HEAD probes from the player (range support detection) WITHOUT
+     * redirecting to a presigned-GET URL. R2 rejects HEAD on a GET-bound
+     * presigned URL with 403 because AWS SigV4 binds the signature to the
+     * exact HTTP method.
+     *
+     * Instead we issue a single HeadObject against R2 ourselves and echo the
+     * size + content-type to the client — cheaper than a redirect (no client
+     * round-trip to R2) and method-safe.
+     */
+    @RequestMapping(value = "/{assetId}/adaptive/{token}/object", method = RequestMethod.HEAD)
+    public ResponseEntity<Void> headObject(
+            @PathVariable UUID assetId,
+            @PathVariable String token,
+            @RequestParam String key
+    ) throws IOException {
+        var meta = adaptiveVideoPlaybackService.headObject(assetId, token, key);
+        ResponseEntity.BodyBuilder builder = ResponseEntity.ok()
+                .contentLength(meta.size())
+                .header(HttpHeaders.ACCEPT_RANGES, "bytes")
+                .header(HttpHeaders.CACHE_CONTROL, "private, max-age=30");
+        if (meta.contentType() != null && !meta.contentType().isBlank()) {
+            builder.contentType(MediaType.parseMediaType(meta.contentType()));
+        }
+        return builder.build();
     }
 }

--- a/backend/src/main/java/com/example/lms/shared/infrastructure/service/R2VideoStorageService.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/service/R2VideoStorageService.java
@@ -104,6 +104,25 @@ public class R2VideoStorageService {
         }
     }
 
+    /**
+     * Read object size + content-type without transferring the body.
+     * Used by the playback controller's HEAD handler so the browser can probe
+     * range support without following a presigned-GET redirect (which would
+     * fail SigV4 because presigned URLs are method-bound).
+     */
+    public ObjectMetadata head(String storageKey) {
+        var resp = r2Client.headObject(HeadObjectRequest.builder()
+                .bucket(videoBucket)
+                .key(storageKey)
+                .build());
+        return new ObjectMetadata(
+                resp.contentLength() == null ? 0L : resp.contentLength(),
+                resp.contentType()
+        );
+    }
+
+    public record ObjectMetadata(long size, String contentType) {}
+
     public void downloadToFile(String storageKey, Path destination) throws IOException {
         if (destination.getParent() != null) {
             Files.createDirectories(destination.getParent());


### PR DESCRIPTION
## Summary

User report video không play sau Phase 3 R2 enable. Console:
\`\`\`
HEAD https://lms-storage.<account>.r2.cloudflarestorage.com/... 403 Forbidden
Access blocked by CORS policy: No 'Access-Control-Allow-Origin'
\`\`\`

## Root cause

AWS SigV4 binds presigned URL to specific HTTP method. Backend \`@GetMapping('/object')\` auto-handles HEAD via Spring (HEAD = GET without body). Player làm HEAD probe (range support detection) → backend trả 302 redirect → browser theo redirect với HEAD method → R2 reject 403 vì presigned URL signature chỉ valid cho GET.

CORS error là consequence: khi R2 trả 403 không kèm CORS headers, browser hiểu là CORS violation.

## Fix

Explicit HEAD handler — backend tự call HeadObject trên R2, return Content-Length + Content-Type + Accept-Ranges. Không redirect → tránh signature mismatch hoàn toàn.

Bonus: 1 fewer client→R2 hop (HEAD response từ backend trực tiếp), cheap operation (R2 Class B, ~free).

## Files changed

- \`R2VideoStorageService.head(key)\` — call HeadObject, return ObjectMetadata
- \`VideoBinaryStorageService.head()\` — fallback chain R2-video → R2 general → local
- \`AdaptiveVideoPlaybackService.headObject()\` — JWT claims validation + delegate
- \`AdaptiveVideoPlaybackCacheService.headObject()\` — passthrough
- \`AdaptiveVideoPlaybackController @RequestMapping HEAD\` — explicit handler

## Test plan

- [x] \`mvn test\` 348 PASS (learning_delivery + shared)
- [x] Compile clean
- [ ] CI 4/4 sau push
- [ ] Manual: F5 video lesson → player load OK, không CSP/403 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)