### PR TITLE
fix(class-roster): drawer rendered nothing — schema mismatch + missing student info

### DIFF
--- a/backend/src/main/java/com/example/lms/learning_delivery/application/dto/ClassStudentResponse.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/application/dto/ClassStudentResponse.java
@@ -1,0 +1,49 @@
+package com.example.lms.learning_delivery.application.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Read model for the "Quản lý học viên" drawer (class roster view).
+ *
+ * Pattern reference: Canvas People page, Coursera Roster — combines enrollment
+ * fact (status, progress, dates) with denormalized student profile fields
+ * (name, email) so the FE renders without a follow-up roundtrip per row.
+ *
+ * Distinct from {@link EnrollmentResponse} which is enrollment-domain-only and
+ * shared across many controllers; this DTO exists for the roster surface and
+ * may grow with UI-specific fields (avatar, last grade, certificate state)
+ * without rippling into other consumers.
+ */
+public record ClassStudentResponse(
+        UUID enrollmentId,
+        UUID studentId,
+        String studentName,
+        String studentEmail,
+        String status,
+        Integer completionPercent,
+        Instant enrolledAt,
+        Instant lastAccessedAt
+) {
+    public static ClassStudentResponse of(
+            UUID enrollmentId,
+            UUID studentId,
+            String studentName,
+            String studentEmail,
+            String status,
+            Integer completionPercent,
+            Instant enrolledAt,
+            Instant lastAccessedAt
+    ) {
+        return new ClassStudentResponse(
+                enrollmentId,
+                studentId,
+                studentName,
+                studentEmail,
+                status,
+                completionPercent,
+                enrolledAt,
+                lastAccessedAt
+        );
+    }
+}

--- a/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/GetClassStudentsUseCase.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/GetClassStudentsUseCase.java
@@ -1,6 +1,8 @@
 package com.example.lms.learning_delivery.application.usecase;
 
-import com.example.lms.learning_delivery.application.dto.EnrollmentResponse;
+import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
+import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
+import com.example.lms.learning_delivery.application.dto.ClassStudentResponse;
 import com.example.lms.learning_delivery.domain.model.Enrollment;
 import com.example.lms.learning_delivery.domain.model.LearningClass;
 import com.example.lms.learning_delivery.domain.repository.EnrollmentRepository;
@@ -13,10 +15,16 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
- * Use case for getting students enrolled in a class.
+ * Returns the class roster enriched with student profile fields.
+ *
+ * Pattern reference: Canvas People, Coursera Roster — denormalize name + email
+ * onto the enrollment so the drawer renders in one round-trip. Batch user
+ * lookup avoids the N+1 trap when classes have hundreds of enrollments.
  */
 @Service
 @RequiredArgsConstructor
