### PR TITLE
fix(player): editor quiz-video-player falls back to DASH when HLS load fails

### DIFF
--- a/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
+++ b/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
@@ -280,7 +280,19 @@ export class QuizVideoPlayerComponent {
       this.isLoading.set(false);
     });
 
-    await player.load(manifestUrl);
+    try {
+      await player.load(manifestUrl);
+    } catch (hlsError) {
+      // Shaka HLS support occasionally trips on multivariant manifests with
+      // I-frame playlists; DASH is the canonical fallback from the same
+      // Shaka Packager output. Mirrors adaptive-video-player.component.ts.
+      const assetId = this.videoAssetId();
+      if (!assetId) throw hlsError;
+      const dashRes: any = await firstValueFrom(this.videoAssetApi.getPlayUrl(assetId, 'dash'));
+      const dashUrl = (dashRes?.data ?? dashRes)?.playUrl;
+      if (!dashUrl || dashUrl === manifestUrl) throw hlsError;
+      await player.load(dashUrl);
+    }
     this.shakaPlayer = player;
     this.syncQuality(player);
     this.isLoading.set(false);


### PR DESCRIPTION
## Summary

Teacher curriculum editor's video preview throws **"Không thể chuẩn bị video."** for sections whose video asset is fully `READY/READY` on the server. Root cause is **client-side path divergence**: editor uses `quiz-video-player.component.ts` (shared block) which lacks the HLS→DASH fallback that lesson-side `adaptive-video-player.component.ts` has.

When `await player.load(hlsManifestUrl)` rejected for any reason (Shaka v5 HLS edge cases on multivariant + I-frame playlists, transient network), the rejection propagated to the outer catch and surfaced the generic fallback string — even though backend was healthy and DASH playback would have succeeded.

## Verified on production (asset `ea829fee-be0c-45d2-9a72-998b5c73776d`)

- `video_assets` row: `status=READY, adaptive_packaging_status=READY`, both manifest keys set
- 4 renditions all READY (SAVER/STANDARD/HIGH/ORIGINAL)
- `GET /api/v3/sections/{id}/video/play` → HTTP 200 with valid `playUrl`
- `GET /api/v3/lessons/{id}/video/play` → HTTP 200
- HLS master.m3u8 → HTTP 200, valid multi-variant manifest (audio + 3 video variants + I-frame playlists), content-type `application/vnd.apple.mpegurl;charset=UTF-8`
- HLS variant playlist → HTTP 200, 6 segments
- Segment HEAD → HTTP 200, 406KB

So the bug is **exclusively** in the editor player code path.

## Fix

Wrap `player.load(hlsManifestUrl)` in try/catch. On failure, fetch DASH playUrl via `videoAssetApi.getPlayUrl(assetId, 'dash')` and retry `player.load(dashUrl)`. Both URLs come from the same Shaka Packager output so this is the canonical fallback. **Mirrors the working lesson-side player at `adaptive-video-player.component.ts:536-554`.**

13 lines added, 1 removed. Karpathy-aligned: surgical, no adjacent changes (retry params, pre-validation guards, comment about Chrome STATUS_BREAKPOINT incident all preserved).

## Test plan

- [ ] Teacher opens curriculum editor for a lesson with uploaded video → video plays without "Không thể chuẩn bị video"
- [ ] Existing lesson-side playback continues to work (this PR only touches editor player)
- [ ] Network tab: if HLS first attempt 4xx, see fallback DASH request to `/api/v3/video-assets/{id}/play?format=dash`
- [ ] No regression in offline-prepared videos (resolveSource path with assetId returns same URL)

## Out of scope

- **Bug 2 (transcoding speed)**: measured via DB on prod — 10 latest videos process at avg 6.2x realtime (45-105s for 5-11min videos). 36s video processes in ~6s. This is mid-tier acceptable for `libx264 veryfast` on a shared 2-vCPU VM. No surgical fix warranted; GPU NVENC would require infra cost decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)