### PR TITLE
feat(curriculum): drag sections in sidebar — within lesson + cross-lesson move

### DIFF
--- a/backend/src/main/java/com/example/lms/course_authoring/application/usecase/ManageContentBlockUseCaseV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/application/usecase/ManageContentBlockUseCaseV3.java
@@ -123,12 +123,15 @@ public class ManageContentBlockUseCaseV3 {
      */
     @Transactional
     public void moveSection(String sectionId, UUID fromLessonId, UUID toLessonId, Integer targetIndex, UUID userId, boolean isAdmin) {
+        // Validate access BEFORE the idempotent short-circuit. A bare same-lesson
+        // request from an unauthorized caller would otherwise return 200 OK and
+        // leak that the endpoint (and possibly the lesson) exists.
+        verifyOwnership(fromLessonId, userId, isAdmin);
         if (fromLessonId.equals(toLessonId)) {
             return;
         }
-
-        verifyOwnership(fromLessonId, userId, isAdmin);
         verifyOwnership(toLessonId, userId, isAdmin);
+
         // requireEditable* returns the Course — capture both to assert same-course in one go.
         var fromCourse = courseDraftMutationUseCase.requireEditableCourseByLesson(fromLessonId);
         var toCourse = courseDraftMutationUseCase.requireEditableCourseByLesson(toLessonId);

--- a/backend/src/main/java/com/example/lms/course_authoring/application/usecase/ManageContentBlockUseCaseV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/application/usecase/ManageContentBlockUseCaseV3.java
@@ -107,6 +107,70 @@ public class ManageContentBlockUseCaseV3 {
     }
 
     /**
+     * Move a content block (section) from one lesson to another.
+     * Pattern reference: Notion block move, Coursera Studio "Move To" lesson dialog.
+     *
+     * Atomic: both lessons are saved in one transaction. A failure mid-way rolls
+     * the source lesson back so we never lose the block — the worst observable
+     * outcome is the move silently failing and the user retrying.
+     *
+     * Idempotent on equal source/target lesson — no-op early exit prevents the
+     * round-trip write that the optimistic UI would happily request.
+     *
+     * Same-course constraint: cross-course moves break enrollment ownership and
+     * payment scoping, so we reject early with AccessDenied. Teachers wanting to
+     * "move" content cross-course should clone instead.
+     */
+    @Transactional
+    public void moveSection(String sectionId, UUID fromLessonId, UUID toLessonId, Integer targetIndex, UUID userId, boolean isAdmin) {
+        if (fromLessonId.equals(toLessonId)) {
+            return;
+        }
+
+        verifyOwnership(fromLessonId, userId, isAdmin);
+        verifyOwnership(toLessonId, userId, isAdmin);
+        // requireEditable* returns the Course — capture both to assert same-course in one go.
+        var fromCourse = courseDraftMutationUseCase.requireEditableCourseByLesson(fromLessonId);
+        var toCourse = courseDraftMutationUseCase.requireEditableCourseByLesson(toLessonId);
+        if (!fromCourse.getId().equals(toCourse.getId())) {
+            throw new AccessDeniedException("Không thể chuyển nội dung sang bài học của khoá học khác");
+        }
+
+        List<ContentBlock> sourceBlocks = lessonRepository.getContentBlocks(fromLessonId)
+                .orElseThrow(() -> new EntityNotFoundException("Lesson", fromLessonId));
+
+        ContentBlock movedBlock = null;
+        int sourceIdx = -1;
+        for (int i = 0; i < sourceBlocks.size(); i++) {
+            if (sourceBlocks.get(i).getId().equals(sectionId)) {
+                movedBlock = sourceBlocks.get(i);
+                sourceIdx = i;
+                break;
+            }
+        }
+        if (movedBlock == null) {
+            throw new EntityNotFoundException("ContentBlock", sectionId);
+        }
+
+        List<ContentBlock> newSource = new ArrayList<>(sourceBlocks);
+        newSource.remove(sourceIdx);
+
+        List<ContentBlock> targetBlocks = lessonRepository.getContentBlocks(toLessonId)
+                .orElseThrow(() -> new EntityNotFoundException("Lesson", toLessonId));
+        List<ContentBlock> newTarget = new ArrayList<>(targetBlocks);
+
+        int insertAt = (targetIndex == null || targetIndex < 0 || targetIndex > newTarget.size())
+                ? newTarget.size()
+                : targetIndex;
+        newTarget.add(insertAt, movedBlock);
+
+        lessonRepository.saveContentBlocks(fromLessonId, newSource);
+        lessonRepository.saveContentBlocks(toLessonId, newTarget);
+        courseDraftMutationUseCase.markCourseChangedByLesson(fromLessonId);
+        courseDraftMutationUseCase.markCourseChangedByLesson(toLessonId);
+    }
+
+    /**
      * Patch specific fields in a ContentBlock's data map (async conversion updates).
      * Does NOT require ownership check — called from background thread after save.
      */

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseAuthoringControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseAuthoringControllerV3.java
@@ -247,6 +247,32 @@ public class CourseAuthoringControllerV3 {
         }
     }
 
+    @Operation(summary = "Move a section (content block) to a different lesson within the same course")
+    @PatchMapping("/sections/move")
+    @PreAuthorize("hasAnyRole('ADMIN', 'TEACHER')")
+    public ResponseEntity<ApiResponse<Void>> moveSection(
+            @Valid @RequestBody MoveSectionRequest request,
+            @AuthenticationPrincipal UserJpaEntity user
+    ) {
+        try {
+            UUID fromLessonId = UUID.fromString(request.fromLessonId());
+            UUID toLessonId = UUID.fromString(request.toLessonId());
+            verifyOwnershipByLesson(fromLessonId, user);
+            verifyOwnershipByLesson(toLessonId, user);
+            manageContentBlockUseCase.moveSection(
+                    request.sectionId(),
+                    fromLessonId,
+                    toLessonId,
+                    request.targetIndex(),
+                    user.getId(),
+                    isAdminRole(user)
+            );
+            return ResponseEntity.ok(ApiResponse.success(null, "Đã chuyển nội dung sang bài học khác"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(ApiResponse.error("Định dạng UUID không hợp lệ"));
+        }
+    }
+
     @Operation(summary = "Reorder sections (content blocks) in a lesson")
     @PatchMapping("/sections/reorder")
     @PreAuthorize("hasAnyRole('ADMIN', 'TEACHER')")
@@ -809,6 +835,14 @@ return ResponseEntity.ok(ApiResponse.success(block, "Cập nhật phần học t
     public record ReorderSectionsRequest(
         @NotBlank(message = "Mã bài học không được để trống") String lessonId,
         @jakarta.validation.constraints.NotEmpty(message = "Danh sách ID không được để trống") java.util.List<String> orderedIds
+    ) {}
+
+    public record MoveSectionRequest(
+        @NotBlank(message = "Mã mục không được để trống") String sectionId,
+        @NotBlank(message = "Mã bài học nguồn không được để trống") String fromLessonId,
+        @NotBlank(message = "Mã bài học đích không được để trống") String toLessonId,
+        /** Optional 0-based insertion index in the target lesson. Null = append. */
+        Integer targetIndex
     ) {}
 }
 

--- a/fe/src/app/features/teacher/course-editor/components/sidebar/sidebar.component.ts
+++ b/fe/src/app/features/teacher/course-editor/components/sidebar/sidebar.component.ts
@@ -1100,20 +1100,41 @@ export class CourseEditorSidebarComponent implements OnDestroy {
   }
 
   /**
+   * Memoized map from lessonId → list of OTHER expanded lessons' drop list IDs.
+   *
+   * Recomputed only when chapters or the expand-state set change. Returning a
+   * fresh array on every template render call would force `cdkDropListConnectedTo`
+   * to tear down and re-attach drop list links every change-detection cycle,
+   * leaking listeners and thrashing CDK's internal registry.
+   */
+  private otherExpandedDropListIdsByLessonId = computed<Map<string, string[]>>(() => {
+    const expanded = this.expandedLessons();
+    const allIds: string[] = [];
+    for (const chapter of this.store.chapters()) {
+      for (const lesson of chapter.lessons) {
+        if (expanded.has(lesson.id)) {
+          allIds.push(this.sectionsDropListId(lesson.id));
+        }
+      }
+    }
+    const map = new Map<string, string[]>();
+    for (const chapter of this.store.chapters()) {
+      for (const lesson of chapter.lessons) {
+        if (!expanded.has(lesson.id)) continue;
+        const selfId = this.sectionsDropListId(lesson.id);
+        map.set(lesson.id, allIds.filter(id => id !== selfId));
+      }
+    }
+    return map;
+  });
+
+  /**
    * Drop list IDs for all OTHER lessons currently expanded in the sidebar.
    * Collapsed lessons aren't connectable because their drop list isn't rendered —
    * teacher must expand the target lesson first to drop into it.
    */
   otherExpandedSectionDropListIds(currentLessonId: string): string[] {
-    const ids: string[] = [];
-    for (const chapter of this.store.chapters()) {
-      for (const lesson of chapter.lessons) {
-        if (lesson.id === currentLessonId) continue;
-        if (!this.isLessonExpanded(lesson.id)) continue;
-        ids.push(this.sectionsDropListId(lesson.id));
-      }
-    }
-    return ids;
+    return this.otherExpandedDropListIdsByLessonId().get(currentLessonId) ?? [];
   }
 
   private parseLessonIdFromDropListId(dropListId: string | null | undefined): string | null {

--- a/fe/src/app/features/teacher/course-editor/components/sidebar/sidebar.component.ts
+++ b/fe/src/app/features/teacher/course-editor/components/sidebar/sidebar.component.ts
@@ -182,6 +182,44 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
       font-size: 0.625rem;
       opacity: 0.5;
     }
+    /* Section drag handle: hidden grip that reveals on row hover (mirror lesson pattern) */
+    .sidebar-section-row__handle {
+      flex-shrink: 0;
+      width: 0.875rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: grab;
+      opacity: 0;
+      transition: opacity 160ms ease 200ms;
+      color: rgb(148 163 184);
+    }
+    .sidebar-section-row:hover .sidebar-section-row__handle,
+    .sidebar-section-row--selected .sidebar-section-row__handle {
+      opacity: 0.7;
+      transition-delay: 0ms;
+    }
+    .sidebar-section-row__handle:active { cursor: grabbing; }
+    @media (pointer: coarse) {
+      .sidebar-section-row__handle { opacity: 0.45; transition-delay: 0ms; }
+    }
+
+    /* Empty drop zone for an expanded lesson with no sections — gives the user a target */
+    .sidebar-sections__empty {
+      margin: 0.25rem 0;
+      padding: 0.5rem 0.625rem;
+      font-size: 0.6875rem;
+      color: rgb(148 163 184);
+      font-style: italic;
+      border: 1px dashed rgb(226 232 240);
+      border-radius: 0.375rem;
+      text-align: center;
+    }
+    .cdk-drop-list-receiving .sidebar-sections__empty {
+      border-color: rgb(0 86 210);
+      color: rgb(0 86 210);
+      background: rgba(0, 86, 210, 0.04);
+    }
 
     /* CDK Drag overrides */
     .cdk-drag-preview { border-radius: 0.5rem; }
@@ -619,17 +657,43 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                                           </div>
                                       </div>
 
-                                      <!-- SECTIONS (L3) — clean list, click to select -->
-                                      @if (isLessonExpanded(lesson.id) && lesson.sections.length) {
-                                        <div class="sidebar-sections">
+                                      <!-- SECTIONS (L3) — drag within lesson + cross-lesson via CDK connected drop lists
+                                           (Notion blocks + Coursera Studio "Move To" patterns combined). -->
+                                      @if (isLessonExpanded(lesson.id)) {
+                                        <div class="sidebar-sections"
+                                             [id]="sectionsDropListId(lesson.id)"
+                                             cdkDropList
+                                             cdkDropListLockAxis="y"
+                                             [cdkDropListData]="lesson.sections"
+                                             [cdkDropListConnectedTo]="otherExpandedSectionDropListIds(lesson.id)"
+                                             (cdkDropListDropped)="dropSection($event, lesson.id)">
+                                          @if (!lesson.sections.length) {
+                                            <!-- Empty drop zone so user can drag a section IN to an empty lesson -->
+                                            <p class="sidebar-sections__empty">Kéo mục vào đây để chuyển sang bài này</p>
+                                          }
                                           @for (section of lesson.sections; track section.id; let secIdx = $index) {
-                                            <button class="sidebar-section-row"
+                                            <div class="sidebar-section-row"
                                                  [class.sidebar-section-row--selected]="selectedSectionId() === section.id"
-                                                 (click)="selectSection(chapter, lesson, section); $event.stopPropagation()">
+                                                 cdkDrag [cdkDragData]="section"
+                                                 [cdkDragStartDelay]="isTouchDevice ? 150 : 0"
+                                                 (click)="selectSection(chapter, lesson, section); $event.stopPropagation()"
+                                                 [attr.role]="'button'"
+                                                 [attr.tabindex]="0"
+                                                 (keydown.enter)="selectSection(chapter, lesson, section); $event.stopPropagation()"
+                                                 (keydown.space)="selectSection(chapter, lesson, section); $event.preventDefault(); $event.stopPropagation()">
+                                              <div *cdkDragPreview class="bg-white shadow-lg rounded-md px-2 py-1 border border-[#0056D2] text-[11px] font-medium text-slate-700 max-w-[240px] line-clamp-1">
+                                                {{ sectionLabel(secIdx) }} {{ getSectionDisplayTitle(section.title) }}
+                                              </div>
+                                              <div *cdkDragPlaceholder class="h-0.5 bg-[#0056D2] rounded-full mx-2 my-0.5"></div>
+                                              <span cdkDragHandle class="sidebar-section-row__handle"
+                                                    (click)="$event.stopPropagation()"
+                                                    [attr.aria-label]="'Kéo để sắp xếp lại ' + getSectionDisplayTitle(section.title)">
+                                                <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="9" cy="6" r="1.5"/><circle cx="15" cy="6" r="1.5"/><circle cx="9" cy="12" r="1.5"/><circle cx="15" cy="12" r="1.5"/><circle cx="9" cy="18" r="1.5"/><circle cx="15" cy="18" r="1.5"/></svg>
+                                              </span>
                                               <span class="sidebar-section-row__num">{{ sectionLabel(secIdx) }}</span>
                                               <span class="sidebar-section-row__title">{{ getSectionDisplayTitle(section.title) }}</span>
                                               <span class="sidebar-section-row__type">{{ section.type === 'TEXT' ? 'văn bản' : section.type === 'VIDEO' ? 'video' : section.type === 'FILE' ? 'tệp' : section.type === 'QUIZ' ? 'trắc nghiệm' : section.type }}</span>
-                                            </button>
+                                            </div>
                                           }
                                         </div>
                                       }
@@ -996,19 +1060,65 @@ export class CourseEditorSidebarComponent implements OnDestroy {
     });
   }
 
+  /**
+   * Drop handler for sidebar sections. Routes to:
+   * - within-lesson reorder when both containers match (existing behavior)
+   * - cross-lesson move when the drop target is a different lesson's drop list
+   *   (CDK connected drop lists — IDs encoded by `sectionsDropListId`)
+   */
   dropSection(event: CdkDragDrop<SectionDraftDTO[]>, lessonId: string) {
-    if (event.previousIndex === event.currentIndex) return;
-    let lesson: LessonDraftDTO | undefined;
-    for (const ch of this.store.chapters()) {
-      const l = ch.lessons.find(ls => ls.id === lessonId);
-      if (l) { lesson = l; break; }
+    const sameContainer = event.previousContainer === event.container;
+
+    if (sameContainer) {
+      if (event.previousIndex === event.currentIndex) return;
+      let lesson: LessonDraftDTO | undefined;
+      for (const ch of this.store.chapters()) {
+        const l = ch.lessons.find(ls => ls.id === lessonId);
+        if (l) { lesson = l; break; }
+      }
+      if (!lesson?.sections) return;
+      const sections = [...lesson.sections];
+      moveItemInArray(sections, event.previousIndex, event.currentIndex);
+      requestAnimationFrame(() => {
+        this.store.reorderSectionsOptimistic(lessonId, sections.map(s => s.id));
+      });
+      return;
     }
-    if (!lesson?.sections) return;
-    const sections = [...lesson.sections];
-    moveItemInArray(sections, event.previousIndex, event.currentIndex);
+
+    // Cross-lesson move
+    const fromLessonId = this.parseLessonIdFromDropListId(event.previousContainer.id);
+    const sectionId = (event.item.data as SectionDraftDTO | undefined)?.id;
+    if (!fromLessonId || !sectionId || fromLessonId === lessonId) return;
+    const targetIndex = event.currentIndex;
     requestAnimationFrame(() => {
-      this.store.reorderSectionsOptimistic(lessonId, sections.map(s => s.id));
+      this.store.moveSectionToLessonOptimistic(sectionId, fromLessonId, lessonId, targetIndex);
     });
+  }
+
+  sectionsDropListId(lessonId: string): string {
+    return 'sidebar-sections-' + lessonId;
+  }
+
+  /**
+   * Drop list IDs for all OTHER lessons currently expanded in the sidebar.
+   * Collapsed lessons aren't connectable because their drop list isn't rendered —
+   * teacher must expand the target lesson first to drop into it.
+   */
+  otherExpandedSectionDropListIds(currentLessonId: string): string[] {
+    const ids: string[] = [];
+    for (const chapter of this.store.chapters()) {
+      for (const lesson of chapter.lessons) {
+        if (lesson.id === currentLessonId) continue;
+        if (!this.isLessonExpanded(lesson.id)) continue;
+        ids.push(this.sectionsDropListId(lesson.id));
+      }
+    }
+    return ids;
+  }
+
+  private parseLessonIdFromDropListId(dropListId: string | null | undefined): string | null {
+    if (!dropListId || !dropListId.startsWith('sidebar-sections-')) return null;
+    return dropListId.slice('sidebar-sections-'.length);
   }
 
   // --- Modal handlers ---

--- a/fe/src/app/features/teacher/course-editor/services/course-authoring.service.ts
+++ b/fe/src/app/features/teacher/course-editor/services/course-authoring.service.ts
@@ -414,6 +414,15 @@ export class CourseAuthoringService {
         });
     }
 
+    moveSection(sectionId: string, fromLessonId: string, toLessonId: string, targetIndex?: number | null): Observable<void> {
+        return this.http.patch<void>(`${this.baseUrl}/courses/sections/move`, {
+            sectionId,
+            fromLessonId,
+            toLessonId,
+            targetIndex: targetIndex ?? null
+        });
+    }
+
     // --- Updates ---
 
     updateCourseInfo(courseId: string, data: Partial<{

--- a/fe/src/app/features/teacher/course-editor/store/course-editor.store.ts
+++ b/fe/src/app/features/teacher/course-editor/store/course-editor.store.ts
@@ -220,6 +220,57 @@ export class CourseEditorStore {
         });
     }
 
+    /**
+     * Move a section to a different lesson (Notion block-move / Coursera "Move To" pattern).
+     * targetIndex null = append at the end of target lesson.
+     * Optimistic: applies the local mutation immediately, rolls back on API error.
+     */
+    moveSectionToLessonOptimistic(sectionId: string, fromLessonId: string, toLessonId: string, targetIndex: number | null = null) {
+        if (fromLessonId === toLessonId) return;
+        const currentTree = this.courseTree();
+        if (!currentTree) return;
+
+        const oldChapters = currentTree.chapters;
+
+        let movedSection: any = null;
+        const stripped = oldChapters.map(ch => ({
+            ...ch,
+            lessons: ch.lessons.map(l => {
+                if (l.id !== fromLessonId) return l;
+                const sections = l.sections || [];
+                const idx = sections.findIndex(s => s.id === sectionId);
+                if (idx < 0) return l;
+                movedSection = sections[idx];
+                const next = [...sections.slice(0, idx), ...sections.slice(idx + 1)];
+                return { ...l, sections: next };
+            })
+        }));
+
+        if (!movedSection) return;
+
+        const newChapters = stripped.map(ch => ({
+            ...ch,
+            lessons: ch.lessons.map(l => {
+                if (l.id !== toLessonId) return l;
+                const sections = l.sections || [];
+                const insertAt = (targetIndex == null || targetIndex < 0 || targetIndex > sections.length)
+                    ? sections.length
+                    : targetIndex;
+                const next = [...sections.slice(0, insertAt), movedSection, ...sections.slice(insertAt)];
+                return { ...l, sections: next };
+            })
+        }));
+
+        this.setCourseTreeState({ ...currentTree, chapters: newChapters });
+
+        this.service.moveSection(sectionId, fromLessonId, toLessonId, targetIndex).subscribe({
+            error: (err: any) => {
+                this.setCourseTreeState({ ...currentTree, chapters: oldChapters });
+                this.toast.error('Chuyển nội dung thất bại' + (err?.error?.message ? ': ' + err.error.message : ''));
+            }
+        });
+    }
+
     updateLessonLocal(chapterId: string, lessonId: string, updates: Partial<LessonDraftDTO>) {
         const currentTree = this.courseTree();
         if (!currentTree) return;

--- a/fe/src/app/features/teacher/course-editor/store/course-editor.store.ts
+++ b/fe/src/app/features/teacher/course-editor/store/course-editor.store.ts
@@ -223,17 +223,54 @@ export class CourseEditorStore {
     /**
      * Move a section to a different lesson (Notion block-move / Coursera "Move To" pattern).
      * targetIndex null = append at the end of target lesson.
-     * Optimistic: applies the local mutation immediately, rolls back on API error.
+     *
+     * Concurrency-safe: rollback reverses the SPECIFIC move via {@link applySectionMove},
+     * not by restoring a captured oldChapters snapshot. Two concurrent moves that both
+     * capture-then-restore would clobber each other; reversing per-move keeps each one
+     * independently undoable regardless of intervening state.
      */
     moveSectionToLessonOptimistic(sectionId: string, fromLessonId: string, toLessonId: string, targetIndex: number | null = null) {
         if (fromLessonId === toLessonId) return;
         const currentTree = this.courseTree();
         if (!currentTree) return;
 
-        const oldChapters = currentTree.chapters;
+        // Snapshot the original position so rollback can put the section back in the exact
+        // slot it came from, not just at the end of the source lesson.
+        let originalIndex = -1;
+        for (const ch of currentTree.chapters) {
+            for (const l of ch.lessons) {
+                if (l.id !== fromLessonId) continue;
+                const idx = (l.sections ?? []).findIndex(s => s.id === sectionId);
+                if (idx >= 0) {
+                    originalIndex = idx;
+                }
+            }
+        }
+        if (originalIndex < 0) return;
 
-        let movedSection: any = null;
-        const stripped = oldChapters.map(ch => ({
+        const moved = this.applySectionMove(fromLessonId, toLessonId, sectionId, targetIndex);
+        if (!moved) return;
+
+        this.service.moveSection(sectionId, fromLessonId, toLessonId, targetIndex).subscribe({
+            error: (err: any) => {
+                // Reverse the move: pull the section back from target to original slot in source.
+                this.applySectionMove(toLessonId, fromLessonId, sectionId, originalIndex);
+                this.toast.error('Chuyển nội dung thất bại' + (err?.error?.message ? ': ' + err.error.message : ''));
+            }
+        });
+    }
+
+    /**
+     * Pure helper: read latest tree, remove section from its current lesson, insert into target.
+     * Returns true if the section was found and moved, false otherwise (e.g. another concurrent
+     * move already removed it). Caller decides whether to roll back or report.
+     */
+    private applySectionMove(fromLessonId: string, toLessonId: string, sectionId: string, targetIndex: number | null): boolean {
+        const currentTree = this.courseTree();
+        if (!currentTree) return false;
+
+        let movedSection: SectionDraftDTO | null = null;
+        const stripped = currentTree.chapters.map(ch => ({
             ...ch,
             lessons: ch.lessons.map(l => {
                 if (l.id !== fromLessonId) return l;
@@ -241,14 +278,13 @@ export class CourseEditorStore {
                 const idx = sections.findIndex(s => s.id === sectionId);
                 if (idx < 0) return l;
                 movedSection = sections[idx];
-                const next = [...sections.slice(0, idx), ...sections.slice(idx + 1)];
-                return { ...l, sections: next };
+                return { ...l, sections: [...sections.slice(0, idx), ...sections.slice(idx + 1)] };
             })
         }));
 
-        if (!movedSection) return;
+        if (!movedSection) return false;
 
-        const newChapters = stripped.map(ch => ({
+        const finalChapters = stripped.map(ch => ({
             ...ch,
             lessons: ch.lessons.map(l => {
                 if (l.id !== toLessonId) return l;
@@ -256,19 +292,12 @@ export class CourseEditorStore {
                 const insertAt = (targetIndex == null || targetIndex < 0 || targetIndex > sections.length)
                     ? sections.length
                     : targetIndex;
-                const next = [...sections.slice(0, insertAt), movedSection, ...sections.slice(insertAt)];
-                return { ...l, sections: next };
+                return { ...l, sections: [...sections.slice(0, insertAt), movedSection!, ...sections.slice(insertAt)] };
             })
         }));
 
-        this.setCourseTreeState({ ...currentTree, chapters: newChapters });
-
-        this.service.moveSection(sectionId, fromLessonId, toLessonId, targetIndex).subscribe({
-            error: (err: any) => {
-                this.setCourseTreeState({ ...currentTree, chapters: oldChapters });
-                this.toast.error('Chuyển nội dung thất bại' + (err?.error?.message ? ': ' + err.error.message : ''));
-            }
-        });
+        this.setCourseTreeState({ ...currentTree, chapters: finalChapters });
+        return true;
     }
 
     updateLessonLocal(chapterId: string, lessonId: string, updates: Partial<LessonDraftDTO>) {


### PR DESCRIPTION
## Bug (image #38)

Sidebar tree cho phép drag chapter và lesson nhưng **section (Mục) hoàn toàn không drag được**. Với 19+ section trong 1 lesson (sau batch upload video), không có cách nào:
1. Reorder section mà không vào side-panel
2. Chuyển section sang lesson khác khi natural split lộ ra (ví dụ: 19 video raw thực ra thuộc 2 tuần khác nhau)

## SOTA reference

- **Notion blocks**: drag bất kỳ block nào trong page hoặc sang page khác qua cùng 1 handle
- **Coursera Studio \"Move To\"**: cross-lesson reorganization là first-class workflow
- **Udemy lectures**: drag-to-reorder trong section

PR này kết hợp 2 pattern: drag handle reorder + CDK connected drop lists cho cross-lesson move.

## BE

| Change | File |
|---|---|
| New \`moveSection()\` use case method | \`ManageContentBlockUseCaseV3.java\` |
| New endpoint \`PATCH /api/v3/courses/sections/move\` | \`CourseAuthoringControllerV3.java\` |
| New DTO \`MoveSectionRequest\` | (in same controller) |

**Atomicity**: \`@Transactional\` — cả 2 lesson save trong 1 tx, fail mid-way rollback toàn bộ.
**Same-course constraint**: cross-course move bị reject (sẽ phá enrollment ownership + payment scoping).
**Idempotent**: same source/target = no-op early exit.

## FE

| Change | File |
|---|---|
| \`moveSection()\` API method | \`course-authoring.service.ts\` |
| \`moveSectionToLessonOptimistic()\` store method | \`course-editor.store.ts\` |
| Sidebar UX: drag handle + cdkDropList connected + empty drop zone | \`sidebar.component.ts\` |

### UX details
- Mỗi sections list có ID stable \`sidebar-sections-{lessonId}\`, connected to all OTHER expanded lessons
- Drag handle grip ⋮⋮ hide-on-default reveal-on-hover (mirror chapter/lesson pattern)
- Empty expanded lesson render dashed drop zone \"Kéo mục vào đây để chuyển sang bài này\" — đổi xanh khi drag hover
- Keyboard accessibility (Enter/Space) preserved alongside click
- \`dropSection\` route: same container → reorder, different container → cross-lesson move

## Test plan

- [ ] Drag section trong cùng lesson → reorder → toast \"Sắp xếp nội dung thất bại\" nếu API fail (existing path, regression check)
- [ ] Expand 2 lesson trong cùng chapter → drag section từ lesson A sang lesson B → optimistic update + API call
- [ ] Drag section sang lesson trong CHAPTER khác (cùng course) → success
- [ ] Drag section sang lesson rỗng (0 section) → empty drop zone hiện, drop OK, lesson B giờ có 1 section
- [ ] API fail → rollback, toast lỗi
- [ ] Section của course A không drag được sang course B (BE 403)
- [ ] Touch device → 150ms hold-to-drag delay (mirror chapter/lesson)
- [ ] Keyboard: focus section row + Enter → select section (chứ không drag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)