### PR TITLE
feat(curriculum): batch video upload — auto-distribute + drag-drop preview

### DIFF
--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-distribution.util.spec.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-distribution.util.spec.ts
@@ -1,0 +1,225 @@
+import {
+  DistributableLesson,
+  distributeByFilenamePrefix,
+  distributeEvenly,
+  extractFilenameTitle,
+} from './batch-distribution.util';
+
+const FOUR_LESSONS: DistributableLesson[] = [
+  { id: 'L1', orderIndex: 1 },
+  { id: 'L2', orderIndex: 2 },
+  { id: 'L3', orderIndex: 3 },
+  { id: 'L4', orderIndex: 4 },
+];
+
+const THREE_LESSONS: DistributableLesson[] = [
+  { id: 'L1', orderIndex: 1 },
+  { id: 'L2', orderIndex: 2 },
+  { id: 'L3', orderIndex: 3 },
+];
+
+function fileNamed(name: string): File {
+  return new File([''], name, { type: 'video/mp4' });
+}
+
+describe('distributeEvenly', () => {
+  it('user case: 23 video / 4 bài → [6, 6, 6, 5]', () => {
+    const items = Array.from({ length: 23 }, (_, i) => `v${i}`);
+    const result = distributeEvenly(items, FOUR_LESSONS);
+    expect(result.get('L1')?.length).toBe(6);
+    expect(result.get('L2')?.length).toBe(6);
+    expect(result.get('L3')?.length).toBe(6);
+    expect(result.get('L4')?.length).toBe(5);
+    const total = [...result.values()].reduce((sum, arr) => sum + arr.length, 0);
+    expect(total).toBe(23);
+  });
+
+  it('chia chẵn: 12 / 4 → [3, 3, 3, 3]', () => {
+    const result = distributeEvenly(
+      Array.from({ length: 12 }, (_, i) => i),
+      FOUR_LESSONS
+    );
+    expect([...result.values()].map((a) => a.length)).toEqual([3, 3, 3, 3]);
+  });
+
+  it('chia chẵn: 100 / 10 → mỗi bài 10', () => {
+    const lessons: DistributableLesson[] = Array.from({ length: 10 }, (_, i) => ({
+      id: `L${i}`,
+      orderIndex: i + 1,
+    }));
+    const result = distributeEvenly(
+      Array.from({ length: 100 }, (_, i) => i),
+      lessons
+    );
+    expect([...result.values()].every((a) => a.length === 10)).toBe(true);
+  });
+
+  it('N < M: bài cuối có 0 video', () => {
+    const result = distributeEvenly([1, 2], FOUR_LESSONS);
+    expect(result.get('L1')?.length).toBe(1);
+    expect(result.get('L2')?.length).toBe(1);
+    expect(result.get('L3')?.length).toBe(0);
+    expect(result.get('L4')?.length).toBe(0);
+  });
+
+  it('items rỗng → mỗi bài có mảng rỗng', () => {
+    const result = distributeEvenly([], FOUR_LESSONS);
+    expect(result.size).toBe(4);
+    expect([...result.values()].every((a) => a.length === 0)).toBe(true);
+  });
+
+  it('lessons rỗng → Map rỗng', () => {
+    const result = distributeEvenly([1, 2, 3], []);
+    expect(result.size).toBe(0);
+  });
+
+  it('respect orderIndex bất kể input order', () => {
+    const reordered: DistributableLesson[] = [
+      { id: 'Z', orderIndex: 1 },
+      { id: 'A', orderIndex: 2 },
+      { id: 'M', orderIndex: 3 },
+    ];
+    const result = distributeEvenly([1, 2, 3, 4, 5, 6, 7], reordered);
+    expect(result.get('Z')).toEqual([1, 2, 3]);
+    expect(result.get('A')).toEqual([4, 5]);
+    expect(result.get('M')).toEqual([6, 7]);
+  });
+
+  it('1 lesson nhận hết khi M=1', () => {
+    const oneLesson: DistributableLesson[] = [{ id: 'X', orderIndex: 1 }];
+    const result = distributeEvenly([1, 2, 3, 4, 5], oneLesson);
+    expect(result.get('X')).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('không mutate input array', () => {
+    const items = [1, 2, 3, 4, 5];
+    const lessons = [{ id: 'L1', orderIndex: 2 }, { id: 'L2', orderIndex: 1 }];
+    distributeEvenly(items, lessons);
+    expect(items).toEqual([1, 2, 3, 4, 5]);
+    expect(lessons[0].id).toBe('L1');
+  });
+});
+
+describe('distributeByFilenamePrefix', () => {
+  it('match đầy đủ: "01_x", "02_x", "03_x" → group đúng theo prefix', () => {
+    const files = [
+      fileNamed('01_intro.mp4'),
+      fileNamed('01_part2.mp4'),
+      fileNamed('02_drill.mp4'),
+      fileNamed('03_quiz.mp4'),
+    ];
+    const result = distributeByFilenamePrefix(files, THREE_LESSONS);
+    expect(result?.get('L1')?.map((f) => f.name)).toEqual(['01_intro.mp4', '01_part2.mp4']);
+    expect(result?.get('L2')?.map((f) => f.name)).toEqual(['02_drill.mp4']);
+    expect(result?.get('L3')?.map((f) => f.name)).toEqual(['03_quiz.mp4']);
+  });
+
+  it('separator đa dạng: "1-", "01.", "01 ", "01_" đều detect', () => {
+    const files = [
+      fileNamed('1-intro.mp4'),
+      fileNamed('01.test.mp4'),
+      fileNamed('2 video.mp4'),
+      fileNamed('02_lesson.mp4'),
+    ];
+    const result = distributeByFilenamePrefix(files, THREE_LESSONS);
+    expect(result?.get('L1')?.length).toBe(2);
+    expect(result?.get('L2')?.length).toBe(2);
+    expect(result?.get('L3')?.length).toBe(0);
+  });
+
+  it('< 50% match prefix → trả undefined để caller fallback', () => {
+    const files = [
+      fileNamed('01_intro.mp4'),
+      fileNamed('hello.mp4'),
+      fileNamed('world.mp4'),
+      fileNamed('video.mp4'),
+    ];
+    expect(distributeByFilenamePrefix(files, THREE_LESSONS)).toBeUndefined();
+  });
+
+  it('exactly 50% match → vẫn detect', () => {
+    const files = [fileNamed('01_a.mp4'), fileNamed('02_b.mp4'), fileNamed('x.mp4'), fileNamed('y.mp4')];
+    const result = distributeByFilenamePrefix(files, THREE_LESSONS);
+    expect(result).toBeDefined();
+    expect(result?.get('L3')?.map((f) => f.name).sort()).toEqual(['x.mp4', 'y.mp4']);
+  });
+
+  it('không có file → undefined', () => {
+    expect(distributeByFilenamePrefix([], THREE_LESSONS)).toBeUndefined();
+  });
+
+  it('không có lesson → undefined', () => {
+    expect(distributeByFilenamePrefix([fileNamed('01.mp4')], [])).toBeUndefined();
+  });
+
+  it('số prefix > số bài → prefixes thừa dồn vào bài cuối', () => {
+    const files = [
+      fileNamed('01.mp4'),
+      fileNamed('02.mp4'),
+      fileNamed('03.mp4'),
+      fileNamed('04.mp4'),
+      fileNamed('05.mp4'),
+    ];
+    const result = distributeByFilenamePrefix(files, THREE_LESSONS);
+    expect(result?.get('L1')?.map((f) => f.name)).toEqual(['01.mp4']);
+    expect(result?.get('L2')?.map((f) => f.name)).toEqual(['02.mp4']);
+    expect(result?.get('L3')?.map((f) => f.name)).toEqual(['03.mp4', '04.mp4', '05.mp4']);
+  });
+
+  it('unmatched files dồn vào bài cuối', () => {
+    const files = [
+      fileNamed('01_a.mp4'),
+      fileNamed('02_b.mp4'),
+      fileNamed('03_c.mp4'),
+      fileNamed('extra.mp4'),
+    ];
+    const result = distributeByFilenamePrefix(files, THREE_LESSONS);
+    expect(result?.get('L3')?.map((f) => f.name)).toEqual(['03_c.mp4', 'extra.mp4']);
+  });
+
+  it('digits liền chữ vẫn detect: "01video.mp4"', () => {
+    const files = [fileNamed('01video.mp4'), fileNamed('02clip.mp4')];
+    const result = distributeByFilenamePrefix(files, THREE_LESSONS);
+    expect(result?.get('L1')?.length).toBe(1);
+    expect(result?.get('L2')?.length).toBe(1);
+  });
+
+  it('digit ở giữa tên KHÔNG match: "video01.mp4"', () => {
+    const files = [fileNamed('video01.mp4'), fileNamed('clip02.mp4')];
+    expect(distributeByFilenamePrefix(files, THREE_LESSONS)).toBeUndefined();
+  });
+});
+
+describe('extractFilenameTitle', () => {
+  it('strip MP4 extension', () => {
+    expect(extractFilenameTitle('intro.mp4')).toBe('intro');
+  });
+
+  it('strip MOV extension (case-preserve)', () => {
+    expect(extractFilenameTitle('video.MOV')).toBe('video');
+  });
+
+  it('preserve dots trong tên', () => {
+    expect(extractFilenameTitle('my.video.with.dots.mp4')).toBe('my.video.with.dots');
+  });
+
+  it('trim whitespace ở đầu/cuối', () => {
+    expect(extractFilenameTitle('  hello.mp4  ')).toBe('hello');
+  });
+
+  it('không có extension → giữ nguyên', () => {
+    expect(extractFilenameTitle('README')).toBe('README');
+  });
+
+  it('hidden file → không strip (extension là cả tên)', () => {
+    expect(extractFilenameTitle('.gitignore')).toBe('.gitignore');
+  });
+
+  it('empty string → empty', () => {
+    expect(extractFilenameTitle('')).toBe('');
+  });
+
+  it('Vietnamese diacritics preserved', () => {
+    expect(extractFilenameTitle('Bài giảng số 1.mp4')).toBe('Bài giảng số 1');
+  });
+});

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-distribution.util.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-distribution.util.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure distribution algorithms for batch video upload.
+ *
+ * Strategies:
+ *  - distributeEvenly: chia N item cho M bucket theo công thức floor + remainder
+ *  - distributeByFilenamePrefix: detect tiền tố số ở đầu tên file (Coursera pattern)
+ *  - extractFilenameTitle: strip extension cho default section title
+ */
+
+export interface DistributableLesson {
+  id: string;
+  orderIndex: number;
+}
+
+/**
+ * Chia N item cho M bucket. Bucket đầu nhận thêm 1 nếu N mod M > 0.
+ * Sort theo orderIndex để output ổn định bất kể input order của lessons.
+ *
+ * Ví dụ: N=23, M=4 → [6, 6, 6, 5]
+ *        N=10, M=4 → [3, 3, 2, 2]
+ *        N=2,  M=4 → [1, 1, 0, 0]   (bài cuối có thể trống)
+ *
+ * Lessons rỗng → Map rỗng (caller phải xử lý: tạo bài mới hoặc báo lỗi).
+ */
+export function distributeEvenly<T>(items: T[], lessons: DistributableLesson[]): Map<string, T[]> {
+  const result = new Map<string, T[]>();
+  if (lessons.length === 0) return result;
+
+  const sorted = [...lessons].sort((a, b) => a.orderIndex - b.orderIndex);
+  const n = items.length;
+  const m = sorted.length;
+  const base = Math.floor(n / m);
+  const extra = n % m;
+
+  let cursor = 0;
+  for (let i = 0; i < m; i++) {
+    const count = base + (i < extra ? 1 : 0);
+    result.set(sorted[i].id, items.slice(cursor, cursor + count));
+    cursor += count;
+  }
+  return result;
+}
+
+/**
+ * Detect filename prefix dạng "01_xx", "1-xx", "01.xx", "01 xx" (Coursera pattern).
+ * Group files theo prefix, assign vào lessons theo thứ tự prefix tăng dần.
+ *
+ * Trả undefined nếu < 50% file match prefix (signal cho caller fallback sang
+ * distributeEvenly). Quy ước này tránh assign tệ khi user chỉ vô tình đặt 1-2
+ * file có tiền tố số.
+ *
+ * Files không match prefix → dồn vào bài cuối cùng.
+ * Số prefix > số bài → prefixes thừa dồn vào bài cuối.
+ */
+export function distributeByFilenamePrefix(
+  files: File[],
+  lessons: DistributableLesson[]
+): Map<string, File[]> | undefined {
+  if (lessons.length === 0 || files.length === 0) return undefined;
+
+  const matched: Array<{ file: File; prefix: number }> = [];
+  const unmatched: File[] = [];
+
+  for (const file of files) {
+    const m = file.name.match(/^(\d+)/);
+    if (m) {
+      matched.push({ file, prefix: parseInt(m[1], 10) });
+    } else {
+      unmatched.push(file);
+    }
+  }
+
+  if (matched.length < files.length / 2) return undefined;
+
+  const sortedLessons = [...lessons].sort((a, b) => a.orderIndex - b.orderIndex);
+  const result = new Map<string, File[]>();
+  for (const lesson of sortedLessons) result.set(lesson.id, []);
+
+  const byPrefix = new Map<number, File[]>();
+  for (const { file, prefix } of matched) {
+    const bucket = byPrefix.get(prefix);
+    if (bucket) {
+      bucket.push(file);
+    } else {
+      byPrefix.set(prefix, [file]);
+    }
+  }
+
+  const prefixesAsc = [...byPrefix.keys()].sort((a, b) => a - b);
+  for (let i = 0; i < prefixesAsc.length; i++) {
+    const lessonIdx = Math.min(i, sortedLessons.length - 1);
+    const bucket = result.get(sortedLessons[lessonIdx].id)!;
+    bucket.push(...byPrefix.get(prefixesAsc[i])!);
+  }
+
+  if (unmatched.length > 0) {
+    const lastLesson = sortedLessons[sortedLessons.length - 1];
+    result.get(lastLesson.id)!.push(...unmatched);
+  }
+
+  return result;
+}
+
+/**
+ * Strip extension cho section title default. Trim whitespace.
+ * Hidden file (".gitignore") → giữ nguyên (extension là toàn bộ tên).
+ */
+export function extractFilenameTitle(filename: string): string {
+  const trimmed = filename.trim();
+  const lastDot = trimmed.lastIndexOf('.');
+  if (lastDot <= 0) return trimmed;
+  return trimmed.substring(0, lastDot);
+}

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-upload-preview-tree.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-upload-preview-tree.component.ts
@@ -1,0 +1,272 @@
+import {
+  CdkDrag,
+  CdkDragDrop,
+  CdkDragHandle,
+  CdkDropList,
+  moveItemInArray,
+  transferArrayItem,
+} from '@angular/cdk/drag-drop';
+import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
+import { BatchTargetLesson, BatchVideoItem } from './batch-video-upload.types';
+
+/**
+ * Vertical tree view: lessons làm group, videos là draggable item bên trong.
+ * Hỗ trợ cross-lesson drag-drop + reorder + inline edit title + remove + retry.
+ *
+ * Dùng được cho cả Stage 2 (PREVIEW — user xếp lại) và Stage 3 (PROGRESS —
+ * status hiển thị real-time, drag bị disable).
+ */
+@Component({
+  selector: 'app-batch-upload-preview-tree',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CdkDropList, CdkDrag, CdkDragHandle],
+  template: `
+    <div class="space-y-3">
+      @for (lesson of lessons(); track lesson.id) {
+        @let lessonItems = itemsByLessonId()[lesson.id] ?? [];
+        <div class="rounded-lg border border-gray-200 bg-white overflow-hidden">
+          <div class="px-4 py-2 border-b border-gray-100 bg-slate-50 flex items-center justify-between">
+            <div class="text-sm font-medium text-gray-900 flex items-center gap-2">
+              <span class="text-gray-400">📚</span>
+              <span>{{ lesson.title }}</span>
+              @if (lesson.existingSectionCount > 0) {
+                <span class="text-xs text-gray-500">({{ lesson.existingSectionCount }} mục có sẵn)</span>
+              }
+            </div>
+            <span class="text-xs font-medium text-gray-600">
+              {{ lessonItems.length }} video
+            </span>
+          </div>
+
+          <div
+            cdkDropList
+            [id]="'drop-' + lesson.id"
+            [cdkDropListData]="lessonItems"
+            [cdkDropListConnectedTo]="allDropListIds()"
+            (cdkDropListDropped)="onDrop($event)"
+            class="min-h-[56px]"
+          >
+            @for (item of lessonItems; track item.id) {
+              <div
+                cdkDrag
+                [cdkDragData]="item.id"
+                [cdkDragDisabled]="!isDraggable(item)"
+                class="px-3 py-2.5 flex items-center gap-3 border-b border-gray-50 last:border-b-0 hover:bg-slate-50/50"
+                [class.opacity-60]="item.status === 'READY'"
+              >
+                @if (isDraggable(item)) {
+                  <span cdkDragHandle class="cursor-move text-gray-300 select-none px-1" aria-label="Kéo để di chuyển">⋮⋮</span>
+                } @else {
+                  <span class="text-gray-200 px-1 select-none">⋮⋮</span>
+                }
+
+                <span class="text-lg flex-shrink-0">{{ statusIcon(item) }}</span>
+
+                <div class="flex-1 min-w-0">
+                  @if (editingId() === item.id) {
+                    <input
+                      type="text"
+                      [value]="item.sectionTitle"
+                      (blur)="commitTitle(item.id, $any($event.target).value)"
+                      (keydown.enter)="commitTitle(item.id, $any($event.target).value)"
+                      (keydown.escape)="editingId.set(null)"
+                      class="w-full text-sm border-b border-[#0056D2] focus:outline-none px-1 py-0.5"
+                    />
+                  } @else {
+                    <button
+                      type="button"
+                      class="text-sm font-medium text-gray-900 truncate w-full text-left hover:text-[#0056D2] hover:underline"
+                      (click)="onTitleClick(item)"
+                      [disabled]="item.status !== 'PENDING'"
+                    >
+                      {{ item.sectionTitle }}
+                    </button>
+                  }
+                  <div class="text-xs text-gray-500 flex items-center gap-2 mt-0.5 truncate">
+                    <span class="truncate">{{ item.file.name }}</span>
+                    <span class="text-gray-300">·</span>
+                    <span class="flex-shrink-0">{{ formatBytes(item.file.size) }}</span>
+                    <span class="text-gray-300">·</span>
+                    <span class="flex-shrink-0" [class]="statusColor(item)">{{ statusLabel(item) }}</span>
+                  </div>
+                  @if (item.status === 'UPLOADING') {
+                    <div class="mt-1.5 h-1 bg-gray-100 rounded-full overflow-hidden">
+                      <div
+                        class="h-full bg-[#0056D2] transition-all duration-200"
+                        [style.width.%]="item.uploadProgress"
+                      ></div>
+                    </div>
+                  }
+                  @if (item.status === 'FAILED' && item.errorMessage) {
+                    <div class="mt-1 text-xs text-red-600 truncate" [title]="item.errorMessage">
+                      {{ item.errorMessage }}
+                    </div>
+                  }
+                </div>
+
+                <div class="flex items-center gap-1 flex-shrink-0">
+                  @if (item.status === 'FAILED') {
+                    <button
+                      type="button"
+                      (click)="retryRequested.emit(item.id)"
+                      class="text-xs text-[#0056D2] hover:bg-[#0056D2]/10 rounded px-2 py-1"
+                    >
+                      Thử lại
+                    </button>
+                  }
+                  @if (item.status === 'PENDING' || item.status === 'FAILED') {
+                    <button
+                      type="button"
+                      (click)="removeRequested.emit(item.id)"
+                      class="text-gray-400 hover:text-red-500 hover:bg-red-50 rounded p-1 text-sm"
+                      aria-label="Xoá khỏi danh sách"
+                    >
+                      ✕
+                    </button>
+                  }
+                </div>
+              </div>
+            } @empty {
+              <div class="px-3 py-6 text-xs text-center text-gray-400 italic">
+                Kéo thả video vào đây
+              </div>
+            }
+          </div>
+        </div>
+      }
+
+      @if (showCreateLessonButton()) {
+        <button
+          type="button"
+          (click)="newLessonRequested.emit()"
+          class="w-full px-4 py-3 border-2 border-dashed border-gray-300 rounded-lg text-sm text-gray-600 hover:bg-slate-50 hover:border-[#0056D2] hover:text-[#0056D2] transition-colors"
+        >
+          + Tạo bài mới
+        </button>
+      }
+    </div>
+  `,
+})
+export class BatchUploadPreviewTreeComponent {
+  readonly lessons = input.required<BatchTargetLesson[]>();
+  readonly items = input.required<BatchVideoItem[]>();
+  readonly showCreateLessonButton = input(true);
+
+  readonly itemMoved = output<{ itemId: string; targetLessonId: string; targetIndex: number }>();
+  readonly removeRequested = output<string>();
+  readonly retryRequested = output<string>();
+  readonly titleChanged = output<{ itemId: string; title: string }>();
+  readonly newLessonRequested = output<void>();
+
+  readonly editingId = signal<string | null>(null);
+
+  readonly itemsByLessonId = computed<Record<string, BatchVideoItem[]>>(() => {
+    const map: Record<string, BatchVideoItem[]> = {};
+    for (const lesson of this.lessons()) {
+      map[lesson.id] = [];
+    }
+    for (const item of this.items()) {
+      if (!map[item.lessonId]) map[item.lessonId] = [];
+      map[item.lessonId].push(item);
+    }
+    return map;
+  });
+
+  readonly allDropListIds = computed(() => this.lessons().map((l) => 'drop-' + l.id));
+
+  isDraggable(item: BatchVideoItem): boolean {
+    return item.status === 'PENDING';
+  }
+
+  onTitleClick(item: BatchVideoItem): void {
+    if (item.status !== 'PENDING') return;
+    this.editingId.set(item.id);
+  }
+
+  commitTitle(itemId: string, value: string): void {
+    const trimmed = (value ?? '').trim();
+    if (trimmed) {
+      this.titleChanged.emit({ itemId, title: trimmed });
+    }
+    this.editingId.set(null);
+  }
+
+  onDrop(event: CdkDragDrop<BatchVideoItem[]>): void {
+    const itemId = event.item.data as string;
+    const targetLessonId = (event.container.id ?? '').replace(/^drop-/, '');
+    if (!targetLessonId) return;
+
+    if (event.previousContainer === event.container) {
+      // Reorder within same lesson — just emit final position
+      moveItemInArray(event.container.data, event.previousIndex, event.currentIndex);
+      this.itemMoved.emit({ itemId, targetLessonId, targetIndex: event.currentIndex });
+    } else {
+      // Cross-lesson move
+      transferArrayItem(
+        event.previousContainer.data,
+        event.container.data,
+        event.previousIndex,
+        event.currentIndex
+      );
+      this.itemMoved.emit({ itemId, targetLessonId, targetIndex: event.currentIndex });
+    }
+  }
+
+  formatBytes(bytes: number): string {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(0) + ' KB';
+    if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+    return (bytes / (1024 * 1024 * 1024)).toFixed(2) + ' GB';
+  }
+
+  statusIcon(item: BatchVideoItem): string {
+    switch (item.status) {
+      case 'PENDING':
+        return '🎬';
+      case 'UPLOADING':
+        return '⬆️';
+      case 'ASSET_CREATING':
+      case 'SECTION_CREATING':
+        return '⏳';
+      case 'PROCESSING':
+        return '🔄';
+      case 'READY':
+        return '✅';
+      case 'FAILED':
+        return '❌';
+    }
+  }
+
+  statusLabel(item: BatchVideoItem): string {
+    switch (item.status) {
+      case 'PENDING':
+        return 'Chờ';
+      case 'UPLOADING':
+        return `Đang upload ${item.uploadProgress}%`;
+      case 'ASSET_CREATING':
+        return 'Đang đăng ký';
+      case 'SECTION_CREATING':
+        return 'Đang tạo mục';
+      case 'PROCESSING':
+        return 'Đang xử lý';
+      case 'READY':
+        return 'Sẵn sàng';
+      case 'FAILED':
+        return 'Lỗi';
+    }
+  }
+
+  statusColor(item: BatchVideoItem): string {
+    switch (item.status) {
+      case 'READY':
+        return 'text-emerald-600';
+      case 'FAILED':
+        return 'text-red-600';
+      case 'PROCESSING':
+      case 'UPLOADING':
+        return 'text-[#0056D2]';
+      default:
+        return 'text-gray-500';
+    }
+  }
+}

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload-modal.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload-modal.component.ts
@@ -1,0 +1,450 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostListener,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { BatchUploadPreviewTreeComponent } from './batch-upload-preview-tree.component';
+import { BatchVideoUploadService } from './batch-video-upload.service';
+import {
+  BatchScope,
+  BatchTargetLesson,
+  BatchUploadConfig,
+  DistributionStrategy,
+} from './batch-video-upload.types';
+
+/**
+ * Modal shell cho batch upload — 3 stage state machine:
+ *  1. PICK: drop zone + scope/strategy chooser
+ *  2. PREVIEW: tree view (xếp lại) + confirm
+ *  3. UPLOADING: progress tree + aggregate stats + close-and-continue
+ *
+ * Service singleton (BatchVideoUploadService) giữ state khi modal đóng → user
+ * có thể navigate khỏi modal mà upload vẫn chạy nền (background safety).
+ *
+ * Reuse 100% existing services + store. KHÔNG refactor adjacent code.
+ */
+@Component({
+  selector: 'app-batch-video-upload-modal',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [BatchUploadPreviewTreeComponent],
+  template: `
+    @if (isOpen()) {
+      <div
+        class="fixed inset-0 z-50 flex items-start justify-center bg-black/40 backdrop-blur-sm overflow-y-auto py-8 px-4"
+        (click)="onBackdropClick($event)"
+      >
+        <div
+          class="relative w-full max-w-3xl bg-white rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[calc(100vh-4rem)]"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="batch-upload-title"
+        >
+          <!-- Header -->
+          <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between flex-shrink-0">
+            <div>
+              <h2 id="batch-upload-title" class="text-lg font-semibold text-gray-900">
+                {{ headerTitle() }}
+              </h2>
+              <p class="text-xs text-gray-500 mt-0.5">{{ headerSubtitle() }}</p>
+            </div>
+            <button
+              type="button"
+              (click)="requestClose()"
+              class="text-gray-400 hover:text-gray-600 p-1 rounded hover:bg-gray-100"
+              aria-label="Đóng"
+            >
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M18 6L6 18M6 6l12 12"/>
+              </svg>
+            </button>
+          </div>
+
+          <!-- Body -->
+          <div class="flex-1 overflow-y-auto px-6 py-5">
+            @switch (svc.mode()) {
+              @case ('PICK') {
+                <ng-container *ngTemplateOutlet="pickStage"></ng-container>
+              }
+              @case ('PREVIEW') {
+                <ng-container *ngTemplateOutlet="previewStage"></ng-container>
+              }
+              @case ('UPLOADING') {
+                <ng-container *ngTemplateOutlet="uploadingStage"></ng-container>
+              }
+              @case ('COMPLETE') {
+                <ng-container *ngTemplateOutlet="uploadingStage"></ng-container>
+              }
+              @default {
+                <ng-container *ngTemplateOutlet="pickStage"></ng-container>
+              }
+            }
+          </div>
+
+          <!-- Footer -->
+          <div class="px-6 py-3 border-t border-gray-200 bg-slate-50 flex items-center justify-between flex-shrink-0">
+            <div class="text-xs text-gray-600">
+              @if (svc.mode() === 'UPLOADING' || svc.mode() === 'COMPLETE') {
+                @let p = svc.aggregateProgress();
+                {{ p.readyCount }}/{{ p.totalCount }} sẵn sàng
+                @if (p.failedCount > 0) {
+                  · {{ p.failedCount }} lỗi
+                }
+              } @else if (svc.mode() === 'PREVIEW') {
+                @let p = svc.aggregateProgress();
+                Tổng: {{ p.totalCount }} video → {{ lessonsWithVideoCount() }} bài
+              } @else {
+                <span>&nbsp;</span>
+              }
+            </div>
+            <div class="flex items-center gap-2">
+              @if (svc.mode() === 'PICK') {
+                <button
+                  type="button"
+                  (click)="requestClose()"
+                  class="px-4 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg"
+                >Hủy</button>
+              }
+              @if (svc.mode() === 'PREVIEW') {
+                <button
+                  type="button"
+                  (click)="onBackToPick()"
+                  class="px-4 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg"
+                >← Chọn lại file</button>
+                <button
+                  type="button"
+                  (click)="onConfirmStart()"
+                  [disabled]="svc.aggregateProgress().totalCount === 0"
+                  class="px-4 py-1.5 text-sm font-semibold text-white bg-[#0056D2] hover:bg-[#004BB5] rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Bắt đầu upload ({{ svc.aggregateProgress().totalCount }} video)
+                </button>
+              }
+              @if (svc.mode() === 'UPLOADING' || svc.mode() === 'COMPLETE') {
+                <button
+                  type="button"
+                  (click)="onCloseAndContinue()"
+                  class="px-4 py-1.5 text-sm font-semibold text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-lg"
+                >
+                  {{ svc.mode() === 'COMPLETE' ? 'Đóng' : 'Đóng — chạy nền' }}
+                </button>
+              }
+            </div>
+          </div>
+        </div>
+      </div>
+    }
+
+    <!-- ========== PICK Stage ========== -->
+    <ng-template #pickStage>
+      <div class="space-y-4">
+        <div
+          (drop)="onFileDrop($event)"
+          (dragover)="$event.preventDefault()"
+          (dragenter)="dragHover.set(true)"
+          (dragleave)="dragHover.set(false)"
+          [class.border-\[\#0056D2\]]="dragHover()"
+          [class.bg-\[\#0056D2\]\/5]="dragHover()"
+          class="border-2 border-dashed border-gray-300 rounded-xl px-8 py-12 text-center hover:border-[#0056D2] transition-colors"
+        >
+          <div class="text-5xl mb-3">📁</div>
+          <p class="text-sm font-medium text-gray-900">Kéo thả nhiều video vào đây</p>
+          <p class="text-xs text-gray-500 mt-1">hoặc</p>
+          <label class="inline-block mt-2 cursor-pointer">
+            <input
+              type="file"
+              multiple
+              accept="video/*"
+              (change)="onFilePickerChange($event)"
+              class="hidden"
+            />
+            <span class="px-4 py-2 text-sm font-semibold text-[#0056D2] bg-[#0056D2]/10 hover:bg-[#0056D2]/20 rounded-lg inline-block">
+              Chọn nhiều file
+            </span>
+          </label>
+          <p class="text-xs text-gray-400 mt-3">Tối đa 5GB / file · MP4, MOV, MKV, WebM</p>
+        </div>
+
+        <fieldset class="border border-gray-200 rounded-lg p-4 space-y-3">
+          <legend class="text-xs font-semibold text-gray-700 px-2">Phạm vi phân bổ</legend>
+          @for (opt of scopeOptions; track opt.value) {
+            <label class="flex items-start gap-2 text-sm cursor-pointer">
+              <input
+                type="radio"
+                name="scope"
+                [value]="opt.value"
+                [checked]="selectedScope() === opt.value"
+                (change)="selectedScope.set(opt.value)"
+                class="mt-0.5 accent-[#0056D2]"
+              />
+              <div>
+                <div class="font-medium text-gray-900">{{ opt.label }}</div>
+                <div class="text-xs text-gray-500">{{ scopeHint(opt.value) }}</div>
+              </div>
+            </label>
+          }
+        </fieldset>
+
+        <fieldset class="border border-gray-200 rounded-lg p-4 space-y-3">
+          <legend class="text-xs font-semibold text-gray-700 px-2">Cách phân bổ mặc định</legend>
+          @for (opt of strategyOptions; track opt.value) {
+            <label class="flex items-start gap-2 text-sm cursor-pointer">
+              <input
+                type="radio"
+                name="strategy"
+                [value]="opt.value"
+                [checked]="selectedStrategy() === opt.value"
+                (change)="selectedStrategy.set(opt.value)"
+                class="mt-0.5 accent-[#0056D2]"
+              />
+              <div>
+                <div class="font-medium text-gray-900">{{ opt.label }}</div>
+                <div class="text-xs text-gray-500">{{ opt.hint }}</div>
+              </div>
+            </label>
+          }
+        </fieldset>
+      </div>
+    </ng-template>
+
+    <!-- ========== PREVIEW Stage ========== -->
+    <ng-template #previewStage>
+      <div class="space-y-4">
+        <div class="flex items-center justify-between text-xs text-gray-600">
+          <span>Kéo thả ⋮⋮ để xếp lại video giữa các bài. Click tên để sửa tiêu đề mục.</span>
+          <button
+            type="button"
+            (click)="onChangeStrategy()"
+            class="text-[#0056D2] hover:underline"
+          >
+            Đổi cách phân bổ
+          </button>
+        </div>
+        <app-batch-upload-preview-tree
+          [lessons]="svc.availableLessons()"
+          [items]="svc.items()"
+          [showCreateLessonButton]="true"
+          (itemMoved)="onItemMoved($event)"
+          (removeRequested)="svc.removeItem($event)"
+          (titleChanged)="svc.updateTitle($event.itemId, $event.title)"
+          (newLessonRequested)="onNewLessonRequested()"
+        />
+      </div>
+    </ng-template>
+
+    <!-- ========== UPLOADING / COMPLETE Stage ========== -->
+    <ng-template #uploadingStage>
+      <div class="space-y-4">
+        @let p = svc.aggregateProgress();
+        <div class="grid grid-cols-5 gap-2 text-xs">
+          <div class="rounded-lg bg-gray-100 px-3 py-2 text-center">
+            <div class="font-semibold text-gray-900">{{ p.pendingCount }}</div>
+            <div class="text-gray-500">Chờ</div>
+          </div>
+          <div class="rounded-lg bg-[#0056D2]/10 px-3 py-2 text-center">
+            <div class="font-semibold text-[#0056D2]">{{ p.uploadingCount }}</div>
+            <div class="text-gray-500">Đang upload</div>
+          </div>
+          <div class="rounded-lg bg-amber-50 px-3 py-2 text-center">
+            <div class="font-semibold text-amber-700">{{ p.processingCount }}</div>
+            <div class="text-gray-500">Đang xử lý</div>
+          </div>
+          <div class="rounded-lg bg-emerald-50 px-3 py-2 text-center">
+            <div class="font-semibold text-emerald-700">{{ p.readyCount }}</div>
+            <div class="text-gray-500">Sẵn sàng</div>
+          </div>
+          <div class="rounded-lg bg-red-50 px-3 py-2 text-center">
+            <div class="font-semibold text-red-700">{{ p.failedCount }}</div>
+            <div class="text-gray-500">Lỗi</div>
+          </div>
+        </div>
+        <app-batch-upload-preview-tree
+          [lessons]="svc.availableLessons()"
+          [items]="svc.items()"
+          [showCreateLessonButton]="false"
+          (removeRequested)="svc.removeItem($event)"
+          (retryRequested)="svc.retryItem($event)"
+        />
+      </div>
+    </ng-template>
+  `,
+})
+export class BatchVideoUploadModalComponent {
+  protected readonly svc = inject(BatchVideoUploadService);
+
+  readonly isOpen = input(false);
+  readonly courseId = input.required<string>();
+  readonly currentChapterId = input<string | null>(null);
+  readonly currentLessonId = input<string | null>(null);
+  /** Lesson tree: parent passes flat list with chapter context */
+  readonly availableLessons = input<BatchTargetLesson[]>([]);
+
+  readonly closed = output<void>();
+
+  readonly dragHover = signal(false);
+  readonly selectedScope = signal<BatchScope>('CURRENT_CHAPTER');
+  readonly selectedStrategy = signal<DistributionStrategy>('EVEN');
+
+  protected readonly scopeOptions: { value: BatchScope; label: string }[] = [
+    { value: 'CURRENT_LESSON', label: 'Bài hiện tại' },
+    { value: 'CURRENT_CHAPTER', label: 'Tất cả bài trong chương hiện tại' },
+    { value: 'ENTIRE_COURSE', label: 'Tất cả bài trong khoá' },
+  ];
+
+  protected readonly strategyOptions: { value: DistributionStrategy; label: string; hint: string }[] = [
+    { value: 'EVEN', label: 'Chia đều', hint: 'Ví dụ: 23 video / 4 bài → [6, 6, 6, 5]' },
+    { value: 'PREFIX', label: 'Theo tiền tố tên file', hint: '"01_intro" → bài 1, "02_drill" → bài 2' },
+    { value: 'SINGLE_LESSON', label: 'Tất cả vào 1 bài', hint: 'Tất cả video vào bài đầu của phạm vi' },
+  ];
+
+  readonly lessonsWithVideoCount = computed(() => {
+    const items = this.svc.items();
+    const ids = new Set(items.map((i) => i.lessonId));
+    return ids.size;
+  });
+
+  protected readonly headerTitle = computed(() => {
+    switch (this.svc.mode()) {
+      case 'PREVIEW':
+        return 'Xem trước phân bổ video';
+      case 'UPLOADING':
+        return 'Đang upload video';
+      case 'COMPLETE':
+        return 'Hoàn thành';
+      default:
+        return 'Upload nhiều video';
+    }
+  });
+
+  protected readonly headerSubtitle = computed(() => {
+    switch (this.svc.mode()) {
+      case 'PREVIEW':
+        return 'Kéo thả để xếp lại, click tên để sửa, sau đó bấm "Bắt đầu upload"';
+      case 'UPLOADING':
+        return 'Có thể đóng tab — upload vẫn chạy nền';
+      case 'COMPLETE':
+        return 'Tất cả video đã được xử lý';
+      default:
+        return 'Chọn nhiều video cùng lúc, hệ thống sẽ tự phân bổ vào các bài';
+    }
+  });
+
+  constructor() {
+    // Auto-reset PICK state when modal closes after COMPLETE
+    effect(() => {
+      if (!this.isOpen() && this.svc.mode() === 'COMPLETE') {
+        this.svc.reset();
+      }
+    });
+  }
+
+  protected scopeHint(scope: BatchScope): string {
+    const lessons = this.computeLessonsForScope(scope);
+    return `(${lessons.length} bài)`;
+  }
+
+  protected onBackdropClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget) {
+      this.requestClose();
+    }
+  }
+
+  @HostListener('document:keydown.escape')
+  protected onEscape(): void {
+    if (this.isOpen()) this.requestClose();
+  }
+
+  protected requestClose(): void {
+    if (this.svc.mode() === 'UPLOADING') {
+      // Service state survives close → background mode
+      this.closed.emit();
+      return;
+    }
+    if (this.svc.mode() === 'COMPLETE' || this.svc.mode() === 'PICK' || this.svc.mode() === 'IDLE') {
+      this.svc.reset();
+    }
+    this.closed.emit();
+  }
+
+  protected onFilePickerChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const files = input.files ? Array.from(input.files) : [];
+    this.handleFilesPicked(files);
+    input.value = ''; // allow same file re-pick
+  }
+
+  protected onFileDrop(event: DragEvent): void {
+    event.preventDefault();
+    this.dragHover.set(false);
+    const files = event.dataTransfer?.files ? Array.from(event.dataTransfer.files) : [];
+    this.handleFilesPicked(files);
+  }
+
+  protected onItemMoved(payload: { itemId: string; targetLessonId: string; targetIndex: number }): void {
+    this.svc.moveItem(payload.itemId, payload.targetLessonId, payload.targetIndex);
+  }
+
+  protected onConfirmStart(): void {
+    this.svc.startUpload();
+  }
+
+  protected onBackToPick(): void {
+    this.svc.reset();
+  }
+
+  protected onCloseAndContinue(): void {
+    this.requestClose();
+  }
+
+  protected onChangeStrategy(): void {
+    const next: DistributionStrategy =
+      this.selectedStrategy() === 'EVEN' ? 'PREFIX' : this.selectedStrategy() === 'PREFIX' ? 'SINGLE_LESSON' : 'EVEN';
+    this.selectedStrategy.set(next);
+    this.svc.redistribute(next);
+  }
+
+  protected async onNewLessonRequested(): Promise<void> {
+    const chapterId = this.currentChapterId();
+    if (!chapterId) return;
+    const title = window.prompt('Tiêu đề bài mới:', 'Bài mới');
+    if (!title?.trim()) return;
+    await this.svc.createNewLesson(chapterId, title.trim());
+  }
+
+  private handleFilesPicked(files: File[]): void {
+    if (files.length === 0) return;
+    const scope = this.selectedScope();
+    const lessons = this.computeLessonsForScope(scope);
+    if (lessons.length === 0) {
+      // No lessons → cannot distribute. Abort with hint.
+      window.alert('Không có bài học nào để phân bổ. Vui lòng tạo bài trước hoặc chọn phạm vi rộng hơn.');
+      return;
+    }
+    this.svc.setupBatch(files, lessons, {
+      scope,
+      strategy: this.selectedStrategy(),
+      courseId: this.courseId(),
+      currentLessonId: this.currentLessonId() ?? undefined,
+      currentChapterId: this.currentChapterId() ?? undefined,
+    });
+  }
+
+  private computeLessonsForScope(scope: BatchScope): BatchTargetLesson[] {
+    const all = this.availableLessons();
+    if (scope === 'ENTIRE_COURSE') return all;
+    if (scope === 'CURRENT_CHAPTER') {
+      const chapterId = this.currentChapterId();
+      return chapterId ? all.filter((l) => l.chapterId === chapterId) : all;
+    }
+    if (scope === 'CURRENT_LESSON') {
+      const lessonId = this.currentLessonId();
+      return lessonId ? all.filter((l) => l.id === lessonId) : all;
+    }
+    return all;
+  }
+}

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload.service.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload.service.ts
@@ -1,0 +1,554 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { firstValueFrom, forkJoin, of } from 'rxjs';
+import { catchError, filter, take, tap } from 'rxjs/operators';
+import { LessonApi } from '../../../../../../../api/client/lesson.api';
+import { SectionApi } from '../../../../../../../api/client/section.api';
+import { VideoAssetApi } from '../../../../../../../api/client/video-asset.api';
+import { PresignedUploadService, UploadEvent } from '../../../../../../../core/services/presigned-upload.service';
+import { ToastService } from '../../../../../../../core/services/toast.service';
+import { CourseEditorStore } from '../../../../store/course-editor.store';
+import {
+  DistributableLesson,
+  distributeByFilenamePrefix,
+  distributeEvenly,
+  extractFilenameTitle,
+} from './batch-distribution.util';
+import {
+  BatchAggregateProgress,
+  BatchItemStatus,
+  BatchMode,
+  BatchTargetLesson,
+  BatchUploadConfig,
+  BatchVideoItem,
+  DistributionStrategy,
+} from './batch-video-upload.types';
+
+const UPLOAD_CONCURRENCY = 3;
+const POLL_INTERVAL_MS = 5_000;
+const POLL_MAX_ATTEMPTS = 120; // 120 × 5s = 10 min cap per item before auto-fail
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024 * 1024; // 5GB per file (matches single-section limit)
+
+/**
+ * Batch video upload orchestrator.
+ *
+ * Trách nhiệm:
+ *  - Hold trạng thái N item (file → lesson assignment + upload status)
+ *  - Distribute files vào lessons theo strategy (even / prefix / single)
+ *  - Cho phép drag-drop reassign + reorder + remove + edit title trước khi upload
+ *  - Chạy upload pipeline (max 3 parallel) + aggregated polling (1 timer cho N asset)
+ *  - Retry per file, không block file khác
+ *  - Sau khi tất cả section trong 1 lesson đã saved → reorderSectionsOptimistic
+ *
+ * Singleton (providedIn root) để state survive khi modal đóng (background mode).
+ *
+ * Reuse 100% existing: PresignedUploadService, VideoAssetApi, SectionApi,
+ * LessonApi, CourseEditorStore. KHÔNG refactor adjacent code.
+ */
+@Injectable({ providedIn: 'root' })
+export class BatchVideoUploadService {
+  private readonly presignedUpload = inject(PresignedUploadService);
+  private readonly videoAssetApi = inject(VideoAssetApi);
+  private readonly sectionApi = inject(SectionApi);
+  private readonly lessonApi = inject(LessonApi);
+  private readonly store = inject(CourseEditorStore);
+  private readonly toast = inject(ToastService);
+
+  readonly mode = signal<BatchMode>('IDLE');
+  readonly items = signal<BatchVideoItem[]>([]);
+  readonly availableLessons = signal<BatchTargetLesson[]>([]);
+  readonly config = signal<BatchUploadConfig | null>(null);
+
+  readonly aggregateProgress = computed<BatchAggregateProgress>(() => {
+    const list = this.items();
+    return {
+      totalCount: list.length,
+      pendingCount: list.filter((i) => i.status === 'PENDING').length,
+      uploadingCount: list.filter(
+        (i) => i.status === 'UPLOADING' || i.status === 'ASSET_CREATING' || i.status === 'SECTION_CREATING'
+      ).length,
+      processingCount: list.filter((i) => i.status === 'PROCESSING').length,
+      readyCount: list.filter((i) => i.status === 'READY').length,
+      failedCount: list.filter((i) => i.status === 'FAILED').length,
+    };
+  });
+
+  readonly isAllDone = computed(() => {
+    const list = this.items();
+    if (list.length === 0) return false;
+    return list.every((i) => i.status === 'READY' || i.status === 'FAILED');
+  });
+
+  private inFlightCount = 0;
+  private pollTimerHandle: ReturnType<typeof setTimeout> | null = null;
+  private pollAttemptsByAsset = new Map<string, number>();
+  private lessonsAwaitingReorder = new Set<string>();
+
+  /**
+   * Khởi tạo batch từ files đã pick.
+   * Distribute mặc định theo strategy chỉ định (default: PREFIX nếu detect được, else EVEN).
+   */
+  setupBatch(files: File[], lessons: BatchTargetLesson[], config: BatchUploadConfig): void {
+    const validFiles = this.validateFiles(files);
+    if (validFiles.length === 0) {
+      this.toast.error('Không có file video hợp lệ');
+      return;
+    }
+
+    this.availableLessons.set(lessons);
+    this.config.set(config);
+
+    const distributable: DistributableLesson[] = lessons.map((l) => ({
+      id: l.id,
+      orderIndex: l.orderIndex,
+    }));
+
+    const items: BatchVideoItem[] = [];
+    const distribution = this.runDistribution(validFiles, distributable, config.strategy);
+
+    for (const [lessonId, lessonFiles] of distribution.entries()) {
+      for (const file of lessonFiles) {
+        items.push({
+          id: this.generateLocalId(),
+          file,
+          lessonId,
+          sectionTitle: extractFilenameTitle(file.name),
+          status: 'PENDING',
+          uploadProgress: 0,
+        });
+      }
+    }
+
+    this.items.set(items);
+    this.mode.set('PREVIEW');
+  }
+
+  /** Re-run distribution algorithm với strategy mới (không touch upload status). */
+  redistribute(strategy: DistributionStrategy): void {
+    const currentItems = this.items();
+    if (currentItems.some((i) => i.status !== 'PENDING')) {
+      this.toast.warning('Không thể đổi cách phân bổ khi đã bắt đầu upload');
+      return;
+    }
+
+    const cfg = this.config();
+    if (!cfg) return;
+
+    const distributable: DistributableLesson[] = this.availableLessons().map((l) => ({
+      id: l.id,
+      orderIndex: l.orderIndex,
+    }));
+
+    this.config.set({ ...cfg, strategy });
+    const files = currentItems.map((i) => i.file);
+    const distribution = this.runDistribution(files, distributable, strategy);
+
+    const newItems: BatchVideoItem[] = [];
+    const titleByFile = new Map(currentItems.map((i) => [i.file, i.sectionTitle]));
+
+    for (const [lessonId, lessonFiles] of distribution.entries()) {
+      for (const file of lessonFiles) {
+        newItems.push({
+          id: this.generateLocalId(),
+          file,
+          lessonId,
+          sectionTitle: titleByFile.get(file) ?? extractFilenameTitle(file.name),
+          status: 'PENDING',
+          uploadProgress: 0,
+        });
+      }
+    }
+
+    this.items.set(newItems);
+  }
+
+  /** Drag-drop reassign: chuyển item sang lesson khác hoặc reorder trong cùng lesson. */
+  moveItem(itemId: string, targetLessonId: string, targetIndex: number): void {
+    const list = [...this.items()];
+    const fromIdx = list.findIndex((i) => i.id === itemId);
+    if (fromIdx < 0) return;
+
+    const item = list[fromIdx];
+    if (item.status !== 'PENDING') {
+      this.toast.warning('Không thể di chuyển video đã bắt đầu upload');
+      return;
+    }
+
+    list.splice(fromIdx, 1);
+
+    const itemsInTarget = list.filter((i) => i.lessonId === targetLessonId);
+    const insertAt =
+      targetIndex >= itemsInTarget.length
+        ? this.findEndOfLesson(list, targetLessonId)
+        : list.indexOf(itemsInTarget[targetIndex]);
+
+    list.splice(insertAt, 0, { ...item, lessonId: targetLessonId });
+    this.items.set(list);
+  }
+
+  removeItem(itemId: string): void {
+    const list = this.items();
+    const item = list.find((i) => i.id === itemId);
+    if (!item) return;
+    if (item.status !== 'PENDING' && item.status !== 'FAILED') {
+      this.toast.warning('Không thể xoá video đang xử lý');
+      return;
+    }
+    this.items.set(list.filter((i) => i.id !== itemId));
+  }
+
+  updateTitle(itemId: string, newTitle: string): void {
+    const trimmed = newTitle.trim();
+    if (!trimmed) return;
+    this.items.update((list) =>
+      list.map((i) => (i.id === itemId ? { ...i, sectionTitle: trimmed } : i))
+    );
+  }
+
+  /** Tạo lesson mới on-the-fly trong chapter chỉ định, append cuối list lessons. */
+  async createNewLesson(chapterId: string, title: string): Promise<BatchTargetLesson | null> {
+    try {
+      const res = await firstValueFrom(
+        this.lessonApi.createLesson(chapterId, { title: title.trim() || 'Bài mới', type: 'LECTURE' as any } as any)
+      );
+      const created: any = res?.data ?? res;
+      if (!created?.id) return null;
+
+      const newLesson: BatchTargetLesson = {
+        id: created.id,
+        chapterId,
+        title: created.title || title,
+        orderIndex: created.orderIndex ?? this.availableLessons().length + 1,
+        existingSectionCount: 0,
+      };
+
+      this.availableLessons.update((list) => [...list, newLesson]);
+      return newLesson;
+    } catch (err: any) {
+      this.toast.error('Không tạo được bài mới: ' + (err?.message ?? 'lỗi không xác định'));
+      return null;
+    }
+  }
+
+  /**
+   * Bắt đầu upload pipeline. State chuyển PREVIEW → UPLOADING.
+   * Pump queue lên đến UPLOAD_CONCURRENCY pipelines.
+   */
+  startUpload(): void {
+    if (this.mode() !== 'PREVIEW') return;
+    if (this.items().length === 0) {
+      this.toast.warning('Không có video nào để upload');
+      return;
+    }
+    this.mode.set('UPLOADING');
+    this.pumpQueue();
+  }
+
+  /** Retry 1 file đã fail. Reset status về PENDING + kick queue. */
+  retryItem(itemId: string): void {
+    this.items.update((list) =>
+      list.map((i) =>
+        i.id === itemId && i.status === 'FAILED'
+          ? { ...i, status: 'PENDING' as BatchItemStatus, errorMessage: undefined, uploadProgress: 0 }
+          : i
+      )
+    );
+    this.pumpQueue();
+  }
+
+  /** Reset state. Không cancel in-flight uploads (chúng sẽ no-op khi update state). */
+  reset(): void {
+    if (this.pollTimerHandle) {
+      clearTimeout(this.pollTimerHandle);
+      this.pollTimerHandle = null;
+    }
+    this.pollAttemptsByAsset.clear();
+    this.lessonsAwaitingReorder.clear();
+    this.inFlightCount = 0;
+    this.items.set([]);
+    this.availableLessons.set([]);
+    this.config.set(null);
+    this.mode.set('IDLE');
+  }
+
+  // ──── Private ────────────────────────────────────────────────────────────
+
+  private validateFiles(files: File[]): File[] {
+    const valid: File[] = [];
+    const tooLarge: string[] = [];
+    const wrongType: string[] = [];
+
+    for (const file of files) {
+      if (file.size > MAX_FILE_SIZE_BYTES) {
+        tooLarge.push(file.name);
+        continue;
+      }
+      if (file.type && !file.type.startsWith('video/')) {
+        wrongType.push(file.name);
+        continue;
+      }
+      valid.push(file);
+    }
+
+    if (tooLarge.length > 0) {
+      this.toast.warning(`Bỏ qua ${tooLarge.length} file quá 5GB`);
+    }
+    if (wrongType.length > 0) {
+      this.toast.warning(`Bỏ qua ${wrongType.length} file không phải video`);
+    }
+    return valid;
+  }
+
+  private runDistribution(
+    files: File[],
+    lessons: DistributableLesson[],
+    strategy: DistributionStrategy
+  ): Map<string, File[]> {
+    if (lessons.length === 0) {
+      return new Map();
+    }
+
+    if (strategy === 'SINGLE_LESSON') {
+      return new Map([[lessons[0].id, files]]);
+    }
+
+    if (strategy === 'PREFIX') {
+      const prefixResult = distributeByFilenamePrefix(files, lessons);
+      if (prefixResult) return prefixResult;
+      // Fallback to even when prefix detection fails
+      return distributeEvenly(files, lessons);
+    }
+
+    return distributeEvenly(files, lessons);
+  }
+
+  private findEndOfLesson(list: BatchVideoItem[], lessonId: string): number {
+    for (let i = list.length - 1; i >= 0; i--) {
+      if (list[i].lessonId === lessonId) return i + 1;
+    }
+    return list.length;
+  }
+
+  private generateLocalId(): string {
+    return crypto.randomUUID();
+  }
+
+  private pumpQueue(): void {
+    while (this.inFlightCount < UPLOAD_CONCURRENCY) {
+      const next = this.items().find((i) => i.status === 'PENDING');
+      if (!next) break;
+      this.inFlightCount++;
+      this.updateItemStatus(next.id, 'UPLOADING');
+      void this.runItemPipeline(next.id);
+    }
+    this.ensurePollingLoop();
+    this.maybeCompleteBatch();
+  }
+
+  private async runItemPipeline(itemId: string): Promise<void> {
+    try {
+      const item = this.items().find((i) => i.id === itemId);
+      if (!item) return;
+
+      // Step 1: Upload to R2 via presigned URL
+      const uploadResult = await firstValueFrom(
+        this.presignedUpload.upload(item.file, 'videos').pipe(
+          tap((event: UploadEvent) => {
+            if (event.type === 'progress') {
+              this.updateItemProgress(itemId, event.progress);
+            }
+          }),
+          filter((event: UploadEvent) => event.type === 'complete'),
+          take(1)
+        )
+      );
+
+      this.updateItem(itemId, { attachmentId: uploadResult.id });
+      this.updateItemStatus(itemId, 'ASSET_CREATING');
+
+      // Step 2: Register video asset (triggers backend ingest queue)
+      const assetRes: any = await firstValueFrom(
+        this.videoAssetApi.createFromUpload(uploadResult.id, item.file.name)
+      );
+      const asset = assetRes?.data ?? assetRes;
+      if (!asset?.id) {
+        throw new Error('Backend không trả videoAssetId');
+      }
+
+      this.updateItem(itemId, { videoAssetId: asset.id });
+      this.updateItemStatus(itemId, 'SECTION_CREATING');
+
+      // Step 3: Create section in lesson with videoAssetId
+      const currentTitle = this.items().find((i) => i.id === itemId)?.sectionTitle ?? extractFilenameTitle(item.file.name);
+      const sectionPayload = {
+        title: currentTitle,
+        type: 'VIDEO',
+        isRequired: false,
+        videoAssetId: asset.id,
+        videoType: 'ADAPTIVE_R2',
+      };
+      const formData = new FormData();
+      formData.append(
+        'data',
+        new Blob([JSON.stringify(sectionPayload)], { type: 'application/json; charset=utf-8' })
+      );
+
+      const sectionRes: any = await firstValueFrom(this.sectionApi.createSection(item.lessonId, formData));
+      const created = sectionRes?.data ?? sectionRes;
+      if (!created?.id) {
+        throw new Error('Backend không trả sectionId');
+      }
+
+      this.updateItem(itemId, { sectionId: created.id });
+      this.lessonsAwaitingReorder.add(item.lessonId);
+
+      // Update local store optimistically
+      this.store.addSectionLocal(item.lessonId, {
+        id: created.id,
+        title: created.title || currentTitle,
+        type: 'VIDEO',
+        videoAssetId: asset.id,
+        videoProcessingStatus: asset.status,
+        videoType: 'ADAPTIVE_R2',
+        orderIndex: created.orderIndex ?? 0,
+        isRequired: false,
+        availableOfflineProfiles: [],
+      } as any);
+
+      // Step 4: Move to PROCESSING (backend transcoding) — wait via polling
+      this.updateItemStatus(itemId, asset.status === 'READY' ? 'READY' : 'PROCESSING');
+    } catch (err: any) {
+      this.markItemFailed(itemId, this.formatError(err));
+    } finally {
+      this.inFlightCount = Math.max(0, this.inFlightCount - 1);
+      this.pumpQueue();
+    }
+  }
+
+  private ensurePollingLoop(): void {
+    if (this.pollTimerHandle) return;
+    const hasProcessing = this.items().some((i) => i.status === 'PROCESSING');
+    if (!hasProcessing) return;
+
+    this.pollTimerHandle = setTimeout(() => {
+      this.pollTimerHandle = null;
+      void this.pollProcessingItems();
+    }, POLL_INTERVAL_MS);
+  }
+
+  private async pollProcessingItems(): Promise<void> {
+    const processing = this.items().filter(
+      (i) => i.status === 'PROCESSING' && !!i.videoAssetId
+    );
+    if (processing.length === 0) {
+      this.maybeCompleteBatch();
+      return;
+    }
+
+    const requests = processing.map((item) =>
+      this.videoAssetApi.getById(item.videoAssetId!).pipe(
+        catchError(() => of(null))
+      )
+    );
+
+    try {
+      const responses = await firstValueFrom(forkJoin(requests));
+      responses.forEach((res: any, idx: number) => {
+        const item = processing[idx];
+        if (!res) return;
+        const asset = res?.data ?? res;
+        const attempts = (this.pollAttemptsByAsset.get(item.videoAssetId!) ?? 0) + 1;
+        this.pollAttemptsByAsset.set(item.videoAssetId!, attempts);
+
+        if (asset?.status === 'READY') {
+          this.updateItemStatus(item.id, 'READY');
+        } else if (asset?.status === 'FAILED') {
+          this.markItemFailed(item.id, asset.errorMessage || 'Backend xử lý thất bại');
+        } else if (attempts >= POLL_MAX_ATTEMPTS) {
+          this.markItemFailed(
+            item.id,
+            'Quá thời gian chờ xử lý (10 phút). Backend có thể đang quá tải.'
+          );
+        }
+      });
+    } catch {
+      // Network error trên polling — không sao, lần sau sẽ retry
+    }
+
+    // Schedule next poll if there's still PROCESSING items
+    if (this.items().some((i) => i.status === 'PROCESSING')) {
+      this.pollTimerHandle = setTimeout(() => {
+        this.pollTimerHandle = null;
+        void this.pollProcessingItems();
+      }, POLL_INTERVAL_MS);
+    } else {
+      this.maybeCompleteBatch();
+    }
+  }
+
+  private maybeCompleteBatch(): void {
+    if (!this.isAllDone()) return;
+    if (this.mode() === 'COMPLETE') return;
+    this.mode.set('COMPLETE');
+
+    // Reorder sections per lesson to match user's intended order
+    for (const lessonId of this.lessonsAwaitingReorder) {
+      this.reorderLessonSections(lessonId);
+    }
+
+    const { readyCount, failedCount, totalCount } = this.aggregateProgress();
+    if (failedCount === 0) {
+      this.toast.success(`Đã hoàn thành ${readyCount}/${totalCount} video`);
+    } else if (readyCount === 0) {
+      this.toast.error(`Tất cả ${totalCount} video đều thất bại — kiểm tra lại`);
+    } else {
+      this.toast.warning(
+        `${readyCount}/${totalCount} video sẵn sàng, ${failedCount} thất bại — bấm "Thử lại" để retry`
+      );
+    }
+  }
+
+  private reorderLessonSections(lessonId: string): void {
+    const itemsInLesson = this.items().filter(
+      (i) => i.lessonId === lessonId && !!i.sectionId
+    );
+    if (itemsInLesson.length === 0) return;
+
+    // Build the target order from current store (existing sections first, then our new ones in batch order)
+    const tree = this.store.courseTree();
+    if (!tree) return;
+    const lesson = tree.chapters.flatMap((c) => c.lessons).find((l) => l.id === lessonId);
+    if (!lesson) return;
+
+    const newSectionIds = itemsInLesson.map((i) => i.sectionId!);
+    const existingIds = (lesson.sections || [])
+      .map((s) => s.id)
+      .filter((id) => !newSectionIds.includes(id));
+    const finalOrder = [...existingIds, ...newSectionIds];
+    this.store.reorderSectionsOptimistic(lessonId, finalOrder);
+  }
+
+  private updateItem(itemId: string, patch: Partial<BatchVideoItem>): void {
+    this.items.update((list) =>
+      list.map((i) => (i.id === itemId ? { ...i, ...patch } : i))
+    );
+  }
+
+  private updateItemStatus(itemId: string, status: BatchItemStatus): void {
+    this.updateItem(itemId, { status });
+  }
+
+  private updateItemProgress(itemId: string, progress: number): void {
+    this.updateItem(itemId, { uploadProgress: Math.round(progress) });
+  }
+
+  private markItemFailed(itemId: string, errorMessage: string): void {
+    this.updateItem(itemId, { status: 'FAILED', errorMessage });
+  }
+
+  private formatError(err: any): string {
+    if (typeof err === 'string') return err;
+    if (err?.error?.message) return String(err.error.message);
+    if (err?.message) return String(err.message);
+    return 'Lỗi không xác định';
+  }
+}

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload.types.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload.types.ts
@@ -1,0 +1,69 @@
+/**
+ * Types cho batch video upload feature.
+ * Tách riêng để dễ test + reuse trong tree component và modal shell.
+ */
+
+export type BatchItemStatus =
+  | 'PENDING'
+  | 'UPLOADING'
+  | 'ASSET_CREATING'
+  | 'SECTION_CREATING'
+  | 'PROCESSING'
+  | 'READY'
+  | 'FAILED';
+
+export type BatchMode = 'IDLE' | 'PICK' | 'PREVIEW' | 'UPLOADING' | 'COMPLETE';
+
+export type DistributionStrategy = 'EVEN' | 'PREFIX' | 'SINGLE_LESSON';
+
+export type BatchScope = 'CURRENT_LESSON' | 'CURRENT_CHAPTER' | 'ENTIRE_COURSE';
+
+export interface BatchVideoItem {
+  /** Local UUID, key cho tracking — không phải sectionId hay assetId */
+  id: string;
+  file: File;
+  /** Lesson đích — có thể đổi qua drag-drop trước khi upload */
+  lessonId: string;
+  /** Tiêu đề section, default = filename không extension, user editable */
+  sectionTitle: string;
+  status: BatchItemStatus;
+  /** 0-100, chỉ valid khi status === 'UPLOADING' */
+  uploadProgress: number;
+  /** Set sau khi presigned upload confirm xong */
+  attachmentId?: string;
+  /** Set sau khi POST /video-assets/from-upload */
+  videoAssetId?: string;
+  /** Set sau khi POST /lessons/{id}/sections — section đã có trong DB */
+  sectionId?: string;
+  /** Set khi status === 'FAILED' — message để show trong UI */
+  errorMessage?: string;
+}
+
+export interface BatchTargetLesson {
+  id: string;
+  chapterId: string;
+  title: string;
+  /** orderIndex hiện tại trong chapter, dùng cho distribution sort */
+  orderIndex: number;
+  /** Số section đã có sẵn trong lesson — dùng để hiển thị "thêm vào X mục có sẵn" */
+  existingSectionCount: number;
+}
+
+export interface BatchUploadConfig {
+  scope: BatchScope;
+  strategy: DistributionStrategy;
+  /** Mặc định = course đang edit */
+  courseId: string;
+  /** Lesson hiện tại đang focus, dùng cho scope=CURRENT_LESSON hoặc fallback */
+  currentLessonId?: string;
+  currentChapterId?: string;
+}
+
+export interface BatchAggregateProgress {
+  totalCount: number;
+  pendingCount: number;
+  uploadingCount: number;
+  processingCount: number;
+  readyCount: number;
+  failedCount: number;
+}

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/chapter-editor/chapter-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/chapter-editor/chapter-editor.component.ts
@@ -69,12 +69,20 @@ type LessonComposerType = 'LECTURE' | 'QUIZ' | 'ASSIGNMENT';
         <div style="display: flex; justify-content: space-between; align-items: center">
           <label class="editor-label">Bài học ({{ lessons().length }})</label>
           @if (lessons().length > 0 && !showLessonComposer()) {
-            <button type="button" (click)="addLesson.emit()" class="add-lesson-header-btn">
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
-              </svg>
-              Thêm bài học
-            </button>
+            <div style="display: flex; gap: 0.5rem; align-items: center">
+              <button type="button" (click)="batchVideoUpload.emit()" class="add-lesson-header-btn" title="Upload nhiều video, tự động chia vào các bài">
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"></path>
+                </svg>
+                Upload nhiều video
+              </button>
+              <button type="button" (click)="addLesson.emit()" class="add-lesson-header-btn">
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+                </svg>
+                Thêm bài học
+              </button>
+            </div>
           }
         </div>
 
