### PR TITLE
fix(progress): retry on dup-key race in trackSegments

### DIFF
--- a/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/TrackVideoProgressUseCase.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/TrackVideoProgressUseCase.java
@@ -5,8 +5,12 @@ import com.example.lms.learning_delivery.domain.model.VideoProgress;
 import com.example.lms.learning_delivery.domain.repository.LearningEventRepository;
 import com.example.lms.learning_delivery.domain.repository.VideoProgressRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 import java.util.Map;
@@ -18,11 +22,37 @@ public class TrackVideoProgressUseCase {
 
     private final VideoProgressRepository videoProgressRepository;
     private final LearningEventRepository learningEventRepository;
+    private final PlatformTransactionManager transactionManager;
 
-    @Transactional
     public VideoProgressDTO trackSegments(UUID studentId, UUID lessonId, String sectionId,
                                            int durationSeconds, int fromSecond, int toSecond,
                                            double lastPosition, Double completionThreshold) {
+        // FE WatchedSegmentsTracker fires multiple parallel POSTs (one per
+        // contiguous range) for the same (student, section). The previous
+        // findByStudentAndSection→save flow was a Read-Modify-Write race:
+        // both requests see no row, both call create()+save(), the second
+        // INSERT trips the unique constraint (student_id, section_id) → 500.
+        //
+        // Retry on DataIntegrityViolationException with a fresh tx — the
+        // failed tx is poisoned (cannot reuse), and on retry the row exists
+        // so we take the UPDATE branch. TransactionTemplate (vs a self-call
+        // through @Transactional) avoids Spring's self-invocation gotcha
+        // where AOP doesn't apply to method calls within the same bean.
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        tx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+        try {
+            return tx.execute(status -> doTrackSegments(studentId, lessonId, sectionId,
+                    durationSeconds, fromSecond, toSecond, lastPosition, completionThreshold));
+        } catch (DataIntegrityViolationException duplicate) {
+            return tx.execute(status -> doTrackSegments(studentId, lessonId, sectionId,
+                    durationSeconds, fromSecond, toSecond, lastPosition, completionThreshold));
+        }
+    }
+
+    private VideoProgressDTO doTrackSegments(UUID studentId, UUID lessonId, String sectionId,
+                                              int durationSeconds, int fromSecond, int toSecond,
+                                              double lastPosition, Double completionThreshold) {
         VideoProgress vp = videoProgressRepository.findByStudentAndSection(studentId, sectionId)
                 .orElseGet(() -> VideoProgress.create(studentId, lessonId, sectionId, durationSeconds));
 
@@ -35,7 +65,6 @@ public class TrackVideoProgressUseCase {
 
         VideoProgress saved = videoProgressRepository.save(vp);
 
-        // Log completion event
         if (saved.isCompleted()) {
             learningEventRepository.save(LearningEvent.create(
                     studentId, lessonId, sectionId,

--- a/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/TrackVideoProgressUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/TrackVideoProgressUseCaseTest.java
@@ -11,6 +11,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +28,7 @@ class TrackVideoProgressUseCaseTest {
 
     @Mock private VideoProgressRepository videoProgressRepository;
     @Mock private LearningEventRepository learningEventRepository;
+    @Mock private PlatformTransactionManager transactionManager;
 
     private TrackVideoProgressUseCase useCase;
 
@@ -34,7 +38,13 @@ class TrackVideoProgressUseCaseTest {
 
     @BeforeEach
     void setUp() {
-        useCase = new TrackVideoProgressUseCase(videoProgressRepository, learningEventRepository);
+        // TransactionTemplate calls getTransaction() / commit(), so stub them
+        // to behave like a no-op tx that always commits cleanly. Tests assert
+        // repository interactions, not tx semantics.
+        lenient().when(transactionManager.getTransaction(any()))
+                .thenReturn(new SimpleTransactionStatus());
+        useCase = new TrackVideoProgressUseCase(
+                videoProgressRepository, learningEventRepository, transactionManager);
     }
 
     @Test
@@ -51,6 +61,29 @@ class TrackVideoProgressUseCaseTest {
         assertThat(result.progressPercent()).isEqualTo(30.0);
         assertThat(result.completed()).isFalse();
         verify(videoProgressRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("trackSegments retries with fresh tx after duplicate-key race (parallel POSTs)")
+    void trackSegmentsRetriesAfterDuplicateKeyRace() {
+        // Regression: production 2026-04-30. FE WatchedSegmentsTracker fires
+        // multiple parallel POSTs (one per range). Both see no row → both
+        // create()+save() → 2nd INSERT trips unique (student_id, section_id)
+        // → 500. Fix: retry with REQUIRES_NEW tx so the 2nd attempt sees the
+        // row inserted by the 1st and takes the UPDATE branch.
+        VideoProgress existing = VideoProgress.create(studentId, lessonId, sectionId, 100);
+        when(videoProgressRepository.findByStudentAndSection(studentId, sectionId))
+                .thenReturn(Optional.empty())              // 1st attempt: no row
+                .thenReturn(Optional.of(existing));        // 2nd attempt: row now exists
+        when(videoProgressRepository.save(any()))
+                .thenThrow(new DataIntegrityViolationException("dup key (student_id, section_id)"))
+                .thenAnswer(inv -> inv.getArgument(0));
+
+        var result = useCase.trackSegments(studentId, lessonId, sectionId, 100, 0, 30, 30.0, null);
+
+        assertThat(result.watchedSeconds()).isEqualTo(30);
+        verify(videoProgressRepository, times(2)).findByStudentAndSection(studentId, sectionId);
+        verify(videoProgressRepository, times(2)).save(any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
500 spam on `POST /api/v3/video-progress/track` confirmed in prod logs. Classic Read-Modify-Write race when FE fires parallel POSTs for contiguous ranges in the same sync cycle.

## Root cause
\`\`\`
duplicate key value violates unique constraint
\"video_progress_student_id_section_id_key\"
Detail: Key (student_id, section_id)=(c194..., 74c6...) already exists.
\`\`\`

Both in-flight requests pass \`findByStudentAndSection\` (empty), both call \`create()\`, both \`save()\`. First INSERT wins, second blows up the unique constraint → 500.

## Fix
Wrap read-modify-write in \`TransactionTemplate(REQUIRES_NEW)\`, retry once on \`DataIntegrityViolationException\`. Retry sees the row inserted by the winning request and takes UPDATE branch.

Used \`TransactionTemplate\` vs \`@Transactional\` self-call to dodge Spring AOP self-invocation gotcha (inner annotation would silently no-op).

## Test plan
- [x] \`mvn test -Dtest=TrackVideoProgressUseCaseTest\` → 13/13 pass
- [x] New regression test asserts 2x find + 2x save when first save throws dup-key
- [ ] Post-deploy: video playback no longer floods 500s on /track

🤖 Generated with [Claude Code](https://claude.com/claude-code)