### PR TITLE
[codex] advance interactive video authoring UX

### DIFF
--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
@@ -147,7 +147,9 @@
       <div class="relative aspect-video w-full rounded-lg overflow-hidden shadow-sm bg-black border border-gray-100 mb-6">
         @if (!section.streamVideoUid && isYouTubeUrl(section.videoUrl || lesson().videoUrl)) {
         <app-youtube-player [videoUrl]="(section.videoUrl || lesson().videoUrl)!" [lessonId]="lesson().id" [sectionId]="section.id"
-          [completionThreshold]="section.completionThreshold" (videoEnded)="onVideoEnd()" />
+          [completionThreshold]="section.completionThreshold"
+          [interactiveVideoSpec]="section.interactiveVideoSpec || null"
+          (videoEnded)="onVideoEnd()" />
         } @else {
         <app-adaptive-video-player [lessonId]="lesson().id" [sectionId]="section.id"
           [videoAssetId]="section.videoAssetId || null" [videoSourceKind]="section.videoSourceKind || null"

--- a/fe/src/app/features/learning/components/youtube-player/youtube-player.component.ts
+++ b/fe/src/app/features/learning/components/youtube-player/youtube-player.component.ts
@@ -3,15 +3,26 @@ import {
   input,
   output,
   inject,
+  signal,
   OnInit,
   OnDestroy,
   ChangeDetectionStrategy,
   ViewEncapsulation,
   NgZone
 } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 import { WatchedSegmentsTracker } from '../../services/watched-segments-tracker.service';
 import { VideoProgressApi } from '../../../../api/client/video-progress.api';
 import { HeartbeatTracker } from '../../services/heartbeat-tracker.service';
+import { LearningActivityApi } from '../../../../api/client/learning-activity.api';
+import { InteractiveVideoOverlayComponent } from '../../../../shared/blocks/video-block/interactive-video-overlay.component';
+import { buildInteractiveVideoAnalyticsProjection } from '../../../../core/utils/interactive-video-analytics';
+import type {
+  InteractiveVideoChoice,
+  InteractiveVideoInteraction,
+  InteractiveVideoRuntimeEvent,
+  InteractiveVideoSpec,
+} from '../../../../api/types/interactive-video.types';
 
 declare global {
   interface Window {
@@ -58,7 +69,19 @@ function extractVideoId(url: string): string | null {
   selector: 'app-youtube-player',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  template: `<div class="youtube-player-wrapper"><div [id]="playerId"></div></div>`,
+  imports: [InteractiveVideoOverlayComponent],
+  template: `
+    <div class="youtube-player-wrapper">
+      <div [id]="playerId"></div>
+      @if (activeInteraction(); as interaction) {
+        <app-interactive-video-overlay
+          [interaction]="interaction"
+          [selectedChoiceId]="selectedChoiceId()"
+          (choiceSelected)="onInteractiveChoice($event)"
+          (continueRequested)="onInteractiveContinue()" />
+      }
+    </div>
+  `,
   styles: [`
     app-youtube-player {
       display: block;
@@ -86,14 +109,23 @@ export class YouTubePlayerComponent implements OnInit, OnDestroy {
   lessonId = input.required<string>();
   sectionId = input.required<string>();
   completionThreshold = input<number | undefined>(undefined);
+  trackingEnabled = input(true);
+  interactiveVideoSpec = input<InteractiveVideoSpec | null>(null);
   videoEnded = output<void>();
+  durationLoaded = output<number>();
+  interactiveEvent = output<InteractiveVideoRuntimeEvent>();
 
   private tracker = inject(WatchedSegmentsTracker);
   private videoProgressApi = inject(VideoProgressApi);
   private heartbeat = inject(HeartbeatTracker);
+  private learningActivityApi = inject(LearningActivityApi);
   private zone = inject(NgZone);
   private player: any = null;
   private pollInterval: ReturnType<typeof setInterval> | null = null;
+  readonly activeInteraction = signal<InteractiveVideoInteraction | null>(null);
+  readonly selectedChoiceId = signal<string | null>(null);
+  private readonly shownInteractionIds = new Set<string>();
+  private readonly completedInteractionIds = new Set<string>();
 
   readonly playerId = 'yt-player-' + Math.random().toString(36).substring(2, 9);
 
@@ -134,10 +166,18 @@ export class YouTubePlayerComponent implements OnInit, OnDestroy {
 
     const duration = event.target.getDuration?.() || 0;
     if (duration > 0) {
-      this.tracker.startTracking(this.lessonId(), this.sectionId(), duration, this.completionThreshold());
+      this.zone.run(() => this.durationLoaded.emit(duration));
+    }
+    if (duration > 0) {
+      if (this.trackingEnabled()) {
+        this.tracker.startTracking(this.lessonId(), this.sectionId(), duration, this.completionThreshold());
+      }
     }
 
     // Resume from last position
+    if (!this.trackingEnabled()) {
+      return;
+    }
     this.videoProgressApi.getResumePosition(this.sectionId()).subscribe({
       next: (res: any) => {
         if (res?.success && res.data?.position > 0 && this.player?.seekTo) {
@@ -153,16 +193,22 @@ export class YouTubePlayerComponent implements OnInit, OnDestroy {
     if (!YT) return;
 
     if (event.data === YT.PlayerState.PLAYING) {
-      this.heartbeat.start(this.lessonId(), this.sectionId(), 'VIDEO');
+      if (this.trackingEnabled()) {
+        this.heartbeat.start(this.lessonId(), this.sectionId(), 'VIDEO');
+      }
       this.startPolling();
     } else {
-      this.heartbeat.stop();
+      if (this.trackingEnabled()) {
+        this.heartbeat.stop();
+      }
       this.stopPolling();
     }
 
     if (event.data === YT.PlayerState.ENDED) {
-      this.tracker.stopTracking();
-      this.heartbeat.stop();
+      if (this.trackingEnabled()) {
+        this.tracker.stopTracking();
+        this.heartbeat.stop();
+      }
       this.zone.run(() => this.videoEnded.emit());
     }
   }
@@ -172,7 +218,10 @@ export class YouTubePlayerComponent implements OnInit, OnDestroy {
     this.pollInterval = setInterval(() => {
       if (this.player?.getCurrentTime) {
         const currentTime = this.player.getCurrentTime();
-        this.tracker.recordSecond(currentTime);
+        if (this.trackingEnabled()) {
+          this.tracker.recordSecond(currentTime);
+        }
+        this.zone.run(() => this.evaluateInteractiveTimeline(currentTime));
       }
     }, 1000);
   }
@@ -184,10 +233,163 @@ export class YouTubePlayerComponent implements OnInit, OnDestroy {
     }
   }
 
+  onInteractiveChoice(choice: InteractiveVideoChoice): void {
+    const interaction = this.activeInteraction();
+    if (!interaction) {
+      return;
+    }
+
+    this.selectedChoiceId.set(choice.id);
+    const action = interaction.type === 'branch' ? 'branch_taken' : 'answered';
+    void this.recordInteractiveEvent(interaction, action, {
+      choiceId: choice.id,
+      isCorrect: choice.isCorrect === true,
+      targetTimeSeconds: choice.targetTimeSeconds ?? null,
+      targetInteractionId: choice.targetInteractionId ?? null,
+    });
+
+    if (interaction.type === 'branch') {
+      this.jumpToInteractiveChoiceTarget(choice);
+    }
+  }
+
+  onInteractiveContinue(): void {
+    const interaction = this.activeInteraction();
+    if (!interaction) {
+      return;
+    }
+
+    this.completedInteractionIds.add(interaction.id);
+    void this.recordInteractiveEvent(interaction, 'continued', {
+      choiceId: this.selectedChoiceId(),
+    });
+    this.activeInteraction.set(null);
+    this.selectedChoiceId.set(null);
+    this.player?.playVideo?.();
+  }
+
+  private evaluateInteractiveTimeline(currentTime: number): void {
+    if (this.activeInteraction()) {
+      return;
+    }
+
+    const spec = this.interactiveVideoSpec();
+    if (!spec || spec.enabled === false || !Array.isArray(spec.timeline) || spec.timeline.length === 0) {
+      return;
+    }
+
+    const dueInteraction = spec.timeline.find(interaction => {
+      if (this.completedInteractionIds.has(interaction.id)) {
+        return false;
+      }
+      if (currentTime < interaction.atSeconds) {
+        return false;
+      }
+
+      const endSeconds = interaction.endSeconds ?? interaction.atSeconds + 5;
+      return interaction.required === true || currentTime <= endSeconds;
+    });
+
+    if (!dueInteraction) {
+      return;
+    }
+
+    this.activeInteraction.set(dueInteraction);
+    this.selectedChoiceId.set(null);
+    if (dueInteraction.pause !== false) {
+      this.player?.pauseVideo?.();
+    }
+
+    if (!this.shownInteractionIds.has(dueInteraction.id)) {
+      this.shownInteractionIds.add(dueInteraction.id);
+      void this.recordInteractiveEvent(dueInteraction, 'shown');
+    }
+  }
+
+  private jumpToInteractiveChoiceTarget(choice: InteractiveVideoChoice): void {
+    const active = this.activeInteraction();
+    if (active) {
+      this.completedInteractionIds.add(active.id);
+    }
+    this.activeInteraction.set(null);
+    this.selectedChoiceId.set(null);
+
+    const targetTime = choice.targetTimeSeconds ?? this.resolveTargetInteractionTime(choice.targetInteractionId);
+    if (typeof targetTime === 'number' && Number.isFinite(targetTime)) {
+      this.player?.seekTo?.(Math.max(0, targetTime), true);
+    }
+    this.player?.playVideo?.();
+  }
+
+  private resolveTargetInteractionTime(targetInteractionId: string | null | undefined): number | null {
+    if (!targetInteractionId) {
+      return null;
+    }
+
+    return this.interactiveVideoSpec()?.timeline
+      ?.find(interaction => interaction.id === targetInteractionId)
+      ?.atSeconds ?? null;
+  }
+
+  private async recordInteractiveEvent(
+    interaction: InteractiveVideoInteraction,
+    action: InteractiveVideoRuntimeEvent['action'],
+    data: Record<string, unknown> = {},
+  ): Promise<void> {
+    const videoTimeSeconds = this.player?.getCurrentTime?.() ?? interaction.atSeconds;
+    const occurredAt = new Date();
+    const runtimeEvent: InteractiveVideoRuntimeEvent = {
+      interactionId: interaction.id,
+      action,
+      videoTimeSeconds,
+      data: {
+        interactionType: interaction.type,
+        sourceKind: 'youtube',
+        ...data,
+      },
+    };
+
+    this.interactiveEvent.emit(runtimeEvent);
+    if (!this.trackingEnabled()) {
+      return;
+    }
+
+    const analyticsProjection = buildInteractiveVideoAnalyticsProjection({
+      lessonId: this.lessonId(),
+      sectionId: this.sectionId(),
+      interaction,
+      event: runtimeEvent,
+      occurredAtIso: occurredAt.toISOString(),
+    });
+    const payload = {
+      lessonId: this.lessonId(),
+      sectionId: this.sectionId(),
+      interactionId: interaction.id,
+      action,
+      videoTimeSeconds,
+      data: {
+        ...runtimeEvent.data,
+        analyticsProjection,
+      },
+      occurredAt: occurredAt.toISOString(),
+      entityId: interaction.id,
+    };
+
+    try {
+      await firstValueFrom(this.learningActivityApi.recordInteractiveVideoEvent(payload));
+    } catch {
+      // YouTube cannot run offline; progress events continue through normal video tracking.
+    }
+  }
+
   ngOnDestroy(): void {
     this.stopPolling();
-    this.tracker.stopTracking();
-    this.heartbeat.stop();
+    this.activeInteraction.set(null);
+    this.selectedChoiceId.set(null);
+    if (this.trackingEnabled()) {
+      this.tracker.stopTracking();
+      this.heartbeat.stop();
+    }
     if (this.player?.destroy) {
       this.player.destroy();
       this.player = null;

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
@@ -115,7 +115,7 @@
           </div>
           <span class="inline-flex items-center gap-1 rounded-full bg-[#0056D2]/5 px-2.5 py-1 text-xs font-semibold text-[#0056D2]">
             <lucide-icon name="layers" [size]="13"></lucide-icon>
-            Timeline
+            {{ timelineScaleLabel() }}
           </span>
         </div>
 
@@ -182,15 +182,17 @@
 
                   <div class="mt-2 flex gap-1.5">
                     <button type="button"
-                      (click)="nudgeInteractiveTime(node.id, -5)"
+                      (click)="nudgeInteractiveTime(node.id, -quickNudgeSeconds())"
                       class="inline-flex h-7 w-7 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 hover:border-[#0056D2]/40 hover:text-[#0056D2]"
-                      [attr.aria-label]="'Đưa điểm ' + node.index + ' sớm hơn 5 giây'">
+                      [attr.title]="quickNudgeEarlierLabel()"
+                      [attr.aria-label]="'Đưa điểm ' + node.index + ' ' + quickNudgeEarlierLabel().toLowerCase()">
                       <lucide-icon name="arrow-left" [size]="13"></lucide-icon>
                     </button>
                     <button type="button"
-                      (click)="nudgeInteractiveTime(node.id, 5)"
+                      (click)="nudgeInteractiveTime(node.id, quickNudgeSeconds())"
                       class="inline-flex h-7 w-7 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 hover:border-[#0056D2]/40 hover:text-[#0056D2]"
-                      [attr.aria-label]="'Đưa điểm ' + node.index + ' muộn hơn 5 giây'">
+                      [attr.title]="quickNudgeLaterLabel()"
+                      [attr.aria-label]="'Đưa điểm ' + node.index + ' ' + quickNudgeLaterLabel().toLowerCase()">
                       <lucide-icon name="arrow-right" [size]="13"></lucide-icon>
                     </button>
                   </div>

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
@@ -1,0 +1,401 @@
+<div class="rounded-xl border border-slate-200 bg-white">
+  <div class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-4 py-3">
+    <div class="flex min-w-0 items-center gap-2.5">
+      <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[#0056D2]/10 text-[#0056D2]">
+        <lucide-icon name="mouse-pointer-2" [size]="16"></lucide-icon>
+      </div>
+      <div class="min-w-0">
+        <h4 class="text-sm font-semibold text-slate-900">Video tương tác</h4>
+        <p class="text-xs text-slate-500">
+          {{ svc.sectionInteractiveVideoInteractionCount() }} điểm tương tác
+        </p>
+      </div>
+    </div>
+    <div class="flex flex-wrap items-center gap-2">
+      <span [class]="compatibilityBadgeClass()">
+        {{ compatibilityLabel() }}
+      </span>
+      <label class="inline-flex cursor-pointer select-none items-center gap-2 text-sm font-semibold text-slate-700">
+        <input type="checkbox"
+          [ngModel]="svc.sectionInteractiveVideoEnabled()"
+          (ngModelChange)="onInteractiveVideoEnabledChange($event)"
+          class="h-4 w-4 rounded text-[#0056D2] focus:ring-[#0056D2]" />
+        Bật
+      </label>
+    </div>
+  </div>
+
+  @if (isYoutubeSource()) {
+    <div class="border-b border-sky-100 bg-sky-50/70 px-4 py-3">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div class="flex min-w-0 gap-2.5">
+          <lucide-icon name="info" [size]="16" class="mt-0.5 shrink-0 text-sky-600"></lucide-icon>
+          <div class="min-w-0">
+            <p class="text-sm font-semibold text-sky-900">YouTube chạy tương tác trực tuyến</p>
+            <p class="mt-1 text-xs leading-relaxed text-sky-800">
+              Điểm dừng, câu hỏi và rẽ nhánh dùng YouTube IFrame API nên hoạt động khi học viên online. Nếu cần xem ngoại tuyến hoặc kiểm soát media đầy đủ, hãy dùng video tải lên.
+            </p>
+          </div>
+        </div>
+        <button type="button"
+          (click)="switchToUpload.emit()"
+          class="shrink-0 rounded-lg border border-sky-200 bg-white px-3 py-1.5 text-xs font-semibold text-sky-800 hover:bg-sky-50">
+          Chuyển sang Tải lên
+        </button>
+      </div>
+    </div>
+  }
+
+  @if (svc.sectionInteractiveVideoEnabled()) {
+    <div class="border-b border-slate-100 px-4 py-3">
+      <div class="flex flex-col gap-3">
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="mr-1 text-xs font-semibold uppercase tracking-wide text-slate-500">Tạo trực tiếp</span>
+          <button type="button"
+            (click)="addInteraction('checkpoint')"
+            class="inline-flex items-center gap-1.5 rounded-lg bg-[#0056D2] px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-[#004BB5]">
+            <lucide-icon name="pause" [size]="13"></lucide-icon>
+            Thêm điểm dừng
+          </button>
+          <button type="button"
+            (click)="addInteraction('single_choice')"
+            class="inline-flex items-center gap-1.5 rounded-lg border border-[#0056D2]/30 bg-[#0056D2]/5 px-3 py-1.5 text-xs font-semibold text-[#0056D2] hover:bg-[#0056D2]/10">
+            <lucide-icon name="help-circle" [size]="13"></lucide-icon>
+            Thêm câu hỏi
+          </button>
+          <button type="button"
+            (click)="addInteraction('branch')"
+            class="inline-flex items-center gap-1.5 rounded-lg border border-[#0056D2]/30 bg-[#0056D2]/5 px-3 py-1.5 text-xs font-semibold text-[#0056D2] hover:bg-[#0056D2]/10">
+            <lucide-icon name="shuffle" [size]="13"></lucide-icon>
+            Thêm rẽ nhánh
+          </button>
+          <span class="text-xs text-slate-500">{{ durationHint() }}</span>
+        </div>
+        <div class="flex flex-wrap items-center gap-2 border-t border-slate-100 pt-3">
+          <span class="mr-1 text-xs font-semibold uppercase tracking-wide text-slate-400">Tệp H5P/JSON</span>
+          <input #interactiveImportInput type="file"
+            accept="application/json,.json,.h5p,application/h5p,application/zip"
+            class="hidden"
+            (change)="onInteractiveImportSelected($event)" />
+          <button type="button"
+            (click)="interactiveImportInput.click()"
+            class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5">
+            <lucide-icon name="upload" [size]="13"></lucide-icon>
+            Nhập từ file
+          </button>
+          <button type="button"
+            (click)="exportInteractiveVideoJson()"
+            [disabled]="!previewSpec()"
+            class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5 disabled:cursor-not-allowed disabled:opacity-50">
+            <lucide-icon name="download" [size]="13"></lucide-icon>
+            Xuất JSON
+          </button>
+          <button type="button"
+            (click)="exportInteractiveVideoH5P()"
+            [disabled]="!previewSpec()"
+            class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5 disabled:cursor-not-allowed disabled:opacity-50">
+            <lucide-icon name="archive" [size]="13"></lucide-icon>
+            Xuất H5P
+          </button>
+        </div>
+      </div>
+    </div>
+
+    @if (interactiveVideoFlowNodes().length > 0) {
+      <section class="border-b border-slate-100 bg-slate-50/50 p-4" aria-label="Sơ đồ luồng video tương tác">
+        <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <h5 class="text-sm font-semibold text-slate-900">Sơ đồ luồng</h5>
+            <div class="mt-1 flex flex-wrap gap-1.5 text-[11px] font-semibold text-slate-500">
+              <span class="rounded-full bg-white px-2 py-0.5 ring-1 ring-slate-200">{{ interactiveVideoFlowStats().total }} điểm</span>
+              <span class="rounded-full bg-white px-2 py-0.5 ring-1 ring-slate-200">{{ interactiveVideoFlowStats().questions }} câu hỏi</span>
+              <span class="rounded-full bg-white px-2 py-0.5 ring-1 ring-slate-200">{{ interactiveVideoFlowStats().branches }} rẽ nhánh</span>
+              <span class="rounded-full bg-white px-2 py-0.5 ring-1 ring-slate-200">{{ interactiveVideoFlowStats().required }} bắt buộc</span>
+            </div>
+          </div>
+          <span class="inline-flex items-center gap-1 rounded-full bg-[#0056D2]/5 px-2.5 py-1 text-xs font-semibold text-[#0056D2]">
+            <lucide-icon name="layers" [size]="13"></lucide-icon>
+            Timeline
+          </span>
+        </div>
+
+        <div class="mb-4 rounded-xl border border-slate-200 bg-white px-3 py-3">
+          <div class="relative h-10">
+            <div class="absolute left-0 right-0 top-1/2 h-1 -translate-y-1/2 rounded-full bg-slate-100"></div>
+            @for (node of interactiveVideoFlowNodes(); track node.id) {
+              <button type="button"
+                class="interactive-timeline-dot absolute top-1/2 flex h-7 w-7 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-white bg-[#0056D2] text-[10px] font-bold text-white shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0056D2] focus-visible:ring-offset-2"
+                [style.left.%]="getTimelinePercent(node.atSeconds)"
+                [attr.aria-label]="'Chỉnh điểm ' + node.index + ' tại ' + node.timeLabel"
+                (click)="scrollInteractiveNodeIntoView(node.id)">
+                {{ node.index }}
+              </button>
+            }
+          </div>
+        </div>
+
+        <div class="overflow-x-auto pb-1">
+          <div class="flex min-w-max items-stretch gap-3" role="list">
+            @for (node of interactiveVideoFlowNodes(); track node.id; let isLast = $last) {
+              <div class="flex items-stretch gap-3" role="listitem">
+                <article
+                  [class]="node.nodeClass"
+                  tabindex="0"
+                  draggable="true"
+                  [attr.aria-label]="'Điểm ' + node.index + ': ' + node.typeLabel + ' tại ' + node.timeLabel"
+                  [attr.aria-current]="dropTargetInteractionId() === node.id ? 'true' : null"
+                  (keydown)="onFlowNodeKeydown($event, node)"
+                  (dragstart)="onFlowNodeDragStart($event, node)"
+                  (dragover)="onFlowNodeDragOver($event, node)"
+                  (drop)="onFlowNodeDrop($event, node)"
+                  (dragend)="onFlowNodeDragEnd()">
+                  <div class="flex items-start justify-between gap-2">
+                    <div class="min-w-0">
+                      <div class="flex items-center gap-1.5">
+                        <span [class]="node.badgeClass">
+                          <lucide-icon [name]="node.iconName" [size]="12"></lucide-icon>
+                          {{ node.typeLabel }}
+                        </span>
+                        <span class="text-[11px] font-bold tabular-nums text-slate-400">#{{ node.index }}</span>
+                      </div>
+                      <p class="mt-2 line-clamp-2 text-sm font-semibold text-slate-900">{{ node.title }}</p>
+                    </div>
+                    <button type="button"
+                      (click)="scrollInteractiveNodeIntoView(node.id)"
+                      class="shrink-0 rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] font-semibold text-slate-500 hover:border-[#0056D2]/40 hover:text-[#0056D2]">
+                      Chỉnh
+                    </button>
+                  </div>
+
+                  <div class="mt-2 flex flex-wrap items-center gap-1.5 text-[11px] font-medium text-slate-500">
+                    <span class="inline-flex items-center gap-1 rounded-full bg-white px-2 py-0.5 ring-1 ring-slate-200">
+                      <lucide-icon name="clock" [size]="11"></lucide-icon>
+                      {{ node.timeLabel }}
+                    </span>
+                    @if (node.pause) {
+                      <span class="rounded-full bg-white px-2 py-0.5 ring-1 ring-slate-200">Tạm dừng</span>
+                    }
+                    @if (node.required) {
+                      <span class="rounded-full bg-amber-50 px-2 py-0.5 text-amber-700 ring-1 ring-amber-200">Bắt buộc</span>
+                    }
+                  </div>
+
+                  <div class="mt-2 flex gap-1.5">
+                    <button type="button"
+                      (click)="nudgeInteractiveTime(node.id, -5)"
+                      class="inline-flex h-7 w-7 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 hover:border-[#0056D2]/40 hover:text-[#0056D2]"
+                      [attr.aria-label]="'Đưa điểm ' + node.index + ' sớm hơn 5 giây'">
+                      <lucide-icon name="arrow-left" [size]="13"></lucide-icon>
+                    </button>
+                    <button type="button"
+                      (click)="nudgeInteractiveTime(node.id, 5)"
+                      class="inline-flex h-7 w-7 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-500 hover:border-[#0056D2]/40 hover:text-[#0056D2]"
+                      [attr.aria-label]="'Đưa điểm ' + node.index + ' muộn hơn 5 giây'">
+                      <lucide-icon name="arrow-right" [size]="13"></lucide-icon>
+                    </button>
+                  </div>
+
+                  @if (node.choices.length > 0) {
+                    <div class="mt-3 max-h-32 space-y-1 overflow-y-auto">
+                      @for (choice of node.choices; track choice.id) {
+                        <div [class]="choice.toneClass">
+                          <span class="min-w-0 flex-1 truncate">{{ choice.label }}</span>
+                          <span class="shrink-0 text-[10px] font-semibold">{{ choice.metaLabel }}</span>
+                        </div>
+                      }
+                    </div>
+                  } @else {
+                    <div class="mt-3 rounded-lg bg-white px-2.5 py-2 text-xs font-medium text-slate-500 ring-1 ring-slate-200">
+                      Tiếp tục theo timeline
+                    </div>
+                  }
+                </article>
+
+                @if (!isLast) {
+                  <div class="flex w-8 items-center justify-center text-slate-300">
+                    <lucide-icon name="arrow-right" [size]="18"></lucide-icon>
+                  </div>
+                }
+              </div>
+            }
+          </div>
+        </div>
+      </section>
+    }
+
+    @if (svc.sectionInteractiveVideoTimeline().length === 0) {
+      <div class="px-4 py-5">
+        <div class="rounded-xl border border-dashed border-slate-200 bg-slate-50/70 p-4 text-center">
+          <lucide-icon name="plus-circle" [size]="30" class="mx-auto text-slate-300"></lucide-icon>
+          <p class="mt-2 text-sm font-semibold text-slate-600">Chưa có điểm tương tác</p>
+          <div class="mt-4 grid gap-2 sm:grid-cols-3">
+            <button type="button"
+              (click)="addInteraction('checkpoint')"
+              class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5">
+              <lucide-icon name="pause" [size]="13"></lucide-icon>
+              Điểm dừng
+            </button>
+            <button type="button"
+              (click)="addInteraction('single_choice')"
+              class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5">
+              <lucide-icon name="help-circle" [size]="13"></lucide-icon>
+              Câu hỏi
+            </button>
+            <button type="button"
+              (click)="addInteraction('branch')"
+              class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5">
+              <lucide-icon name="shuffle" [size]="13"></lucide-icon>
+              Rẽ nhánh
+            </button>
+          </div>
+        </div>
+      </div>
+    } @else {
+      <div class="space-y-3 p-4">
+        @for (interaction of svc.sectionInteractiveVideoTimeline(); track interaction.id; let idx = $index) {
+          <div [attr.id]="getInteractiveNodeDomId(interaction.id)" class="rounded-lg border border-slate-200 bg-slate-50/60 p-3">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[#0056D2]/10 text-xs font-bold text-[#0056D2] tabular-nums">
+                {{ idx + 1 }}
+              </span>
+              <div class="min-w-[10rem] flex-1">
+                <select
+                  [ngModel]="interaction.type"
+                  (ngModelChange)="onInteractiveTypeChange(interaction.id, $event)"
+                  class="w-full rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm font-medium text-slate-700 focus:border-[#0056D2] focus:ring-[#0056D2]">
+                  @for (type of interactiveVideoTypes; track type) {
+                    <option [ngValue]="type">{{ getInteractiveTypeLabel(type) }}</option>
+                  }
+                </select>
+                <p class="mt-1 text-[11px] leading-snug text-slate-500">{{ getInteractiveTypeHint(interaction.type) }}</p>
+              </div>
+              <div class="flex items-center gap-1.5">
+                <label class="text-xs font-medium text-slate-500">Thời điểm</label>
+                <input type="number" min="0" step="1"
+                  [attr.max]="maxInteractiveTimeSeconds() ?? null"
+                  [ngModel]="interaction.atSeconds"
+                  (ngModelChange)="onInteractiveTimeChange(interaction.id, $event)"
+                  class="w-24 rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm tabular-nums focus:border-[#0056D2] focus:ring-[#0056D2]" />
+                <span class="text-xs font-medium text-slate-400">giây</span>
+                <span class="rounded-full bg-white px-2 py-0.5 text-[11px] font-semibold tabular-nums text-slate-500 ring-1 ring-slate-200">
+                  {{ formatInteractiveTimeLabel(interaction.atSeconds) }}
+                </span>
+              </div>
+              <button type="button"
+                (click)="svc.removeInteractiveVideoInteraction(interaction.id)"
+                class="ml-auto flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-slate-400 hover:bg-red-50 hover:text-red-600"
+                aria-label="Xóa điểm tương tác">
+                <lucide-icon name="trash-2" [size]="14"></lucide-icon>
+              </button>
+            </div>
+
+            <div class="mt-3 grid gap-3 sm:grid-cols-2">
+              <div>
+                <label class="mb-1.5 block text-xs font-medium text-slate-600">Tiêu đề</label>
+                <input type="text"
+                  [ngModel]="interaction.title"
+                  (ngModelChange)="svc.updateInteractiveVideoInteraction(interaction.id, { title: $event })"
+                  placeholder="Tiêu đề hiển thị trên video"
+                  class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:border-[#0056D2] focus:ring-[#0056D2]" />
+              </div>
+              <div class="flex flex-wrap items-end gap-4">
+                <label class="inline-flex cursor-pointer items-center gap-2 text-sm text-slate-700">
+                  <input type="checkbox"
+                    [ngModel]="interaction.pause !== false"
+                    (ngModelChange)="svc.updateInteractiveVideoInteraction(interaction.id, { pause: $event })"
+                    class="h-4 w-4 rounded text-[#0056D2] focus:ring-[#0056D2]" />
+                  Tạm dừng video
+                </label>
+                <label class="inline-flex cursor-pointer items-center gap-2 text-sm text-slate-700">
+                  <input type="checkbox"
+                    [ngModel]="interaction.required === true"
+                    (ngModelChange)="svc.updateInteractiveVideoInteraction(interaction.id, { required: $event })"
+                    class="h-4 w-4 rounded text-[#0056D2] focus:ring-[#0056D2]" />
+                  Bắt buộc trả lời
+                </label>
+              </div>
+            </div>
+
+            <div class="mt-3">
+              <label class="mb-1.5 block text-xs font-medium text-slate-600">Nội dung</label>
+              <textarea rows="2"
+                [ngModel]="interaction.body"
+                (ngModelChange)="svc.updateInteractiveVideoInteraction(interaction.id, { body: $event })"
+                placeholder="Nội dung hiển thị cho học viên"
+                class="w-full resize-y rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:border-[#0056D2] focus:ring-[#0056D2]"></textarea>
+            </div>
+
+            @if (isChoiceInteraction(interaction)) {
+              <div class="mt-3 rounded-lg border border-slate-200 bg-white">
+                <div class="flex items-center justify-between gap-2 border-b border-slate-100 px-3 py-2">
+                  <span class="text-xs font-semibold uppercase text-slate-500">Lựa chọn</span>
+                  <button type="button"
+                    (click)="svc.addInteractiveVideoChoice(interaction.id)"
+                    class="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold text-[#0056D2] hover:bg-[#0056D2]/5">
+                    <lucide-icon name="plus" [size]="12"></lucide-icon>
+                    Thêm
+                  </button>
+                </div>
+                <div class="divide-y divide-slate-100">
+                  @for (choice of interaction.choices || []; track choice.id; let choiceIdx = $index) {
+                    <div [class]="getInteractiveChoiceRowClass(interaction.type)">
+                      <div class="space-y-2">
+                        <input type="text"
+                          [ngModel]="choice.label"
+                          (ngModelChange)="svc.updateInteractiveVideoChoice(interaction.id, choice.id, { label: $event })"
+                          placeholder="Nội dung lựa chọn"
+                          class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-[#0056D2] focus:ring-[#0056D2]"
+                          [attr.aria-label]="'Lựa chọn ' + (choiceIdx + 1)" />
+                        @if (interaction.type === 'single_choice') {
+                          <input type="text"
+                            [ngModel]="choice.feedback || ''"
+                            (ngModelChange)="svc.updateInteractiveVideoChoice(interaction.id, choice.id, { feedback: $event })"
+                            placeholder="Phản hồi sau khi chọn (không bắt buộc)"
+                            class="w-full rounded-lg border border-slate-200 px-3 py-2 text-xs focus:border-[#0056D2] focus:ring-[#0056D2]"
+                            [attr.aria-label]="'Phản hồi cho lựa chọn ' + (choiceIdx + 1)" />
+                        }
+                      </div>
+                      @if (interaction.type === 'branch') {
+                        <input type="number" min="0" step="1"
+                          [attr.max]="maxInteractiveTimeSeconds() ?? null"
+                          [ngModel]="choice.targetTimeSeconds ?? interaction.atSeconds"
+                          (ngModelChange)="onInteractiveChoiceTargetChange(interaction.id, choice.id, $event)"
+                          placeholder="Nhảy tới giây"
+                          class="rounded-lg border border-slate-200 px-3 py-2 text-sm tabular-nums focus:border-[#0056D2] focus:ring-[#0056D2]"
+                          aria-label="Giây đích" />
+                        <select
+                          [ngModel]="choice.targetInteractionId ?? ''"
+                          (ngModelChange)="onInteractiveChoiceTargetInteractionChange(interaction.id, choice.id, $event)"
+                          class="rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm text-slate-700 focus:border-[#0056D2] focus:ring-[#0056D2]"
+                          aria-label="Điểm đích">
+                          <option [ngValue]="''">Theo giây</option>
+                          @for (target of getInteractiveBranchTargets(interaction.id); track target.id) {
+                            <option [ngValue]="target.id">{{ formatInteractiveBranchTargetLabel(target) }}</option>
+                          }
+                        </select>
+                      } @else {
+                        <label class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 px-2 text-xs font-medium text-slate-600">
+                          <input type="checkbox"
+                            [ngModel]="choice.isCorrect === true"
+                            (ngModelChange)="svc.updateInteractiveVideoChoice(interaction.id, choice.id, { isCorrect: $event })"
+                            class="h-3.5 w-3.5 rounded text-[#0056D2] focus:ring-[#0056D2]" />
+                          Đáp án đúng
+                        </label>
+                      }
+                      <button type="button"
+                        (click)="svc.removeInteractiveVideoChoice(interaction.id, choice.id)"
+                        class="flex h-9 w-9 items-center justify-center rounded-lg text-slate-400 hover:bg-red-50 hover:text-red-600"
+                        aria-label="Xóa lựa chọn">
+                        <lucide-icon name="x" [size]="14"></lucide-icon>
+                      </button>
+                    </div>
+                  }
+                </div>
+              </div>
+            }
+          </div>
+        }
+      </div>
+    }
+  }
+</div>

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
@@ -120,14 +120,21 @@
         </div>
 
         <div class="mb-4 rounded-xl border border-slate-200 bg-white px-3 py-3">
-          <div class="relative h-10">
+          <div #timelineRail class="relative h-10">
             <div class="absolute left-0 right-0 top-1/2 h-1 -translate-y-1/2 rounded-full bg-slate-100"></div>
             @for (node of interactiveVideoFlowNodes(); track node.id) {
               <button type="button"
-                class="interactive-timeline-dot absolute top-1/2 flex h-7 w-7 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-white bg-[#0056D2] text-[10px] font-bold text-white shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0056D2] focus-visible:ring-offset-2"
+                class="interactive-timeline-dot absolute top-1/2 flex h-7 w-7 -translate-x-1/2 -translate-y-1/2 touch-none items-center justify-center rounded-full border border-white bg-[#0056D2] text-[10px] font-bold text-white shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0056D2] focus-visible:ring-offset-2"
                 [style.left.%]="getTimelinePercent(node.atSeconds)"
+                [attr.aria-current]="timelineDraggingInteractionId() === node.id ? 'true' : null"
                 [attr.aria-label]="'Chỉnh điểm ' + node.index + ' tại ' + node.timeLabel"
-                (click)="scrollInteractiveNodeIntoView(node.id)">
+                [attr.title]="'Kéo để đổi thời điểm · ' + node.timeLabel"
+                (click)="onTimelineDotClick(node)"
+                (keydown)="onFlowNodeKeydown($event, node)"
+                (pointerdown)="onTimelineDotPointerDown($event, node)"
+                (pointermove)="onTimelineDotPointerMove($event)"
+                (pointerup)="onTimelineDotPointerUp($event)"
+                (pointercancel)="onTimelineDotPointerCancel()">
                 {{ node.index }}
               </button>
             }

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.scss
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.scss
@@ -1,3 +1,8 @@
+:host :where(input, textarea)::placeholder {
+  color: #94a3b8;
+  opacity: 1;
+}
+
 .interactive-flow-node {
   transition:
     border-color 160ms ease,
@@ -16,9 +21,16 @@
 }
 
 .interactive-timeline-dot {
+  cursor: grab;
   transition:
     transform 140ms ease,
     box-shadow 140ms ease;
+}
+
+.interactive-timeline-dot[aria-current='true'] {
+  cursor: grabbing;
+  transform: translate(-50%, -50%) scale(1.08);
+  box-shadow: 0 8px 18px rgba(0, 86, 210, 0.22);
 }
 
 .interactive-timeline-dot:hover {

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.scss
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.scss
@@ -1,0 +1,27 @@
+.interactive-flow-node {
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.interactive-flow-node:hover {
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  transform: translateY(-1px);
+}
+
+.interactive-flow-node[aria-current='true'] {
+  border-color: #0056d2;
+  box-shadow: 0 0 0 3px rgba(0, 86, 210, 0.14);
+}
+
+.interactive-timeline-dot {
+  transition:
+    transform 140ms ease,
+    box-shadow 140ms ease;
+}
+
+.interactive-timeline-dot:hover {
+  transform: translate(-50%, -50%) scale(1.08);
+  box-shadow: 0 8px 18px rgba(0, 86, 210, 0.22);
+}

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
@@ -2,10 +2,12 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  ElementRef,
   inject,
   input,
   output,
   signal,
+  viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { LucideAngularModule } from 'lucide-angular';
@@ -70,6 +72,9 @@ export class InteractiveVideoAuthoringPanelComponent {
   readonly interactiveVideoTypes: InteractiveVideoInteractionType[] = ['checkpoint', 'single_choice', 'branch'];
   readonly draggingInteractionId = signal<string | null>(null);
   readonly dropTargetInteractionId = signal<string | null>(null);
+  readonly timelineDraggingInteractionId = signal<string | null>(null);
+  readonly timelineRail = viewChild<ElementRef<HTMLElement>>('timelineRail');
+  private suppressNextTimelineClick = false;
 
   readonly isYoutubeSource = computed(() => this.sourceKind() === 'youtube');
   readonly previewSpec = computed<InteractiveVideoSpec | null>(() =>
@@ -308,13 +313,61 @@ export class InteractiveVideoAuthoringPanelComponent {
   }
 
   getTimelinePercent(seconds: number): number {
-    const max = this.maxInteractiveTimeSeconds();
-    if (max == null || max <= 0) {
-      const timeline = this.svc.sectionInteractiveVideoTimeline();
-      const latest = Math.max(1, ...timeline.map(item => item.atSeconds));
-      return Math.min(100, Math.max(0, (seconds / latest) * 100));
+    const max = this.getTimelineScaleMaxSeconds();
+    if (max <= 0) {
+      return 0;
     }
     return Math.min(100, Math.max(0, (seconds / max) * 100));
+  }
+
+  onTimelineDotClick(node: InteractiveVideoFlowNode): void {
+    if (this.suppressNextTimelineClick) {
+      this.suppressNextTimelineClick = false;
+      return;
+    }
+    this.scrollInteractiveNodeIntoView(node.id);
+  }
+
+  onTimelineDotPointerDown(event: PointerEvent, node: InteractiveVideoFlowNode): void {
+    if (event.button !== 0) {
+      return;
+    }
+    this.timelineDraggingInteractionId.set(node.id);
+    this.suppressNextTimelineClick = false;
+    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+  }
+
+  onTimelineDotPointerMove(event: PointerEvent): void {
+    const interactionId = this.timelineDraggingInteractionId();
+    if (!interactionId) {
+      return;
+    }
+
+    const nextSeconds = this.getTimelineSecondsFromPointer(event);
+    const current = this.svc.sectionInteractiveVideoTimeline()
+      .find(item => item.id === interactionId);
+    if (!current || current.atSeconds === nextSeconds) {
+      return;
+    }
+
+    this.suppressNextTimelineClick = true;
+    this.svc.updateInteractiveVideoInteraction(interactionId, {
+      atSeconds: nextSeconds,
+    });
+  }
+
+  onTimelineDotPointerUp(event: PointerEvent): void {
+    const target = event.currentTarget as HTMLElement;
+    if (this.timelineDraggingInteractionId()) {
+      if (target.hasPointerCapture(event.pointerId)) {
+        target.releasePointerCapture(event.pointerId);
+      }
+    }
+    this.timelineDraggingInteractionId.set(null);
+  }
+
+  onTimelineDotPointerCancel(): void {
+    this.timelineDraggingInteractionId.set(null);
   }
 
   nudgeInteractiveTime(interactionId: string, deltaSeconds: number): void {
@@ -553,6 +606,23 @@ export class InteractiveVideoAuthoringPanelComponent {
     const next = this.toNonNegativeInteger(value);
     const max = this.maxInteractiveTimeSeconds();
     return max == null ? next : Math.min(max, next);
+  }
+
+  private getTimelineSecondsFromPointer(event: PointerEvent): number {
+    const rail = this.timelineRail()?.nativeElement;
+    if (!rail) {
+      return 0;
+    }
+
+    const rect = rail.getBoundingClientRect();
+    const ratio = rect.width <= 0
+      ? 0
+      : Math.min(1, Math.max(0, (event.clientX - rect.left) / rect.width));
+    return this.clampInteractiveTime(Math.round(ratio * this.getTimelineScaleMaxSeconds()));
+  }
+
+  private getTimelineScaleMaxSeconds(): number {
+    return this.maxInteractiveTimeSeconds() ?? Math.max(30, this.getLastTimelineSecond());
   }
 
   private getLastTimelineSecond(): number {

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
@@ -1,0 +1,583 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { LucideAngularModule } from 'lucide-angular';
+import { ToastService } from '../../../../../../../core/services/toast.service';
+import type {
+  InteractiveVideoChoice,
+  InteractiveVideoInteraction,
+  InteractiveVideoInteractionType,
+  InteractiveVideoSpec,
+} from '../../../../../../../api/types/interactive-video.types';
+import { CurriculumEditorService } from '../../../../services/curriculum-editor.service';
+import {
+  buildInteractiveVideoSpec,
+} from '../../../../utils/interactive-video-authoring';
+import {
+  exportInteractiveVideoBundle,
+  exportInteractiveVideoH5PPackage,
+  importInteractiveVideoBundle,
+  importInteractiveVideoH5PPackage,
+} from '../../../../utils/interactive-video-interoperability';
+
+type InteractiveVideoSourceKind = 'upload' | 'youtube';
+
+interface InteractiveVideoFlowChoice {
+  id: string;
+  label: string;
+  metaLabel: string;
+  toneClass: string;
+}
+
+interface InteractiveVideoFlowNode {
+  id: string;
+  index: number;
+  type: InteractiveVideoInteractionType;
+  typeLabel: string;
+  title: string;
+  atSeconds: number;
+  timeLabel: string;
+  iconName: string;
+  nodeClass: string;
+  badgeClass: string;
+  choices: InteractiveVideoFlowChoice[];
+  required: boolean;
+  pause: boolean;
+}
+
+@Component({
+  selector: 'app-interactive-video-authoring-panel',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, LucideAngularModule],
+  templateUrl: './interactive-video-authoring-panel.component.html',
+  styleUrl: './interactive-video-authoring-panel.component.scss',
+})
+export class InteractiveVideoAuthoringPanelComponent {
+  readonly svc = inject(CurriculumEditorService);
+  private readonly toast = inject(ToastService);
+
+  readonly sourceKind = input<InteractiveVideoSourceKind>('upload');
+  readonly switchToUpload = output<void>();
+
+  readonly interactiveVideoTypes: InteractiveVideoInteractionType[] = ['checkpoint', 'single_choice', 'branch'];
+  readonly draggingInteractionId = signal<string | null>(null);
+  readonly dropTargetInteractionId = signal<string | null>(null);
+
+  readonly isYoutubeSource = computed(() => this.sourceKind() === 'youtube');
+  readonly previewSpec = computed<InteractiveVideoSpec | null>(() =>
+    buildInteractiveVideoSpec(
+      this.svc.sectionInteractiveVideoEnabled(),
+      this.svc.sectionInteractiveVideoTimeline(),
+    ),
+  );
+  readonly maxInteractiveTimeSeconds = computed(() => {
+    const duration = this.svc.sectionVideoDurationSec();
+    if (!duration || !Number.isFinite(duration) || duration <= 0) {
+      return null;
+    }
+    return Math.max(0, Math.round(duration) - 1);
+  });
+  readonly compatibilityLabel = computed(() =>
+    this.isYoutubeSource() ? 'Tương tác online' : 'Hỗ trợ tương tác',
+  );
+  readonly compatibilityBadgeClass = computed(() =>
+    this.isYoutubeSource()
+      ? 'inline-flex items-center rounded-full bg-sky-50 px-2.5 py-1 text-[11px] font-semibold text-sky-700 ring-1 ring-sky-200'
+      : 'inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-700 ring-1 ring-emerald-200',
+  );
+  readonly durationHint = computed(() => {
+    const max = this.maxInteractiveTimeSeconds();
+    if (max == null) {
+      return 'Mốc mới sẽ được đặt theo nhịp timeline hiện có.';
+    }
+    return `Mốc mới nằm trong thời lượng video (${this.formatInteractiveFlowTime(max + 1)}).`;
+  });
+  readonly interactiveVideoFlowNodes = computed<InteractiveVideoFlowNode[]>(() =>
+    this.buildInteractiveVideoFlowNodes(this.svc.sectionInteractiveVideoTimeline()),
+  );
+  readonly interactiveVideoFlowStats = computed(() => {
+    const nodes = this.interactiveVideoFlowNodes();
+    return {
+      total: nodes.length,
+      branches: nodes.filter(node => node.type === 'branch').length,
+      questions: nodes.filter(node => node.type === 'single_choice').length,
+      required: nodes.filter(node => node.required).length,
+    };
+  });
+
+  onInteractiveVideoEnabledChange(enabled: boolean): void {
+    this.svc.setInteractiveVideoEnabled(enabled);
+  }
+
+  addInteraction(type: InteractiveVideoInteractionType): void {
+    this.svc.addInteractiveVideoInteraction(type);
+  }
+
+  onInteractiveTypeChange(
+    interactionId: string,
+    type: InteractiveVideoInteractionType,
+  ): void {
+    this.svc.updateInteractiveVideoInteractionType(interactionId, type);
+  }
+
+  onInteractiveTimeChange(interactionId: string, value: unknown): void {
+    this.svc.updateInteractiveVideoInteraction(interactionId, {
+      atSeconds: this.clampInteractiveTime(value),
+    });
+  }
+
+  onInteractiveChoiceTargetChange(
+    interactionId: string,
+    choiceId: string,
+    value: unknown,
+  ): void {
+    this.svc.updateInteractiveVideoChoice(interactionId, choiceId, {
+      targetTimeSeconds: this.clampInteractiveTime(value),
+      targetInteractionId: null,
+    });
+  }
+
+  onInteractiveChoiceTargetInteractionChange(
+    interactionId: string,
+    choiceId: string,
+    value: string,
+  ): void {
+    this.svc.updateInteractiveVideoChoice(interactionId, choiceId, {
+      targetInteractionId: value || null,
+      targetTimeSeconds: value ? null : undefined,
+    });
+  }
+
+  async onInteractiveImportSelected(event: Event): Promise<void> {
+    const inputElement = event.target as HTMLInputElement;
+    const file = inputElement.files?.[0];
+    inputElement.value = '';
+    if (!file) {
+      return;
+    }
+
+    try {
+      const spec = await this.readInteractiveImportSpec(file);
+      if (!spec || spec.timeline.length === 0) {
+        this.toast.error('Tệp nhập không có dữ liệu video tương tác hợp lệ.');
+        return;
+      }
+
+      this.svc.sectionInteractiveVideoEnabled.set(spec.enabled !== false);
+      this.svc.sectionInteractiveVideoTimeline.set(spec.timeline);
+      this.svc.markDirty();
+      this.toast.success(`Đã nhập ${spec.timeline.length} điểm tương tác.`);
+    } catch {
+      this.toast.error('Không thể đọc tệp video tương tác.');
+    }
+  }
+
+  exportInteractiveVideoJson(): void {
+    const spec = this.previewSpec();
+    if (!spec) {
+      this.toast.error('Chưa có dữ liệu video tương tác để xuất.');
+      return;
+    }
+
+    try {
+      const bundle = exportInteractiveVideoBundle(spec, this.svc.sectionVideoUrl());
+      this.downloadJsonFile(bundle, this.getInteractiveExportFileName('json'));
+      this.toast.success('Đã xuất JSON video tương tác.');
+    } catch {
+      this.toast.error('Không thể xuất JSON video tương tác.');
+    }
+  }
+
+  async exportInteractiveVideoH5P(): Promise<void> {
+    const spec = this.previewSpec();
+    if (!spec) {
+      this.toast.error('Chưa có dữ liệu video tương tác để xuất.');
+      return;
+    }
+
+    try {
+      const blob = await exportInteractiveVideoH5PPackage(spec, this.svc.sectionVideoUrl(), {
+        title: this.svc.sectionTitle(),
+        language: 'vi',
+      });
+      this.downloadBlobFile(blob, this.getInteractiveExportFileName('h5p'));
+      this.toast.success('Đã xuất H5P video tương tác.');
+    } catch {
+      this.toast.error('Không thể xuất H5P video tương tác.');
+    }
+  }
+
+  isChoiceInteraction(interaction: InteractiveVideoInteraction): boolean {
+    return interaction.type === 'single_choice' || interaction.type === 'branch';
+  }
+
+  getInteractiveBranchTargets(sourceInteractionId: string): InteractiveVideoInteraction[] {
+    return this.svc.sectionInteractiveVideoTimeline()
+      .filter(interaction => interaction.id !== sourceInteractionId)
+      .sort((a, b) => a.atSeconds - b.atSeconds);
+  }
+
+  getInteractiveTypeLabel(type: InteractiveVideoInteractionType): string {
+    switch (type) {
+      case 'single_choice': return 'Câu hỏi';
+      case 'branch': return 'Rẽ nhánh';
+      case 'hotspot': return 'Hotspot';
+      default: return 'Điểm dừng';
+    }
+  }
+
+  getInteractiveTypeHint(type: InteractiveVideoInteractionType): string {
+    switch (type) {
+      case 'single_choice':
+        return 'Dừng video để hỏi nhanh và phản hồi theo lựa chọn.';
+      case 'branch':
+        return 'Cho học viên chọn đường đi tiếp theo trong video.';
+      case 'hotspot':
+        return 'Dành cho vùng bấm trên video khi nhập từ gói tương tác.';
+      default:
+        return 'Tạm dừng video tại mốc này để nhấn mạnh nội dung.';
+    }
+  }
+
+  getInteractiveNodeDomId(interactionId: string): string {
+    return `interactive-node-${interactionId}`;
+  }
+
+  scrollInteractiveNodeIntoView(interactionId: string): void {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    document.getElementById(this.getInteractiveNodeDomId(interactionId))
+      ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  formatInteractiveTimeLabel(seconds: number | null | undefined): string {
+    return this.formatInteractiveFlowTime(seconds);
+  }
+
+  formatInteractiveBranchTargetLabel(target: InteractiveVideoInteraction): string {
+    const title = target.title?.trim() || this.getInteractiveTypeLabel(target.type);
+    return `${this.formatInteractiveFlowTime(target.atSeconds)} · ${title}`;
+  }
+
+  getInteractiveChoiceRowClass(type: InteractiveVideoInteractionType): string {
+    const base = 'grid gap-2 px-3 py-2';
+    return type === 'branch'
+      ? `${base} sm:grid-cols-[minmax(0,1fr)_7rem_minmax(8rem,10rem)_auto]`
+      : `${base} sm:grid-cols-[minmax(0,1fr)_8rem_auto]`;
+  }
+
+  getTimelinePercent(seconds: number): number {
+    const max = this.maxInteractiveTimeSeconds();
+    if (max == null || max <= 0) {
+      const timeline = this.svc.sectionInteractiveVideoTimeline();
+      const latest = Math.max(1, ...timeline.map(item => item.atSeconds));
+      return Math.min(100, Math.max(0, (seconds / latest) * 100));
+    }
+    return Math.min(100, Math.max(0, (seconds / max) * 100));
+  }
+
+  nudgeInteractiveTime(interactionId: string, deltaSeconds: number): void {
+    const interaction = this.svc.sectionInteractiveVideoTimeline()
+      .find(item => item.id === interactionId);
+    if (!interaction) {
+      return;
+    }
+    this.svc.updateInteractiveVideoInteraction(interactionId, {
+      atSeconds: this.clampInteractiveTime(interaction.atSeconds + deltaSeconds),
+    });
+  }
+
+  moveInteractiveTimeToBoundary(interactionId: string, boundary: 'start' | 'end'): void {
+    const max = this.maxInteractiveTimeSeconds();
+    const target = boundary === 'start'
+      ? 0
+      : max ?? this.getLastTimelineSecond() + 30;
+    this.svc.updateInteractiveVideoInteraction(interactionId, {
+      atSeconds: this.clampInteractiveTime(target),
+    });
+  }
+
+  onFlowNodeKeydown(event: KeyboardEvent, node: InteractiveVideoFlowNode): void {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+
+    const smallStep = event.shiftKey ? 5 : 1;
+    switch (event.key) {
+      case 'ArrowLeft':
+        event.preventDefault();
+        this.nudgeInteractiveTime(node.id, -smallStep);
+        break;
+      case 'ArrowRight':
+        event.preventDefault();
+        this.nudgeInteractiveTime(node.id, smallStep);
+        break;
+      case 'Home':
+        event.preventDefault();
+        this.moveInteractiveTimeToBoundary(node.id, 'start');
+        break;
+      case 'End':
+        event.preventDefault();
+        this.moveInteractiveTimeToBoundary(node.id, 'end');
+        break;
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        this.scrollInteractiveNodeIntoView(node.id);
+        break;
+    }
+  }
+
+  onFlowNodeDragStart(event: DragEvent, node: InteractiveVideoFlowNode): void {
+    this.draggingInteractionId.set(node.id);
+    event.dataTransfer?.setData('text/plain', node.id);
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+    }
+  }
+
+  onFlowNodeDragOver(event: DragEvent, node: InteractiveVideoFlowNode): void {
+    const sourceId = this.draggingInteractionId();
+    if (!sourceId || sourceId === node.id) {
+      return;
+    }
+    event.preventDefault();
+    this.dropTargetInteractionId.set(node.id);
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+  }
+
+  onFlowNodeDrop(event: DragEvent, node: InteractiveVideoFlowNode): void {
+    event.preventDefault();
+    const sourceId = event.dataTransfer?.getData('text/plain') || this.draggingInteractionId();
+    this.draggingInteractionId.set(null);
+    this.dropTargetInteractionId.set(null);
+    if (!sourceId || sourceId === node.id) {
+      return;
+    }
+    this.moveInteractionBefore(sourceId, node.id);
+  }
+
+  onFlowNodeDragEnd(): void {
+    this.draggingInteractionId.set(null);
+    this.dropTargetInteractionId.set(null);
+  }
+
+  private moveInteractionBefore(sourceId: string, targetId: string): void {
+    const timeline = [...this.svc.sectionInteractiveVideoTimeline()]
+      .sort((a, b) => a.atSeconds - b.atSeconds);
+    const source = timeline.find(item => item.id === sourceId);
+    if (!source) {
+      return;
+    }
+
+    const withoutSource = timeline.filter(item => item.id !== sourceId);
+    const targetIndex = withoutSource.findIndex(item => item.id === targetId);
+    if (targetIndex < 0) {
+      return;
+    }
+
+    const previous = withoutSource[targetIndex - 1] ?? null;
+    const target = withoutSource[targetIndex];
+    const nextTime = this.chooseTimeBetween(previous?.atSeconds ?? null, target.atSeconds);
+    this.svc.updateInteractiveVideoInteraction(sourceId, { atSeconds: nextTime });
+  }
+
+  private chooseTimeBetween(previousTime: number | null, nextTime: number | null): number {
+    if (previousTime == null && nextTime == null) {
+      return 0;
+    }
+    if (previousTime == null) {
+      return this.clampInteractiveTime(Math.max(0, (nextTime ?? 0) - 1));
+    }
+    if (nextTime == null) {
+      return this.clampInteractiveTime(previousTime + 5);
+    }
+    if (nextTime - previousTime > 1) {
+      return this.clampInteractiveTime(Math.round(previousTime + ((nextTime - previousTime) / 2)));
+    }
+    return this.clampInteractiveTime(nextTime);
+  }
+
+  private buildInteractiveVideoFlowNodes(
+    timeline: InteractiveVideoInteraction[],
+  ): InteractiveVideoFlowNode[] {
+    const sorted = [...timeline].sort((a, b) => a.atSeconds - b.atSeconds);
+    const byId = new Map(sorted.map(interaction => [interaction.id, interaction]));
+
+    return sorted.map((interaction, index) => ({
+      id: interaction.id,
+      index: index + 1,
+      type: interaction.type,
+      typeLabel: this.getInteractiveTypeLabel(interaction.type),
+      title: interaction.title?.trim() || this.getInteractiveTypeLabel(interaction.type),
+      atSeconds: interaction.atSeconds,
+      timeLabel: this.formatInteractiveFlowTime(interaction.atSeconds),
+      iconName: this.getInteractiveFlowIconName(interaction.type),
+      nodeClass: this.getInteractiveFlowNodeClass(interaction.type),
+      badgeClass: this.getInteractiveFlowBadgeClass(interaction.type),
+      choices: this.buildInteractiveFlowChoices(interaction, byId),
+      required: interaction.required === true,
+      pause: interaction.pause !== false,
+    }));
+  }
+
+  private buildInteractiveFlowChoices(
+    interaction: InteractiveVideoInteraction,
+    byId: Map<string, InteractiveVideoInteraction>,
+  ): InteractiveVideoFlowChoice[] {
+    if (!this.isChoiceInteraction(interaction)) {
+      return [];
+    }
+
+    return (interaction.choices ?? []).map((choice, index) => {
+      const label = choice.label?.trim() || `Lựa chọn ${index + 1}`;
+
+      if (interaction.type === 'branch') {
+        const target = choice.targetInteractionId ? byId.get(choice.targetInteractionId) : null;
+        const missingTarget = Boolean(choice.targetInteractionId && !target);
+        return {
+          id: choice.id,
+          label,
+          metaLabel: missingTarget
+            ? 'Mất đích'
+            : target
+              ? `${this.formatInteractiveFlowTime(target.atSeconds)} · ${target.title?.trim() || this.getInteractiveTypeLabel(target.type)}`
+              : choice.targetTimeSeconds == null
+                ? 'Theo timeline'
+                : this.formatInteractiveFlowTime(choice.targetTimeSeconds),
+          toneClass: missingTarget
+            ? 'flex items-center gap-2 rounded-md bg-red-50 px-2 py-1 text-xs text-red-700 ring-1 ring-red-100'
+            : 'flex items-center gap-2 rounded-md bg-white px-2 py-1 text-xs text-slate-600 ring-1 ring-slate-200',
+        };
+      }
+
+      return {
+        id: choice.id,
+        label,
+        metaLabel: choice.isCorrect ? 'Đúng' : 'Chưa đúng',
+        toneClass: choice.isCorrect
+          ? 'flex items-center gap-2 rounded-md bg-emerald-50 px-2 py-1 text-xs text-emerald-700 ring-1 ring-emerald-100'
+          : 'flex items-center gap-2 rounded-md bg-white px-2 py-1 text-xs text-slate-600 ring-1 ring-slate-200',
+      };
+    });
+  }
+
+  private getInteractiveFlowIconName(type: InteractiveVideoInteractionType): string {
+    switch (type) {
+      case 'single_choice': return 'help-circle';
+      case 'branch': return 'shuffle';
+      case 'hotspot': return 'mouse-pointer-2';
+      default: return 'pause';
+    }
+  }
+
+  private getInteractiveFlowNodeClass(type: InteractiveVideoInteractionType): string {
+    const base = 'interactive-flow-node w-64 rounded-xl border bg-white p-3 shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0056D2] focus-visible:ring-offset-2';
+    switch (type) {
+      case 'single_choice':
+        return `${base} border-sky-200`;
+      case 'branch':
+        return `${base} border-amber-200`;
+      case 'hotspot':
+        return `${base} border-teal-200`;
+      default:
+        return `${base} border-slate-200`;
+    }
+  }
+
+  private getInteractiveFlowBadgeClass(type: InteractiveVideoInteractionType): string {
+    const base = 'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-bold';
+    switch (type) {
+      case 'single_choice':
+        return `${base} bg-sky-50 text-sky-700`;
+      case 'branch':
+        return `${base} bg-amber-50 text-amber-700`;
+      case 'hotspot':
+        return `${base} bg-teal-50 text-teal-700`;
+      default:
+        return `${base} bg-slate-100 text-slate-600`;
+    }
+  }
+
+  private formatInteractiveFlowTime(seconds: number | null | undefined): string {
+    const safeSeconds = this.toNonNegativeInteger(seconds ?? 0);
+    const minutes = Math.floor(safeSeconds / 60);
+    const rest = safeSeconds % 60;
+    return `${minutes}:${rest.toString().padStart(2, '0')}`;
+  }
+
+  private clampInteractiveTime(value: unknown): number {
+    const next = this.toNonNegativeInteger(value);
+    const max = this.maxInteractiveTimeSeconds();
+    return max == null ? next : Math.min(max, next);
+  }
+
+  private getLastTimelineSecond(): number {
+    const timeline = this.svc.sectionInteractiveVideoTimeline();
+    return Math.max(0, ...timeline.map(item => this.toNonNegativeInteger(item.atSeconds)));
+  }
+
+  private toNonNegativeInteger(value: unknown): number {
+    const next = typeof value === 'number' ? value : Number(value);
+    return Number.isFinite(next) ? Math.max(0, Math.round(next)) : 0;
+  }
+
+  private async readInteractiveImportSpec(file: File): Promise<InteractiveVideoSpec | null> {
+    if (this.isH5PFile(file)) {
+      return importInteractiveVideoH5PPackage(await file.arrayBuffer());
+    }
+
+    return importInteractiveVideoBundle(JSON.parse(await file.text()));
+  }
+
+  private isH5PFile(file: File): boolean {
+    const name = file.name.toLowerCase();
+    return name.endsWith('.h5p')
+      || name.endsWith('.zip')
+      || file.type === 'application/h5p'
+      || file.type === 'application/zip'
+      || file.type === 'application/x-zip-compressed';
+  }
+
+  private downloadJsonFile(payload: unknown, filename: string): void {
+    this.downloadBlobFile(
+      new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' }),
+      filename,
+    );
+  }
+
+  private downloadBlobFile(blob: Blob, filename: string): void {
+    if (typeof document === 'undefined' || typeof URL === 'undefined') {
+      return;
+    }
+
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  private getInteractiveExportFileName(extension: 'json' | 'h5p'): string {
+    const base = (this.svc.sectionTitle() || 'interactive-video')
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 64);
+    return `${base || 'interactive-video'}-holilihu-v1.${extension}`;
+  }
+}

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
@@ -19,6 +19,7 @@ import type {
 import { CurriculumEditorService } from '../../../../services/curriculum-editor.service';
 import {
   buildInteractiveVideoSpec,
+  suggestNextInteractiveVideoTimeSeconds,
 } from '../../../../utils/interactive-video-authoring';
 import {
   exportInteractiveVideoBundle,
@@ -93,11 +94,42 @@ export class InteractiveVideoAuthoringPanelComponent {
       : 'inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-700 ring-1 ring-emerald-200',
   );
   readonly durationHint = computed(() => {
-    const max = this.maxInteractiveTimeSeconds();
-    if (max == null) {
-      return 'Mốc mới sẽ được đặt theo nhịp timeline hiện có.';
+    const nextSeconds = suggestNextInteractiveVideoTimeSeconds(
+      this.svc.sectionInteractiveVideoTimeline(),
+      { durationSeconds: this.svc.sectionVideoDurationSec() },
+    );
+    const duration = this.svc.sectionVideoDurationSec();
+    const nextLabel = this.formatInteractiveFlowTime(nextSeconds);
+    if (!duration || !Number.isFinite(duration) || duration <= 0) {
+      return `Mốc kế tiếp: ${nextLabel}.`;
     }
-    return `Mốc mới nằm trong thời lượng video (${this.formatInteractiveFlowTime(max + 1)}).`;
+    return `Mốc kế tiếp: ${nextLabel} / ${this.formatInteractiveFlowTime(duration)}.`;
+  });
+  readonly quickNudgeSeconds = computed(() => {
+    const duration = this.svc.sectionVideoDurationSec();
+    if (!duration || !Number.isFinite(duration) || duration <= 0) {
+      return 5;
+    }
+    if (duration <= 30) {
+      return 1;
+    }
+    if (duration <= 120) {
+      return 5;
+    }
+    if (duration <= 600) {
+      return 10;
+    }
+    return 30;
+  });
+  readonly quickNudgeLabel = computed(() => `${this.quickNudgeSeconds()} giây`);
+  readonly quickNudgeEarlierLabel = computed(() => `Sớm hơn ${this.quickNudgeLabel()}`);
+  readonly quickNudgeLaterLabel = computed(() => `Muộn hơn ${this.quickNudgeLabel()}`);
+  readonly timelineScaleLabel = computed(() => {
+    const duration = this.svc.sectionVideoDurationSec();
+    if (!duration || !Number.isFinite(duration) || duration <= 0) {
+      return 'Timeline';
+    }
+    return `Timeline ${this.formatInteractiveFlowTime(duration)}`;
   });
   readonly interactiveVideoFlowNodes = computed<InteractiveVideoFlowNode[]>(() =>
     this.buildInteractiveVideoFlowNodes(this.svc.sectionInteractiveVideoTimeline()),
@@ -311,7 +343,7 @@ export class InteractiveVideoAuthoringPanelComponent {
       return;
     }
 
-    const smallStep = event.shiftKey ? 5 : 1;
+    const smallStep = event.shiftKey ? this.quickNudgeSeconds() : 1;
     switch (event.key) {
       case 'ArrowLeft':
         event.preventDefault();

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
@@ -27,43 +27,11 @@ import { formatOfflineVideoProfileLabel, type OfflineVideoProfileDescriptor } fr
 import { QuizVideoPlayerComponent } from '../../../../../../../shared/blocks/video-block/quiz-video-player.component';
 import { BlockRendererComponent } from '../../../../../../../shared/blocks/block-renderer/block-renderer.component';
 import { formatDuration, formatResolution } from '../../../../../../../core/utils/video-probe.util';
-import type {
-  InteractiveVideoInteraction,
-  InteractiveVideoInteractionType,
-  InteractiveVideoSpec,
-} from '../../../../../../../api/types/interactive-video.types';
 import { buildInteractiveVideoSpec } from '../../../../utils/interactive-video-authoring';
-import {
-  exportInteractiveVideoBundle,
-  exportInteractiveVideoH5PPackage,
-  importInteractiveVideoH5PPackage,
-  importInteractiveVideoBundle,
-} from '../../../../utils/interactive-video-interoperability';
+import { YouTubePlayerComponent } from '../../../../../../learning/components/youtube-player/youtube-player.component';
+import { InteractiveVideoAuthoringPanelComponent } from './interactive-video-authoring-panel.component';
 
 type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
-
-interface InteractiveVideoFlowChoice {
-  id: string;
-  label: string;
-  metaLabel: string;
-  toneClass: string;
-}
-
-interface InteractiveVideoFlowNode {
-  id: string;
-  index: number;
-  type: InteractiveVideoInteractionType;
-  typeLabel: string;
-  title: string;
-  atSeconds: number;
-  timeLabel: string;
-  iconName: string;
-  nodeClass: string;
-  badgeClass: string;
-  choices: InteractiveVideoFlowChoice[];
-  required: boolean;
-  pause: boolean;
-}
 
 /**
  * Section Editor — inline panel replacing the old 25-input modal.
@@ -78,7 +46,15 @@ interface InteractiveVideoFlowNode {
 @Component({
   selector: 'app-section-editor',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormsModule, LucideAngularModule, TiptapEditorComponent, QuizVideoPlayerComponent, BlockRendererComponent],
+  imports: [
+    FormsModule,
+    LucideAngularModule,
+    TiptapEditorComponent,
+    QuizVideoPlayerComponent,
+    BlockRendererComponent,
+    YouTubePlayerComponent,
+    InteractiveVideoAuthoringPanelComponent,
+  ],
   styleUrls: ['./section-editor-prose.scss'],
   template: `
     <!-- ═══ Expanded TEXT mode: full-screen Tiptap only (course-info pattern) ═══ -->
@@ -562,10 +538,13 @@ interface InteractiveVideoFlowNode {
                 <!-- YouTube preview embed -->
                 @if (youtubeVideoId(); as videoId) {
                   <div class="overflow-hidden rounded-xl border border-slate-200">
-                    <iframe [src]="getYouTubeEmbedUrl(videoId)"
-                            class="aspect-video w-full" frameborder="0"
-                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                            allowfullscreen></iframe>
+                    <app-youtube-player
+                      [videoUrl]="svc.sectionVideoUrl()!"
+                      [lessonId]="lessonId()"
+                      [sectionId]="svc.editingSectionId() || 'preview'"
+                      [trackingEnabled]="false"
+                      [interactiveVideoSpec]="interactiveVideoPreviewSpec()"
+                      (durationLoaded)="onYouTubeDurationLoaded($event)" />
                   </div>
                 }
 
@@ -579,369 +558,9 @@ interface InteractiveVideoFlowNode {
               </div>
             }
 
-            <div class="rounded-xl border border-slate-200 bg-white">
-              <div class="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-4 py-3">
-                <div class="flex min-w-0 items-center gap-2.5">
-                  <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[#0056D2]/10 text-[#0056D2]">
-                    <lucide-icon name="mouse-pointer-2" [size]="16"></lucide-icon>
-                  </div>
-                  <div class="min-w-0">
-                    <h4 class="text-sm font-semibold text-slate-900">Video tương tác</h4>
-                    <p class="text-xs text-slate-500">
-                      {{ svc.sectionInteractiveVideoInteractionCount() }} điểm tương tác
-                    </p>
-                  </div>
-                </div>
-                <div class="flex flex-wrap items-center gap-2">
-                  <span [class]="interactiveVideoCompatibilityBadgeClass()">
-                    {{ interactiveVideoCompatibilityLabel() }}
-                  </span>
-                  <label class="inline-flex select-none items-center gap-2 text-sm font-semibold"
-                    [class.cursor-pointer]="canAuthorInteractiveVideo()"
-                    [class.cursor-not-allowed]="!canAuthorInteractiveVideo()"
-                    [class.text-slate-700]="canAuthorInteractiveVideo()"
-                    [class.text-slate-400]="!canAuthorInteractiveVideo()">
-                    <input type="checkbox"
-                      [ngModel]="svc.sectionInteractiveVideoEnabled()"
-                      (ngModelChange)="onInteractiveVideoEnabledChange($event)"
-                      [disabled]="!canAuthorInteractiveVideo()"
-                      class="h-4 w-4 rounded text-[#0056D2] focus:ring-[#0056D2] disabled:cursor-not-allowed disabled:opacity-50" />
-                    Bật
-                  </label>
-                </div>
-              </div>
-
-              @if (!canAuthorInteractiveVideo()) {
-                <div class="border-b border-amber-100 bg-amber-50/70 px-4 py-3">
-                  <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                    <div class="flex min-w-0 gap-2.5">
-                      <lucide-icon name="alert-triangle" [size]="16" class="mt-0.5 shrink-0 text-amber-600"></lucide-icon>
-                      <div class="min-w-0">
-                        <p class="text-sm font-semibold text-amber-900">YouTube đang ở chế độ nhúng</p>
-                        <p class="mt-1 text-xs leading-relaxed text-amber-800">
-                          Điểm dừng, câu hỏi và rẽ nhánh cần video tải lên để đồng bộ thời điểm, tạm dừng và chuyển nhánh chính xác.
-                        </p>
-                      </div>
-                    </div>
-                    <button type="button"
-                      (click)="switchVideoTab('upload')"
-                      class="shrink-0 rounded-lg border border-amber-200 bg-white px-3 py-1.5 text-xs font-semibold text-amber-800 hover:bg-amber-50">
-                      Chuyển sang Tải lên
-                    </button>
-                  </div>
-                </div>
-              }
-
-              @if (svc.sectionInteractiveVideoEnabled() && canAuthorInteractiveVideo()) {
-                <div class="border-b border-slate-100 px-4 py-3">
-                  <div class="flex flex-col gap-3">
-                    <div class="flex flex-wrap items-center gap-2">
-                      <span class="mr-1 text-xs font-semibold uppercase tracking-wide text-slate-500">Tạo trực tiếp</span>
-                      <button type="button"
-                        (click)="svc.addInteractiveVideoInteraction('checkpoint')"
-                        class="inline-flex items-center gap-1.5 rounded-lg bg-[#0056D2] px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-[#004BB5]">
-                        <lucide-icon name="pause" [size]="13"></lucide-icon>
-                        Thêm điểm dừng
-                      </button>
-                      <button type="button"
-                        (click)="svc.addInteractiveVideoInteraction('single_choice')"
-                        class="inline-flex items-center gap-1.5 rounded-lg border border-[#0056D2]/30 bg-[#0056D2]/5 px-3 py-1.5 text-xs font-semibold text-[#0056D2] hover:bg-[#0056D2]/10">
-                        <lucide-icon name="help-circle" [size]="13"></lucide-icon>
-                        Thêm câu hỏi
-                      </button>
-                      <button type="button"
-                        (click)="svc.addInteractiveVideoInteraction('branch')"
-                        class="inline-flex items-center gap-1.5 rounded-lg border border-[#0056D2]/30 bg-[#0056D2]/5 px-3 py-1.5 text-xs font-semibold text-[#0056D2] hover:bg-[#0056D2]/10">
-                        <lucide-icon name="shuffle" [size]="13"></lucide-icon>
-                        Thêm rẽ nhánh
-                      </button>
-                    </div>
-                    <div class="flex flex-wrap items-center gap-2 border-t border-slate-100 pt-3">
-                      <span class="mr-1 text-xs font-semibold uppercase tracking-wide text-slate-400">Tệp H5P/JSON</span>
-                      <input #interactiveImportInput type="file"
-                        accept="application/json,.json,.h5p,application/h5p,application/zip"
-                        class="hidden"
-                        (change)="onInteractiveImportSelected($event)" />
-                      <button type="button"
-                        (click)="interactiveImportInput.click()"
-                        class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5">
-                        <lucide-icon name="upload" [size]="13"></lucide-icon>
-                        Nhập từ file
-                      </button>
-                      <button type="button"
-                        (click)="exportInteractiveVideoJson()"
-                        [disabled]="!interactiveVideoPreviewSpec()"
-                        class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5 disabled:cursor-not-allowed disabled:opacity-50">
-                        <lucide-icon name="download" [size]="13"></lucide-icon>
-                        Xuất JSON
-                      </button>
-                      <button type="button"
-                        (click)="exportInteractiveVideoH5P()"
-                        [disabled]="!interactiveVideoPreviewSpec()"
-                        class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5 disabled:cursor-not-allowed disabled:opacity-50">
-                        <lucide-icon name="archive" [size]="13"></lucide-icon>
-                        Xuất H5P
-                      </button>
-                    </div>
-                  </div>
-                </div>
-
-                @if (interactiveVideoFlowNodes().length > 0) {
-                  <div class="border-b border-slate-100 bg-slate-50/50 p-4">
-                    <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
-                      <div>
-                        <h5 class="text-sm font-semibold text-slate-900">Sơ đồ luồng</h5>
-                        <div class="mt-1 flex flex-wrap gap-1.5 text-[11px] font-semibold text-slate-500">
-                          <span class="rounded-full bg-white px-2 py-0.5 ring-1 ring-slate-200">{{ interactiveVideoFlowStats().total }} điểm</span>
-                          <span class="rounded-full bg-white px-2 py-0.5 ring-1 ring-slate-200">{{ interactiveVideoFlowStats().questions }} câu hỏi</span>
-                          <span class="rounded-full bg-white px-2 py-0.5 ring-1 ring-slate-200">{{ interactiveVideoFlowStats().branches }} rẽ nhánh</span>
-                          <span class="rounded-full bg-white px-2 py-0.5 ring-1 ring-slate-200">{{ interactiveVideoFlowStats().required }} bắt buộc</span>
-                        </div>
-                      </div>
-                      <span class="inline-flex items-center gap-1 rounded-full bg-[#0056D2]/5 px-2.5 py-1 text-xs font-semibold text-[#0056D2]">
-                        <lucide-icon name="layers" [size]="13"></lucide-icon>
-                        Timeline
-                      </span>
-                    </div>
-
-                    <div class="overflow-x-auto pb-1">
-                      <div class="flex min-w-max items-stretch gap-3">
-                        @for (node of interactiveVideoFlowNodes(); track node.id; let isLast = $last) {
-                          <div class="flex items-stretch gap-3">
-                            <div [class]="node.nodeClass">
-                              <div class="flex items-start justify-between gap-2">
-                                <div class="min-w-0">
-                                  <div class="flex items-center gap-1.5">
-                                    <span [class]="node.badgeClass">
-                                      <lucide-icon [name]="node.iconName" [size]="12"></lucide-icon>
-                                      {{ node.typeLabel }}
-                                    </span>
-                                    <span class="text-[11px] font-bold tabular-nums text-slate-400">#{{ node.index }}</span>
-                                  </div>
-                                  <p class="mt-2 line-clamp-2 text-sm font-semibold text-slate-900">{{ node.title }}</p>
-                                </div>
-                                <button type="button"
-                                  (click)="scrollInteractiveNodeIntoView(node.id)"
-                                  class="shrink-0 rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] font-semibold text-slate-500 hover:border-[#0056D2]/40 hover:text-[#0056D2]">
-                                  Chỉnh
-                                </button>
-                              </div>
-
-                              <div class="mt-2 flex flex-wrap items-center gap-1.5 text-[11px] font-medium text-slate-500">
-                                <span class="inline-flex items-center gap-1 rounded-full bg-white px-2 py-0.5 ring-1 ring-slate-200">
-                                  <lucide-icon name="clock" [size]="11"></lucide-icon>
-                                  {{ node.timeLabel }}
-                                </span>
-                                @if (node.pause) {
-                                  <span class="rounded-full bg-white px-2 py-0.5 ring-1 ring-slate-200">Tạm dừng</span>
-                                }
-                                @if (node.required) {
-                                  <span class="rounded-full bg-amber-50 px-2 py-0.5 text-amber-700 ring-1 ring-amber-200">Bắt buộc</span>
-                                }
-                              </div>
-
-                              @if (node.choices.length > 0) {
-                                <div class="mt-3 max-h-32 space-y-1 overflow-y-auto">
-                                  @for (choice of node.choices; track choice.id) {
-                                    <div [class]="choice.toneClass">
-                                      <span class="min-w-0 flex-1 truncate">{{ choice.label }}</span>
-                                      <span class="shrink-0 text-[10px] font-semibold">{{ choice.metaLabel }}</span>
-                                    </div>
-                                  }
-                                </div>
-                              } @else {
-                                <div class="mt-3 rounded-lg bg-white px-2.5 py-2 text-xs font-medium text-slate-500 ring-1 ring-slate-200">
-                                  Tiếp tục theo timeline
-                                </div>
-                              }
-                            </div>
-
-                            @if (!isLast) {
-                              <div class="flex w-8 items-center justify-center text-slate-300">
-                                <lucide-icon name="arrow-right" [size]="18"></lucide-icon>
-                              </div>
-                            }
-                          </div>
-                        }
-                      </div>
-                    </div>
-                  </div>
-                }
-
-                @if (svc.sectionInteractiveVideoTimeline().length === 0) {
-                  <div class="px-4 py-5">
-                    <div class="rounded-xl border border-dashed border-slate-200 bg-slate-50/70 p-4 text-center">
-                      <lucide-icon name="plus-circle" [size]="30" class="mx-auto text-slate-300"></lucide-icon>
-                      <p class="mt-2 text-sm font-semibold text-slate-600">Chưa có điểm tương tác</p>
-                      <div class="mt-4 grid gap-2 sm:grid-cols-3">
-                        <button type="button"
-                          (click)="svc.addInteractiveVideoInteraction('checkpoint')"
-                          class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5">
-                          <lucide-icon name="pause" [size]="13"></lucide-icon>
-                          Điểm dừng
-                        </button>
-                        <button type="button"
-                          (click)="svc.addInteractiveVideoInteraction('single_choice')"
-                          class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5">
-                          <lucide-icon name="help-circle" [size]="13"></lucide-icon>
-                          Câu hỏi
-                        </button>
-                        <button type="button"
-                          (click)="svc.addInteractiveVideoInteraction('branch')"
-                          class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5">
-                          <lucide-icon name="shuffle" [size]="13"></lucide-icon>
-                          Rẽ nhánh
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                } @else {
-                  <div class="space-y-3 p-4">
-                    @for (interaction of svc.sectionInteractiveVideoTimeline(); track interaction.id; let idx = $index) {
-                      <div [attr.id]="getInteractiveNodeDomId(interaction.id)" class="rounded-lg border border-slate-200 bg-slate-50/60 p-3">
-                        <div class="flex flex-wrap items-center gap-2">
-                          <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[#0056D2]/10 text-xs font-bold text-[#0056D2] tabular-nums">
-                            {{ idx + 1 }}
-                          </span>
-                          <div class="min-w-[10rem] flex-1">
-                            <select
-                              [ngModel]="interaction.type"
-                              (ngModelChange)="onInteractiveTypeChange(interaction.id, $event)"
-                              class="w-full rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm font-medium text-slate-700 focus:border-[#0056D2] focus:ring-[#0056D2]">
-                              @for (type of interactiveVideoTypes; track type) {
-                                <option [ngValue]="type">{{ getInteractiveTypeLabel(type) }}</option>
-                              }
-                            </select>
-                            <p class="mt-1 text-[11px] leading-snug text-slate-500">{{ getInteractiveTypeHint(interaction.type) }}</p>
-                          </div>
-                          <div class="flex items-center gap-1.5">
-                            <label class="text-xs font-medium text-slate-500">Thời điểm</label>
-                            <input type="number" min="0" step="1"
-                              [ngModel]="interaction.atSeconds"
-                              (ngModelChange)="onInteractiveTimeChange(interaction.id, $event)"
-                              class="w-24 rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm tabular-nums focus:border-[#0056D2] focus:ring-[#0056D2]" />
-                            <span class="text-xs font-medium text-slate-400">giây</span>
-                            <span class="rounded-full bg-white px-2 py-0.5 text-[11px] font-semibold tabular-nums text-slate-500 ring-1 ring-slate-200">
-                              {{ formatInteractiveTimeLabel(interaction.atSeconds) }}
-                            </span>
-                          </div>
-                          <button type="button"
-                            (click)="svc.removeInteractiveVideoInteraction(interaction.id)"
-                            class="ml-auto flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-slate-400 hover:bg-red-50 hover:text-red-600"
-                            aria-label="Xóa điểm tương tác">
-                            <lucide-icon name="trash-2" [size]="14"></lucide-icon>
-                          </button>
-                        </div>
-
-                        <div class="mt-3 grid gap-3 sm:grid-cols-2">
-                          <div>
-                            <label class="mb-1.5 block text-xs font-medium text-slate-600">Tiêu đề</label>
-                            <input type="text"
-                              [ngModel]="interaction.title"
-                              (ngModelChange)="svc.updateInteractiveVideoInteraction(interaction.id, { title: $event })"
-                              placeholder="Tiêu đề hiển thị trên video"
-                              class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:border-[#0056D2] focus:ring-[#0056D2]" />
-                          </div>
-                          <div class="flex flex-wrap items-end gap-4">
-                            <label class="inline-flex cursor-pointer items-center gap-2 text-sm text-slate-700">
-                              <input type="checkbox"
-                                [ngModel]="interaction.pause !== false"
-                                (ngModelChange)="svc.updateInteractiveVideoInteraction(interaction.id, { pause: $event })"
-                                class="h-4 w-4 rounded text-[#0056D2] focus:ring-[#0056D2]" />
-                              Tạm dừng video
-                            </label>
-                            <label class="inline-flex cursor-pointer items-center gap-2 text-sm text-slate-700">
-                              <input type="checkbox"
-                                [ngModel]="interaction.required === true"
-                                (ngModelChange)="svc.updateInteractiveVideoInteraction(interaction.id, { required: $event })"
-                                class="h-4 w-4 rounded text-[#0056D2] focus:ring-[#0056D2]" />
-                              Bắt buộc trả lời
-                            </label>
-                          </div>
-                        </div>
-
-                        <div class="mt-3">
-                          <label class="mb-1.5 block text-xs font-medium text-slate-600">Nội dung</label>
-                          <textarea rows="2"
-                            [ngModel]="interaction.body"
-                            (ngModelChange)="svc.updateInteractiveVideoInteraction(interaction.id, { body: $event })"
-                            placeholder="Nội dung hiển thị cho học viên"
-                            class="w-full resize-y rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:border-[#0056D2] focus:ring-[#0056D2]"></textarea>
-                        </div>
-
-                        @if (isChoiceInteraction(interaction)) {
-                          <div class="mt-3 rounded-lg border border-slate-200 bg-white">
-                            <div class="flex items-center justify-between gap-2 border-b border-slate-100 px-3 py-2">
-                              <span class="text-xs font-semibold uppercase text-slate-500">Lựa chọn</span>
-                              <button type="button"
-                                (click)="svc.addInteractiveVideoChoice(interaction.id)"
-                                class="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold text-[#0056D2] hover:bg-[#0056D2]/5">
-                                <lucide-icon name="plus" [size]="12"></lucide-icon>
-                                Thêm
-                              </button>
-                            </div>
-                            <div class="divide-y divide-slate-100">
-                              @for (choice of interaction.choices || []; track choice.id; let choiceIdx = $index) {
-                                <div [class]="getInteractiveChoiceRowClass(interaction.type)">
-                                  <div class="space-y-2">
-                                    <input type="text"
-                                      [ngModel]="choice.label"
-                                      (ngModelChange)="svc.updateInteractiveVideoChoice(interaction.id, choice.id, { label: $event })"
-                                      placeholder="Nội dung lựa chọn"
-                                      class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-[#0056D2] focus:ring-[#0056D2]"
-                                      [attr.aria-label]="'Lựa chọn ' + (choiceIdx + 1)" />
-                                    @if (interaction.type === 'single_choice') {
-                                      <input type="text"
-                                        [ngModel]="choice.feedback || ''"
-                                        (ngModelChange)="svc.updateInteractiveVideoChoice(interaction.id, choice.id, { feedback: $event })"
-                                        placeholder="Phản hồi sau khi chọn (không bắt buộc)"
-                                        class="w-full rounded-lg border border-slate-200 px-3 py-2 text-xs focus:border-[#0056D2] focus:ring-[#0056D2]"
-                                        [attr.aria-label]="'Phản hồi cho lựa chọn ' + (choiceIdx + 1)" />
-                                    }
-                                  </div>
-                                  @if (interaction.type === 'branch') {
-                                    <input type="number" min="0" step="1"
-                                      [ngModel]="choice.targetTimeSeconds ?? interaction.atSeconds"
-                                      (ngModelChange)="onInteractiveChoiceTargetChange(interaction.id, choice.id, $event)"
-                                      placeholder="Nhảy tới giây"
-                                      class="rounded-lg border border-slate-200 px-3 py-2 text-sm tabular-nums focus:border-[#0056D2] focus:ring-[#0056D2]"
-                                      aria-label="Giây đích" />
-                                    <select
-                                      [ngModel]="choice.targetInteractionId ?? ''"
-                                      (ngModelChange)="onInteractiveChoiceTargetInteractionChange(interaction.id, choice.id, $event)"
-                                      class="rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm text-slate-700 focus:border-[#0056D2] focus:ring-[#0056D2]"
-                                      aria-label="Điểm đích">
-                                      <option [ngValue]="''">Theo giây</option>
-                                      @for (target of getInteractiveBranchTargets(interaction.id); track target.id) {
-                                        <option [ngValue]="target.id">{{ formatInteractiveBranchTargetLabel(target) }}</option>
-                                      }
-                                    </select>
-                                  } @else {
-                                    <label class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 px-2 text-xs font-medium text-slate-600">
-                                      <input type="checkbox"
-                                        [ngModel]="choice.isCorrect === true"
-                                        (ngModelChange)="svc.updateInteractiveVideoChoice(interaction.id, choice.id, { isCorrect: $event })"
-                                        class="h-3.5 w-3.5 rounded text-[#0056D2] focus:ring-[#0056D2]" />
-                                      Đáp án đúng
-                                    </label>
-                                  }
-                                  <button type="button"
-                                    (click)="svc.removeInteractiveVideoChoice(interaction.id, choice.id)"
-                                    class="flex h-9 w-9 items-center justify-center rounded-lg text-slate-400 hover:bg-red-50 hover:text-red-600"
-                                    aria-label="Xóa lựa chọn">
-                                    <lucide-icon name="x" [size]="14"></lucide-icon>
-                                  </button>
-                                </div>
-                              }
-                            </div>
-                          </div>
-                        }
-                      </div>
-                    }
-                  </div>
-                }
-              }
-            </div>
+            <app-interactive-video-authoring-panel
+              [sourceKind]="isYoutubeVideoSource() ? 'youtube' : 'upload'"
+              (switchToUpload)="switchVideoTab('upload')" />
 
           </div>
         }
@@ -1975,43 +1594,15 @@ export class SectionEditorComponent {
   readonly editorUploadFn = createTiptapUploadFn(this.http, environment.apiUrl, this.presignedUpload ?? undefined);
   readonly editorVideoUploadFn = this.presignedUpload ? createTiptapVideoUploadFn(this.presignedUpload) : null;
   readonly quizTypes: SectionQuizAssessmentType[] = ['PRACTICE', 'ASSESSMENT', 'EXAM'];
-  readonly interactiveVideoTypes: InteractiveVideoInteractionType[] = ['checkpoint', 'single_choice', 'branch'];
   readonly lessonTemplates = LESSON_TEMPLATES;
   readonly showTemplatePicker = signal(true);
   readonly isYoutubeVideoSource = computed(() =>
     this.videoSourceTab() === 'youtube' || this.svc.sectionVideoType() === 'YOUTUBE',
   );
-  readonly canAuthorInteractiveVideo = computed(() => !this.isYoutubeVideoSource());
-  readonly interactiveVideoCompatibilityLabel = computed(() =>
-    this.canAuthorInteractiveVideo() ? 'Hỗ trợ tương tác' : 'YouTube chỉ nhúng',
-  );
-  readonly interactiveVideoCompatibilityBadgeClass = computed(() =>
-    this.canAuthorInteractiveVideo()
-      ? 'inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-700 ring-1 ring-emerald-200'
-      : 'inline-flex items-center rounded-full bg-amber-50 px-2.5 py-1 text-[11px] font-semibold text-amber-700 ring-1 ring-amber-200',
-  );
-  readonly interactiveVideoPreviewSpec = computed(() => {
-    if (!this.canAuthorInteractiveVideo()) {
-      return null;
-    }
-
-    return buildInteractiveVideoSpec(
-      this.svc.sectionInteractiveVideoEnabled(),
-      this.svc.sectionInteractiveVideoTimeline(),
-    );
-  });
-  readonly interactiveVideoFlowNodes = computed<InteractiveVideoFlowNode[]>(() =>
-    this.buildInteractiveVideoFlowNodes(this.svc.sectionInteractiveVideoTimeline()),
-  );
-  readonly interactiveVideoFlowStats = computed(() => {
-    const nodes = this.interactiveVideoFlowNodes();
-    return {
-      total: nodes.length,
-      branches: nodes.filter(node => node.type === 'branch').length,
-      questions: nodes.filter(node => node.type === 'single_choice').length,
-      required: nodes.filter(node => node.required).length,
-    };
-  });
+  readonly interactiveVideoPreviewSpec = computed(() => buildInteractiveVideoSpec(
+    this.svc.sectionInteractiveVideoEnabled(),
+    this.svc.sectionInteractiveVideoTimeline(),
+  ));
   readonly isContentEmpty = computed(() => {
     const content = this.svc.sectionContent();
     if (!content) return true;
@@ -2529,8 +2120,11 @@ export class SectionEditorComponent {
     // User switching tabs to explore is not the same as replacing video
     this.svc.sectionVideoType.set(tab === 'youtube' ? 'YOUTUBE' : null);
     this.videoSourceTab.set(tab);
+    if (tab === 'youtube') {
+      this.svc.sectionVideoDurationSec.set(null);
+    }
     if (tab === 'youtube' && this.svc.sectionInteractiveVideoEnabled()) {
-      this.toast.warning('YouTube chưa chạy điểm dừng, câu hỏi hoặc rẽ nhánh. Dữ liệu tương tác vẫn được giữ nếu bạn quay lại video tải lên.');
+      this.toast.info('Video tương tác trên YouTube hoạt động khi học viên online; chế độ ngoại tuyến vẫn cần video tải lên.');
     }
   }
 
@@ -2573,340 +2167,14 @@ export class SectionEditorComponent {
   onYouTubeUrlChange(url: string): void {
     this.svc.sectionVideoUrl.set(url);
     this.svc.sectionVideoType.set('YOUTUBE');
+    this.svc.sectionVideoDurationSec.set(null);
     this.svc.markDirty();
-    if (this.svc.sectionInteractiveVideoEnabled()) {
-      this.toast.warning('YouTube chỉ hỗ trợ nhúng video. Hãy dùng video tải lên để chạy video tương tác.');
+  }
+
+  onYouTubeDurationLoaded(durationSeconds: number): void {
+    if (Number.isFinite(durationSeconds) && durationSeconds > 0) {
+      this.svc.sectionVideoDurationSec.set(Math.round(durationSeconds));
     }
-  }
-
-  onInteractiveVideoEnabledChange(enabled: boolean): void {
-    if (enabled && !this.canAuthorInteractiveVideo()) {
-      this.toast.error('Video tương tác hiện chỉ hỗ trợ video tải lên. YouTube chỉ dùng để nhúng và theo dõi tiến độ.');
-      return;
-    }
-    this.svc.setInteractiveVideoEnabled(enabled);
-  }
-
-  onInteractiveTypeChange(
-    interactionId: string,
-    type: InteractiveVideoInteractionType,
-  ): void {
-    this.svc.updateInteractiveVideoInteractionType(interactionId, type);
-  }
-
-  onInteractiveTimeChange(interactionId: string, value: unknown): void {
-    this.svc.updateInteractiveVideoInteraction(interactionId, {
-      atSeconds: this.toNonNegativeInteger(value),
-    });
-  }
-
-  onInteractiveChoiceTargetChange(
-    interactionId: string,
-    choiceId: string,
-    value: unknown,
-  ): void {
-    this.svc.updateInteractiveVideoChoice(interactionId, choiceId, {
-      targetTimeSeconds: this.toNonNegativeInteger(value),
-      targetInteractionId: null,
-    });
-  }
-
-  onInteractiveChoiceTargetInteractionChange(
-    interactionId: string,
-    choiceId: string,
-    value: string,
-  ): void {
-    this.svc.updateInteractiveVideoChoice(interactionId, choiceId, {
-      targetInteractionId: value || null,
-      targetTimeSeconds: value ? null : undefined,
-    });
-  }
-
-  async onInteractiveImportSelected(event: Event): Promise<void> {
-    const inputElement = event.target as HTMLInputElement;
-    const file = inputElement.files?.[0];
-    inputElement.value = '';
-    if (!file) {
-      return;
-    }
-
-    try {
-      const spec = await this.readInteractiveImportSpec(file);
-      if (!spec || spec.timeline.length === 0) {
-        this.toast.error('Tệp nhập không có dữ liệu video tương tác hợp lệ.');
-        return;
-      }
-
-      this.svc.sectionInteractiveVideoEnabled.set(spec.enabled !== false);
-      this.svc.sectionInteractiveVideoTimeline.set(spec.timeline);
-      this.svc.markDirty();
-      this.toast.success(`Đã nhập ${spec.timeline.length} điểm tương tác.`);
-    } catch {
-      this.toast.error('Không thể đọc tệp video tương tác.');
-    }
-  }
-
-  exportInteractiveVideoJson(): void {
-    const spec = this.interactiveVideoPreviewSpec();
-    if (!spec) {
-      this.toast.error('Chưa có dữ liệu video tương tác để xuất.');
-      return;
-    }
-
-    try {
-      const bundle = exportInteractiveVideoBundle(spec, this.svc.sectionVideoUrl());
-      this.downloadJsonFile(bundle, this.getInteractiveExportFileName('json'));
-      this.toast.success('Đã xuất JSON video tương tác.');
-    } catch {
-      this.toast.error('Không thể xuất JSON video tương tác.');
-    }
-  }
-
-  async exportInteractiveVideoH5P(): Promise<void> {
-    const spec = this.interactiveVideoPreviewSpec();
-    if (!spec) {
-      this.toast.error('Chưa có dữ liệu video tương tác để xuất.');
-      return;
-    }
-
-    try {
-      const blob = await exportInteractiveVideoH5PPackage(spec, this.svc.sectionVideoUrl(), {
-        title: this.svc.sectionTitle(),
-        language: 'vi',
-      });
-      this.downloadBlobFile(blob, this.getInteractiveExportFileName('h5p'));
-      this.toast.success('Đã xuất H5P video tương tác.');
-    } catch {
-      this.toast.error('Không thể xuất H5P video tương tác.');
-    }
-  }
-
-  isChoiceInteraction(interaction: InteractiveVideoInteraction): boolean {
-    return interaction.type === 'single_choice' || interaction.type === 'branch';
-  }
-
-  getInteractiveBranchTargets(sourceInteractionId: string): InteractiveVideoInteraction[] {
-    return this.svc.sectionInteractiveVideoTimeline()
-      .filter(interaction => interaction.id !== sourceInteractionId)
-      .sort((a, b) => a.atSeconds - b.atSeconds);
-  }
-
-  getInteractiveTypeLabel(type: InteractiveVideoInteractionType): string {
-    switch (type) {
-      case 'single_choice': return 'Câu hỏi';
-      case 'branch': return 'Rẽ nhánh';
-      case 'hotspot': return 'Hotspot';
-      default: return 'Điểm dừng';
-    }
-  }
-
-  getInteractiveTypeHint(type: InteractiveVideoInteractionType): string {
-    switch (type) {
-      case 'single_choice':
-        return 'Dừng video để hỏi nhanh và phản hồi theo lựa chọn.';
-      case 'branch':
-        return 'Cho học viên chọn đường đi tiếp theo trong video.';
-      case 'hotspot':
-        return 'Dành cho vùng bấm trên video khi nhập từ gói tương tác.';
-      default:
-        return 'Tạm dừng video tại mốc này để nhấn mạnh nội dung.';
-    }
-  }
-
-  getInteractiveNodeDomId(interactionId: string): string {
-    return `interactive-node-${interactionId}`;
-  }
-
-  scrollInteractiveNodeIntoView(interactionId: string): void {
-    if (typeof document === 'undefined') {
-      return;
-    }
-
-    document.getElementById(this.getInteractiveNodeDomId(interactionId))
-      ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-  }
-
-  formatInteractiveTimeLabel(seconds: number | null | undefined): string {
-    return this.formatInteractiveFlowTime(seconds);
-  }
-
-  formatInteractiveBranchTargetLabel(target: InteractiveVideoInteraction): string {
-    const title = target.title?.trim() || this.getInteractiveTypeLabel(target.type);
-    return `${this.formatInteractiveFlowTime(target.atSeconds)} · ${title}`;
-  }
-
-  getInteractiveChoiceRowClass(type: InteractiveVideoInteractionType): string {
-    const base = 'grid gap-2 px-3 py-2';
-    return type === 'branch'
-      ? `${base} sm:grid-cols-[minmax(0,1fr)_7rem_minmax(8rem,10rem)_auto]`
-      : `${base} sm:grid-cols-[minmax(0,1fr)_8rem_auto]`;
-  }
-
-  private buildInteractiveVideoFlowNodes(
-    timeline: InteractiveVideoInteraction[],
-  ): InteractiveVideoFlowNode[] {
-    const sorted = [...timeline].sort((a, b) => a.atSeconds - b.atSeconds);
-    const byId = new Map(sorted.map(interaction => [interaction.id, interaction]));
-
-    return sorted.map((interaction, index) => ({
-      id: interaction.id,
-      index: index + 1,
-      type: interaction.type,
-      typeLabel: this.getInteractiveTypeLabel(interaction.type),
-      title: interaction.title?.trim() || this.getInteractiveTypeLabel(interaction.type),
-      atSeconds: interaction.atSeconds,
-      timeLabel: this.formatInteractiveFlowTime(interaction.atSeconds),
-      iconName: this.getInteractiveFlowIconName(interaction.type),
-      nodeClass: this.getInteractiveFlowNodeClass(interaction.type),
-      badgeClass: this.getInteractiveFlowBadgeClass(interaction.type),
-      choices: this.buildInteractiveFlowChoices(interaction, byId),
-      required: interaction.required === true,
-      pause: interaction.pause !== false,
-    }));
-  }
-
-  private buildInteractiveFlowChoices(
-    interaction: InteractiveVideoInteraction,
-    byId: Map<string, InteractiveVideoInteraction>,
-  ): InteractiveVideoFlowChoice[] {
-    if (!this.isChoiceInteraction(interaction)) {
-      return [];
-    }
-
-    return (interaction.choices ?? []).map((choice, index) => {
-      const label = choice.label?.trim() || `Lựa chọn ${index + 1}`;
-
-      if (interaction.type === 'branch') {
-        const target = choice.targetInteractionId ? byId.get(choice.targetInteractionId) : null;
-        const missingTarget = Boolean(choice.targetInteractionId && !target);
-        return {
-          id: choice.id,
-          label,
-          metaLabel: missingTarget
-            ? 'Mất đích'
-            : target
-              ? `${this.formatInteractiveFlowTime(target.atSeconds)} · ${target.title?.trim() || this.getInteractiveTypeLabel(target.type)}`
-              : choice.targetTimeSeconds == null
-                ? 'Theo timeline'
-                : this.formatInteractiveFlowTime(choice.targetTimeSeconds),
-          toneClass: missingTarget
-            ? 'flex items-center gap-2 rounded-md bg-red-50 px-2 py-1 text-xs text-red-700 ring-1 ring-red-100'
-            : 'flex items-center gap-2 rounded-md bg-white px-2 py-1 text-xs text-slate-600 ring-1 ring-slate-200',
-        };
-      }
-
-      return {
-        id: choice.id,
-        label,
-        metaLabel: choice.isCorrect ? 'Đúng' : 'Chưa đúng',
-        toneClass: choice.isCorrect
-          ? 'flex items-center gap-2 rounded-md bg-emerald-50 px-2 py-1 text-xs text-emerald-700 ring-1 ring-emerald-100'
-          : 'flex items-center gap-2 rounded-md bg-white px-2 py-1 text-xs text-slate-600 ring-1 ring-slate-200',
-      };
-    });
-  }
-
-  private getInteractiveFlowIconName(type: InteractiveVideoInteractionType): string {
-    switch (type) {
-      case 'single_choice': return 'help-circle';
-      case 'branch': return 'shuffle';
-      case 'hotspot': return 'mouse-pointer-2';
-      default: return 'pause';
-    }
-  }
-
-  private getInteractiveFlowNodeClass(type: InteractiveVideoInteractionType): string {
-    const base = 'w-64 rounded-xl border bg-white p-3 shadow-sm';
-    switch (type) {
-      case 'single_choice':
-        return `${base} border-sky-200`;
-      case 'branch':
-        return `${base} border-amber-200`;
-      case 'hotspot':
-        return `${base} border-teal-200`;
-      default:
-        return `${base} border-slate-200`;
-    }
-  }
-
-  private getInteractiveFlowBadgeClass(type: InteractiveVideoInteractionType): string {
-    const base = 'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-bold';
-    switch (type) {
-      case 'single_choice':
-        return `${base} bg-sky-50 text-sky-700`;
-      case 'branch':
-        return `${base} bg-amber-50 text-amber-700`;
-      case 'hotspot':
-        return `${base} bg-teal-50 text-teal-700`;
-      default:
-        return `${base} bg-slate-100 text-slate-600`;
-    }
-  }
-
-  private formatInteractiveFlowTime(seconds: number | null | undefined): string {
-    const safeSeconds = this.toNonNegativeInteger(seconds ?? 0);
-    const minutes = Math.floor(safeSeconds / 60);
-    const rest = safeSeconds % 60;
-    return `${minutes}:${rest.toString().padStart(2, '0')}`;
-  }
-
-  private toNonNegativeInteger(value: unknown): number {
-    const next = typeof value === 'number' ? value : Number(value);
-    return Number.isFinite(next) ? Math.max(0, Math.round(next)) : 0;
-  }
-
-  private async readInteractiveImportSpec(file: File): Promise<InteractiveVideoSpec | null> {
-    if (this.isH5PFile(file)) {
-      return importInteractiveVideoH5PPackage(await file.arrayBuffer());
-    }
-
-    return importInteractiveVideoBundle(JSON.parse(await file.text()));
-  }
-
-  private isH5PFile(file: File): boolean {
-    const name = file.name.toLowerCase();
-    return name.endsWith('.h5p')
-      || name.endsWith('.zip')
-      || file.type === 'application/h5p'
-      || file.type === 'application/zip'
-      || file.type === 'application/x-zip-compressed';
-  }
-
-  private downloadJsonFile(payload: unknown, filename: string): void {
-    this.downloadBlobFile(
-      new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' }),
-      filename,
-    );
-  }
-
-  private downloadBlobFile(blob: Blob, filename: string): void {
-    if (typeof document === 'undefined' || typeof URL === 'undefined') {
-      return;
-    }
-
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = filename;
-    link.click();
-    URL.revokeObjectURL(url);
-  }
-
-  private getInteractiveExportFileName(extension: 'json' | 'h5p'): string {
-    const base = (this.svc.sectionTitle() || 'interactive-video')
-      .toLowerCase()
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      .slice(0, 64);
-    return `${base || 'interactive-video'}-holilihu-v1.${extension}`;
-  }
-
-  getYouTubeEmbedUrl(videoId: string): SafeResourceUrl {
-    return this.sanitizer.bypassSecurityTrustResourceUrl(
-      `https://www.youtube.com/embed/${videoId}`
-    );
   }
 
   // ── File section helpers ─────────────────────────────────────────────

--- a/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
+++ b/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
@@ -194,20 +194,14 @@ export class CurriculumEditorService {
   }
 
   setInteractiveVideoEnabled(enabled: boolean): void {
-    if (enabled && this.sectionVideoType() === 'YOUTUBE') {
-      this.toast.error('Video tương tác hiện chỉ hỗ trợ video tải lên. YouTube chỉ dùng để nhúng và theo dõi tiến độ.');
-      return;
-    }
     this.sectionInteractiveVideoEnabled.set(enabled);
     this.markDirty();
   }
 
   addInteractiveVideoInteraction(type: InteractiveVideoInteractionType): void {
-    if (this.sectionVideoType() === 'YOUTUBE') {
-      this.toast.error('Hãy dùng video tải lên để thêm điểm dừng, câu hỏi hoặc rẽ nhánh.');
-      return;
-    }
-    const next = createInteractiveVideoInteraction(this.sectionInteractiveVideoTimeline(), type);
+    const next = createInteractiveVideoInteraction(this.sectionInteractiveVideoTimeline(), type, {
+      durationSeconds: this.sectionVideoDurationSec(),
+    });
     this.sectionInteractiveVideoTimeline.update(timeline => [...timeline, next]);
     this.sectionInteractiveVideoEnabled.set(true);
     this.markDirty();
@@ -729,11 +723,6 @@ export class CurriculumEditorService {
   private validateInteractiveVideoAuthoring(): boolean {
     if (!this.sectionInteractiveVideoEnabled()) {
       return true;
-    }
-
-    if (this.sectionVideoType() === 'YOUTUBE') {
-      this.toast.error('Video YouTube chưa hỗ trợ điểm dừng, câu hỏi hoặc rẽ nhánh. Hãy tắt Video tương tác hoặc chuyển sang video tải lên.');
-      return false;
     }
 
     const timeline = this.sectionInteractiveVideoTimeline();

--- a/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
+++ b/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
@@ -732,8 +732,19 @@ export class CurriculumEditorService {
     }
 
     const durationSeconds = this.sectionVideoDurationSec();
-    if (durationSeconds && timeline.some(interaction => interaction.atSeconds > durationSeconds)) {
+    const maxInteractiveSeconds = durationSeconds
+      ? Math.max(0, Math.round(durationSeconds) - 1)
+      : null;
+    if (maxInteractiveSeconds != null && timeline.some(interaction => interaction.atSeconds > maxInteractiveSeconds)) {
       this.toast.error('Có điểm tương tác nằm sau thời lượng video. Hãy chỉnh lại thời điểm.');
+      return false;
+    }
+    if (maxInteractiveSeconds != null && timeline.some(interaction =>
+      (interaction.choices ?? []).some(choice =>
+        choice.targetTimeSeconds != null && choice.targetTimeSeconds > maxInteractiveSeconds,
+      ),
+    )) {
+      this.toast.error('Có nhánh rẽ tới thời điểm nằm sau thời lượng video. Hãy chỉnh lại điểm đích.');
       return false;
     }
 

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.spec.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.spec.ts
@@ -20,6 +20,28 @@ describe('interactive-video-authoring', () => {
     expect(created.pause).toBeTrue();
   });
 
+  it('places the first interaction inside short videos instead of hard-coding 30s', () => {
+    const created = createInteractiveVideoInteraction([], 'checkpoint', {
+      durationSeconds: 15,
+    });
+
+    expect(created.atSeconds).toBe(8);
+  });
+
+  it('keeps later generated interactions inside the known video duration', () => {
+    const existing: InteractiveVideoInteraction[] = [
+      { id: 'a', type: 'checkpoint', atSeconds: 6, pause: true, required: false },
+      { id: 'b', type: 'checkpoint', atSeconds: 12, pause: true, required: false },
+    ];
+
+    const created = createInteractiveVideoInteraction(existing, 'branch', {
+      durationSeconds: 15,
+    });
+
+    expect(created.atSeconds).toBeLessThan(15);
+    expect(created.atSeconds).toBeGreaterThanOrEqual(0);
+  });
+
   it('builds a sorted spec when enabled and returns null when disabled', () => {
     const timeline: InteractiveVideoInteraction[] = [
       { id: 'later', type: 'checkpoint', atSeconds: 90, title: 'Later', pause: true },

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.spec.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.spec.ts
@@ -2,6 +2,7 @@ import {
   buildInteractiveVideoSpec,
   createInteractiveVideoInteraction,
   normalizeInteractiveVideoSpec,
+  suggestNextInteractiveVideoTimeSeconds,
 } from './interactive-video-authoring';
 import type { InteractiveVideoInteraction } from '../../../../api/types/interactive-video.types';
 
@@ -26,6 +27,26 @@ describe('interactive-video-authoring', () => {
     });
 
     expect(created.atSeconds).toBe(8);
+  });
+
+  it('places the first interaction after the intro for long videos', () => {
+    const created = createInteractiveVideoInteraction([], 'checkpoint', {
+      durationSeconds: 22 * 60,
+    });
+
+    expect(created.atSeconds).toBe(30);
+  });
+
+  it('spreads later generated interactions into the largest remaining gap', () => {
+    const existing: InteractiveVideoInteraction[] = [
+      { id: 'intro', type: 'checkpoint', atSeconds: 30, pause: true, required: false },
+    ];
+
+    const next = suggestNextInteractiveVideoTimeSeconds(existing, {
+      durationSeconds: 22 * 60,
+    });
+
+    expect(next).toBe(675);
   });
 
   it('keeps later generated interactions inside the known video duration', () => {

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
@@ -6,6 +6,12 @@ import type {
 } from '../../../../api/types/interactive-video.types';
 
 const DEFAULT_OFFSET_SECONDS = 30;
+const MIN_DURATION_AWARE_OFFSET_SECONDS = 2;
+
+interface CreateInteractiveVideoInteractionOptions {
+  durationSeconds?: number | null;
+  preferredSeconds?: number | null;
+}
 
 export function buildInteractiveVideoSpec(
   enabled: boolean,
@@ -57,8 +63,9 @@ export function normalizeInteractiveVideoSpec(value: unknown): InteractiveVideoS
 export function createInteractiveVideoInteraction(
   timeline: InteractiveVideoInteraction[],
   type: InteractiveVideoInteractionType = 'checkpoint',
+  options: CreateInteractiveVideoInteractionOptions = {},
 ): InteractiveVideoInteraction {
-  const atSeconds = getNextInteractionTimeSeconds(timeline);
+  const atSeconds = getNextInteractionTimeSeconds(timeline, options);
 
   return {
     id: createAuthoringId('iv'),
@@ -182,13 +189,41 @@ function normalizeInteractiveVideoChoice(value: unknown): InteractiveVideoChoice
   };
 }
 
-function getNextInteractionTimeSeconds(timeline: InteractiveVideoInteraction[]): number {
+function getNextInteractionTimeSeconds(
+  timeline: InteractiveVideoInteraction[],
+  options: CreateInteractiveVideoInteractionOptions,
+): number {
+  const maxSeconds = normalizeDurationSeconds(options.durationSeconds);
+  if (options.preferredSeconds != null) {
+    return clampToVideoDuration(toNonNegativeNumber(options.preferredSeconds, 0), maxSeconds);
+  }
+
   if (timeline.length === 0) {
+    if (maxSeconds != null) {
+      return clampToVideoDuration(Math.round(maxSeconds * 0.5), maxSeconds);
+    }
     return DEFAULT_OFFSET_SECONDS;
   }
 
   const latest = Math.max(...timeline.map(item => toNonNegativeNumber(item.atSeconds, 0)));
-  return latest + DEFAULT_OFFSET_SECONDS;
+  if (maxSeconds == null) {
+    return latest + DEFAULT_OFFSET_SECONDS;
+  }
+
+  const durationAwareOffset = Math.min(
+    DEFAULT_OFFSET_SECONDS,
+    Math.max(MIN_DURATION_AWARE_OFFSET_SECONDS, Math.round(maxSeconds * 0.2)),
+  );
+  const next = latest + durationAwareOffset;
+  if (next < maxSeconds) {
+    return next;
+  }
+
+  const sortedTimes = timeline
+    .map(item => clampToVideoDuration(item.atSeconds, maxSeconds))
+    .sort((a, b) => a - b);
+  const candidate = findLargestTimelineGapMidpoint(sortedTimes, maxSeconds);
+  return clampToVideoDuration(candidate, maxSeconds);
 }
 
 function normalizeInteractionType(value: unknown): InteractiveVideoInteractionType {
@@ -224,6 +259,45 @@ function toNonNegativeNumber(value: unknown, fallback: number): number {
     return Math.max(0, fallback);
   }
   return Math.max(0, Math.round(next));
+}
+
+function normalizeDurationSeconds(value: number | null | undefined): number | null {
+  if (value == null || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return Math.max(1, Math.round(value));
+}
+
+function clampToVideoDuration(value: number, maxSeconds: number | null): number {
+  const safe = toNonNegativeNumber(value, 0);
+  if (maxSeconds == null) {
+    return safe;
+  }
+  const upperBound = Math.max(0, maxSeconds - 1);
+  return Math.min(upperBound, safe);
+}
+
+function findLargestTimelineGapMidpoint(sortedTimes: number[], maxSeconds: number): number {
+  let bestStart = 0;
+  let bestEnd = maxSeconds;
+  let bestGap = -1;
+  const points = [0, ...sortedTimes, maxSeconds];
+
+  for (let i = 0; i < points.length - 1; i += 1) {
+    const start = points[i];
+    const end = points[i + 1];
+    const gap = end - start;
+    if (gap > bestGap) {
+      bestGap = gap;
+      bestStart = start;
+      bestEnd = end;
+    }
+  }
+
+  if (bestGap <= 1) {
+    return maxSeconds;
+  }
+  return Math.round(bestStart + bestGap / 2);
 }
 
 function createAuthoringId(prefix: string): string {

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
@@ -7,8 +7,11 @@ import type {
 
 const DEFAULT_OFFSET_SECONDS = 30;
 const MIN_DURATION_AWARE_OFFSET_SECONDS = 2;
+const SHORT_VIDEO_SECONDS = 30;
+const SHORT_LESSON_SECONDS = 90;
+const SHORT_LESSON_FIRST_INTERACTION_RATIO = 0.4;
 
-interface CreateInteractiveVideoInteractionOptions {
+export interface CreateInteractiveVideoInteractionOptions {
   durationSeconds?: number | null;
   preferredSeconds?: number | null;
 }
@@ -65,7 +68,7 @@ export function createInteractiveVideoInteraction(
   type: InteractiveVideoInteractionType = 'checkpoint',
   options: CreateInteractiveVideoInteractionOptions = {},
 ): InteractiveVideoInteraction {
-  const atSeconds = getNextInteractionTimeSeconds(timeline, options);
+  const atSeconds = suggestNextInteractiveVideoTimeSeconds(timeline, options);
 
   return {
     id: createAuthoringId('iv'),
@@ -100,6 +103,34 @@ export function sortInteractiveVideoTimeline(
 
 export function choiceTypeNeedsChoices(type: InteractiveVideoInteractionType): boolean {
   return type === 'single_choice' || type === 'branch';
+}
+
+export function suggestNextInteractiveVideoTimeSeconds(
+  timeline: InteractiveVideoInteraction[],
+  options: CreateInteractiveVideoInteractionOptions = {},
+): number {
+  const maxSeconds = normalizeDurationSeconds(options.durationSeconds);
+  if (options.preferredSeconds != null) {
+    return clampToVideoDuration(toNonNegativeNumber(options.preferredSeconds, 0), maxSeconds);
+  }
+
+  if (timeline.length === 0) {
+    if (maxSeconds != null) {
+      return getFirstInteractionTimeSeconds(maxSeconds);
+    }
+    return DEFAULT_OFFSET_SECONDS;
+  }
+
+  const latest = Math.max(...timeline.map(item => toNonNegativeNumber(item.atSeconds, 0)));
+  if (maxSeconds == null) {
+    return latest + DEFAULT_OFFSET_SECONDS;
+  }
+
+  const sortedTimes = timeline
+    .map(item => clampToVideoDuration(item.atSeconds, maxSeconds))
+    .sort((a, b) => a - b);
+  const candidate = findLargestTimelineGapMidpoint(sortedTimes, maxSeconds);
+  return clampToVideoDuration(candidate, maxSeconds);
 }
 
 function normalizeInteractiveVideoInteraction(value: unknown): InteractiveVideoInteraction | null {
@@ -189,43 +220,6 @@ function normalizeInteractiveVideoChoice(value: unknown): InteractiveVideoChoice
   };
 }
 
-function getNextInteractionTimeSeconds(
-  timeline: InteractiveVideoInteraction[],
-  options: CreateInteractiveVideoInteractionOptions,
-): number {
-  const maxSeconds = normalizeDurationSeconds(options.durationSeconds);
-  if (options.preferredSeconds != null) {
-    return clampToVideoDuration(toNonNegativeNumber(options.preferredSeconds, 0), maxSeconds);
-  }
-
-  if (timeline.length === 0) {
-    if (maxSeconds != null) {
-      return clampToVideoDuration(Math.round(maxSeconds * 0.5), maxSeconds);
-    }
-    return DEFAULT_OFFSET_SECONDS;
-  }
-
-  const latest = Math.max(...timeline.map(item => toNonNegativeNumber(item.atSeconds, 0)));
-  if (maxSeconds == null) {
-    return latest + DEFAULT_OFFSET_SECONDS;
-  }
-
-  const durationAwareOffset = Math.min(
-    DEFAULT_OFFSET_SECONDS,
-    Math.max(MIN_DURATION_AWARE_OFFSET_SECONDS, Math.round(maxSeconds * 0.2)),
-  );
-  const next = latest + durationAwareOffset;
-  if (next < maxSeconds) {
-    return next;
-  }
-
-  const sortedTimes = timeline
-    .map(item => clampToVideoDuration(item.atSeconds, maxSeconds))
-    .sort((a, b) => a - b);
-  const candidate = findLargestTimelineGapMidpoint(sortedTimes, maxSeconds);
-  return clampToVideoDuration(candidate, maxSeconds);
-}
-
 function normalizeInteractionType(value: unknown): InteractiveVideoInteractionType {
   return value === 'single_choice' || value === 'branch' || value === 'hotspot'
     ? value
@@ -277,6 +271,24 @@ function clampToVideoDuration(value: number, maxSeconds: number | null): number 
   return Math.min(upperBound, safe);
 }
 
+function getFirstInteractionTimeSeconds(maxSeconds: number): number {
+  if (maxSeconds <= SHORT_VIDEO_SECONDS) {
+    return clampToVideoDuration(Math.round(maxSeconds * 0.5), maxSeconds);
+  }
+
+  if (maxSeconds <= SHORT_LESSON_SECONDS) {
+    return clampToVideoDuration(
+      Math.min(
+        DEFAULT_OFFSET_SECONDS,
+        Math.round(maxSeconds * SHORT_LESSON_FIRST_INTERACTION_RATIO),
+      ),
+      maxSeconds,
+    );
+  }
+
+  return clampToVideoDuration(DEFAULT_OFFSET_SECONDS, maxSeconds);
+}
+
 function findLargestTimelineGapMidpoint(sortedTimes: number[], maxSeconds: number): number {
   let bestStart = 0;
   let bestEnd = maxSeconds;
@@ -295,7 +307,8 @@ function findLargestTimelineGapMidpoint(sortedTimes: number[], maxSeconds: numbe
   }
 
   if (bestGap <= 1) {
-    return maxSeconds;
+    const latest = Math.max(0, ...sortedTimes);
+    return latest + MIN_DURATION_AWARE_OFFSET_SECONDS;
   }
   return Math.round(bestStart + bestGap / 2);
 }


### PR DESCRIPTION
﻿## Summary
- Extract the interactive-video authoring surface into a focused Angular component with its own template/styles.
- Add duration-aware interaction timestamps so short videos no longer receive a hard-coded 30s checkpoint.
- Add an accessible flow/timeline map with focusable draggable nodes and button/keyboard alternatives for timing adjustments.
- Extend the YouTube IFrame player path to support interactive overlays, branching, duration reporting, and analytics events while keeping tracking optional for teacher preview.

## Why
The previous authoring UI mixed too much logic into `section-editor` and treated YouTube as embed-only. It also defaulted new interactions to 30s even when the known video duration was shorter, which made the micro UX feel broken for short clips.

## Validation
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless --include=src/app/features/teacher/course-editor/utils/interactive-video-authoring.spec.ts`
- `git diff --check`
- Local Playwright smoke on `http://127.0.0.1:4200` against the teacher curriculum editor: upload authoring panel, flow/timeline controls, focusable draggable nodes, YouTube online-interactive state, no blocking console errors.

## Notes
- `npm run test:ci -- --include=...` still fails locally because the repo's `ChromeHeadlessCI` browser launcher is not registered in this environment, so the same spec was run with `ChromeHeadless`.
- YouTube interactive video is online-only; offline learning still requires uploaded video assets.