@@ -421,6 +429,7 @@ export class ChapterEditorComponent {
   readonly saveClicked = output<void>();
   readonly lessonClicked = output<LessonDraftDTO>();
   readonly addLesson = output<void>();
+  readonly batchVideoUpload = output<void>();
   readonly lessonDraftTitleChange = output<string>();
   readonly lessonDraftTypeChange = output<LessonComposerType>();
   readonly createLesson = output<void>();

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.html
@@ -78,6 +78,7 @@
         (saveClicked)="saveChapter()"
         (lessonClicked)="selectLessonFromChapter($event)"
         (addLesson)="requestAddLessonForCurrentChapter()"
+        (batchVideoUpload)="openBatchVideoUploadModal()"
         (lessonDraftTitleChange)="onLessonComposerTitleChange($event)"
         (lessonDraftTypeChange)="onLessonComposerTypeChange($event)"
         (createLesson)="createLessonFromComposer()"
@@ -150,3 +151,13 @@
 
   <!-- Quiz Package Modals (decomposed) -->
   <app-quiz-package-modals></app-quiz-package-modals>
+
+  <!-- Batch Video Upload Modal -->
+  <app-batch-video-upload-modal
+    [isOpen]="isBatchUploadModalOpen()"
+    [courseId]="store.courseTree()?.id ?? ''"
+    [currentChapterId]="selectedChapterId()"
+    [currentLessonId]="selectedLessonId()"
+    [availableLessons]="batchUploadAvailableLessons()"
+    (closed)="closeBatchVideoUploadModal()">
+  </app-batch-video-upload-modal>

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.ts
@@ -34,6 +34,8 @@ import { ChapterEditorComponent } from './components/chapter-editor/chapter-edit
 import { LessonEditorComponent } from './components/lesson-editor/lesson-editor.component';
 import { CurriculumEditorService } from '../../services/curriculum-editor.service';
 import { QuizPackageModalsComponent } from './components/quiz-package-modals/quiz-package-modals.component';
+import { BatchVideoUploadModalComponent } from './components/batch-video-upload/batch-video-upload-modal.component';
+import type { BatchTargetLesson } from './components/batch-video-upload/batch-video-upload.types';
 import { buildCurriculumLabel, stripCurriculumPrefix } from '../../utils/curriculum-labels';
 
 type SectionQuizAssessmentType = 'PRACTICE' | 'ASSESSMENT' | 'EXAM';
@@ -48,7 +50,8 @@ type LessonComposerType = 'LECTURE' | 'QUIZ' | 'ASSIGNMENT';
     DragDropModule,
     ChapterEditorComponent,
     LessonEditorComponent,
-    QuizPackageModalsComponent
+    QuizPackageModalsComponent,
+    BatchVideoUploadModalComponent
   ],
   styleUrl: './course-curriculum.component.scss',
   providers: [],
