### PR TITLE
fix(cache): no-store cho video-assets endpoints — chống stale 5xx

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -23,7 +23,14 @@ holilihu.online {
     handle @adaptivePlayback {
         import edge_response_headers
         reverse_proxy backend:8080 {
-            header_down Cache-Control "private, max-age=30"
+            # No caching for adaptive playback responses.
+            # 1) Manifests + segments contain JWT-signed URLs that expire (60s-4h).
+            # 2) Previous setting `private, max-age=30` cached 5xx errors at the
+            #    browser layer, so users hit stale 504/403 for 30s after the
+            #    server-side fix had already deployed (incident 2026-04-30).
+            # Trade-off: lose minor browser cache hit rate (segments rarely
+            #    re-fetched anyway), gain immediate recovery from transient errors.
+            header_down Cache-Control "no-store, must-revalidate"
             header_down -Pragma
             header_down -Expires
         }

--- a/fe/ngsw-config.json
+++ b/fe/ngsw-config.json
@@ -79,6 +79,19 @@
         "maxAge": "30d",
         "strategy": "performance"
       }
+    },
+    {
+      "name": "video-playback-bypass",
+      "_comment": "Defense-in-depth: explicit freshness + short timeout cho video-assets endpoints. Trước đây không match dataGroup nào (pass-through), nhưng add explicit để: (1) ensure NGSW không bao giờ cache responses (manifest có JWT expire), (2) tránh stale 5xx replay sau server-side fix. Issue 2026-04-30: 504 cached state blocked playback sau khi backend đã fix.",
+      "urls": [
+        "/api/v3/video-assets/**"
+      ],
+      "cacheConfig": {
+        "maxSize": 1,
+        "maxAge": "10s",
+        "strategy": "freshness",
+        "timeout": "2s"
+      }
     }
   ],
   "navigationUrls": [


### PR DESCRIPTION
Fix browser cache stale errors. Caddy + NGSW. See commit message. Caddy đã apply runtime, NGSW deploy qua FE rebuild.