### PR TITLE
fix(csp): embed CSP meta + freshness nav strategy

### DIFF
--- a/fe/ngsw-config.json
+++ b/fe/ngsw-config.json
@@ -100,5 +100,6 @@
     "!/api/**",
     "!/actuator/**"
   ],
-  "navigationRequestStrategy": "performance"
+  "_comment_navigation": "freshness (network-first) over performance (cache-first): HTML carries response headers (CSP, Cache-Control, security policy). With cache-first, server-side header policy changes never reach already-installed users — they keep enforcing the CSP/policy frozen at SW install time. Trade-off: ~30-100ms HTML latency vs always-correct security policy. CSP cache-stale bug 2026-05-02 (YouTube iframe API blocked by old CSP cached pre-fix) made the case for freshness.",
+  "navigationRequestStrategy": "freshness"
 }

--- a/fe/src/index.html
+++ b/fe/src/index.html
@@ -12,6 +12,22 @@
   <!-- Search Engine Verification (redundant với BingSiteAuth.xml + GSC DNS verify) -->
   <meta name="msvalidate.01" content="08B9D89FB9A6880E0769B1C6834F5297" />
 
+  <!--
+    Content Security Policy — embedded in HTML body so it travels with every
+    cached HTML response (NGSW, browser disk cache, CDN). Defense against
+    "stale CSP" bug: server-side CSP changes (Caddy header) only reach NEW
+    requests; cached HTML keeps OLD CSP forever otherwise. By baking CSP
+    into the HTML bytes, any change here flips the bundle hash → ngsw.json
+    invalidates → SW auto-updates → users get new policy without manual
+    /clear-site-data step.
+
+    Spec: meta + header CSPs are intersected (most restrictive wins). Keep
+    this list ⊇ Caddyfile to avoid accidentally removing allowed origins.
+    Header-only directives (frame-ancestors, report-to) live in Caddy only.
+  -->
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://www.youtube.com https://s.ytimg.com; style-src 'self' 'unsafe-inline' https://accounts.google.com https://fonts.googleapis.com; img-src 'self' data: blob: https: https://ui-avatars.com; connect-src 'self' https://accounts.google.com https://lh3.googleusercontent.com https://ui-avatars.com https://fonts.googleapis.com https://fonts.gstatic.com https://wiii.holilihu.online https://cdn.holilihu.online https://media.holilihu.online https://*.r2.cloudflarestorage.com https://sandbox.vnpayment.vn https://pay.vnpay.vn https://qr.sepay.vn https://videodelivery.net wss:; media-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https: blob:; object-src 'none'; base-uri 'self';">
+
   <!-- PWA Meta Tags -->
   <meta name="theme-color" content="#0056D2">
   <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
## Problem
User's Chrome enforces OLD CSP (3 directives, pre-PR-#317) despite Caddy serving NEW CSP (4 directives, includes youtube.com). YouTube IFrame API blocked.

## Root cause chain
1. NGSW \`navigationRequestStrategy: \"performance\"\` serves cached HTML first
2. Cached HTML has OLD CSP response headers from before fix
3. Caddyfile-only edit doesn't change any FE-bundled file hash
4. ngsw.json hash unchanged → SW thinks it's up-to-date → never invalidates HTML cache
5. CSP at edge only = single point of failure for cache invalidation

## SOTA fix (Vercel/Cloudflare/Angular SW docs)
Defense in depth across 3 layers:

**Layer 1 — meta CSP in index.html**: travels with HTML bytes. Any CSP edit flips ngsw.json hash → auto SW update.

**Layer 2 — freshness navigation strategy**: HTML network-first. Future header policy changes reach users immediately. Cost: ~30-100ms HTML TTFB.

**Layer 3 — Caddy header** (unchanged): header-only directives (frame-ancestors, report-to). Defense alongside meta.

Browser intersects meta+header CSP (most restrictive wins). Both lists identical → identity → no breakage.

## Test plan
- [x] meta CSP includes all directives from Caddy
- [ ] Post-deploy: existing users get new SW automatically
- [ ] YouTube IFrame API loads without CSP violation
- [ ] Future CSP changes propagate without manual /clear-site-data

🤖 Generated with [Claude Code](https://claude.com/claude-code)