### PR TITLE
fix: main content refresh on PROCESSING→READY + Chưa phát hành badge tooltip

### DIFF
--- a/fe/src/app/features/teacher/course-editor/pages/course-classes/course-classes.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-classes/course-classes.component.html
@@ -204,16 +204,19 @@
                             <!-- Version badge -->
                             <span class="flex items-center gap-1 mt-1">
                                 @if (cls.publicationNumber) {
-                                <span class="px-1 py-0.5 text-[9px] font-bold bg-slate-100 text-slate-500 border border-slate-200 rounded tabular-nums">
+                                <span class="px-1 py-0.5 text-[9px] font-bold bg-slate-100 text-slate-500 border border-slate-200 rounded tabular-nums"
+                                      title="Lớp đang gắn với bản phát hành v{{ cls.publicationNumber }} của khoá học. Học viên thấy nội dung của bản này.">
                                     v{{ cls.publicationNumber }}
                                 </span>
                                 } @else {
-                                <span class="px-1 py-0.5 text-[9px] font-bold bg-amber-50 text-amber-600 border border-amber-200 rounded">
+                                <span class="px-1 py-0.5 text-[9px] font-bold bg-amber-50 text-amber-700 border border-amber-200 rounded cursor-help"
+                                      title="Khoá học chưa được xuất bản. Học viên trong lớp này sẽ KHÔNG thấy nội dung. Bấm 'Xuất bản' ở đầu trang để công bố nội dung khoá.">
                                     Chưa phát hành
                                 </span>
                                 }
                                 @if (cls.updateAvailable) {
-                                <span class="px-1 py-0.5 text-[9px] font-bold bg-emerald-50 text-emerald-600 border border-emerald-200 rounded">
+                                <span class="px-1 py-0.5 text-[9px] font-bold bg-emerald-50 text-emerald-600 border border-emerald-200 rounded"
+                                      title="Khoá học có bản phát hành mới hơn (v{{ cls.latestPublicationNumber }}). Có thể nâng cấp lớp này để dùng nội dung mới.">
                                     v{{ cls.latestPublicationNumber }} mới
                                 </span>
                                 }

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload.service.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload.service.ts
@@ -584,12 +584,26 @@ export class BatchVideoUploadService {
 
         if (asset?.status === 'READY') {
           this.updateItemStatus(item.id, 'READY');
+          // Propagate status update vào store cho main content auto-refresh
+          // (lecture-sections-panel hiển thị videoProcessingStatus per row)
+          if (item.sectionId) {
+            this.store.updateSectionLocal(item.lessonId, item.sectionId, {
+              videoProcessingStatus: 'READY',
+            } as any);
+            this.forceSyncSelectionForLesson(item.lessonId);
+          }
         } else if (asset?.status === 'FAILED') {
           this.markItemFailed(item.id, asset.errorMessage || 'Backend xử lý thất bại');
+          if (item.sectionId) {
+            this.store.updateSectionLocal(item.lessonId, item.sectionId, {
+              videoProcessingStatus: 'FAILED',
+            } as any);
+            this.forceSyncSelectionForLesson(item.lessonId);
+          }
         } else if (attempts >= POLL_MAX_ATTEMPTS) {
           this.markItemFailed(
             item.id,
-            'Quá thời gian chờ xử lý (10 phút). Backend có thể đang quá tải.'
+            'Quá thời gian chờ xử lý (60 phút). Backend có thể đang quá tải.'
           );
         }
       });


### PR DESCRIPTION
## Issue 1: Main content không update khi video transcoding xong

**Root cause** (sau investigate):
\`addSectionLocal\` khi tạo section ban đầu set \`videoProcessingStatus=PROCESSING\`. Khi polling sau đó nhận READY từ BE, batch service CHỈ update batch item state (trong batch list local), KHÔNG propagate vào store. → Section trong lesson view giữ stale status → không hiển thị READY indicator (green dot).

**Fix**: trong \`pollProcessingItems\`, sau khi mark item READY/FAILED, gọi \`store.updateSectionLocal(lessonId, sectionId, { videoProcessingStatus: ... })\` để propagate vào courseTree → lesson editor re-derives → main content refresh.

Plus \`forceSyncSelectionForLesson\` sau mỗi update để đảm bảo selectedLesson signal được sync (bypass editorDirty guard).

## Issue 2: "Chưa phát hành" badge ý nghĩa không rõ

User feedback (Image #34): không hiểu badge này có tác dụng gì.

**Sự thật** (sau investigate code):
- Class có \`courseVersionId\` trỏ đến \`CoursePublication\` snapshot
- Nếu course chưa xuất bản → \`publicationNumber=null\` → badge "Chưa phát hành"
- **Hệ quả**: student trong class **KHÔNG thấy nội dung** vì class không gắn với bản công bố nào

Badge **IS functional** nhưng UX confusing — user không biết nghĩa gì hay action gì.

**Fix**: thêm \`title\` tooltip cho cả 3 badge variants:

| Badge | Tooltip |
|---|---|
| \`v{N}\` | "Lớp đang gắn với bản phát hành v{N}. Học viên thấy nội dung của bản này." |
| **Chưa phát hành** | "Khoá học chưa được xuất bản. Học viên trong lớp này sẽ KHÔNG thấy nội dung. Bấm 'Xuất bản' ở đầu trang để công bố nội dung khoá." |
| \`v{N} mới\` | "Khoá học có bản phát hành mới hơn. Có thể nâng cấp lớp này..." |

Plus: \`cursor-help\` cho amber badge indicate hover hint, color tweak amber-600 → amber-700 contrast better.

## Bonus: typo fix poll timeout

"Quá thời gian chờ xử lý **(10 phút)**" → **"(60 phút)"** (sync với POLL_MAX_ATTEMPTS=720 đã bump trong PR #328).

## Karpathy

- 2 file edit, 0 file mới
- Surgical: 1 fix per concern
- TS + Angular build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)