@@ -133,6 +136,36 @@ export class CourseCurriculumComponent implements OnDestroy {
   // Selection signals
   selectedChapterId = this.selectionService.selectedChapterId;
   selectedLessonId = this.selectionService.selectedLessonId;
+
+  /** Batch video upload modal state — modal singleton, service holds upload state across open/close. */
+  isBatchUploadModalOpen = signal(false);
+
+  /** Flatten course tree → list lessons with chapter context cho batch modal scope filter. */
+  batchUploadAvailableLessons = computed<BatchTargetLesson[]>(() => {
+    const tree = this.store.courseTree();
+    if (!tree) return [];
+    const result: BatchTargetLesson[] = [];
+    for (const ch of tree.chapters) {
+      for (const l of ch.lessons) {
+        result.push({
+          id: l.id,
+          chapterId: ch.id,
+          title: stripCurriculumPrefix(l.title || '', 'lesson') || l.title || '',
+          orderIndex: l.orderIndex ?? 0,
+          existingSectionCount: (l.sections ?? []).length,
+        });
+      }
+    }
+    return result;
+  });
+
+  openBatchVideoUploadModal(): void {
+    this.isBatchUploadModalOpen.set(true);
+  }
+
+  closeBatchVideoUploadModal(): void {
+    this.isBatchUploadModalOpen.set(false);
+  }
   selectedLesson = this.selectionService.selectedLesson;
   selectedSectionId = this.selectionService.selectedSectionId; // [NEW]
   selectedSection = this.selectionService.selectedSection; // [NEW]


### PR DESCRIPTION
## Tóm tắt

Teacher upload N video cùng lúc → hệ thống tự chia đều vào các bài → user kéo-thả xếp lại trong tree view → confirm → upload chạy nền với 3 parallel pipelines + aggregated polling. Modal đóng được giữa chừng, service singleton giữ state.

**Use case thực**: 23 video / 4 bài → auto chia `[6, 6, 6, 5]`. Tiết kiệm ~2 tiếng manual click cho teacher có batch lớn.

## Why now

Per measured data trên prod: pipeline transcode 6.2x realtime (acceptable), nhưng **manual workflow** repeat 23 lần (open → pick → save → close → next lesson) là gánh nặng thật của teacher. Đây là Tier 1 fix theo karpathy: surgical, không refactor backend.

## SOTA UX patterns applied (chốt 2026-05-03)

| Pattern | Source | Applied |
|---|---|---|
| Smart defaults (auto-distribute) | Coursera Studio v3, Wistia | EVEN + PREFIX detect |
| Optimistic UI (section tạo ngay) | Mux Mosaic | Section persists khi asset registered, status=PROCESSING |
| Cross-list drag-drop | Coursera Authoring | CDK DragDrop với connectedTo |
| Per-file retry | Vimeo Manage | Failure isolation, không block batch |
| Background processing | Articulate Rise 360 | Modal đóng → service singleton tiếp tục |
| Aggregate progress dashboard | YouTube Studio | 5-card status grid |

## Architecture (4 file mới + 3 file edit, 0 refactor existing)

```
batch-video-upload/
├── batch-distribution.util.ts        Pure: distributeEvenly, distributeByFilenamePrefix, extractFilenameTitle
├── batch-distribution.util.spec.ts   27 unit tests, edge cases (N<M, N=0, M=0, prefix variants)
├── batch-video-upload.types.ts       BatchItemStatus, BatchVideoItem, BatchTargetLesson, ...
├── batch-video-upload.service.ts     Orchestrator: state machine, queue (max 3 parallel),
│                                     aggregated polling (1 timer × N forkJoin), retry per file
├── batch-upload-preview-tree.component.ts  Vertical tree với CDK cross-list drag-drop
└── batch-video-upload-modal.component.ts   3-stage shell: PICK → PREVIEW → UPLOADING/COMPLETE
```

**Reuse 100% existing services**: `PresignedUploadService`, `VideoAssetApi`, `SectionApi`, `LessonApi`, `CourseEditorStore`, `ToastService`, `CDK DragDrop`. Không touch backend.

## Distribution algorithms

```
distributeEvenly(N items, M lessons):
  base = floor(N/M); extra = N mod M
  → bài 1..extra nhận base+1, còn lại nhận base
  → 23/4 = [6,6,6,5], 100/4=[25,25,25,25], 5/10=[1,1,1,1,1,0,0,0,0,0]

distributeByFilenamePrefix:
  Detect "01_xx", "02-xx", "03.xx", "01 xx" tiền tố
  Nếu < 50% file match → return undefined → caller fallback EVEN
  Excess prefixes → dồn vào bài cuối
  Unmatched files → dồn vào bài cuối
```

## Concurrency strategy (an toàn cho browser + backend)

| Layer | Limit | Reasoning |
|---|---|---|
| Upload pipelines | 3 parallel | Browser network safety, R2 multipart đã handle within-file parallel |
| Section creation | parallel (non-blocking) | Backend single-add only, không có bulk endpoint |
| Polling timer | 1 timer × N forkJoin | Tránh storm 23 timers riêng |
| Polling interval | 5s | Backend transcode ~1 phút/video, 5s đủ responsive |
| Polling cap | 120 attempts (10 phút) | Auto-fail nếu backend hang |
| Reorder commit | 1 lần per lesson, sau khi tất cả sections trong lesson đó saved | Preserve user's drag-drop intent |

## Karpathy alignment

- ✅ 4 file mới + 3 file edit, **0 refactor existing**
- ✅ Reuse 100% existing services (no extension)
- ✅ Pure utility functions tested in isolation (27 tests pass via Karma)
- ✅ 1 service singleton (justified — non-trivial state machine)
- ✅ State machine clearly visible (BatchMode + BatchItemStatus enums)
- ✅ No premature abstractions for "future flexibility"
- ✅ Bug 2 (transcoding speed) explicitly NOT addressed — measured data showed it's already SOTA-acceptable (6.2x realtime)

## Test plan

- [ ] Open curriculum editor for any chapter with ≥ 2 lessons
- [ ] Click "Upload nhiều video" button (next to "Thêm bài học")
- [ ] Modal opens at PICK stage, drop 5 video files
- [ ] PREVIEW stage shows tree với auto-distribute
- [ ] Drag-drop 1 video sang bài khác
- [ ] Click tên section → inline edit → enter to save
- [ ] Remove 1 video before upload
- [ ] Click "Bắt đầu upload" → status realtime
- [ ] Đóng modal giữa chừng → reopen → progress vẫn chạy
- [ ] 1 video fail → "Thử lại" button → retry không block batch
- [ ] All complete → toast "X/N hoàn thành" + sections appear in lesson view với đúng order
- [ ] Stress 23 video × ~6 phút → backend queue chạy 6.2x realtime ≈ ~10-15 phút processing total

## Out of scope

- Backend bulk-create section endpoint (FE iterates N times — fine for ≤ 100)
- Tiered processing (preview-first 360p, full-res sau) — Tier 2
- Email notification khi batch complete — Tier 1.5 (defer)
- Global progress widget ở header (cross-page) — Tier 1.5 (defer)
- TUS resumable protocol — backend chưa support, multipart đủ cho most cases
- Mobile-first layout — vertical tree đã graceful degrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)