### PR TITLE
[codex] fix learner interactive video spec contract

### DIFF
--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
@@ -762,6 +762,7 @@ public class CourseQueryControllerV3 {
                     section.setStreamVideoUid(null);
                     section.setFileUrl(null);
                     section.setQuizData(null);
+                    section.setInteractiveVideoSpec(null);
                 }
             }
         }
@@ -1077,6 +1078,7 @@ public class CourseQueryControllerV3 {
                     .orderIndex(safeInt(data.get("orderIndex"), 0))
                     .isRequired(safeBool(data.get("isRequired"), false))
                     .quizData(showContent ? buildSectionQuizData(data, questionMap) : null)
+                    .interactiveVideoSpec(showContent ? normalizeInteractiveVideoSpec(data.get("interactiveVideoSpec")) : null)
                     .build();
             if (showContent) {
                 applyVideoAssetView(response, data, resolveVideoAssetView(videoAssets, data.get("videoAssetId")), videoType);
@@ -1232,6 +1234,21 @@ public class CourseQueryControllerV3 {
             normalized.put("questions", normalizeLegacySectionQuizQuestions(quizData.get("questions")));
         }
 
+        return normalized;
+    }
+
+    private Map<String, Object> normalizeInteractiveVideoSpec(Object value) {
+        Map<String, Object> spec = asMap(value);
+        if (spec == null || spec.isEmpty()) {
+            return null;
+        }
+
+        Map<String, Object> normalized = new LinkedHashMap<>(spec);
+        normalized.putIfAbsent("version", 1);
+        Object timeline = normalized.get("timeline");
+        if (!(timeline instanceof List<?>)) {
+            normalized.put("timeline", List.of());
+        }
         return normalized;
     }
 
@@ -1589,6 +1606,7 @@ public class CourseQueryControllerV3 {
         private Boolean isRequired;
         private List<Map<String, Object>> availableOfflineProfiles;
         private Map<String, Object> quizData;
+        private Map<String, Object> interactiveVideoSpec;
     }
 
     @lombok.Builder

--- a/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3ContractTest.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3ContractTest.java
@@ -383,6 +383,36 @@ class CourseQueryControllerV3ContractTest {
     }
 
     @Test
+    @DisplayName("section response preserves interactive video spec from published snapshots")
+    void sectionResponsePreservesInteractiveVideoSpec() {
+        Map<String, Object> interaction = Map.of(
+                "id", "iv-1",
+                "type", "single_choice",
+                "atSeconds", 30,
+                "choices", List.of(Map.of(
+                        "id", "choice-1",
+                        "label", "Continue",
+                        "isCorrect", true
+                ))
+        );
+        Map<String, Object> interactiveSpec = Map.of(
+                "version", 1,
+                "enabled", true,
+                "timeline", List.of(interaction)
+        );
+        CourseQueryControllerV3.SectionResponse section = CourseQueryControllerV3.SectionResponse.builder()
+                .id("section-1")
+                .title("Interactive video")
+                .type("VIDEO")
+                .interactiveVideoSpec(interactiveSpec)
+                .build();
+
+        assertThat(section.getInteractiveVideoSpec()).isNotNull();
+        assertThat(section.getInteractiveVideoSpec()).containsEntry("enabled", true);
+        assertThat((List<?>) section.getInteractiveVideoSpec().get("timeline")).hasSize(1);
+    }
+
+    @Test
     @DisplayName("published lesson detail falls back to persisted lesson video when publication snapshot predates lesson videoUrl support")
     void getLessonByIdHydratesLegacyPublishedLessonLevelVideo() {
         UUID courseId = approvedPaidCourse.getId();


### PR DESCRIPTION
## Summary
- expose interactiveVideoSpec on learner-facing section responses
- preserve the spec from published snapshots and draft content responses
- mask the spec for locked paid lessons

## Verification
- mvn -Dtest=CourseQueryControllerV3ContractTest test
- mvn test