### PR TITLE
[codex] Polish interactive video flow

### DIFF
--- a/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/LearningActivityUseCase.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/LearningActivityUseCase.java
@@ -85,11 +85,26 @@ public class LearningActivityUseCase {
     public void recordInteractiveVideoEvent(UUID studentId, UUID lessonId, String sectionId,
                                             String interactionId, String action,
                                             double videoTimeSeconds, Map<String, Object> data) {
+        recordInteractiveVideoEvent(studentId, lessonId, sectionId, interactionId, action,
+                videoTimeSeconds, data, null, null);
+    }
+
+    @Transactional
+    public void recordInteractiveVideoEvent(UUID studentId, UUID lessonId, String sectionId,
+                                            String interactionId, String action,
+                                            double videoTimeSeconds, Map<String, Object> data,
+                                            Instant occurredAt, String entityId) {
         Map<String, Object> eventData = new java.util.LinkedHashMap<>();
         eventData.put("interactionId", interactionId);
         eventData.put("action", action);
         eventData.put("videoTimeSeconds", videoTimeSeconds);
         eventData.put("data", data != null ? data : Map.of());
+        if (occurredAt != null) {
+            eventData.put("occurredAt", occurredAt.toString());
+        }
+        if (entityId != null && !entityId.isBlank()) {
+            eventData.put("entityId", entityId);
+        }
 
         learningEventRepository.save(LearningEvent.create(
                 studentId,
@@ -188,7 +203,9 @@ public class LearningActivityUseCase {
             String interactionId,
             String action,
             double videoTimeSeconds,
-            Map<String, Object> data
+            Map<String, Object> data,
+            Instant occurredAt,
+            String entityId
     ) {}
 
     public record ContinueWhereLeftOffDTO(

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/LearningActivityControllerV3.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/LearningActivityControllerV3.java
@@ -86,7 +86,9 @@ public class LearningActivityControllerV3 {
                 request.interactionId(),
                 request.action(),
                 request.videoTimeSeconds(),
-                request.data()
+                request.data(),
+                request.occurredAt(),
+                request.entityId()
         );
         return ResponseEntity.ok(ApiResponse.success(null, "Đã ghi nhận tương tác video"));
     }

--- a/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/LearningActivityUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/LearningActivityUseCaseTest.java
@@ -91,6 +91,7 @@ class LearningActivityUseCaseTest {
     @DisplayName("recordInteractiveVideoEvent saves interaction metadata")
     void recordInteractiveVideoEventSavesEvent() {
         when(learningEventRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        Instant occurredAt = Instant.parse("2026-05-06T10:15:30Z");
 
         useCase.recordInteractiveVideoEvent(
                 studentId,
@@ -99,7 +100,9 @@ class LearningActivityUseCaseTest {
                 "iv-1",
                 "answered",
                 42.5,
-                Map.of("choiceId", "choice-a", "isCorrect", true)
+                Map.of("choiceId", "choice-a", "isCorrect", true),
+                occurredAt,
+                "iv-1"
         );
 
         ArgumentCaptor<LearningEvent> captor = ArgumentCaptor.forClass(LearningEvent.class);
@@ -113,7 +116,9 @@ class LearningActivityUseCaseTest {
         assertThat(saved.getEventData())
                 .containsEntry("interactionId", "iv-1")
                 .containsEntry("action", "answered")
-                .containsEntry("videoTimeSeconds", 42.5);
+                .containsEntry("videoTimeSeconds", 42.5)
+                .containsEntry("occurredAt", occurredAt.toString())
+                .containsEntry("entityId", "iv-1");
         assertThat(saved.getEventData().get("data"))
                 .isEqualTo(Map.of("choiceId", "choice-a", "isCorrect", true));
     }

--- a/fe/package.json
+++ b/fe/package.json
@@ -9,7 +9,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "test:coverage": "ng test --code-coverage",
-    "test:ci": "ng test --watch=false --browsers=ChromeHeadlessCI",
+    "test:ci": "ng test --watch=false --browsers=ChromeHeadlessNoSandbox",
     "test:e2e": "playwright test",
     "test:e2e:smoke": "npm run build && playwright test --config=playwright.smoke.config.ts --grep @smoke",
     "test:e2e:release": "npm run build && playwright test --config=playwright.smoke.config.ts --grep \"@smoke|@release\"",

--- a/fe/src/app/api/client/learning-activity.api.ts
+++ b/fe/src/app/api/client/learning-activity.api.ts
@@ -23,6 +23,8 @@ export interface InteractiveVideoEventRequest {
   action: string;
   videoTimeSeconds: number;
   data?: Record<string, unknown>;
+  occurredAt?: string;
+  entityId?: string;
 }
 
 export interface ContinueWhereLeftOffResponse {

--- a/fe/src/app/features/learning/pages/course-learning.component.ts
+++ b/fe/src/app/features/learning/pages/course-learning.component.ts
@@ -26,6 +26,11 @@ import { NetworkStatusService } from '../../../core/services/network-status.serv
 import { OfflineSyncService } from '../../../core/services/offline-sync.service';
 import { getOfflineCourseStaleCopy } from '../../../core/utils/offline-course-staleness';
 import { IconComponent } from '../../../shared/components/icon/icon.component';
+import {
+  hasPlayableVideoContent,
+  isPlayableVideoSection,
+  resolveProgressTrackingVideoSectionId,
+} from '../utils/video-section-gating';
 
 /**
  * Course Learning Component
@@ -620,7 +625,7 @@ export class CourseLearningComponent implements OnInit {
         const currentSection = currentLesson.sections[this.currentSectionIndex()];
 
         // 🔒 VIDEO: always check server-side threshold
-        if (currentSection.type === 'VIDEO' && (currentSection.videoUrl || currentSection.streamVideoUid)) {
+        if (isPlayableVideoSection(currentSection)) {
           const canProceed = await this.ensureVideoProgressThreshold(currentSection.id, 'next-section');
           if (!canProceed) return;
         }
@@ -714,7 +719,7 @@ export class CourseLearningComponent implements OnInit {
     }
 
     // 🔒 VIDEO: always check server-side threshold
-    if (currentSection.type === 'VIDEO' && (currentSection.videoUrl || currentSection.streamVideoUid)) {
+    if (isPlayableVideoSection(currentSection)) {
       const canProceed = await this.ensureVideoProgressThreshold(currentSection.id, 'complete-section');
       if (!canProceed) {
         return false;
@@ -774,14 +779,14 @@ export class CourseLearningComponent implements OnInit {
       // Ignore best-effort completion lookup and continue with backend sync.
     }
 
-    if (this.hasVideoContent(lesson)) {
-      const videoSection = this.getFirstVideoSection(lesson);
-      if (!videoSection) {
+    if (hasPlayableVideoContent(lesson)) {
+      const videoSectionId = resolveProgressTrackingVideoSectionId(lesson);
+      if (!videoSectionId) {
         this.toast.error('Không tìm thấy video trong bài học này.');
         return false;
       }
 
-      const canProceed = await this.ensureVideoProgressThreshold(videoSection.id, 'complete-lesson');
+      const canProceed = await this.ensureVideoProgressThreshold(videoSectionId, 'complete-lesson');
       if (!canProceed) {
         return false;
       }
@@ -803,27 +808,6 @@ export class CourseLearningComponent implements OnInit {
       this.toast.error('Không thể cập nhật trạng thái hoàn thành. Vui lòng thử lại.');
       return false;
     }
-  }
-
-  // Helper: Check if lesson has video content
-  private hasVideoContent(lesson: any): boolean {
-    // Check if lesson has videoUrl (fallback)
-    if (lesson.videoUrl || lesson.streamVideoUid) {
-      return true;
-    }
-    // Check if lesson has sections with VIDEO type
-    if (lesson.sections && lesson.sections.length > 0) {
-      return lesson.sections.some((s: any) => s.type === 'VIDEO' && (s.videoUrl || s.streamVideoUid));
-    }
-    return false;
-  }
-
-  // Helper: Get first video section from lesson
-  private getFirstVideoSection(lesson: any): any {
-    if (lesson.sections && lesson.sections.length > 0) {
-      return lesson.sections.find((s: any) => s.type === 'VIDEO' && (s.videoUrl || s.streamVideoUid));
-    }
-    return null;
   }
 
   // Section completion helpers

--- a/fe/src/app/features/learning/utils/video-section-gating.spec.ts
+++ b/fe/src/app/features/learning/utils/video-section-gating.spec.ts
@@ -1,0 +1,81 @@
+import type { LessonDetail, SectionContent } from '../models/learning.models';
+import { LessonType } from '../models/lesson-types.enum';
+import {
+  getFirstPlayableVideoSection,
+  hasPlayableVideoContent,
+  isPlayableVideoSection,
+  resolveProgressTrackingVideoSectionId,
+} from './video-section-gating';
+
+describe('video-section-gating', () => {
+  const buildSection = (overrides: Partial<SectionContent> = {}): SectionContent => ({
+    id: 'section-1',
+    title: 'Video section',
+    type: 'VIDEO',
+    orderIndex: 0,
+    isRequired: true,
+    ...overrides,
+  });
+
+  const buildLesson = (overrides: Partial<LessonDetail> = {}): LessonDetail => ({
+    id: 'lesson-1',
+    title: 'Lesson',
+    description: '',
+    lessonType: LessonType.LECTURE,
+    duration: 0,
+    orderIndex: 0,
+    content: '',
+    attachments: [],
+    sectionId: 'chapter-1',
+    sectionTitle: 'Chapter',
+    courseId: 'course-1',
+    courseTitle: 'Course',
+    sections: [],
+    ...overrides,
+  });
+
+  it('treats uploaded adaptive video sections as gated video content', () => {
+    const section = buildSection({
+      videoAssetId: 'asset-1',
+      videoUrl: undefined,
+      streamVideoUid: undefined,
+    });
+
+    expect(isPlayableVideoSection(section)).toBeTrue();
+    expect(hasPlayableVideoContent(buildLesson({ sections: [section] }))).toBeTrue();
+    expect(getFirstPlayableVideoSection(buildLesson({ sections: [section] }))?.id).toBe('section-1');
+  });
+
+  it('keeps ADAPTIVE_R2 sections gated even when only source metadata is present', () => {
+    const section = buildSection({
+      videoAssetId: undefined,
+      videoUrl: undefined,
+      streamVideoUid: undefined,
+      videoSourceKind: 'ADAPTIVE_R2',
+    });
+
+    expect(isPlayableVideoSection(section)).toBeTrue();
+  });
+
+  it('does not gate non-video sections or empty video shells', () => {
+    expect(isPlayableVideoSection(buildSection({ videoAssetId: undefined }))).toBeFalse();
+    expect(isPlayableVideoSection({
+      id: 'text-1',
+      type: 'TEXT',
+      title: 'Reading',
+      orderIndex: 0,
+      isRequired: true,
+      videoAssetId: 'asset-1',
+    })).toBeFalse();
+  });
+
+  it('resolves the server progress id for section-level and lesson-level videos', () => {
+    expect(resolveProgressTrackingVideoSectionId(buildLesson({
+      sections: [buildSection({ streamVideoUid: 'stream-1' })],
+    }))).toBe('section-1');
+
+    expect(resolveProgressTrackingVideoSectionId(buildLesson({
+      videoUrl: 'https://cdn.example.com/video.mp4',
+    }))).toBe('lesson-lesson-1');
+  });
+});

--- a/fe/src/app/features/learning/utils/video-section-gating.ts
+++ b/fe/src/app/features/learning/utils/video-section-gating.ts
@@ -1,0 +1,67 @@
+import type { LessonDetail, SectionContent } from '../models/learning.models';
+
+type PlayableVideoSource = {
+  videoUrl?: string | null;
+  streamVideoUid?: string | null;
+  videoAssetId?: string | null;
+  videoSourceKind?: string | null;
+  videoType?: string | null;
+};
+
+export function hasPlayableVideoSource(source: PlayableVideoSource | null | undefined): boolean {
+  if (!source) {
+    return false;
+  }
+
+  return Boolean(
+    hasText(source.videoUrl)
+    || hasText(source.streamVideoUid)
+    || hasText(source.videoAssetId)
+    || source.videoSourceKind === 'ADAPTIVE_R2'
+    || source.videoType === 'ADAPTIVE_R2',
+  );
+}
+
+export function isPlayableVideoSection(
+  section: Partial<SectionContent> | null | undefined,
+): boolean {
+  return section?.type === 'VIDEO' && hasPlayableVideoSource(section);
+}
+
+export function hasPlayableVideoContent(
+  lesson: Partial<LessonDetail> | null | undefined,
+): boolean {
+  if (!lesson) {
+    return false;
+  }
+
+  return hasPlayableVideoSource(lesson)
+    || (Array.isArray(lesson.sections) && lesson.sections.some(isPlayableVideoSection));
+}
+
+export function getFirstPlayableVideoSection(
+  lesson: Partial<LessonDetail> | null | undefined,
+): SectionContent | null {
+  if (!Array.isArray(lesson?.sections)) {
+    return null;
+  }
+
+  return lesson.sections.find(isPlayableVideoSection) ?? null;
+}
+
+export function resolveProgressTrackingVideoSectionId(
+  lesson: Partial<LessonDetail> | null | undefined,
+): string | null {
+  const section = getFirstPlayableVideoSection(lesson);
+  if (hasText(section?.id)) {
+    return section.id;
+  }
+
+  return hasPlayableVideoSource(lesson) && hasText(lesson?.id)
+    ? `lesson-${lesson.id}`
+    : null;
+}
+
+function hasText(value: string | null | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}

--- a/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.spec.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.spec.ts
@@ -36,6 +36,9 @@ describe('InteractiveVideoOverlayComponent', () => {
     expect(dialog.getAttribute('aria-labelledby')).toBe('interactive-video-title-q1');
     expect(dialog.getAttribute('aria-describedby')).toBe('interactive-video-body-q1');
     expect(continueButton.disabled).toBeTrue();
+    expect(continueButton.getAttribute('aria-describedby')).toBe('interactive-video-choice-hint-q1');
+    expect(element.querySelector('#interactive-video-choice-hint-q1')?.textContent?.trim())
+      .toBe('Chọn một phương án để tiếp tục.');
 
     fixture.componentRef.setInput('selectedChoiceId', 'a');
     fixture.detectChanges();
@@ -44,5 +47,7 @@ describe('InteractiveVideoOverlayComponent', () => {
       .find(button => button.textContent?.includes('Check the chart')) as HTMLButtonElement;
     expect(selectedChoice.getAttribute('aria-pressed')).toBe('true');
     expect(continueButton.disabled).toBeFalse();
+    expect(continueButton.hasAttribute('aria-describedby')).toBeFalse();
+    expect(element.querySelector('#interactive-video-choice-hint-q1')).toBeNull();
   });
 });

--- a/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
@@ -79,11 +79,17 @@ import type {
           </p>
         }
 
-        <div class="mt-4 flex justify-end">
+        <div class="mt-4 flex items-center justify-between gap-3">
+          @if (requiresChoiceBeforeContinue()) {
+            <p [id]="choiceRequirementHintId()" class="min-w-0 text-xs font-medium text-slate-500">
+              Chọn một phương án để tiếp tục.
+            </p>
+          }
           <button
             type="button"
-            class="rounded-lg bg-[#0056D2] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#004BB5] disabled:cursor-not-allowed disabled:opacity-50"
+            class="ml-auto shrink-0 rounded-lg bg-[#0056D2] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#004BB5] disabled:cursor-not-allowed disabled:opacity-50"
             [disabled]="requiresChoiceBeforeContinue()"
+            [attr.aria-describedby]="requiresChoiceBeforeContinue() ? choiceRequirementHintId() : null"
             (click)="continueRequested.emit()">
             Tiếp tục
           </button>
@@ -103,6 +109,7 @@ export class InteractiveVideoOverlayComponent {
   readonly hasChoices = computed(() => (this.interaction().choices?.length ?? 0) > 0);
   readonly titleId = computed(() => `interactive-video-title-${this.interaction().id}`);
   readonly bodyId = computed(() => `interactive-video-body-${this.interaction().id}`);
+  readonly choiceRequirementHintId = computed(() => `interactive-video-choice-hint-${this.interaction().id}`);
 
   constructor() {
     effect(() => {


### PR DESCRIPTION
﻿## Summary
- Tighten learner video gating so uploaded/adaptive R2 videos require the same server-side progress threshold as URL/Stream videos before next/complete actions.
- Preserve interactive-video event `occurredAt` and `entityId` through the API into `LearningEvent` metadata for better analytics/audit trails.
- Add a small required-choice UX hint with accessibility wiring on the interactive overlay.
- Add focused frontend coverage for video-source gating and adjust the Angular 20 CI test launcher to the built-in headless no-sandbox profile.

## Validation
- `mvn "-Dtest=LearningActivityUseCaseTest,SyncUseCaseTest" test` — 41 tests, 0 failures.
- `npm run build` — passed; existing Angular/Sass/CommonJS warnings remain unrelated.
- `git diff --check` — passed.

## Notes
- Local Karma/Chrome test execution still hung after bundle generation on this Windows desktop, so the targeted frontend specs were added and type-checked by the production build but not completed by the local browser runner here.
