### PR TITLE
[codex] fix adaptive video object fallback playback

### DIFF
--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackCacheService.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackCacheService.java
@@ -40,4 +40,9 @@ public class AdaptiveVideoPlaybackCacheService {
             headObject(String storageKey) throws IOException {
         return videoBinaryStorageService.head(storageKey);
     }
+
+    public com.example.lms.shared.infrastructure.service.R2VideoStorageService.ObjectBytes
+            readObject(String storageKey, String rangeHeader) throws IOException {
+        return videoBinaryStorageService.readObject(storageKey, rangeHeader);
+    }
 }

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackService.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackService.java
@@ -110,6 +110,13 @@ public class AdaptiveVideoPlaybackService {
         return adaptiveVideoPlaybackCacheService.headObject(storageKey);
     }
 
+    public com.example.lms.shared.infrastructure.service.R2VideoStorageService.ObjectBytes
+            readObject(UUID assetId, String token, String storageKey, String rangeHeader) throws IOException {
+        validateClaims(token, assetId, null);
+        ensureStorageKeyAllowed(assetId, storageKey);
+        return adaptiveVideoPlaybackCacheService.readObject(storageKey, rangeHeader);
+    }
+
     private VideoPlaybackTokenService.PlaybackClaims validateClaims(String token, UUID assetId, String expectedFormat) {
         VideoPlaybackTokenService.PlaybackClaims claims = videoPlaybackTokenService.parseAndValidate(token);
         if (!assetId.equals(claims.assetId())) {

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/VideoBinaryStorageService.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/VideoBinaryStorageService.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -157,6 +158,27 @@ public class VideoBinaryStorageService {
         throw new IOException("No storage backend configured to head object");
     }
 
+    public R2VideoStorageService.ObjectBytes readObject(String storageKey, String rangeHeader) throws IOException {
+        if (r2VideoStorageService.isPresent()) {
+            return r2VideoStorageService.get().read(storageKey, rangeHeader);
+        }
+
+        Path tempFile = Files.createTempFile("video-object-", suffixFromStorageKey(storageKey));
+        try {
+            if (r2StorageService.isPresent()) {
+                r2StorageService.get().downloadToFile(storageKey, tempFile);
+                return readLocalObject(tempFile, rangeHeader);
+            }
+            if (localStorageService.isPresent()) {
+                localStorageService.get().downloadToFile(storageKey, tempFile);
+                return readLocalObject(tempFile, rangeHeader);
+            }
+            throw new IOException("No storage backend configured to read generated object");
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
     public void delete(String storageKey) {
         if (r2VideoStorageService.isPresent()) {
             r2VideoStorageService.get().delete(storageKey);
@@ -210,6 +232,66 @@ public class VideoBinaryStorageService {
         }
         return storageKey.substring(storageKey.lastIndexOf('.'));
     }
+
+    private R2VideoStorageService.ObjectBytes readLocalObject(Path file, String rangeHeader) throws IOException {
+        byte[] allBytes = Files.readAllBytes(file);
+        String contentType = Files.probeContentType(file);
+        ByteRange range = parseByteRange(rangeHeader, allBytes.length);
+        if (range == null) {
+            return new R2VideoStorageService.ObjectBytes(allBytes, allBytes.length, contentType, null);
+        }
+
+        byte[] bytes = Arrays.copyOfRange(allBytes, (int) range.start(), (int) range.end() + 1);
+        String contentRange = "bytes " + range.start() + "-" + range.end() + "/" + allBytes.length;
+        return new R2VideoStorageService.ObjectBytes(bytes, bytes.length, contentType, contentRange);
+    }
+
+    private ByteRange parseByteRange(String rangeHeader, long size) throws IOException {
+        if (rangeHeader == null || rangeHeader.isBlank()) {
+            return null;
+        }
+        String value = rangeHeader.trim();
+        if (!value.startsWith("bytes=") || value.contains(",")) {
+            return null;
+        }
+
+        String spec = value.substring("bytes=".length());
+        int dashIndex = spec.indexOf('-');
+        if (dashIndex < 0) {
+            return null;
+        }
+
+        String startPart = spec.substring(0, dashIndex).trim();
+        String endPart = spec.substring(dashIndex + 1).trim();
+        if (startPart.isBlank() && endPart.isBlank()) {
+            return null;
+        }
+
+        try {
+            long start;
+            long end;
+            if (startPart.isBlank()) {
+                long suffixLength = Long.parseLong(endPart);
+                if (suffixLength <= 0) {
+                    return null;
+                }
+                start = Math.max(0, size - suffixLength);
+                end = size - 1;
+            } else {
+                start = Long.parseLong(startPart);
+                end = endPart.isBlank() ? size - 1 : Long.parseLong(endPart);
+            }
+
+            if (start < 0 || end < start || start >= size) {
+                throw new IOException("Invalid Range header for video object");
+            }
+            return new ByteRange(start, Math.min(end, size - 1));
+        } catch (NumberFormatException exception) {
+            return null;
+        }
+    }
+
+    private record ByteRange(long start, long end) {}
 
     public record SourceBinary(
             Path path,

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackController.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackController.java
@@ -8,13 +8,13 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.UUID;
 
 @RestController
@@ -56,15 +56,27 @@ public class AdaptiveVideoPlaybackController {
     }
 
     @GetMapping("/{assetId}/adaptive/{token}/object")
-    public ResponseEntity<Void> redirectObject(
+    public ResponseEntity<byte[]> getObject(
             @PathVariable UUID assetId,
             @PathVariable String token,
-            @RequestParam String key
-    ) {
-        String redirectUrl = adaptiveVideoPlaybackService.resolveObjectRedirect(assetId, token, key);
-        return ResponseEntity.status(HttpStatus.FOUND)
-                .header(HttpHeaders.LOCATION, URI.create(redirectUrl).toString())
-                .build();
+            @RequestParam String key,
+            @RequestHeader(value = HttpHeaders.RANGE, required = false) String rangeHeader
+    ) throws IOException {
+        var object = adaptiveVideoPlaybackService.readObject(assetId, token, key, rangeHeader);
+        HttpStatus status = object.contentRange() == null ? HttpStatus.OK : HttpStatus.PARTIAL_CONTENT;
+        ResponseEntity.BodyBuilder builder = ResponseEntity.status(status)
+                .contentLength(object.contentLength())
+                .header(HttpHeaders.ACCEPT_RANGES, "bytes")
+                .header(HttpHeaders.CACHE_CONTROL, "private, max-age=30");
+
+        if (object.contentRange() != null && !object.contentRange().isBlank()) {
+            builder.header(HttpHeaders.CONTENT_RANGE, object.contentRange());
+        }
+        if (object.contentType() != null && !object.contentType().isBlank()) {
+            builder.contentType(MediaType.parseMediaType(object.contentType()));
+        }
+
+        return builder.body(object.bytes());
     }
 
     /**

--- a/backend/src/main/java/com/example/lms/shared/infrastructure/service/R2VideoStorageService.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/service/R2VideoStorageService.java
@@ -123,6 +123,29 @@ public class R2VideoStorageService {
 
     public record ObjectMetadata(long size, String contentType) {}
 
+    public ObjectBytes read(String storageKey, String rangeHeader) {
+        GetObjectRequest.Builder request = GetObjectRequest.builder()
+                .bucket(videoBucket)
+                .key(storageKey);
+
+        String normalizedRange = normalizeRangeHeader(rangeHeader);
+        if (normalizedRange != null) {
+            request.range(normalizedRange);
+        }
+
+        ResponseBytes<GetObjectResponse> response = r2Client.getObjectAsBytes(request.build());
+        byte[] bytes = response.asByteArray();
+        GetObjectResponse metadata = response.response();
+        return new ObjectBytes(
+                bytes,
+                bytes.length,
+                metadata.contentType(),
+                metadata.contentRange()
+        );
+    }
+
+    public record ObjectBytes(byte[] bytes, long contentLength, String contentType, String contentRange) {}
+
     public void downloadToFile(String storageKey, Path destination) throws IOException {
         if (destination.getParent() != null) {
             Files.createDirectories(destination.getParent());
@@ -196,6 +219,18 @@ public class R2VideoStorageService {
                         .build())
                 .build();
         return r2Presigner.presignUploadPart(request).url().toString();
+    }
+
+    private String normalizeRangeHeader(String rangeHeader) {
+        if (rangeHeader == null || rangeHeader.isBlank()) {
+            return null;
+        }
+        String value = rangeHeader.trim();
+        if (!value.startsWith("bytes=") || value.contains(",")) {
+            return null;
+        }
+        String spec = value.substring("bytes=".length());
+        return spec.matches("(\\d+-\\d*|-\\d+)") ? value : null;
     }
 
     public void completeMultipartUpload(String storageKey, String uploadId, List<CompletedUploadPart> parts) {

--- a/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackServiceTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/service/AdaptiveVideoPlaybackServiceTest.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -225,5 +226,30 @@ class AdaptiveVideoPlaybackServiceTest {
         String redirectUrl = service.resolveObjectRedirect(assetId, token, storageKey);
 
         assertThat(redirectUrl).isEqualTo("https://signed.example/segment.m4s");
+    }
+
+    @Test
+    @DisplayName("readObject validates the playback token and reads same-origin bytes")
+    void readObjectValidatesTokenAndReadsBytes() throws Exception {
+        UUID assetId = UUID.randomUUID();
+        String token = "play-token";
+        String storageKey = "video-packages/" + assetId + "/segments/standard/1.m4s";
+        String rangeHeader = "bytes=0-1023";
+        var objectBytes = new com.example.lms.shared.infrastructure.service.R2VideoStorageService.ObjectBytes(
+                new byte[]{1, 2, 3},
+                3,
+                "video/iso.segment",
+                "bytes 0-2/10"
+        );
+
+        when(videoPlaybackTokenService.parseAndValidate(token)).thenReturn(
+                new VideoPlaybackTokenService.PlaybackClaims(assetId, UUID.randomUUID(), "hls")
+        );
+        when(adaptiveVideoPlaybackCacheService.readObject(storageKey, rangeHeader)).thenReturn(objectBytes);
+
+        var result = service.readObject(assetId, token, storageKey, rangeHeader);
+
+        assertThat(result).isSameAs(objectBytes);
+        verify(adaptiveVideoPlaybackCacheService).readObject(storageKey, rangeHeader);
     }
 }

--- a/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackControllerTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackControllerTest.java
@@ -1,0 +1,53 @@
+package com.example.lms.learning_delivery.infrastructure.web;
+
+import com.example.lms.learning_delivery.infrastructure.service.AdaptiveVideoPlaybackService;
+import com.example.lms.shared.infrastructure.service.R2VideoStorageService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdaptiveVideoPlaybackControllerTest {
+
+    @Mock
+    private AdaptiveVideoPlaybackService adaptiveVideoPlaybackService;
+
+    @InjectMocks
+    private AdaptiveVideoPlaybackController controller;
+
+    @Test
+    @DisplayName("object endpoint streams same-origin bytes with range headers")
+    void objectEndpointStreamsSameOriginBytesWithRangeHeaders() throws Exception {
+        UUID assetId = UUID.randomUUID();
+        String token = "play-token";
+        String key = "video-packages/" + assetId + "/segments/saver/1.m4s";
+        String rangeHeader = "bytes=0-2";
+        byte[] bytes = new byte[]{1, 2, 3};
+
+        when(adaptiveVideoPlaybackService.readObject(assetId, token, key, rangeHeader))
+                .thenReturn(new R2VideoStorageService.ObjectBytes(
+                        bytes,
+                        bytes.length,
+                        "video/iso.segment",
+                        "bytes 0-2/10"
+                ));
+
+        var response = controller.getObject(assetId, token, key, rangeHeader);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(206);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.LOCATION)).isNull();
+        assertThat(response.getHeaders().getFirst(HttpHeaders.ACCEPT_RANGES)).isEqualTo("bytes");
+        assertThat(response.getHeaders().getFirst(HttpHeaders.CONTENT_RANGE)).isEqualTo("bytes 0-2/10");
+        assertThat(response.getHeaders().getContentLength()).isEqualTo(bytes.length);
+        assertThat(response.getBody()).containsExactly(bytes);
+    }
+}


### PR DESCRIPTION
## Summary
- Stream adaptive video object bytes from the backend fallback endpoint instead of redirecting browser playback to raw R2 presigned URLs.
- Preserve range semantics with `Accept-Ranges`, `Content-Range`, and `206 Partial Content` so Shaka/HLS segment requests remain same-origin when media-domain edge auth is not active.
- Add focused service/controller coverage for token validation and same-origin object streaming.

## Verification
- `git diff --check`
- `mvn -Dtest=AdaptiveVideoPlaybackServiceTest,AdaptiveVideoPlaybackControllerTest test`
- `mvn test` (1111 tests, 0 failures)

## Production context
The production interactive video lesson rendered the timeline overlay correctly, but adaptive playback showed "Khong tai duoc video" because `/object` responses were issuing `302` redirects to `*.r2.cloudflarestorage.com`. This PR keeps the fallback path browser-safe while preserving the existing media-domain path for scaled delivery.
