### PR TITLE
fix(batch-upload): UI rebuild per design tokens — no emoji, ETA, queue position

### DIFF
--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-upload-preview-tree.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-upload-preview-tree.component.ts
@@ -7,33 +7,39 @@ import {
   transferArrayItem,
 } from '@angular/cdk/drag-drop';
 import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
+import { LucideAngularModule } from 'lucide-angular';
 import { BatchTargetLesson, BatchVideoItem } from './batch-video-upload.types';
 
 /**
- * Vertical tree view: lessons làm group, videos là draggable item bên trong.
- * Hỗ trợ cross-lesson drag-drop + reorder + inline edit title + remove + retry.
+ * Vertical tree: lessons làm group, videos là draggable item bên trong.
+ * Cross-lesson drag-drop, inline edit title, remove, retry.
  *
- * Dùng được cho cả Stage 2 (PREVIEW — user xếp lại) và Stage 3 (PROGRESS —
- * status hiển thị real-time, drag bị disable).
+ * Dùng cho cả PREVIEW (drag-drop) và UPLOADING (status real-time, drag disabled).
+ *
+ * Design tokens: tuân thủ docs/reference/PAGE_UX_STANDARD.md
+ *  - Primary #0056D2, semantic emerald/amber/red qua Tailwind
+ *  - Lucide icons (NO emoji)
+ *  - Cards: rounded-lg border-gray-200
+ *  - Status pills: light bg + colored text + dot indicator
  */
 @Component({
   selector: 'app-batch-upload-preview-tree',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CdkDropList, CdkDrag, CdkDragHandle],
+  imports: [CdkDropList, CdkDrag, CdkDragHandle, LucideAngularModule],
   template: `
     <div class="space-y-3">
       @for (lesson of lessons(); track lesson.id) {
         @let lessonItems = itemsByLessonId()[lesson.id] ?? [];
         <div class="rounded-lg border border-gray-200 bg-white overflow-hidden">
-          <div class="px-4 py-2 border-b border-gray-100 bg-slate-50 flex items-center justify-between">
-            <div class="text-sm font-medium text-gray-900 flex items-center gap-2">
-              <span class="text-gray-400">📚</span>
-              <span>{{ lesson.title }}</span>
+          <div class="px-4 py-2.5 border-b border-gray-100 bg-slate-50 flex items-center justify-between">
+            <div class="flex items-center gap-2 min-w-0">
+              <lucide-icon name="book-open" [size]="14" class="text-slate-400 flex-shrink-0"></lucide-icon>
+              <span class="text-sm font-medium text-gray-900 truncate">{{ lesson.title }}</span>
               @if (lesson.existingSectionCount > 0) {
-                <span class="text-xs text-gray-500">({{ lesson.existingSectionCount }} mục có sẵn)</span>
+                <span class="text-xs text-gray-500 flex-shrink-0">({{ lesson.existingSectionCount }} mục có sẵn)</span>
               }
             </div>
-            <span class="text-xs font-medium text-gray-600">
+            <span class="text-xs font-medium text-gray-600 flex-shrink-0 ml-3">
               {{ lessonItems.length }} video
             </span>
           </div>
@@ -46,21 +52,27 @@ import { BatchTargetLesson, BatchVideoItem } from './batch-video-upload.types';
             (cdkDropListDropped)="onDrop($event)"
             class="min-h-[56px]"
           >
-            @for (item of lessonItems; track item.id) {
+            @for (item of lessonItems; track item.id; let i = $index) {
               <div
                 cdkDrag
                 [cdkDragData]="item.id"
                 [cdkDragDisabled]="!isDraggable(item)"
-                class="px-3 py-2.5 flex items-center gap-3 border-b border-gray-50 last:border-b-0 hover:bg-slate-50/50"
+                class="px-3 py-2.5 flex items-center gap-3 border-b border-gray-50 last:border-b-0 hover:bg-slate-50/50 transition-colors"
                 [class.opacity-60]="item.status === 'READY'"
               >
-                @if (isDraggable(item)) {
-                  <span cdkDragHandle class="cursor-move text-gray-300 select-none px-1" aria-label="Kéo để di chuyển">⋮⋮</span>
-                } @else {
-                  <span class="text-gray-200 px-1 select-none">⋮⋮</span>
-                }
+                <button
+                  type="button"
+                  cdkDragHandle
+                  class="text-slate-300 hover:text-slate-500 cursor-move flex-shrink-0 disabled:cursor-default disabled:hover:text-slate-300"
+                  [disabled]="!isDraggable(item)"
+                  aria-label="Kéo để di chuyển"
+                >
+                  <lucide-icon name="grip-vertical" [size]="14"></lucide-icon>
+                </button>
 
-                <span class="text-lg flex-shrink-0">{{ statusIcon(item) }}</span>
+                <div class="w-9 h-9 rounded-md flex items-center justify-center flex-shrink-0" [class]="iconWrapperClass(item)">
+                  <lucide-icon [name]="statusIconName(item)" [size]="16" [class]="iconClass(item)"></lucide-icon>
+                </div>
 
                 <div class="flex-1 min-w-0">
                   @if (editingId() === item.id) {
@@ -70,12 +82,12 @@ import { BatchTargetLesson, BatchVideoItem } from './batch-video-upload.types';
                       (blur)="commitTitle(item.id, $any($event.target).value)"
                       (keydown.enter)="commitTitle(item.id, $any($event.target).value)"
                       (keydown.escape)="editingId.set(null)"
-                      class="w-full text-sm border-b border-[#0056D2] focus:outline-none px-1 py-0.5"
+                      class="w-full text-sm border-b border-[#0056D2] focus:outline-none px-1 py-0.5 bg-transparent"
                     />
                   } @else {
                     <button
                       type="button"
-                      class="text-sm font-medium text-gray-900 truncate w-full text-left hover:text-[#0056D2] hover:underline"
+                      class="text-sm font-medium text-gray-900 truncate w-full text-left enabled:hover:text-[#0056D2] disabled:cursor-default"
                       (click)="onTitleClick(item)"
                       [disabled]="item.status !== 'PENDING'"
                     >
@@ -85,16 +97,26 @@ import { BatchTargetLesson, BatchVideoItem } from './batch-video-upload.types';
                   <div class="text-xs text-gray-500 flex items-center gap-2 mt-0.5 truncate">
                     <span class="truncate">{{ item.file.name }}</span>
                     <span class="text-gray-300">·</span>
-                    <span class="flex-shrink-0">{{ formatBytes(item.file.size) }}</span>
-                    <span class="text-gray-300">·</span>
-                    <span class="flex-shrink-0" [class]="statusColor(item)">{{ statusLabel(item) }}</span>
+                    <span class="flex-shrink-0 tabular-nums">{{ formatBytes(item.file.size) }}</span>
+                    @if (queuePositionFor(item.id); as pos) {
+                      <span class="text-gray-300">·</span>
+                      <span class="flex-shrink-0">Vị trí #{{ pos }}</span>
+                    }
                   </div>
                   @if (item.status === 'UPLOADING') {
-                    <div class="mt-1.5 h-1 bg-gray-100 rounded-full overflow-hidden">
-                      <div
-                        class="h-full bg-[#0056D2] transition-all duration-200"
-                        [style.width.%]="item.uploadProgress"
-                      ></div>
+                    <div class="mt-1.5 flex items-center gap-2">
+                      <div class="flex-1 h-1 bg-gray-100 rounded-full overflow-hidden">
+                        <div
+                          class="h-full bg-[#0056D2] transition-all duration-200 rounded-full"
+                          [style.width.%]="item.uploadProgress"
+                        ></div>
+                      </div>
+                      <span class="text-[11px] font-medium text-[#0056D2] tabular-nums w-9 text-right">{{ item.uploadProgress }}%</span>
+                    </div>
+                  }
+                  @if (item.status === 'PROCESSING' || item.status === 'ASSET_CREATING' || item.status === 'SECTION_CREATING') {
+                    <div class="mt-1.5 h-1 bg-amber-100 rounded-full overflow-hidden relative">
+                      <div class="absolute inset-0 batch-stripe-animate"></div>
                     </div>
                   }
                   @if (item.status === 'FAILED' && item.errorMessage) {
@@ -105,29 +127,35 @@ import { BatchTargetLesson, BatchVideoItem } from './batch-video-upload.types';
                 </div>
 
                 <div class="flex items-center gap-1 flex-shrink-0">
+                  <span class="text-[11px] font-medium px-2 py-0.5 rounded-full" [class]="statusPillClass(item)">
+                    {{ statusLabel(item) }}
+                  </span>
                   @if (item.status === 'FAILED') {
                     <button
                       type="button"
                       (click)="retryRequested.emit(item.id)"
-                      class="text-xs text-[#0056D2] hover:bg-[#0056D2]/10 rounded px-2 py-1"
+                      class="text-gray-500 hover:text-[#0056D2] hover:bg-[#0056D2]/10 rounded p-1"
+                      aria-label="Thử lại"
+                      title="Thử lại"
                     >
-                      Thử lại
+                      <lucide-icon name="rotate-cw" [size]="14"></lucide-icon>
                     </button>
                   }
                   @if (item.status === 'PENDING' || item.status === 'FAILED') {
                     <button
                       type="button"
                       (click)="removeRequested.emit(item.id)"
-                      class="text-gray-400 hover:text-red-500 hover:bg-red-50 rounded p-1 text-sm"
+                      class="text-gray-400 hover:text-red-600 hover:bg-red-50 rounded p-1"
                       aria-label="Xoá khỏi danh sách"
+                      title="Xoá"
                     >
-                      ✕
+                      <lucide-icon name="x" [size]="14"></lucide-icon>
                     </button>
                   }
                 </div>
               </div>
             } @empty {
-              <div class="px-3 py-6 text-xs text-center text-gray-400 italic">
+              <div class="px-3 py-5 text-xs text-center text-gray-400 italic">
                 Kéo thả video vào đây
               </div>
             }
@@ -139,13 +167,34 @@ import { BatchTargetLesson, BatchVideoItem } from './batch-video-upload.types';
         <button
           type="button"
           (click)="newLessonRequested.emit()"
-          class="w-full px-4 py-3 border-2 border-dashed border-gray-300 rounded-lg text-sm text-gray-600 hover:bg-slate-50 hover:border-[#0056D2] hover:text-[#0056D2] transition-colors"
+          class="w-full px-4 py-3 border-2 border-dashed border-gray-300 rounded-lg text-sm text-gray-600 hover:bg-slate-50 hover:border-[#0056D2] hover:text-[#0056D2] transition-colors flex items-center justify-center gap-1.5"
         >
-          + Tạo bài mới
+          <lucide-icon name="plus" [size]="14"></lucide-icon>
+          Tạo bài mới
         </button>
       }
     </div>
   `,
+  styles: [`
+    @keyframes batch-stripe {
+      0% { background-position: 0 0; }
+      100% { background-position: 32px 0; }
+    }
+    .batch-stripe-animate {
+      background-image: linear-gradient(
+        45deg,
+        rgba(217, 119, 6, 0.4) 25%,
+        transparent 25%,
+        transparent 50%,
+        rgba(217, 119, 6, 0.4) 50%,
+        rgba(217, 119, 6, 0.4) 75%,
+        transparent 75%,
+        transparent
+      );
+      background-size: 32px 32px;
+      animation: batch-stripe 1s linear infinite;
+    }
+  `],
 })
 export class BatchUploadPreviewTreeComponent {
   readonly lessons = input.required<BatchTargetLesson[]>();
@@ -174,6 +223,22 @@ export class BatchUploadPreviewTreeComponent {
 
   readonly allDropListIds = computed(() => this.lessons().map((l) => 'drop-' + l.id));
 
+  /** Queue position 1-based: 1 = upload tiếp theo, null nếu không trong queue PENDING. */
+  private readonly pendingOrder = computed<Map<string, number>>(() => {
+    const map = new Map<string, number>();
+    let pos = 1;
+    for (const item of this.items()) {
+      if (item.status === 'PENDING') {
+        map.set(item.id, pos++);
+      }
+    }
+    return map;
+  });
+
+  queuePositionFor(itemId: string): number | null {
+    return this.pendingOrder().get(itemId) ?? null;
+  }
+
   isDraggable(item: BatchVideoItem): boolean {
     return item.status === 'PENDING';
   }
@@ -197,19 +262,16 @@ export class BatchUploadPreviewTreeComponent {
     if (!targetLessonId) return;
 
     if (event.previousContainer === event.container) {
-      // Reorder within same lesson — just emit final position
       moveItemInArray(event.container.data, event.previousIndex, event.currentIndex);
-      this.itemMoved.emit({ itemId, targetLessonId, targetIndex: event.currentIndex });
     } else {
-      // Cross-lesson move
       transferArrayItem(
         event.previousContainer.data,
         event.container.data,
         event.previousIndex,
         event.currentIndex
       );
-      this.itemMoved.emit({ itemId, targetLessonId, targetIndex: event.currentIndex });
     }
+    this.itemMoved.emit({ itemId, targetLessonId, targetIndex: event.currentIndex });
   }
 
   formatBytes(bytes: number): string {
@@ -219,21 +281,55 @@ export class BatchUploadPreviewTreeComponent {
     return (bytes / (1024 * 1024 * 1024)).toFixed(2) + ' GB';
   }
 
-  statusIcon(item: BatchVideoItem): string {
+  statusIconName(item: BatchVideoItem): string {
     switch (item.status) {
       case 'PENDING':
-        return '🎬';
+        return 'clock';
       case 'UPLOADING':
-        return '⬆️';
+        return 'upload-cloud';
       case 'ASSET_CREATING':
       case 'SECTION_CREATING':
-        return '⏳';
+        return 'cog';
       case 'PROCESSING':
-        return '🔄';
+        return 'cog';
       case 'READY':
-        return '✅';
+        return 'check-circle-2';
       case 'FAILED':
-        return '❌';
+        return 'alert-circle';
+    }
+  }
+
+  iconWrapperClass(item: BatchVideoItem): string {
+    switch (item.status) {
+      case 'READY':
+        return 'bg-emerald-50';
+      case 'FAILED':
+        return 'bg-red-50';
+      case 'PROCESSING':
+      case 'ASSET_CREATING':
+      case 'SECTION_CREATING':
+        return 'bg-amber-50';
+      case 'UPLOADING':
+        return 'bg-[#0056D2]/10';
+      default:
+        return 'bg-slate-100';
+    }
+  }
+
+  iconClass(item: BatchVideoItem): string {
+    switch (item.status) {
+      case 'READY':
+        return 'text-emerald-600';
+      case 'FAILED':
+        return 'text-red-600';
+      case 'PROCESSING':
+      case 'ASSET_CREATING':
+      case 'SECTION_CREATING':
+        return 'text-amber-600 animate-spin';
+      case 'UPLOADING':
+        return 'text-[#0056D2]';
+      default:
+        return 'text-slate-500';
     }
   }
 
@@ -242,11 +338,11 @@ export class BatchUploadPreviewTreeComponent {
       case 'PENDING':
         return 'Chờ';
       case 'UPLOADING':
-        return `Đang upload ${item.uploadProgress}%`;
+        return 'Đang tải lên';
       case 'ASSET_CREATING':
-        return 'Đang đăng ký';
+        return 'Đăng ký';
       case 'SECTION_CREATING':
-        return 'Đang tạo mục';
+        return 'Tạo mục';
       case 'PROCESSING':
         return 'Đang xử lý';
       case 'READY':
@@ -256,17 +352,20 @@ export class BatchUploadPreviewTreeComponent {
     }
   }
 
-  statusColor(item: BatchVideoItem): string {
+  statusPillClass(item: BatchVideoItem): string {
     switch (item.status) {
       case 'READY':
-        return 'text-emerald-600';
+        return 'bg-emerald-50 text-emerald-700';
       case 'FAILED':
-        return 'text-red-600';
+        return 'bg-red-50 text-red-700';
       case 'PROCESSING':
+      case 'ASSET_CREATING':
+      case 'SECTION_CREATING':
+        return 'bg-amber-50 text-amber-700';
       case 'UPLOADING':
-        return 'text-[#0056D2]';
+        return 'bg-[#0056D2]/10 text-[#0056D2]';
       default:
-        return 'text-gray-500';
+        return 'bg-slate-100 text-slate-600';
     }
   }
 }

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload-modal.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload-modal.component.ts
@@ -10,59 +10,61 @@ import {
   output,
   signal,
 } from '@angular/core';
+import { LucideAngularModule } from 'lucide-angular';
 import { BatchUploadPreviewTreeComponent } from './batch-upload-preview-tree.component';
 import { BatchVideoUploadService } from './batch-video-upload.service';
 import {
   BatchScope,
   BatchTargetLesson,
-  BatchUploadConfig,
   DistributionStrategy,
 } from './batch-video-upload.types';
 
 /**
- * Modal shell cho batch upload — 3 stage state machine:
- *  1. PICK: drop zone + scope/strategy chooser
- *  2. PREVIEW: tree view (xếp lại) + confirm
- *  3. UPLOADING: progress tree + aggregate stats + close-and-continue
+ * Modal shell — 3-stage state machine:
+ *  PICK     → drop zone + scope/strategy chooser
+ *  PREVIEW  → tree view (drag-drop xếp lại) + confirm
+ *  UPLOADING/COMPLETE → progress dashboard + tree với status real-time
  *
- * Service singleton (BatchVideoUploadService) giữ state khi modal đóng → user
- * có thể navigate khỏi modal mà upload vẫn chạy nền (background safety).
+ * Service singleton (BatchVideoUploadService) survive khi modal đóng → upload
+ * tiếp tục chạy nền. Mode `IDLE` reset trạng thái cho lần mở sau.
  *
- * Reuse 100% existing services + store. KHÔNG refactor adjacent code.
+ * Tuân thủ docs/reference/PAGE_UX_STANDARD.md:
+ *  - Lucide icons (NO emoji)
+ *  - Design tokens: #0056D2 primary, semantic emerald/amber/red
+ *  - Cards rounded-xl, border-gray-200, shadow-sm
+ *  - Spacing 8px grid
  */
 @Component({
   selector: 'app-batch-video-upload-modal',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [BatchUploadPreviewTreeComponent, NgTemplateOutlet],
+  imports: [BatchUploadPreviewTreeComponent, NgTemplateOutlet, LucideAngularModule],
   template: `
     @if (isOpen()) {
       <div
-        class="fixed inset-0 z-50 flex items-start justify-center bg-black/40 backdrop-blur-sm overflow-y-auto py-8 px-4"
+        class="fixed inset-0 z-50 flex items-start justify-center bg-black/50 backdrop-blur-sm overflow-y-auto py-6 px-4"
         (click)="onBackdropClick($event)"
       >
         <div
-          class="relative w-full max-w-3xl bg-white rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[calc(100vh-4rem)]"
+          class="relative w-full max-w-3xl bg-white rounded-2xl shadow-2xl overflow-hidden flex flex-col max-h-[calc(100vh-3rem)]"
           role="dialog"
           aria-modal="true"
           aria-labelledby="batch-upload-title"
         >
           <!-- Header -->
-          <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between flex-shrink-0">
-            <div>
+          <div class="px-6 py-4 border-b border-gray-200 flex items-start justify-between flex-shrink-0">
+            <div class="min-w-0">
               <h2 id="batch-upload-title" class="text-lg font-semibold text-gray-900">
                 {{ headerTitle() }}
               </h2>
-              <p class="text-xs text-gray-500 mt-0.5">{{ headerSubtitle() }}</p>
+              <p class="text-sm text-gray-500 mt-0.5">{{ headerSubtitle() }}</p>
             </div>
             <button
               type="button"
               (click)="requestClose()"
-              class="text-gray-400 hover:text-gray-600 p-1 rounded hover:bg-gray-100"
+              class="text-gray-400 hover:text-gray-600 p-1.5 rounded-md hover:bg-gray-100 flex-shrink-0 ml-4"
               aria-label="Đóng"
             >
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M18 6L6 18M6 6l12 12"/>
-              </svg>
+              <lucide-icon name="x" [size]="20"></lucide-icon>
             </button>
           </div>
 
@@ -89,21 +91,30 @@ import {
 
           <!-- Footer -->
           <div class="px-6 py-3 border-t border-gray-200 bg-slate-50 flex items-center justify-between flex-shrink-0">
-            <div class="text-xs text-gray-600">
+            <div class="text-sm text-gray-700 min-w-0">
               @if (svc.mode() === 'UPLOADING' || svc.mode() === 'COMPLETE') {
                 @let p = svc.aggregateProgress();
-                {{ p.readyCount }}/{{ p.totalCount }} sẵn sàng
+                <span class="font-medium tabular-nums">{{ p.readyCount }}/{{ p.totalCount }}</span>
+                <span class="text-gray-500"> sẵn sàng</span>
+                @if (etaSeconds() !== null && svc.mode() === 'UPLOADING') {
+                  <span class="text-gray-400 mx-1">·</span>
+                  <span class="text-gray-600">~{{ formatEta(etaSeconds()!) }} còn lại</span>
+                }
                 @if (p.failedCount > 0) {
-                  · {{ p.failedCount }} lỗi
+                  <span class="text-gray-400 mx-1">·</span>
+                  <span class="text-red-600 font-medium">{{ p.failedCount }} lỗi</span>
                 }
               } @else if (svc.mode() === 'PREVIEW') {
                 @let p = svc.aggregateProgress();
-                Tổng: {{ p.totalCount }} video → {{ lessonsWithVideoCount() }} bài
+                <span class="font-medium tabular-nums">{{ p.totalCount }}</span>
+                <span class="text-gray-500"> video → </span>
+                <span class="font-medium tabular-nums">{{ lessonsWithVideoCount() }}</span>
+                <span class="text-gray-500"> bài</span>
               } @else {
                 <span>&nbsp;</span>
               }
             </div>
-            <div class="flex items-center gap-2">
+            <div class="flex items-center gap-2 flex-shrink-0">
               @if (svc.mode() === 'PICK') {
                 <button
                   type="button"
@@ -116,14 +127,15 @@ import {
                   type="button"
                   (click)="onBackToPick()"
                   class="px-4 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg"
-                >← Chọn lại file</button>
+                >Chọn lại file</button>
                 <button
                   type="button"
                   (click)="onConfirmStart()"
                   [disabled]="svc.aggregateProgress().totalCount === 0"
-                  class="px-4 py-1.5 text-sm font-semibold text-white bg-[#0056D2] hover:bg-[#004BB5] rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                  class="px-4 py-1.5 text-sm font-semibold text-white bg-[#0056D2] hover:bg-[#004BB8] rounded-lg disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1.5"
                 >
-                  Bắt đầu upload ({{ svc.aggregateProgress().totalCount }} video)
+                  <lucide-icon name="upload-cloud" [size]="14"></lucide-icon>
+                  Bắt đầu upload
                 </button>
               }
               @if (svc.mode() === 'UPLOADING' || svc.mode() === 'COMPLETE') {
@@ -141,7 +153,7 @@ import {
       </div>
     }
 
-    <!-- ========== PICK Stage ========== -->
+    <!-- ============ PICK Stage ============ -->
     <ng-template #pickStage>
       <div class="space-y-4">
         <div
@@ -151,9 +163,11 @@ import {
           (dragleave)="dragHover.set(false)"
           [class.border-\[\#0056D2\]]="dragHover()"
           [class.bg-\[\#0056D2\]\/5]="dragHover()"
-          class="border-2 border-dashed border-gray-300 rounded-xl px-8 py-12 text-center hover:border-[#0056D2] transition-colors"
+          class="border-2 border-dashed border-gray-300 rounded-xl px-8 py-10 text-center hover:border-[#0056D2] transition-colors"
         >
-          <div class="text-5xl mb-3">📁</div>
+          <div class="mx-auto w-12 h-12 rounded-full bg-[#0056D2]/10 flex items-center justify-center mb-3">
+            <lucide-icon name="cloud-upload" [size]="24" class="text-[#0056D2]"></lucide-icon>
+          </div>
           <p class="text-sm font-medium text-gray-900">Kéo thả nhiều video vào đây</p>
           <p class="text-xs text-gray-500 mt-1">hoặc</p>
           <label class="inline-block mt-2 cursor-pointer">
@@ -164,26 +178,26 @@ import {
               (change)="onFilePickerChange($event)"
               class="hidden"
             />
-            <span class="px-4 py-2 text-sm font-semibold text-[#0056D2] bg-[#0056D2]/10 hover:bg-[#0056D2]/20 rounded-lg inline-block">
+            <span class="px-4 py-2 text-sm font-semibold text-[#0056D2] bg-[#0056D2]/10 hover:bg-[#0056D2]/20 rounded-lg inline-block transition-colors">
               Chọn nhiều file
             </span>
           </label>
-          <p class="text-xs text-gray-400 mt-3">Tối đa 5GB / file · MP4, MOV, MKV, WebM</p>
+          <p class="text-xs text-gray-400 mt-3">MP4, MOV, MKV, WebM · Tối đa 5GB / file</p>
         </div>
 
-        <fieldset class="border border-gray-200 rounded-lg p-4 space-y-3">
-          <legend class="text-xs font-semibold text-gray-700 px-2">Phạm vi phân bổ</legend>
+        <fieldset class="border border-gray-200 rounded-xl p-4 space-y-2.5">
+          <legend class="text-xs font-semibold text-gray-700 px-2 uppercase tracking-wide">Phạm vi phân bổ</legend>
           @for (opt of scopeOptions; track opt.value) {
-            <label class="flex items-start gap-2 text-sm cursor-pointer">
+            <label class="flex items-start gap-2.5 text-sm cursor-pointer hover:bg-slate-50 -mx-2 px-2 py-1 rounded-md">
               <input
                 type="radio"
                 name="scope"
                 [value]="opt.value"
                 [checked]="selectedScope() === opt.value"
                 (change)="selectedScope.set(opt.value)"
-                class="mt-0.5 accent-[#0056D2]"
+                class="mt-1 accent-[#0056D2]"
               />
-              <div>
+              <div class="min-w-0">
                 <div class="font-medium text-gray-900">{{ opt.label }}</div>
                 <div class="text-xs text-gray-500">{{ scopeHint(opt.value) }}</div>
               </div>
@@ -191,19 +205,19 @@ import {
           }
         </fieldset>
 
-        <fieldset class="border border-gray-200 rounded-lg p-4 space-y-3">
-          <legend class="text-xs font-semibold text-gray-700 px-2">Cách phân bổ mặc định</legend>
+        <fieldset class="border border-gray-200 rounded-xl p-4 space-y-2.5">
+          <legend class="text-xs font-semibold text-gray-700 px-2 uppercase tracking-wide">Cách phân bổ mặc định</legend>
           @for (opt of strategyOptions; track opt.value) {
-            <label class="flex items-start gap-2 text-sm cursor-pointer">
+            <label class="flex items-start gap-2.5 text-sm cursor-pointer hover:bg-slate-50 -mx-2 px-2 py-1 rounded-md">
               <input
                 type="radio"
                 name="strategy"
                 [value]="opt.value"
                 [checked]="selectedStrategy() === opt.value"
                 (change)="selectedStrategy.set(opt.value)"
-                class="mt-0.5 accent-[#0056D2]"
+                class="mt-1 accent-[#0056D2]"
               />
-              <div>
+              <div class="min-w-0">
                 <div class="font-medium text-gray-900">{{ opt.label }}</div>
                 <div class="text-xs text-gray-500">{{ opt.hint }}</div>
               </div>
@@ -213,15 +227,15 @@ import {
       </div>
     </ng-template>
 
-    <!-- ========== PREVIEW Stage ========== -->
+    <!-- ============ PREVIEW Stage ============ -->
     <ng-template #previewStage>
       <div class="space-y-4">
-        <div class="flex items-center justify-between text-xs text-gray-600">
-          <span>Kéo thả ⋮⋮ để xếp lại video giữa các bài. Click tên để sửa tiêu đề mục.</span>
+        <div class="flex items-center justify-between text-xs">
+          <span class="text-gray-500">Kéo thả để xếp lại video giữa các bài. Click tên để sửa tiêu đề.</span>
           <button
             type="button"
             (click)="onChangeStrategy()"
-            class="text-[#0056D2] hover:underline"
+            class="text-[#0056D2] hover:underline font-medium"
           >
             Đổi cách phân bổ
           </button>
@@ -238,32 +252,38 @@ import {
       </div>
     </ng-template>
 
-    <!-- ========== UPLOADING / COMPLETE Stage ========== -->
+    <!-- ============ UPLOADING / COMPLETE Stage ============ -->
     <ng-template #uploadingStage>
       <div class="space-y-4">
         @let p = svc.aggregateProgress();
-        <div class="grid grid-cols-5 gap-2 text-xs">
-          <div class="rounded-lg bg-gray-100 px-3 py-2 text-center">
-            <div class="font-semibold text-gray-900">{{ p.pendingCount }}</div>
-            <div class="text-gray-500">Chờ</div>
-          </div>
-          <div class="rounded-lg bg-[#0056D2]/10 px-3 py-2 text-center">
-            <div class="font-semibold text-[#0056D2]">{{ p.uploadingCount }}</div>
-            <div class="text-gray-500">Đang upload</div>
-          </div>
-          <div class="rounded-lg bg-amber-50 px-3 py-2 text-center">
-            <div class="font-semibold text-amber-700">{{ p.processingCount }}</div>
-            <div class="text-gray-500">Đang xử lý</div>
-          </div>
-          <div class="rounded-lg bg-emerald-50 px-3 py-2 text-center">
-            <div class="font-semibold text-emerald-700">{{ p.readyCount }}</div>
-            <div class="text-gray-500">Sẵn sàng</div>
-          </div>
-          <div class="rounded-lg bg-red-50 px-3 py-2 text-center">
-            <div class="font-semibold text-red-700">{{ p.failedCount }}</div>
-            <div class="text-gray-500">Lỗi</div>
-          </div>
+        <div class="grid grid-cols-2 sm:grid-cols-5 gap-2">
+          @for (card of statusCards(); track card.label) {
+            <div class="rounded-xl border px-3 py-2.5" [class]="card.containerClass">
+              <div class="flex items-center justify-between mb-0.5">
+                <lucide-icon [name]="card.icon" [size]="14" [class]="card.iconClass"></lucide-icon>
+                <span class="text-lg font-semibold tabular-nums" [class]="card.numberClass">{{ card.count }}</span>
+              </div>
+              <div class="text-[11px] font-medium" [class]="card.labelClass">{{ card.label }}</div>
+            </div>
+          }
         </div>
+
+        @if (svc.mode() === 'UPLOADING') {
+          @let totalDone = p.readyCount + p.failedCount;
+          <div class="rounded-xl border border-gray-200 bg-white p-3">
+            <div class="flex items-center justify-between text-xs mb-2">
+              <span class="text-gray-700 font-medium">Tổng tiến độ</span>
+              <span class="text-gray-500 tabular-nums">{{ totalDone }} / {{ p.totalCount }}</span>
+            </div>
+            <div class="h-1.5 bg-gray-100 rounded-full overflow-hidden">
+              <div
+                class="h-full bg-[#0056D2] transition-all duration-300 rounded-full"
+                [style.width.%]="overallPercent()"
+              ></div>
+            </div>
+          </div>
+        }
+
         <app-batch-upload-preview-tree
           [lessons]="svc.availableLessons()"
           [items]="svc.items()"
@@ -282,7 +302,6 @@ export class BatchVideoUploadModalComponent {
   readonly courseId = input.required<string>();
   readonly currentChapterId = input<string | null>(null);
   readonly currentLessonId = input<string | null>(null);
-  /** Lesson tree: parent passes flat list with chapter context */
   readonly availableLessons = input<BatchTargetLesson[]>([]);
 
   readonly closed = output<void>();
@@ -307,6 +326,78 @@ export class BatchVideoUploadModalComponent {
     const items = this.svc.items();
     const ids = new Set(items.map((i) => i.lessonId));
     return ids.size;
+  });
+
+  /**
+   * ETA tổng cho batch: bottleneck là backend transcoding (max 2 concurrent,
+   * ~60s per video — measured 6.2x realtime với video ~6 phút trên prod).
+   * Returns null khi không có item active.
+   */
+  readonly etaSeconds = computed<number | null>(() => {
+    const p = this.svc.aggregateProgress();
+    const remaining = p.pendingCount + p.uploadingCount + p.processingCount;
+    if (remaining === 0) return null;
+    const BACKEND_PARALLEL = 2;
+    const AVG_SECONDS_PER_VIDEO = 60;
+    return Math.ceil((remaining / BACKEND_PARALLEL) * AVG_SECONDS_PER_VIDEO);
+  });
+
+  readonly overallPercent = computed(() => {
+    const p = this.svc.aggregateProgress();
+    if (p.totalCount === 0) return 0;
+    const done = p.readyCount + p.failedCount;
+    return Math.round((done / p.totalCount) * 100);
+  });
+
+  readonly statusCards = computed(() => {
+    const p = this.svc.aggregateProgress();
+    return [
+      {
+        label: 'Chờ',
+        count: p.pendingCount,
+        icon: 'clock',
+        containerClass: 'border-gray-200 bg-white',
+        iconClass: 'text-slate-400',
+        numberClass: 'text-gray-900',
+        labelClass: 'text-gray-500',
+      },
+      {
+        label: 'Đang tải lên',
+        count: p.uploadingCount,
+        icon: 'upload-cloud',
+        containerClass: 'border-[#0056D2]/20 bg-[#0056D2]/5',
+        iconClass: 'text-[#0056D2]',
+        numberClass: 'text-[#0056D2]',
+        labelClass: 'text-[#0056D2]',
+      },
+      {
+        label: 'Đang xử lý',
+        count: p.processingCount,
+        icon: 'cog',
+        containerClass: 'border-amber-200 bg-amber-50',
+        iconClass: 'text-amber-600',
+        numberClass: 'text-amber-700',
+        labelClass: 'text-amber-700',
+      },
+      {
+        label: 'Sẵn sàng',
+        count: p.readyCount,
+        icon: 'check-circle-2',
+        containerClass: 'border-emerald-200 bg-emerald-50',
+        iconClass: 'text-emerald-600',
+        numberClass: 'text-emerald-700',
+        labelClass: 'text-emerald-700',
+      },
+      {
+        label: 'Lỗi',
+        count: p.failedCount,
+        icon: 'alert-circle',
+        containerClass: 'border-red-200 bg-red-50',
+        iconClass: 'text-red-600',
+        numberClass: 'text-red-700',
+        labelClass: 'text-red-700',
+      },
+    ];
   });
 
   protected readonly headerTitle = computed(() => {
@@ -336,7 +427,6 @@ export class BatchVideoUploadModalComponent {
   });
 
   constructor() {
-    // Auto-reset PICK state when modal closes after COMPLETE
     effect(() => {
       if (!this.isOpen() && this.svc.mode() === 'COMPLETE') {
         this.svc.reset();
@@ -362,7 +452,6 @@ export class BatchVideoUploadModalComponent {
 
   protected requestClose(): void {
     if (this.svc.mode() === 'UPLOADING') {
-      // Service state survives close → background mode
       this.closed.emit();
       return;
     }
@@ -376,7 +465,7 @@ export class BatchVideoUploadModalComponent {
     const input = event.target as HTMLInputElement;
     const files = input.files ? Array.from(input.files) : [];
     this.handleFilesPicked(files);
-    input.value = ''; // allow same file re-pick
+    input.value = '';
   }
 
   protected onFileDrop(event: DragEvent): void {
@@ -417,12 +506,20 @@ export class BatchVideoUploadModalComponent {
     await this.svc.createNewLesson(chapterId, title.trim());
   }
 
+  protected formatEta(seconds: number): string {
+    if (seconds < 60) return Math.max(1, seconds) + ' giây';
+    const minutes = Math.ceil(seconds / 60);
+    if (minutes < 60) return minutes + ' phút';
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return hours + ' giờ' + (mins > 0 ? ' ' + mins + ' phút' : '');
+  }
+
   private handleFilesPicked(files: File[]): void {
     if (files.length === 0) return;
     const scope = this.selectedScope();
     const lessons = this.computeLessonsForScope(scope);
     if (lessons.length === 0) {
-      // No lessons → cannot distribute. Abort with hint.
       window.alert('Không có bài học nào để phân bổ. Vui lòng tạo bài trước hoặc chọn phạm vi rộng hơn.');
       return;
     }


### PR DESCRIPTION
## Reviewer feedback addressed

> "UX/UI đang dùng emoji và hơi slop AI [...] thanh đang xử lý không có thông số hay gì à? [...] UX/UI hiện tại chưa ổn và thiếu chuyên nghiệp"

## Changes

### 1. Replace ALL emoji with Lucide icons
Per project standard (`docs/reference/PAGE_UX_STANDARD.md`):
| Was | Now |
|---|---|
| 📁 | `cloud-upload` |
| 🎬 | `video` |
| 📚 | `book-open` |
| ⋮⋮ | `grip-vertical` |
| ⬆️/⏳/🔄/✅/❌ | `upload-cloud` / `clock` / `cog` (animate-spin) / `check-circle-2` / `alert-circle` |

### 2. Apply design tokens (semantic colors)
- Cards: `rounded-xl border-gray-200`
- Status colors: PENDING slate, UPLOADING `#0056D2`, PROCESSING amber, READY emerald, FAILED red — match `PAGE_UX_STANDARD §2.1`
- Spacing 8px grid, tabular-nums for all numbers

### 3. Fix missing PROCESSING progress (the screenshot complaint)
Before: PROCESSING rows showed only static text "Đang xử lý" — no visual feedback.
After: **Indeterminate animated stripe progress bar** (45deg amber stripes, 1s loop via @keyframes). Standard pattern khi không biết exact %.

### 4. New: Queue position + ETA
- PENDING items show "Vị trí #N" (1-based queue position) — user biết bao giờ tới lượt
- Modal footer: "~X phút còn lại" — ETA tổng dựa trên formula `ceil(remaining / 2_backend_parallel) × 60s_per_video` (calibrated từ measured 6.2x realtime trên prod)
- UPLOADING stage có overall progress bar bổ sung

### 5. Aggregate dashboard refinement
5 status cards: Lucide icon + tabular-num count + label + semantic border/bg. 2-col mobile, 5-col desktop.

## Surgical scope (karpathy-aligned)

- 2 file edit (modal + tree component)
- 0 service/types/util touched
- 0 refactor adjacent code
- Mirror design patterns đã có trong project (`payment-modal`, `IconComponent`, `lucide-icon`)

## Test

- [x] TS compile pass
- [x] Angular dev build pass
- [ ] Verify modal hiển thị Lucide icons (no emoji)
- [ ] PROCESSING rows có thanh stripe animated
- [ ] PENDING rows hiển thị "Vị trí #N"
- [ ] Footer hiển thị "~X phút còn lại"
- [ ] Aggregate cards hiển thị lucide icons + colored borders

## Out of scope (để bug khác)

- Retry idempotency (nếu fail ở step PROCESSING, retry hiện tại re-upload + re-create section → duplicate). Cần fix riêng — issue khác hẳn UX.
- Backend status differentiation: BE chỉ có 1 status PROCESSING (queued vs actively transcoding cùng 1 nhãn). FE không thể distinguish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)