### PR TITLE
fix(video): preserve $Number$ DASH template across /object?key= rewrite

### DIFF
--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackService.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackService.java
@@ -323,7 +323,14 @@ public class AdaptiveVideoPlaybackService {
     }
 
     private String urlEncode(String value) {
-        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+        // Preserve `$` literal: DASH template variables ($Number$, $Time$, $Bandwidth$,
+        // $RepresentationID$, $SubNumber$ per ISO/IEC 23009-1 §5.3.9.4.4) must survive
+        // the manifest rewrite so the player can substitute them before issuing the
+        // request. Encoding `$` → `%24` makes Shaka/dash.js fail to recognize the
+        // template, send the request with literal `%24Number%24.m4s`, and R2 returns
+        // 404 (no such object). `$` is a sub-delim per RFC 3986 §2.2 and is legal
+        // unencoded in query strings, so this is spec-safe.
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("%24", "$");
     }
 
     public record PlaybackSession(

--- a/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackServiceTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackServiceTest.java
@@ -173,6 +173,42 @@ class AdaptiveVideoPlaybackServiceTest {
     }
 
     @Test
+    @DisplayName("renderDashManifest preserves $Number$ template in /object?key= so player can substitute")
+    void renderDashManifestPreservesTemplateVariablesInObjectQuery() throws Exception {
+        // Regression: production bug 2026-04-30. `urlEncode` encoded $Number$ → %24Number%24
+        // so Shaka couldn't substitute → request URL had literal %24Number%24.m4s → R2 404.
+        // Backend has no media-domain edge auth → falls back to /object?key= path. That
+        // path is the one that broke; the media-domain path was already correct.
+        UUID assetId = UUID.randomUUID();
+        String token = "play-token";
+        String manifestKey = "video-packages/" + assetId + "/dash/manifest.mpd";
+
+        VideoAssetJpaEntity asset = VideoAssetJpaEntity.builder()
+                .id(assetId)
+                .status("READY")
+                .adaptivePackagingStatus("READY")
+                .dashManifestStorageKey(manifestKey)
+                .build();
+
+        when(videoAssetRepository.findById(assetId)).thenReturn(Optional.of(asset));
+        when(videoPlaybackTokenService.parseAndValidate(token)).thenReturn(
+                new VideoPlaybackTokenService.PlaybackClaims(assetId, UUID.randomUUID(), "dash")
+        );
+        when(adaptiveVideoPlaybackCacheService.readManifest(manifestKey)).thenReturn("""
+                <MPD>
+                  <Representation initialization="segments/saver/init.mp4" media="segments/saver/$Number$.m4s" />
+                </MPD>
+                """);
+
+        String rewritten = service.renderDashManifest(assetId, token);
+
+        assertThat(rewritten)
+                .contains("/object?key=")
+                .contains("$Number$.m4s")
+                .doesNotContain("%24Number%24");
+    }
+
+    @Test
     @DisplayName("resolveObjectRedirect returns a short-lived signed storage URL")
     void resolveObjectRedirectUsesVideoStorageReadUrl() {
         UUID assetId = UUID.randomUUID();


### PR DESCRIPTION
## Summary
- Backend `urlEncode()` was encoding `$` → `%24`, breaking DASH `SegmentTemplate` substitution in Shaka/dash.js.
- Result: `?key=...%24Number%24.m4s` reached R2 literally → 404 on every video segment.
- Surfaces only when HLS playback fails first and player falls back to DASH (e.g. cached old CSP blocking R2 endpoint).

## Root cause
`AdaptiveVideoPlaybackService.rewriteDashManifest()` calls `buildObjectUrl()` → `urlEncode(storageKey)` → `URLEncoder.encode("segments/saver/$Number$.m4s")` returns `segments%2Fsaver%2F%24Number%24.m4s`. The DASH player parses `media="..."` attribute as a template and substitutes literal `$Number$` patterns BEFORE issuing the request. Once `$` becomes `%24`, no substitution happens and the literal URL is sent.

Per ISO/IEC 23009-1 §5.3.9.4.4, template variables (`$Number$`, `$Time$`, `$Bandwidth$`, `$RepresentationID$`, `$SubNumber$`) must remain literal. Per RFC 3986 §2.2, `$` is a sub-delim and is legal unencoded in query strings.

The media-domain rewrite path (`buildMediaObjectUrl`) was already correct — it does raw string concat, no encoding.

## Fix
Replace `%24` → `$` after `URLEncoder.encode()`. Verify tokens, playback tokens, and storage keys don't contain `$`, so this is safe.

## Test plan
- [x] New unit test `renderDashManifestPreservesTemplateVariablesInObjectQuery` — asserts `$Number$.m4s` literal preserved, no `%24Number%24`.
- [x] `mvn test -Dtest=AdaptiveVideoPlaybackServiceTest` → 6/6 pass.
- [ ] Post-deploy: hit lesson 131cd3f7 → Shaka loads HLS → if CSP cleared, plays via HLS; if HLS fails, DASH fallback now works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)