### PR TITLE
fix(curriculum): batch upload modal empty body + 2nd entry point in lesson editor

### DIFF
--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload-modal.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload-modal.component.ts
@@ -1,3 +1,4 @@
+import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -32,7 +33,7 @@ import {
 @Component({
   selector: 'app-batch-video-upload-modal',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [BatchUploadPreviewTreeComponent],
+  imports: [BatchUploadPreviewTreeComponent, NgTemplateOutlet],
   template: `
     @if (isOpen()) {
       <div

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lecture-sections-panel/lecture-sections-panel.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lecture-sections-panel/lecture-sections-panel.component.html
@@ -1,6 +1,11 @@
 <div class="sections-header">
   <label class="editor-label">Nội dung ({{ sections().length }} mục)</label>
 
+  <div style="display: flex; gap: 0.5rem; align-items: center">
+    <button type="button" class="add-content-btn" (click)="batchVideoUpload.emit()" title="Upload nhiều video, hệ thống tự phân bổ vào các bài">
+      <lucide-icon name="upload-cloud" [size]="14"></lucide-icon>
+      Upload nhiều video
+    </button>
   <div class="add-content-wrapper">
     <button type="button" class="add-content-btn" (click)="toggleDropdown()">
       <lucide-icon name="plus" [size]="14"></lucide-icon>
@@ -51,6 +56,7 @@
         </button>
       </div>
     }
+  </div>
   </div>
 </div>
 

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lecture-sections-panel/lecture-sections-panel.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lecture-sections-panel/lecture-sections-panel.component.ts
@@ -239,6 +239,7 @@ export class LectureSectionsPanelComponent {
   activeSectionId = input<string | null>(null);
 
   createSection = output<SectionEditorType>();
+  batchVideoUpload = output<void>();
   editSection = output<SectionDraftDTO>();
   deleteSection = output<string>();
   dropSection = output<CdkDragDrop<SectionDraftDTO[]>>();

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lesson-editor/lesson-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lesson-editor/lesson-editor.component.ts
@@ -164,6 +164,7 @@ import { stripCurriculumPrefix } from '../../../../utils/curriculum-labels';
           [sections]="lesson().sections || []"
           [activeSectionId]="editorSvc.editingSectionId()"
           (createSection)="createSection.emit($event)"
+          (batchVideoUpload)="batchVideoUpload.emit()"
           (editSection)="editSection.emit($event)"
           (deleteSection)="deleteSection.emit($event)"
           (dropSection)="dropSection.emit($event)"
@@ -335,6 +336,7 @@ export class LessonEditorComponent {
   readonly backClicked = output<void>();
 
   readonly createSection = output<string>();
+  readonly batchVideoUpload = output<void>();
   readonly editSection = output<SectionDraftDTO>();
   readonly deleteSection = output<string>();
   readonly dropSection = output<CdkDragDrop<SectionDraftDTO[]>>();

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.html
@@ -131,6 +131,7 @@
         (saveClicked)="saveLesson()"
         (backClicked)="backToChapter()"
         (createSection)="openSectionEditor($any($event))"
+        (batchVideoUpload)="openBatchVideoUploadModal()"
         (editSection)="editSection($event)"
         (deleteSection)="deleteSection($event)"
         (dropSection)="dropSection($event)"


### PR DESCRIPTION
## Bug 1 (CRITICAL) — Modal body trống

Verified qua agent-browser trên prod: button "Upload nhiều video" mở modal nhưng **body hoàn toàn trống** — chỉ hiện header + subtitle, không có drop zone / scope / strategy.

**Root cause**: `batch-video-upload-modal.component.ts` template dùng `*ngTemplateOutlet="pickStage"` để render templates per stage, NHƯNG forgot import `NgTemplateOutlet` directive từ `@angular/common`. Standalone components yêu cầu explicit imports cho mọi directive (kể cả CommonModule directives). Result: `ng-template` references không render gì cả.

**Fix**: 1 import + 1 entry trong imports array.

## Bug 2 (UX discoverability) — chỉ 1 entry point

User feedback: "tại sao không có nút upload nhiều video ở mainlayout (trong phần video?)" — họ đang ở lesson editor, không thấy button vì button chỉ ở chapter view.

**SOTA pattern (2026)**: Coursera Studio v3, Wistia, Mux Mosaic — bulk upload có **multiple entry points** cùng cho 1 action.

**Fix**: thêm button thứ 2 trong `lecture-sections-panel` cạnh dropdown "Thêm mục". Emit event cascade qua `lesson-editor` → `course-curriculum` → cùng `BatchVideoUploadModalComponent` đã có. User trong lesson view click "Upload nhiều video" → modal mở với scope default = CURRENT_CHAPTER (giữ behavior nhất quán với button ở chapter view).

## Test

- [x] TS compile pass
- [x] Angular dev build pass
- [ ] Verify modal body hiện đầy đủ sau deploy
- [ ] Verify button thứ 2 hiển thị trong lesson view (cạnh "Thêm mục")
- [ ] Click button thứ 2 → modal mở giống button cũ

🤖 Generated with [Claude Code](https://claude.com/claude-code)