### PR TITLE
[codex] lazy-load offline enrollment fallback

### DIFF
--- a/fe/src/app/core/guards/enrollment.guard.ts
+++ b/fe/src/app/core/guards/enrollment.guard.ts
@@ -1,8 +1,7 @@
-import { inject } from '@angular/core';
+import { inject, Injector } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { CourseApi } from '../../api/client/course.api';
 import { firstValueFrom } from 'rxjs';
-import { CourseDownloadService } from '../services/course-download.service';
 
 /**
  * Enrollment Guard - Ensures student is enrolled in the course before accessing learning content.
@@ -13,7 +12,7 @@ import { CourseDownloadService } from '../services/course-download.service';
  */
 export const enrollmentGuard: CanActivateFn = async (route) => {
   const courseApi = inject(CourseApi);
-  const courseDownload = inject(CourseDownloadService);
+  const injector = inject(Injector);
   const router = inject(Router);
 
   const courseId = route.paramMap.get('courseId') || route.paramMap.get('id');
@@ -31,6 +30,8 @@ export const enrollmentGuard: CanActivateFn = async (route) => {
 
     return true;
   } catch {
+    const { CourseDownloadService } = await import('../services/course-download.service');
+    const courseDownload = injector.get(CourseDownloadService);
     if (await courseDownload.isDownloaded(courseId)) {
       // A downloaded course must remain accessible when the progress endpoint
       // is temporarily unavailable or the learner is offline.


### PR DESCRIPTION
## Summary

- Lazy-load `CourseDownloadService` only when the online enrollment/progress check fails.
- Keep the normal online learning route focused on the progress API instead of eagerly pulling offline download/IndexedDB code into the guard path.

## Why

Production smoke for the interactive-video lesson reached the student learning route but showed the critical path was too sensitive around the route guard/bootstrap sequence. The guard previously injected `CourseDownloadService` before making the online progress request, which pulled the offline stack into the initial learning navigation even when the learner was online and enrolled.

## Validation

- `npm run build`
- `git diff --check`
- Local Playwright smoke against the built app with API proxied to production: confirmed `/api/v3/student/progress/courses/{courseId}`, course content, lesson progress, section video play, and adaptive manifest requests are reached; the student page renders the interactive-video lesson text.

Note: local smoke shows R2 segment CORS errors only because the app was served from `127.0.0.1` while signed media redirects to the production R2 host. This is not expected on the production origin.