### PR TITLE
fix(preview): authors get draft lesson detail, not stale published snapshot

### DIFF
--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
@@ -412,6 +412,17 @@ public class CourseQueryControllerV3 {
             @PathVariable UUID lessonId,
             @AuthenticationPrincipal UserJpaEntity currentUser
     ) {
+        // Authors (teacher owner, ADMIN, ORG_ADMIN) get the live draft so the
+        // /preview surface reflects unsaved-since-publish changes (e.g. new
+        // sections added in the editor). Students/learners get the published
+        // snapshot below. Without this branch, sidebar reads draft (N sections)
+        // but lesson detail returns published snapshot (older N-1 sections),
+        // and clicking the new section leaves currentSection() null → blank
+        // video frame (issue 2026-04-30: YouTube section invisible in preview).
+        if (shouldPreferDraftLessonView(lessonId, currentUser)) {
+            return loadDraftLessonDetail(lessonId, currentUser);
+        }
+
         try {
             LessonDetailResponse publishedLesson = getPublishedLessonDetail(lessonId, currentUser);
             if (publishedLesson != null) {
@@ -421,6 +432,31 @@ public class CourseQueryControllerV3 {
             // Published path failed — fall through to draft query
         }
 
+        return loadDraftLessonDetail(lessonId, currentUser);
+    }
+
+    private boolean shouldPreferDraftLessonView(UUID lessonId, UserJpaEntity currentUser) {
+        if (currentUser == null) {
+            return false;
+        }
+        if (isSystemAdminRole(currentUser) || isOrgAdminRole(currentUser)) {
+            return true;
+        }
+        if (currentUser.getRole() != UserJpaEntity.UserRole.TEACHER) {
+            return false;
+        }
+        // Teacher only sees draft for courses they own. Avoids leaking another
+        // teacher's unpublished work-in-progress.
+        return lessonRepository.findById(lessonId)
+                .flatMap(lesson -> chapterRepository.findById(lesson.getChapterId()))
+                .flatMap(chapter -> courseRepository.findById(chapter.getCourseId()))
+                .map(course -> course.getTeacherId() != null
+                        && course.getTeacherId().equals(currentUser.getId()))
+                .orElse(false);
+    }
+
+    private ResponseEntity<ApiResponse<LessonDetailResponse>> loadDraftLessonDetail(
+            UUID lessonId, UserJpaEntity currentUser) {
         // Query chain: Lesson -> Chapter -> Course (3 indexed queries, no nested loops)
         return lessonRepository.findById(lessonId)
                 .flatMap(lesson -> chapterRepository.findById(lesson.getChapterId())


### PR DESCRIPTION
## Summary
Teacher adds a section in the editor → opens \`/teacher/courses/X/preview\` → sidebar shows it but the content area is blank. The new section is missing from the published snapshot, and \`getLessonById\` was returning the snapshot instead of the live draft.

## Root cause
- Sidebar reads draft (\`lessons.content_blocks\` — N items)
- Lesson detail returned published snapshot (frozen at last publish — N-1 items)
- Frontend section index N-1 falls out of bounds → \`currentSection()\` is null → \`@if\` guards skip render → blank video frame

## Fix
\`shouldPreferDraftLessonView\` returns true for:
- ADMIN, ORG_ADMIN (already had authoring scope)
- TEACHER who owns this specific course (\`course.teacherId == currentUser.id\`)

Other teachers viewing someone else's course still see the published snapshot. Students unaffected.

Existing fallback draft path was extracted into \`loadDraftLessonDetail\` so both the new author-prefers-draft branch and the existing \"published was empty\" fallback share one implementation.

## Test plan
- [x] \`mvn test\` → 1107/1107 pass
- [ ] Post-deploy: course owner adds section → /preview shows it without re-publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)