@@ -24,16 +32,38 @@ public class GetClassStudentsUseCase {
 
     private final LearningClassRepository classRepository;
     private final EnrollmentRepository enrollmentRepository;
+    private final UserJpaRepository userRepository;
 
     @Transactional(readOnly = true)
-    public PageResponse<EnrollmentResponse> execute(UUID classId, Pageable pageable) {
-        // Verify class exists
+    public PageResponse<ClassStudentResponse> execute(UUID classId, Pageable pageable) {
         LearningClass learningClass = classRepository.findById(classId)
                 .orElseThrow(() -> new EntityNotFoundException("Lớp học", classId));
 
-        // Get enrollments
         Page<Enrollment> enrollments = enrollmentRepository.findByClassId(classId, pageable);
 
-        return PageResponse.from(enrollments, EnrollmentResponse::from);
+        var studentIds = enrollments.getContent().stream()
+                .map(Enrollment::getStudentId)
+                .collect(Collectors.toSet());
+
+        Map<UUID, UserJpaEntity> usersById = studentIds.isEmpty()
+                ? Map.of()
+                : userRepository.findAllById(studentIds).stream()
+                        .collect(Collectors.toMap(UserJpaEntity::getId, u -> u));
+
+        return PageResponse.from(enrollments, enrollment -> toResponse(enrollment, usersById));
+    }
+
+    private ClassStudentResponse toResponse(Enrollment enrollment, Map<UUID, UserJpaEntity> usersById) {
+        UserJpaEntity student = usersById.get(enrollment.getStudentId());
+        return ClassStudentResponse.of(
+                enrollment.getId(),
+                enrollment.getStudentId(),
+                student != null ? student.getFullName() : null,
+                student != null ? student.getEmail() : null,
+                enrollment.getStatus() != null ? enrollment.getStatus().name() : null,
+                enrollment.getCompletionPercent(),
+                enrollment.getEnrolledAt(),
+                enrollment.getLastAccessedAt()
+        );
     }
 }

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/ClassControllerV3.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/ClassControllerV3.java
@@ -432,10 +432,10 @@ public class ClassControllerV3 {
         return ResponseEntity.ok(ApiResponse.success(enrollmentId, "Đã thêm học viên vào lớp"));
     }
 
-    @Operation(summary = "Get students in class")
+    @Operation(summary = "Get students in class (enriched roster: name + email + progress)")
     @GetMapping("/{classId}/students")
     @PreAuthorize("hasAnyRole('ADMIN', 'TEACHER')")
-    public ResponseEntity<ApiResponse<PageResponse<EnrollmentResponse>>> getClassStudents(
+    public ResponseEntity<ApiResponse<PageResponse<com.example.lms.learning_delivery.application.dto.ClassStudentResponse>>> getClassStudents(
             @PathVariable String classId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "1000") int size,
@@ -443,7 +443,7 @@ public class ClassControllerV3 {
     ) {
         var context = resolveOwnedClassContext(UUID.fromString(classId), user);
         ensureInstructorLedCourse(context.course());
-        PageResponse<EnrollmentResponse> students = getClassStudentsUseCase.execute(
+        PageResponse<com.example.lms.learning_delivery.application.dto.ClassStudentResponse> students = getClassStudentsUseCase.execute(
                 UUID.fromString(classId),
                 PageRequest.of(page, size)
         );

--- a/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/GetClassStudentsUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/GetClassStudentsUseCaseTest.java
@@ -1,6 +1,8 @@
 package com.example.lms.learning_delivery.application.usecase;
 
-import com.example.lms.learning_delivery.application.dto.EnrollmentResponse;
+import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
+import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
+import com.example.lms.learning_delivery.application.dto.ClassStudentResponse;
 import com.example.lms.learning_delivery.domain.model.Enrollment;
 import com.example.lms.learning_delivery.domain.model.LearningClass;
 import com.example.lms.learning_delivery.domain.repository.EnrollmentRepository;
@@ -25,6 +27,7 @@ import java.util.*;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyIterable;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -40,6 +43,9 @@ class GetClassStudentsUseCaseTest {
 
     @Mock
     private EnrollmentRepository enrollmentRepository;
+
+    @Mock
+    private UserJpaRepository userRepository;
 
     @InjectMocks
     private GetClassStudentsUseCase useCase;
@@ -68,13 +74,16 @@ class GetClassStudentsUseCaseTest {
     class HappyPathTests {
 
         @Test
-        @DisplayName("Should return students enrolled in class")
+        @DisplayName("Should return students enrolled in class with name and email enriched")
         void shouldReturnStudentsInClass() {
             // Given
+            UUID studentId1 = UUID.randomUUID();
+            UUID studentId2 = UUID.randomUUID();
+
             Enrollment enrollment1 = Enrollment.builder()
                 .id(UUID.randomUUID())
                 .learningClass(learningClass)
-                .studentId(UUID.randomUUID())
+                .studentId(studentId1)
                 .status(Enrollment.EnrollmentStatus.ACTIVE)
                 .progress(new HashMap<>())
                 .completionPercent(45)
@@ -84,7 +93,7 @@ class GetClassStudentsUseCaseTest {
             Enrollment enrollment2 = Enrollment.builder()
                 .id(UUID.randomUUID())
                 .learningClass(learningClass)
-                .studentId(UUID.randomUUID())
+                .studentId(studentId2)
                 .status(Enrollment.EnrollmentStatus.ACTIVE)
                 .progress(new HashMap<>())
                 .completionPercent(80)
@@ -95,25 +104,49 @@ class GetClassStudentsUseCaseTest {
                 List.of(enrollment1, enrollment2), pageable, 2
             );
 
+            UserJpaEntity user1 = mock(UserJpaEntity.class);
+            when(user1.getId()).thenReturn(studentId1);
+            when(user1.getFullName()).thenReturn("Nguyễn Văn A");
+            when(user1.getEmail()).thenReturn("a@maritime.edu");
+
+            UserJpaEntity user2 = mock(UserJpaEntity.class);
+            when(user2.getId()).thenReturn(studentId2);
+            when(user2.getFullName()).thenReturn("Trần Thị B");
+            when(user2.getEmail()).thenReturn("b@maritime.edu");
+
             when(classRepository.findById(classId)).thenReturn(Optional.of(learningClass));
             when(enrollmentRepository.findByClassId(classId, pageable)).thenReturn(enrollmentPage);
+            when(userRepository.findAllById(anyIterable())).thenReturn(List.of(user1, user2));
 
             // When
-            PageResponse<EnrollmentResponse> result = useCase.execute(classId, pageable);
+            PageResponse<ClassStudentResponse> result = useCase.execute(classId, pageable);
 
             // Then
             assertThat(result).isNotNull();
             assertThat(result.getContent()).hasSize(2);
             assertThat(result.getTotalElements()).isEqualTo(2);
-            assertThat(result.getContent().get(0).studentId()).isEqualTo(enrollment1.getStudentId());
-            assertThat(result.getContent().get(1).studentId()).isEqualTo(enrollment2.getStudentId());
+
+            ClassStudentResponse row1 = result.getContent().stream()
+                .filter(r -> r.studentId().equals(studentId1))
+                .findFirst().orElseThrow();
+            assertThat(row1.studentName()).isEqualTo("Nguyễn Văn A");
+            assertThat(row1.studentEmail()).isEqualTo("a@maritime.edu");
+            assertThat(row1.completionPercent()).isEqualTo(45);
+            assertThat(row1.status()).isEqualTo("ACTIVE");
+
+            ClassStudentResponse row2 = result.getContent().stream()
+                .filter(r -> r.studentId().equals(studentId2))
+                .findFirst().orElseThrow();
+            assertThat(row2.studentName()).isEqualTo("Trần Thị B");
+            assertThat(row2.completionPercent()).isEqualTo(80);
 
             verify(classRepository).findById(classId);
             verify(enrollmentRepository).findByClassId(classId, pageable);
+            verify(userRepository).findAllById(anyIterable());
         }
 
         @Test
-        @DisplayName("Should return empty page when no students enrolled")
+        @DisplayName("Should return empty page when no students enrolled — and skip user batch lookup")
         void shouldReturnEmptyPageWhenNoStudents() {
             // Given
             Page<Enrollment> emptyPage = new PageImpl<>(
@@ -124,12 +157,15 @@ class GetClassStudentsUseCaseTest {
             when(enrollmentRepository.findByClassId(classId, pageable)).thenReturn(emptyPage);
 
             // When
-            PageResponse<EnrollmentResponse> result = useCase.execute(classId, pageable);
+            PageResponse<ClassStudentResponse> result = useCase.execute(classId, pageable);
 
             // Then
             assertThat(result).isNotNull();
             assertThat(result.getContent()).isEmpty();
             assertThat(result.getTotalElements()).isZero();
+
+            // Empty enrollment page → no studentIds → skip the user batch lookup entirely.
+            verify(userRepository, never()).findAllById(any());
         }
 
         @Test

--- a/fe/src/app/features/teacher/course-editor/pages/course-classes/class-students/add-student-drawer/add-student-drawer.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-classes/class-students/add-student-drawer/add-student-drawer.component.ts
@@ -1,27 +1,19 @@
 import { Component, inject, signal, computed, input, output, resource, effect, ChangeDetectionStrategy } from '@angular/core';
 
 import { firstValueFrom } from 'rxjs';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTabsModule } from '@angular/material/tabs';
-import { ClassService } from '../../../../../../../state/class.service';
+import { ClassService, ClassStudentRow } from '../../../../../../../state/class.service';
 import { SideDrawerComponent } from '../../../../../../../shared/components/side-drawer/side-drawer.component';
 import { ConfirmDialogService } from '../../../../../../../core/services/confirm-dialog.service';
 import { ToastService } from '../../../../../../../core/services/toast.service';
 
-interface EnrolledStudent {
-    id: string;
-    email: string;
-    fullName: string;
-    enrolledAt: string;
-    status?: string;
-}
-
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
     selector: 'app-add-student-drawer',
-    imports: [ReactiveFormsModule, MatIconModule, MatButtonModule, MatTabsModule, SideDrawerComponent],
+    imports: [FormsModule, ReactiveFormsModule, MatIconModule, MatButtonModule, MatTabsModule, SideDrawerComponent],
     template: `
     <app-side-drawer 
         [isOpen]="isOpen()" 
@@ -32,27 +24,45 @@ interface EnrolledStudent {
       
       <div class="space-y-6">
         <mat-tab-group [selectedIndex]="activeTabIndex()" (selectedIndexChange)="onTabChange($event)">
-          <!-- Tab 1: Danh sách học viên hiện tại -->
+          <!-- Tab 1: Danh sách học viên hiện tại — Canvas/Coursera roster pattern -->
           <mat-tab label="Danh sách học viên">
             <div class="pt-6 space-y-4">
-                <!-- Header Stats -->
-                <div class="flex items-center justify-between px-4 py-3 bg-slate-50 rounded-xl border border-slate-100">
-                    <div class="flex items-center gap-2">
-                        <mat-icon class="text-slate-500">groups</mat-icon>
-                        <span class="text-sm font-bold text-slate-700">Tổng số học viên</span>
+                <!-- Header Stats: total + active + completed (Canvas People summary) -->
+                <div class="grid grid-cols-3 gap-2">
+                    <div class="px-3 py-2.5 bg-slate-50 rounded-lg border border-slate-100">
+                        <p class="text-[10px] font-bold text-slate-500 uppercase tracking-wide">Tổng số</p>
+                        <p class="text-lg font-black text-slate-900 tabular-nums">{{ enrolledStudents().length }}</p>
                     </div>
-                    <span class="text-lg font-black text-[#0056D2]">{{ enrolledStudents().length }}</span>
+                    <div class="px-3 py-2.5 bg-emerald-50 rounded-lg border border-emerald-100">
+                        <p class="text-[10px] font-bold text-emerald-700 uppercase tracking-wide">Đang học</p>
+                        <p class="text-lg font-black text-emerald-700 tabular-nums">{{ activeCount() }}</p>
+                    </div>
+                    <div class="px-3 py-2.5 bg-blue-50 rounded-lg border border-blue-100">
+                        <p class="text-[10px] font-bold text-[#0056D2] uppercase tracking-wide">Hoàn thành</p>
+                        <p class="text-lg font-black text-[#0056D2] tabular-nums">{{ completedCount() }}</p>
+                    </div>
                 </div>
+
+                <!-- Search filter (when 5+ students — progressive disclosure) -->
+                @if (enrolledStudents().length >= 5) {
+                    <div class="relative">
+                        <mat-icon class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-base">search</mat-icon>
+                        <input type="text" [(ngModel)]="rosterFilter"
+                               (input)="onFilterChange()"
+                               class="w-full pl-10 pr-3 py-2 bg-white border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-[#0056D2]/20 focus:border-[#0056D2] outline-none transition-all"
+                               placeholder="Tìm theo tên hoặc email...">
+                    </div>
+                }
 
                 <!-- Loading State -->
                 @if (isLoadingStudents()) {
                     <div class="flex flex-col items-center justify-center py-12 gap-3">
-                        <div class="w-10 h-10 border-4 border-[#0056D2] border-t-transparent rounded-full animate-spin"></div>
+                        <div class="w-10 h-10 border-4 border-[#0056D2] border-t-transparent rounded-full animate-spin" aria-hidden="true"></div>
                         <p class="text-sm text-gray-500">Đang tải danh sách...</p>
                     </div>
                 }
 
-                <!-- Empty State -->
+                <!-- Empty State (true zero) -->
                 @if (!isLoadingStudents() && enrolledStudents().length === 0) {
                     <div class="text-center py-12 bg-gray-50 rounded-2xl border border-dashed border-gray-200">
                         <mat-icon class="text-5xl text-gray-300 mb-3">person_off</mat-icon>
@@ -61,35 +71,63 @@ interface EnrolledStudent {
                     </div>
                 }
 
-                <!-- Student List -->
-                @if (!isLoadingStudents() && enrolledStudents().length > 0) {
-                    <div class="max-h-[400px] overflow-y-auto space-y-2 pr-1">
-                        @for (student of enrolledStudents(); track student.id; let i = $index) {
-                            <div class="flex items-center gap-3 p-3 bg-white border border-gray-100 rounded-xl hover:border-[#0056D2]/20 hover:shadow-sm transition-all group">
+                <!-- Empty State (filter no match) -->
+                @if (!isLoadingStudents() && enrolledStudents().length > 0 && filteredStudents().length === 0) {
+                    <div class="text-center py-8 bg-gray-50 rounded-xl border border-gray-100">
+                        <p class="text-sm text-gray-500">Không tìm thấy học viên khớp <strong>"{{ rosterFilter }}"</strong></p>
+                        <button type="button" (click)="clearFilter()" class="text-xs text-[#0056D2] font-bold hover:underline mt-1">Xoá bộ lọc</button>
+                    </div>
+                }
+
+                <!-- Student List — SOTA: avatar + name/email + status pill + progress bar + last activity -->
+                @if (!isLoadingStudents() && filteredStudents().length > 0) {
+                    <div class="max-h-[460px] overflow-y-auto space-y-2 pr-1">
+                        @for (student of filteredStudents(); track student.enrollmentId) {
+                            <article class="flex items-center gap-3 p-3 bg-white border border-gray-100 rounded-xl hover:border-[#0056D2]/30 hover:shadow-sm transition-all group">
                                 <!-- Avatar -->
-                                <div class="w-10 h-10 bg-[#0056D2] rounded-full flex items-center justify-center text-white font-bold text-sm flex-shrink-0">
-                                    {{ getInitials(student.fullName || student.email) }}
-                                </div>
-                                
-                                <!-- Info -->
-                                <div class="flex-1 min-w-0">
-                                    <p class="text-sm font-bold text-gray-800 truncate">{{ student.fullName || 'Chưa cập nhật' }}</p>
-                                    <p class="text-xs text-gray-500 truncate">{{ student.email }}</p>
+                                <div class="w-10 h-10 bg-[#0056D2] rounded-full flex items-center justify-center text-white font-bold text-sm flex-shrink-0"
+                                     [attr.aria-label]="'Ảnh đại diện ' + (student.studentName || student.studentEmail || 'học viên')">
+                                    {{ getInitials(student.studentName || student.studentEmail) }}
                                 </div>
 
-                                <!-- Enrolled Date -->
-                                <div class="text-right hidden sm:block">
-                                    <p class="text-[10px] text-gray-400 uppercase">Ghi danh</p>
-                                    <p class="text-xs font-medium text-gray-600">{{ formatDate(student.enrolledAt) }}</p>
+                                <!-- Main info column -->
+                                <div class="flex-1 min-w-0">
+                                    <div class="flex items-center gap-2 mb-0.5">
+                                        <p class="text-sm font-bold text-gray-900 truncate">{{ student.studentName || 'Chưa cập nhật' }}</p>
+                                        <span class="px-1.5 py-0.5 text-[9px] font-bold rounded uppercase tracking-wide flex-shrink-0"
+                                              [class]="statusBadgeClass(student.status)"
+                                              [attr.title]="statusLabel(student.status)">
+                                            {{ statusLabel(student.status) }}
+                                        </span>
+                                    </div>
+                                    <p class="text-xs text-gray-500 truncate mb-1.5">{{ student.studentEmail || '—' }}</p>
+
+                                    <!-- Progress + last activity row -->
+                                    <div class="flex items-center gap-3 text-[10px] text-gray-500">
+                                        <div class="flex items-center gap-1.5 flex-1 min-w-0">
+                                            <div class="flex-1 h-1 bg-gray-100 rounded-full overflow-hidden max-w-[120px]">
+                                                <div class="h-full rounded-full transition-all"
+                                                     [style.width.%]="student.completionPercent"
+                                                     [class]="progressBarClass(student.completionPercent)"></div>
+                                            </div>
+                                            <span class="font-semibold tabular-nums" [class.text-emerald-600]="student.completionPercent >= 100">
+                                                {{ student.completionPercent }}%
+                                            </span>
+                                        </div>
+                                        <span class="hidden sm:inline truncate" [title]="'Truy cập cuối: ' + relativeTime(student.lastAccessedAt)">
+                                            {{ relativeTime(student.lastAccessedAt) }}
+                                        </span>
+                                    </div>
                                 </div>
 
                                 <!-- Remove Button -->
-                                <button (click)="removeStudent(student)" 
-                                        class="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg opacity-0 group-hover:opacity-100 transition-all"
-                                        title="Xóa học viên">
+                                <button type="button" (click)="removeStudent(student)"
+                                        class="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg opacity-0 group-hover:opacity-100 focus:opacity-100 transition-all"
+                                        [attr.aria-label]="'Xóa ' + (student.studentName || student.studentEmail) + ' khỏi lớp'"
+                                        title="Xóa khỏi lớp">
                                     <mat-icon class="text-lg">person_remove</mat-icon>
                                 </button>
-                            </div>
+                            </article>
                         }
                     </div>
                 }
@@ -261,11 +299,27 @@ export class AddStudentDrawerComponent {
     isLoading = signal(false);
     manualError = signal('');
     isLoadingStudents = signal(false);
-    enrolledStudents = signal<EnrolledStudent[]>([]);
+    enrolledStudents = signal<ClassStudentRow[]>([]);
+
+    /** Roster filter (search by name or email) — only shown when 5+ students. */
+    rosterFilter = '';
+    private rosterFilterSig = signal('');
 
     selectedFile = signal<File | null>(null);
     isDragging = signal(false);
     actionError = signal('');
+
+    activeCount = computed(() => this.enrolledStudents().filter(s => s.status === 'ACTIVE').length);
+    completedCount = computed(() => this.enrolledStudents().filter(s => s.status === 'COMPLETED').length);
+
+    filteredStudents = computed(() => {
+        const q = this.rosterFilterSig().trim().toLowerCase();
+        if (!q) return this.enrolledStudents();
+        return this.enrolledStudents().filter(s =>
+            (s.studentName ?? '').toLowerCase().includes(q)
+            || (s.studentEmail ?? '').toLowerCase().includes(q)
+        );
+    });
 
     // Resource API for Excel Validation
     validationResource = resource<any, any>({
@@ -315,7 +369,7 @@ export class AddStudentDrawerComponent {
         }
     }
 
-    getInitials(name: string): string {
+    getInitials(name: string | null | undefined): string {
         if (!name) return '?';
         const parts = name.split(' ').filter(p => p);
         if (parts.length >= 2) {
@@ -324,7 +378,7 @@ export class AddStudentDrawerComponent {
         return name.substring(0, 2).toUpperCase();
     }
 
-    formatDate(dateStr: string): string {
+    formatDate(dateStr: string | null | undefined): string {
         if (!dateStr) return '-';
         try {
             const date = new Date(dateStr);
@@ -334,10 +388,62 @@ export class AddStudentDrawerComponent {
         }
     }
 
-    async removeStudent(student: EnrolledStudent) {
+    /** Vietnamese relative time ("3 ngày trước", "Vừa xong", "Chưa truy cập") — Canvas People activity column pattern. */
+    relativeTime(dateStr: string | null | undefined): string {
+        if (!dateStr) return 'Chưa truy cập';
+        const then = new Date(dateStr).getTime();
+        if (Number.isNaN(then)) return 'Chưa truy cập';
+        const diffMin = Math.floor((Date.now() - then) / 60_000);
+        if (diffMin < 1) return 'Vừa xong';
+        if (diffMin < 60) return diffMin + ' phút trước';
+        const diffHour = Math.floor(diffMin / 60);
+        if (diffHour < 24) return diffHour + ' giờ trước';
+        const diffDay = Math.floor(diffHour / 24);
+        if (diffDay < 30) return diffDay + ' ngày trước';
+        const diffMonth = Math.floor(diffDay / 30);
+        if (diffMonth < 12) return diffMonth + ' tháng trước';
+        return Math.floor(diffMonth / 12) + ' năm trước';
+    }
+
+    statusLabel(status: string | null | undefined): string {
+        switch (status) {
+            case 'ACTIVE': return 'Đang học';
+            case 'COMPLETED': return 'Hoàn thành';
+            case 'DROPPED': return 'Đã rời';
+            default: return status || 'Khác';
+        }
+    }
+
+    statusBadgeClass(status: string | null | undefined): string {
+        switch (status) {
+            case 'ACTIVE': return 'bg-emerald-50 text-emerald-700 border border-emerald-200';
+            case 'COMPLETED': return 'bg-blue-50 text-[#0056D2] border border-blue-200';
+            case 'DROPPED': return 'bg-gray-100 text-gray-600 border border-gray-200';
+            default: return 'bg-slate-100 text-slate-600 border border-slate-200';
+        }
+    }
+
+    progressBarClass(percent: number): string {
+        if (percent >= 100) return 'bg-emerald-500';
+        if (percent >= 60) return 'bg-[#0056D2]';
+        if (percent > 0) return 'bg-amber-400';
+        return 'bg-gray-300';
+    }
+
+    onFilterChange() {
+        this.rosterFilterSig.set(this.rosterFilter);
+    }
+
+    clearFilter() {
+        this.rosterFilter = '';
+        this.rosterFilterSig.set('');
+    }
+
+    async removeStudent(student: ClassStudentRow) {
+        const displayName = student.studentName || student.studentEmail || 'học viên';
         const confirmed = await this.confirmDialog.confirm({
             title: 'Xóa học viên',
-            message: `Bạn chắc chắn muốn xóa học viên "${student.fullName || student.email}" khỏi lớp?`,
+            message: `Bạn chắc chắn muốn xóa học viên "${displayName}" khỏi lớp?`,
             variant: 'danger',
             confirmText: 'Xóa',
             cancelText: 'Hủy'
@@ -346,7 +452,7 @@ export class AddStudentDrawerComponent {
 
         this.isLoading.set(true);
         try {
-            await firstValueFrom(this.classService.removeStudentFromClass(this.classId(), student.id));
+            await firstValueFrom(this.classService.removeStudentFromClass(this.classId(), student.studentId));
             this.loadEnrolledStudents();
             this.onSaved.emit();
         } catch (err: any) {
@@ -367,6 +473,8 @@ export class AddStudentDrawerComponent {
         this.selectedFile.set(null);
         this.isLoading.set(false);
         this.activeTabIndex.set(0);
+        this.rosterFilter = '';
+        this.rosterFilterSig.set('');
     }
 
     saveManual() {

--- a/fe/src/app/state/class.service.ts
+++ b/fe/src/app/state/class.service.ts
@@ -27,6 +27,17 @@ export interface AdoptResult {
     versionMode: 'PINNED' | 'FOLLOW_LATEST';
 }
 
+export interface ClassStudentRow {
+    enrollmentId: string;
+    studentId: string;
+    studentName: string | null;
+    studentEmail: string | null;
+    status: 'ACTIVE' | 'DROPPED' | 'COMPLETED' | string;
+    completionPercent: number;
+    enrolledAt: string | null;
+    lastAccessedAt: string | null;
+}
+
 export interface BulkAdoptResult {
     publicationId: string;
     publicationNumber: number;
@@ -95,9 +106,27 @@ export class ClassService {
             .pipe(map(() => void 0));
     }
 
-    getClassStudents(classId: string): Observable<any[]> {
-        return this.http.get<ApiResponse<any[]>>(`${this.API_URL}/classes/${classId}/students`)
-            .pipe(map(response => response.data));
+    getClassStudents(classId: string): Observable<ClassStudentRow[]> {
+        // BE wraps the roster in PageResponse<ClassStudentResponse> — extract content[].
+        return this.http.get<ApiResponse<{ content: any[] } | any[]>>(`${this.API_URL}/classes/${classId}/students`)
+            .pipe(map(response => {
+                const data = response.data;
+                const rows = Array.isArray(data) ? data : (data?.content ?? []);
+                return rows.map(this.mapClassStudentRow);
+            }));
+    }
+
+    private mapClassStudentRow(row: any): ClassStudentRow {
+        return {
+            enrollmentId: row?.enrollmentId ?? row?.id ?? '',
+            studentId: row?.studentId ?? '',
+            studentName: row?.studentName ?? row?.fullName ?? null,
+            studentEmail: row?.studentEmail ?? row?.email ?? null,
+            status: row?.status ?? 'ACTIVE',
+            completionPercent: typeof row?.completionPercent === 'number' ? row.completionPercent : 0,
+            enrolledAt: row?.enrolledAt ?? null,
+            lastAccessedAt: row?.lastAccessedAt ?? null
+        };
     }
 
     removeStudentFromClass(classId: string, studentId: string): Observable<void> {


### PR DESCRIPTION
## Bug

Drawer **\"Quản lý học viên\"** ở trang Lớp học chỉ render header card trống — không số đếm, không loading, không empty state, không list. Báo cáo: image #37.

## 2 nguyên nhân lồng nhau

### 1. FE schema mismatch
BE trả \`PageResponse<EnrollmentResponse>\` (object có \`.content[]\`), FE service typed \`Observable<any[]>\` rồi gán nguyên \`response.data\` (object) vào signal. Trong template, \`enrolledStudents().length\` = undefined trên object → count blank, cả 3 conditional render (loading/empty/list) đều false → **drawer trống**.

### 2. BE thiếu thông tin học viên
\`EnrollmentResponse\` chỉ có \`studentId\` UUID + status + dates. KHÔNG có \`name\`, \`email\`. Dù fix #1 xong, list cũng chỉ render UUIDs xấu.

## Fix — SOTA roster pattern (Canvas People + Coursera Roster)

### BE
- **New \`ClassStudentResponse\` DTO** — tách riêng khỏi \`EnrollmentResponse\` (5 consumers khác) để surface này tự do mở rộng. Fields: \`enrollmentId, studentId, studentName, studentEmail, status, completionPercent, enrolledAt, lastAccessedAt\`.
- **\`GetClassStudentsUseCase\` enriched** — batch lookup user qua \`userRepository.findAllById(studentIds)\`, không N+1.
- Controller signature: \`PageResponse<ClassStudentResponse>\`.

### FE service
- \`getClassStudents\` extract \`.content[]\` từ PageResponse (có array fallback an toàn). Return typed \`ClassStudentRow[]\`.
- \`mapClassStudentRow\` normalize shape + defensive defaults.

### FE drawer redesign
- **Stats grid**: tổng / đang học / hoàn thành (Canvas summary).
- **Search filter** — chỉ hiện khi 5+ học viên (Hick's Law).
- **Per-row**: avatar + name + status pill (ACTIVE xanh / COMPLETED xanh dương / DROPPED xám) + email + progress bar 0-100% color-coded + relative time \"3 ngày trước\" tiếng Việt.
- **Empty states**: phân biệt true-zero vs filter-no-match.
- **a11y**: aria-label trên remove button có tên học viên, status pill có title.

## Test plan

- [ ] Mở drawer trên class có học viên → thấy avatar + tên + email + status pill + progress + last activity
- [ ] Class có 0 học viên → empty state \"Chưa có học viên nào\"
- [ ] Class có 5+ học viên → search bar xuất hiện, gõ filter realtime, có nút \"Xoá bộ lọc\" khi no match
- [ ] Stats card update đúng: tổng = active + completed + dropped
- [ ] Progress bar màu: 100%=xanh, 60-99%=blue, 1-59%=amber, 0%=gray
- [ ] Remove student → confirm → xoá thành công, count update

🤖 Generated with [Claude Code](https://claude.com/claude-code)