### PR TITLE
fix(batch-upload): smart auto-naming + 60min poll cap + honest tab-close copy

### DIFF
--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-distribution.util.spec.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-distribution.util.spec.ts
@@ -3,6 +3,8 @@ import {
   distributeByFilenamePrefix,
   distributeEvenly,
   extractFilenameTitle,
+  isGenericFilename,
+  smartSectionTitle,
 } from './batch-distribution.util';
 
 const FOUR_LESSONS: DistributableLesson[] = [
@@ -221,5 +223,65 @@ describe('extractFilenameTitle', () => {
 
   it('Vietnamese diacritics preserved', () => {
     expect(extractFilenameTitle('Bài giảng số 1.mp4')).toBe('Bài giảng số 1');
+  });
+});
+
+describe('isGenericFilename', () => {
+  it('detect "export-..." (camera export pattern)', () => {
+    expect(isGenericFilename('export-1777613145929.mp4')).toBe(true);
+  });
+
+  it('detect "VID_001.mov" (camera default)', () => {
+    expect(isGenericFilename('VID_001.mov')).toBe(true);
+  });
+
+  it('detect "IMG_1234.mp4"', () => {
+    expect(isGenericFilename('IMG_1234.mp4')).toBe(true);
+  });
+
+  it('detect "recording-2026-01-15.webm"', () => {
+    expect(isGenericFilename('recording-2026-01-15.webm')).toBe(true);
+  });
+
+  it('detect "untitled.mp4"', () => {
+    expect(isGenericFilename('untitled.mp4')).toBe(true);
+  });
+
+  it('detect "video.mp4" minimal', () => {
+    expect(isGenericFilename('video.mp4')).toBe(true);
+  });
+
+  it('KHÔNG detect tên tiếng Việt có ý nghĩa', () => {
+    expect(isGenericFilename('Bài 1 An toàn hàng hải.mp4')).toBe(false);
+    expect(isGenericFilename('Giới thiệu khoá học.mp4')).toBe(false);
+  });
+
+  it('KHÔNG detect tên English có ý nghĩa', () => {
+    expect(isGenericFilename('intro-to-safety.mp4')).toBe(false);
+    expect(isGenericFilename('chapter-1-overview.mov')).toBe(false);
+    expect(isGenericFilename('SOLAS-Lecture.mp4')).toBe(false);
+  });
+});
+
+describe('smartSectionTitle', () => {
+  it('máy tự sinh → "Video N"', () => {
+    expect(smartSectionTitle('export-1777613145929.mp4', 5)).toBe('Video 5');
+    expect(smartSectionTitle('VID_001.mov', 1)).toBe('Video 1');
+  });
+
+  it('tên có ý nghĩa → giữ nguyên (không extension)', () => {
+    expect(smartSectionTitle('Bài 1 An toàn hàng hải.mp4', 5)).toBe('Bài 1 An toàn hàng hải');
+    expect(smartSectionTitle('intro-to-safety.mov', 3)).toBe('intro-to-safety');
+  });
+
+  it('tên quá ngắn (< 3 ký tự) → "Video N"', () => {
+    expect(smartSectionTitle('a.mp4', 7)).toBe('Video 7');
+    expect(smartSectionTitle('xx.mp4', 2)).toBe('Video 2');
+  });
+
+  it('positionInLesson tính từ existing sections', () => {
+    // Bài có 4 mục có sẵn, video mới đầu → "Video 5"
+    expect(smartSectionTitle('export-x.mp4', 5)).toBe('Video 5');
+    expect(smartSectionTitle('export-y.mp4', 6)).toBe('Video 6');
   });
 });

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-distribution.util.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-distribution.util.ts
@@ -111,3 +111,33 @@ export function extractFilenameTitle(filename: string): string {
   if (lastDot <= 0) return trimmed;
   return trimmed.substring(0, lastDot);
 }
+
+/**
+ * Detect filename "máy tự sinh" (export, VID_001, IMG_1234, recording-...)
+ * không có ý nghĩa cho học viên. Match → nên đổi thành "Video N".
+ *
+ * Quy tắc: tên (không extension) chỉ gồm prefix kỹ thuật + số/ký tự ngẫu nhiên.
+ */
+export function isGenericFilename(filename: string): boolean {
+  const stripped = extractFilenameTitle(filename).toLowerCase();
+  return /^(export|vid|img|mov|video|recording|untitled|new|file|clip|temp|tmp|untitled-?\d*)[-_\s]?[\w\d-]*$/i.test(
+    stripped
+  );
+}
+
+/**
+ * Smart section title:
+ *  - Filename "có ý nghĩa" (vd "Bài 1 Giới thiệu", "intro-safety") → giữ tên
+ *  - Filename "máy tự sinh" (vd "export-1777613145929", "VID_001") → "Video N"
+ *
+ * positionInLesson: vị trí video MỚI trong lesson (1-based, đã tính
+ * existingSectionCount). VD: lesson có 4 mục có sẵn, video mới đầu tiên
+ * → positionInLesson = 5 → "Video 5".
+ */
+export function smartSectionTitle(filename: string, positionInLesson: number): string {
+  const stripped = extractFilenameTitle(filename);
+  if (stripped.length < 3 || isGenericFilename(filename)) {
+    return `Video ${positionInLesson}`;
+  }
+  return stripped;
+}

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload-modal.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload-modal.component.ts
@@ -144,7 +144,7 @@ import {
                   (click)="onCloseAndContinue()"
                   class="px-4 py-1.5 text-sm font-semibold text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-lg"
                 >
-                  {{ svc.mode() === 'COMPLETE' ? 'Đóng' : 'Đóng — chạy nền' }}
+                  {{ svc.mode() === 'COMPLETE' ? 'Đóng' : 'Thu nhỏ — chạy nền' }}
                 </button>
               }
             </div>
@@ -527,7 +527,7 @@ export class BatchVideoUploadModalComponent {
       case 'PREVIEW':
         return 'Kéo thả để xếp lại, click tên để sửa, sau đó bấm "Bắt đầu tải lên"';
       case 'UPLOADING':
-        return 'Có thể đóng tab — tải lên vẫn chạy nền';
+        return 'Có thể đóng modal — tải lên vẫn chạy nền (cần giữ tab này mở)';
       case 'COMPLETE':
         return 'Tất cả video đã được xử lý';
       default:

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload.service.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload.service.ts
@@ -12,6 +12,7 @@ import {
   distributeByFilenamePrefix,
   distributeEvenly,
   extractFilenameTitle,
+  smartSectionTitle,
 } from './batch-distribution.util';
 import {
   BatchAggregateProgress,
@@ -25,7 +26,15 @@ import {
 
 const UPLOAD_CONCURRENCY = 3;
 const POLL_INTERVAL_MS = 5_000;
-const POLL_MAX_ATTEMPTS = 120; // 120 × 5s = 10 min cap per item before auto-fail
+/**
+ * 720 × 5s = 60 min cap per item.
+ * Tăng từ 120 (10 min) → 720 vì backend max 2 concurrent transcode + video lớn
+ * (1+ GB) có thể chờ trong queue 15-20 phút trước khi tới lượt. False timeout
+ * gây user confusion (BE actually still processing).
+ * 60 min cover được mọi case practical (nếu BE thật sự stuck >60min, có vấn đề
+ * thực sự cần investigate manual).
+ */
+const POLL_MAX_ATTEMPTS = 720;
 const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024 * 1024; // 5GB per file (matches single-section limit)
 
 /**
@@ -111,12 +120,16 @@ export class BatchVideoUploadService {
     const distribution = this.runDistribution(validFiles, distributable, config.strategy);
 
     for (const [lessonId, lessonFiles] of distribution.entries()) {
+      const existingCount = lessons.find((l) => l.id === lessonId)?.existingSectionCount ?? 0;
+      // 1-based position trong lesson, kể cả existing sections.
+      // Vd: lesson có 4 mục, video mới đầu → "Video 5"
+      let positionInLesson = existingCount + 1;
       for (const file of lessonFiles) {
         items.push({
           id: this.generateLocalId(),
           file,
           lessonId,
-          sectionTitle: extractFilenameTitle(file.name),
+          sectionTitle: smartSectionTitle(file.name, positionInLesson++),
           status: 'PENDING',
           uploadProgress: 0,
         });
@@ -151,12 +164,15 @@ export class BatchVideoUploadService {
     const titleByFile = new Map(currentItems.map((i) => [i.file, i.sectionTitle]));
 
     for (const [lessonId, lessonFiles] of distribution.entries()) {
+      const existingCount = this.availableLessons().find((l) => l.id === lessonId)?.existingSectionCount ?? 0;
+      let positionInLesson = existingCount + 1;
       for (const file of lessonFiles) {
         newItems.push({
           id: this.generateLocalId(),
           file,
           lessonId,
-          sectionTitle: titleByFile.get(file) ?? extractFilenameTitle(file.name),
+          // Preserve user-edited titles. Else apply smart naming.
+          sectionTitle: titleByFile.get(file) ?? smartSectionTitle(file.name, positionInLesson++),
           status: 'PENDING',
           uploadProgress: 0,
         });


### PR DESCRIPTION
## 3 fixes triệt để theo user feedback

### 1. Smart auto-naming sections (vấn đề "tên xấu export-1777613145929")

User feedback: tên section default đang là filename gốc → \`export-1777613145929\` không hữu ích.

**Smart heuristic**: detect machine-generated patterns, tự đổi → "Video N":
- ✅ Match (đổi thành "Video N"): \`export-...\`, \`VID_001\`, \`IMG_1234\`, \`recording-2026-01-15\`, \`untitled\`, \`video.mp4\`, \`MOV_...\`, \`temp\`, \`clip\`
- ❌ Không match (giữ tên): \`Bài 1 An toàn hàng hải\`, \`intro-to-safety\`, \`SOLAS-Lecture\`, \`chapter-1-overview\`

**N tính từ existing sections + position trong batch (1-based)**: Bài có 4 mục có sẵn → video mới đầu tiên = "Video 5", thứ 2 = "Video 6"...

User vẫn override được trong PREVIEW stage (click tên section).

12 unit tests cover edge cases (Vietnamese diacritics, English, machine prefixes, length checks).

### 2. Bump POLL_MAX_ATTEMPTS 120 → 720 (10min → 60min)

**Vấn đề** (Image #33): 6 video lớn (1.33 GB mỗi cái) queue ở backend max 2 concurrent. Video cuối chờ trong queue 15-20 phút trước khi tới lượt transcode → 10-min cap quá aggressive → **3/6 false timeout** "Quá thời gian chờ xử lý (10 phút). Backend có thể đang quá tải."

**Root cause**: backend không expose queue position vs actively-processing. FE không phân biệt được. Bump cap để cover practical large batches.

**60 min cap** đủ cho mọi case practical:
- Video duration tối đa 60 min × 6.2x realtime = ~10 min process
- 6 video queue × 2 concurrent = ~30 min worst case
- Còn 30 min headroom

Nếu BE thật sự stuck >60 min cần investigate manual.

### 3. Honest copy về tab close (vấn đề "tắt tab có còn upload không?")

**Sự thật** (kỹ thuật): đóng MODAL OK (service singleton), đóng TAB → JavaScript context dies → XHR upload chết. Để survive tab close cần:
- Backend TUS resumable upload protocol (chưa có)
- Service Worker quản lý upload state
- IndexedDB persist

**BIG architecture change, KHÔNG trong scope**.

Copy cũ "Có thể đóng tab — tải lên vẫn chạy nền" → **LỪA user**.

**Copy mới**:
- Subtitle: "Có thể đóng modal — tải lên vẫn chạy nền **(cần giữ tab này mở)**"
- Button: "Đóng — chạy nền" → **"Thu nhỏ — chạy nền"** (rõ semantic: minimize, không close)

## Out of scope (defer cho PR riêng)

| Vấn đề | Reason defer |
|---|---|
| Per-item ETA cho PROCESSING | Cần BE expose queue position |
| Resume sau tab close | TUS protocol + Service Worker = BIG arch change |
| Single-video resume | Same TUS requirement |
| Auto-refresh content sau import (issue #5) | Cần test reproducible |

## Karpathy alignment

- 4 file edit (utility + service + modal + spec), 0 file mới
- Surgical: smart-naming logic ở pure util (testable), apply ở 2 chỗ (setup + redistribute)
- 12 unit tests mới, 39/39 total pass
- TS compile + Angular build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)