### PR TITLE
fix(video): static MPD + tracker defense against Infinity duration

### DIFF
--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/ShakaPackagerService.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/ShakaPackagerService.java
@@ -59,6 +59,13 @@ public class ShakaPackagerService {
             command.add("hls/master.m3u8");
             command.add("--mpd_output");
             command.add("dash/manifest.mpd");
+            // Force static MPD for VOD content. Without this, Shaka Packager v3.4+
+            // emits `type="dynamic"` with `minimumUpdatePeriod` for live-profile MPDs
+            // even when content is finite. Players (Shaka, dash.js) then treat it as
+            // live: video.duration → Infinity, current time keeps advancing past
+            // EOF, and the watched-segments tracker sends Infinity → JSON null →
+            // backend `@Positive int` validation rejects with 400 (issue 2026-04-30).
+            command.add("--generate_static_live_mpd");
 
             runCommand(command, outputDir);
 

--- a/fe/src/app/features/learning/services/watched-segments-tracker.service.ts
+++ b/fe/src/app/features/learning/services/watched-segments-tracker.service.ts
@@ -34,6 +34,13 @@ export class WatchedSegmentsTracker implements OnDestroy {
 
   startTracking(lessonId: string, sectionId: string, duration: number, completionThreshold?: number): void {
     this.stopTracking();
+    // Reject Infinity/NaN/<=0: a dynamic-MPD live stream reports
+    // video.duration = Infinity, and Math.ceil(Infinity) = Infinity, which
+    // serializes to JSON null and trips backend `@Positive int` → 400.
+    // If we don't have a real duration, we can't track watched percent anyway.
+    if (!Number.isFinite(duration) || duration <= 0) {
+      return;
+    }
     this.currentConfig = { lessonId, sectionId, duration: Math.ceil(duration), completionThreshold };
     this.segments.clear();
     this.lastSyncedSegments.clear();


### PR DESCRIPTION
## Summary
- Shaka Packager was emitting `type=\"dynamic\"` MPDs for VOD content → Shaka Player treated as live → `video.duration = Infinity` → tracker sent `Infinity` → JSON null → backend 400.
- Add `--generate_static_live_mpd` flag to force static MPD on every package.
- Add FE tracker guard: reject non-finite or non-positive duration (silent no-op).

## Symptoms (prod 2026-04-30)
- Lesson 131cd3f7 video plays but timer keeps advancing past actual end (~36s → 60s+).
- Console floods with `POST /api/v3/video-progress/track 400 (Bad Request)` every 10s.
- Existing 4 broken packages must be re-encoded after deploy.

## Root cause chain
1. `--generate_static_live_mpd` not set → MPD `type=\"dynamic\"` + `minimumUpdatePeriod=PT5S`.
2. Shaka Player live mode → `video.duration = Infinity`.
3. `WatchedSegmentsTracker.startTracking(Infinity)` stored `Math.ceil(Infinity)`.
4. `JSON.stringify(Infinity) = \"null\"` → backend gets `durationSeconds: null`.
5. `@Positive int durationSeconds` fails deserialization → 400.

## Test plan
- [x] `mvn test -Dtest=AdaptiveVideoPlaybackServiceTest,ShakaPackagerService*` → 8/8.
- [ ] Deploy → re-trigger 4 stuck assets → verify MPD `type=\"static\"`.
- [ ] Verify lesson 131cd3f7 video plays with correct duration, no 400 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)