### PR TITLE
[codex] Polish interactive video authoring guardrails

### DIFF
--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
@@ -101,6 +101,49 @@
       </div>
     </div>
 
+    @if (svc.sectionInteractiveVideoEnabled()) {
+      <div class="border-b border-slate-100 px-4 py-3">
+        <div
+          [class]="interactiveVideoQualitySummary().toneClass"
+          role="status"
+          aria-live="polite">
+          <div class="flex items-start gap-2.5">
+            <lucide-icon
+              [name]="interactiveVideoQualitySummary().iconName"
+              [size]="16"
+              class="mt-0.5 shrink-0"></lucide-icon>
+            <div class="min-w-0 flex-1">
+              <p class="text-sm font-semibold">{{ interactiveVideoQualitySummary().title }}</p>
+              <p class="mt-0.5 text-xs leading-relaxed opacity-90">{{ interactiveVideoQualitySummary().body }}</p>
+            </div>
+          </div>
+
+          @if (visibleInteractiveVideoQualityIssues().length > 0) {
+            <div class="mt-2 grid gap-1.5">
+              @for (issue of visibleInteractiveVideoQualityIssues(); track issue.code + '-' + (issue.interactionId || '') + '-' + (issue.choiceId || '')) {
+                <div [class]="getInteractiveQualityIssueClass(issue)">
+                  <div class="flex items-start gap-2">
+                    <lucide-icon
+                      [name]="getInteractiveQualityIssueIconName(issue)"
+                      [size]="13"
+                      class="mt-0.5 shrink-0"></lucide-icon>
+                    <span class="min-w-0 flex-1">{{ issue.message }}</span>
+                    @if (issue.interactionId) {
+                      <button type="button"
+                        (click)="focusInteractiveQualityIssue(issue)"
+                        class="shrink-0 rounded-md px-2 py-0.5 text-[11px] font-semibold text-[#0056D2] hover:bg-[#0056D2]/5">
+                        Sửa
+                      </button>
+                    }
+                  </div>
+                </div>
+              }
+            </div>
+          }
+        </div>
+      </div>
+    }
+
     @if (interactiveVideoFlowNodes().length > 0) {
       <section class="border-b border-slate-100 bg-slate-50/50 p-4" aria-label="Sơ đồ luồng video tương tác">
         <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
@@ -124,10 +167,15 @@
             <div class="absolute left-0 right-0 top-1/2 h-1 -translate-y-1/2 rounded-full bg-slate-100"></div>
             @for (node of interactiveVideoFlowNodes(); track node.id) {
               <button type="button"
+                role="slider"
                 class="interactive-timeline-dot absolute top-1/2 flex h-7 w-7 -translate-x-1/2 -translate-y-1/2 touch-none items-center justify-center rounded-full border border-white bg-[#0056D2] text-[10px] font-bold text-white shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0056D2] focus-visible:ring-offset-2"
                 [style.left.%]="getTimelinePercent(node.atSeconds)"
                 [attr.aria-current]="timelineDraggingInteractionId() === node.id ? 'true' : null"
                 [attr.aria-label]="'Chỉnh điểm ' + node.index + ' tại ' + node.timeLabel"
+                [attr.aria-valuemin]="0"
+                [attr.aria-valuemax]="timelineMaxSeconds()"
+                [attr.aria-valuenow]="node.atSeconds"
+                [attr.aria-valuetext]="node.timeLabel"
                 [attr.title]="'Kéo để đổi thời điểm · ' + node.timeLabel"
                 (click)="onTimelineDotClick(node)"
                 (keydown)="onFlowNodeKeydown($event, node)"

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
@@ -21,7 +21,9 @@ import type {
 import { CurriculumEditorService } from '../../../../services/curriculum-editor.service';
 import {
   buildInteractiveVideoSpec,
+  getInteractiveVideoAuthoringIssues,
   suggestNextInteractiveVideoTimeSeconds,
+  type InteractiveVideoAuthoringIssue,
 } from '../../../../utils/interactive-video-authoring';
 import {
   exportInteractiveVideoBundle,
@@ -53,6 +55,13 @@ interface InteractiveVideoFlowNode {
   choices: InteractiveVideoFlowChoice[];
   required: boolean;
   pause: boolean;
+}
+
+interface InteractiveVideoQualitySummary {
+  iconName: string;
+  title: string;
+  body: string;
+  toneClass: string;
 }
 
 @Component({
@@ -148,6 +157,50 @@ export class InteractiveVideoAuthoringPanelComponent {
       required: nodes.filter(node => node.required).length,
     };
   });
+  readonly timelineMaxSeconds = computed(() => this.getTimelineScaleMaxSeconds());
+  readonly interactiveVideoQualityIssues = computed(() =>
+    getInteractiveVideoAuthoringIssues(
+      this.svc.sectionInteractiveVideoEnabled(),
+      this.svc.sectionInteractiveVideoTimeline(),
+      { durationSeconds: this.svc.sectionVideoDurationSec() },
+    ),
+  );
+  readonly interactiveVideoQualitySummary = computed<InteractiveVideoQualitySummary>(() => {
+    const issues = this.interactiveVideoQualityIssues();
+    const errorCount = issues.filter(issue => issue.severity === 'error').length;
+    const warningCount = issues.filter(issue => issue.severity === 'warning').length;
+    const baseClass = 'rounded-lg border px-3 py-2.5';
+
+    if (errorCount > 0) {
+      return {
+        iconName: 'alert-circle',
+        title: `${errorCount} việc cần sửa trước khi lưu`,
+        body: warningCount > 0
+          ? `Có thêm ${warningCount} điểm nên rà soát.`
+          : 'Các lỗi này có thể làm học viên bị kẹt hoặc dữ liệu ghi nhận sai.',
+        toneClass: `${baseClass} border-red-200 bg-red-50 text-red-800`,
+      };
+    }
+
+    if (warningCount > 0) {
+      return {
+        iconName: 'alert-triangle',
+        title: `${warningCount} điểm nên rà soát`,
+        body: 'Bài vẫn có thể lưu, nhưng các điểm này dễ làm học viên hiểu nhầm.',
+        toneClass: `${baseClass} border-amber-200 bg-amber-50 text-amber-800`,
+      };
+    }
+
+    return {
+      iconName: 'check-circle-2',
+      title: 'Luồng tương tác ổn',
+      body: 'Thời điểm, lựa chọn và nhánh đang hợp lệ để lưu.',
+      toneClass: `${baseClass} border-emerald-200 bg-emerald-50 text-emerald-800`,
+    };
+  });
+  readonly visibleInteractiveVideoQualityIssues = computed(() =>
+    this.interactiveVideoQualityIssues().slice(0, 5),
+  );
 
   onInteractiveVideoEnabledChange(enabled: boolean): void {
     this.svc.setInteractiveVideoEnabled(enabled);
@@ -332,6 +385,7 @@ export class InteractiveVideoAuthoringPanelComponent {
     if (event.button !== 0) {
       return;
     }
+    event.preventDefault();
     this.timelineDraggingInteractionId.set(node.id);
     this.suppressNextTimelineClick = false;
     (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
@@ -456,6 +510,22 @@ export class InteractiveVideoAuthoringPanelComponent {
   onFlowNodeDragEnd(): void {
     this.draggingInteractionId.set(null);
     this.dropTargetInteractionId.set(null);
+  }
+
+  getInteractiveQualityIssueClass(issue: InteractiveVideoAuthoringIssue): string {
+    return issue.severity === 'error'
+      ? 'rounded-lg border border-red-100 bg-white px-3 py-2 text-xs leading-relaxed text-red-700'
+      : 'rounded-lg border border-amber-100 bg-white px-3 py-2 text-xs leading-relaxed text-amber-700';
+  }
+
+  getInteractiveQualityIssueIconName(issue: InteractiveVideoAuthoringIssue): string {
+    return issue.severity === 'error' ? 'x-circle' : 'alert-triangle';
+  }
+
+  focusInteractiveQualityIssue(issue: InteractiveVideoAuthoringIssue): void {
+    if (issue.interactionId) {
+      this.scrollInteractiveNodeIntoView(issue.interactionId);
+    }
   }
 
   private moveInteractionBefore(sourceId: string, targetId: string): void {

--- a/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
+++ b/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
@@ -28,7 +28,9 @@ import {
   choiceTypeNeedsChoices,
   createInteractiveVideoChoice,
   createInteractiveVideoInteraction,
+  getInteractiveVideoAuthoringIssues,
   normalizeInteractiveVideoSpec,
+  removeInteractiveVideoInteractionAndRetargetBranches,
 } from '../utils/interactive-video-authoring';
 import {
   probeVideoFile,
@@ -256,7 +258,7 @@ export class CurriculumEditorService {
 
   removeInteractiveVideoInteraction(interactionId: string): void {
     this.sectionInteractiveVideoTimeline.update(
-      timeline => timeline.filter(interaction => interaction.id !== interactionId),
+      timeline => removeInteractiveVideoInteractionAndRetargetBranches(timeline, interactionId),
     );
     this.markDirty();
   }
@@ -721,60 +723,14 @@ export class CurriculumEditorService {
   // ── Internal ─────────────────────────────────────────────────────────
 
   private validateInteractiveVideoAuthoring(): boolean {
-    if (!this.sectionInteractiveVideoEnabled()) {
-      return true;
-    }
+    const blockingIssue = getInteractiveVideoAuthoringIssues(
+      this.sectionInteractiveVideoEnabled(),
+      this.sectionInteractiveVideoTimeline(),
+      { durationSeconds: this.sectionVideoDurationSec() },
+    ).find(issue => issue.severity === 'error');
 
-    const timeline = this.sectionInteractiveVideoTimeline();
-    if (timeline.length === 0) {
-      this.toast.error('Hãy thêm ít nhất một điểm tương tác hoặc tắt Video tương tác.');
-      return false;
-    }
-
-    const durationSeconds = this.sectionVideoDurationSec();
-    const maxInteractiveSeconds = durationSeconds
-      ? Math.max(0, Math.round(durationSeconds) - 1)
-      : null;
-    if (maxInteractiveSeconds != null && timeline.some(interaction => interaction.atSeconds > maxInteractiveSeconds)) {
-      this.toast.error('Có điểm tương tác nằm sau thời lượng video. Hãy chỉnh lại thời điểm.');
-      return false;
-    }
-    if (maxInteractiveSeconds != null && timeline.some(interaction =>
-      (interaction.choices ?? []).some(choice =>
-        choice.targetTimeSeconds != null && choice.targetTimeSeconds > maxInteractiveSeconds,
-      ),
-    )) {
-      this.toast.error('Có nhánh rẽ tới thời điểm nằm sau thời lượng video. Hãy chỉnh lại điểm đích.');
-      return false;
-    }
-
-    const invalidChoiceInteraction = timeline.find(interaction =>
-      choiceTypeNeedsChoices(interaction.type)
-      && (interaction.choices?.filter(choice => choice.label.trim()).length ?? 0) < 2,
-    );
-    if (invalidChoiceInteraction) {
-      this.toast.error('Câu hỏi và rẽ nhánh cần ít nhất 2 lựa chọn có nội dung.');
-      return false;
-    }
-
-    const questionWithoutCorrectAnswer = timeline.find(interaction =>
-      interaction.type === 'single_choice'
-      && !(interaction.choices ?? []).some(choice => choice.isCorrect === true),
-    );
-    if (questionWithoutCorrectAnswer) {
-      this.toast.error('Mỗi câu hỏi cần một đáp án đúng.');
-      return false;
-    }
-
-    const interactionIds = new Set(timeline.map(interaction => interaction.id));
-    const branchWithMissingTarget = timeline.find(interaction =>
-      interaction.type === 'branch'
-      && (interaction.choices ?? []).some(choice =>
-        Boolean(choice.targetInteractionId) && !interactionIds.has(choice.targetInteractionId!),
-      ),
-    );
-    if (branchWithMissingTarget) {
-      this.toast.error('Có nhánh đang trỏ tới điểm tương tác không còn tồn tại.');
+    if (blockingIssue) {
+      this.toast.error(blockingIssue.message);
       return false;
     }
 

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.spec.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.spec.ts
@@ -1,7 +1,9 @@
 import {
   buildInteractiveVideoSpec,
   createInteractiveVideoInteraction,
+  getInteractiveVideoAuthoringIssues,
   normalizeInteractiveVideoSpec,
+  removeInteractiveVideoInteractionAndRetargetBranches,
   suggestNextInteractiveVideoTimeSeconds,
 } from './interactive-video-authoring';
 import type { InteractiveVideoInteraction } from '../../../../api/types/interactive-video.types';
@@ -98,5 +100,81 @@ describe('interactive-video-authoring', () => {
     expect(spec?.timeline[0].atSeconds).toBe(12);
     expect(spec?.timeline[0].body).toBe('What is next?');
     expect(spec?.timeline[0].choices?.map(choice => choice.label)).toEqual(['Correct', 'Wrong']);
+  });
+
+  it('reports blocking authoring issues before saving', () => {
+    const timeline: InteractiveVideoInteraction[] = [
+      {
+        id: 'q1',
+        type: 'single_choice',
+        atSeconds: 120,
+        title: 'Question',
+        pause: true,
+        required: true,
+        choices: [
+          { id: 'a', label: '', isCorrect: true },
+          { id: 'b', label: 'Second option' },
+        ],
+      },
+      {
+        id: 'b1',
+        type: 'branch',
+        atSeconds: 10,
+        title: 'Branch',
+        pause: true,
+        choices: [
+          { id: 'go', label: 'Go', targetInteractionId: 'missing' },
+          { id: 'stay', label: 'Stay', targetTimeSeconds: 20 },
+        ],
+      },
+    ];
+
+    const issues = getInteractiveVideoAuthoringIssues(true, timeline, { durationSeconds: 60 });
+
+    expect(issues.some(issue => issue.code === 'interaction_after_duration')).toBeTrue();
+    expect(issues.some(issue => issue.code === 'too_few_choices')).toBeTrue();
+    expect(issues.some(issue => issue.code === 'blank_correct_answer')).toBeTrue();
+    expect(issues.some(issue => issue.code === 'missing_branch_target')).toBeTrue();
+  });
+
+  it('surfaces teacher-friendly warnings without blocking a valid flow', () => {
+    const timeline: InteractiveVideoInteraction[] = [
+      {
+        id: 'q1',
+        type: 'single_choice',
+        atSeconds: 12,
+        title: '',
+        body: '',
+        pause: true,
+        choices: [
+          { id: 'a', label: 'Lựa chọn 1', isCorrect: true },
+          { id: 'b', label: 'Lựa chọn 2' },
+        ],
+      },
+      { id: 'pause', type: 'checkpoint', atSeconds: 12, title: 'Pause', pause: true },
+    ];
+
+    const issues = getInteractiveVideoAuthoringIssues(true, timeline, { durationSeconds: 90 });
+
+    expect(issues.every(issue => issue.severity === 'warning')).toBeTrue();
+    expect(issues.some(issue => issue.code === 'empty_student_copy')).toBeTrue();
+    expect(issues.some(issue => issue.code === 'placeholder_choice_label')).toBeTrue();
+    expect(issues.some(issue => issue.code === 'duplicate_timestamp')).toBeTrue();
+  });
+
+  it('retargets branches to the removed timestamp when deleting an interaction', () => {
+    const timeline: InteractiveVideoInteraction[] = [
+      { id: 'branch', type: 'branch', atSeconds: 10, pause: true, choices: [
+        { id: 'a', label: 'Next', targetInteractionId: 'target', targetTimeSeconds: null },
+      ] },
+      { id: 'target', type: 'checkpoint', atSeconds: 45, title: 'Target', pause: true },
+    ];
+
+    const next = removeInteractiveVideoInteractionAndRetargetBranches(timeline, 'target');
+    const choice = next[0].choices?.[0];
+
+    expect(next.map(interaction => interaction.id)).toEqual(['branch']);
+    expect(choice?.targetInteractionId).toBeNull();
+    expect(choice?.targetTimeSeconds).toBe(45);
   });
 });

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
@@ -11,9 +11,23 @@ const SHORT_VIDEO_SECONDS = 30;
 const SHORT_LESSON_SECONDS = 90;
 const SHORT_LESSON_FIRST_INTERACTION_RATIO = 0.4;
 
+export type InteractiveVideoAuthoringIssueSeverity = 'error' | 'warning';
+
 export interface CreateInteractiveVideoInteractionOptions {
   durationSeconds?: number | null;
   preferredSeconds?: number | null;
+}
+
+export interface InteractiveVideoAuthoringIssue {
+  code: string;
+  severity: InteractiveVideoAuthoringIssueSeverity;
+  message: string;
+  interactionId?: string;
+  choiceId?: string;
+}
+
+export interface InteractiveVideoAuthoringIssueOptions {
+  durationSeconds?: number | null;
 }
 
 export function buildInteractiveVideoSpec(
@@ -99,6 +113,211 @@ export function sortInteractiveVideoTimeline(
   timeline: InteractiveVideoInteraction[],
 ): InteractiveVideoInteraction[] {
   return [...timeline].sort((a, b) => a.atSeconds - b.atSeconds);
+}
+
+export function getInteractiveVideoAuthoringIssues(
+  enabled: boolean,
+  timeline: InteractiveVideoInteraction[],
+  options: InteractiveVideoAuthoringIssueOptions = {},
+): InteractiveVideoAuthoringIssue[] {
+  if (!enabled) {
+    return [];
+  }
+
+  const issues: InteractiveVideoAuthoringIssue[] = [];
+  if (timeline.length === 0) {
+    issues.push({
+      code: 'empty_timeline',
+      severity: 'error',
+      message: 'Hãy thêm ít nhất một điểm tương tác hoặc tắt Video tương tác.',
+    });
+    return issues;
+  }
+
+  const maxInteractiveSeconds = getMaxInteractiveSeconds(options.durationSeconds);
+  const timelineById = new Map(timeline.map(interaction => [interaction.id, interaction]));
+  const timeCounts = new Map<number, number>();
+
+  for (const interaction of timeline) {
+    const atSeconds = toNonNegativeNumber(interaction.atSeconds, 0);
+    timeCounts.set(atSeconds, (timeCounts.get(atSeconds) ?? 0) + 1);
+
+    if (maxInteractiveSeconds != null && atSeconds > maxInteractiveSeconds) {
+      issues.push({
+        code: 'interaction_after_duration',
+        severity: 'error',
+        message: `Điểm tại ${formatAuthoringTime(atSeconds)} nằm sau thời lượng video.`,
+        interactionId: interaction.id,
+      });
+    }
+
+    if (!interaction.title?.trim() && !interaction.body?.trim()) {
+      issues.push({
+        code: 'empty_student_copy',
+        severity: 'warning',
+        message: `Điểm tại ${formatAuthoringTime(atSeconds)} chưa có nội dung học viên nhìn thấy.`,
+        interactionId: interaction.id,
+      });
+    }
+
+    if (!choiceTypeNeedsChoices(interaction.type)) {
+      continue;
+    }
+
+    const choices = interaction.choices ?? [];
+    const filledChoices = choices.filter(choice => choice.label.trim());
+    if (filledChoices.length < 2) {
+      issues.push({
+        code: 'too_few_choices',
+        severity: 'error',
+        message: `${interaction.type === 'branch' ? 'Rẽ nhánh' : 'Câu hỏi'} tại ${formatAuthoringTime(atSeconds)} cần ít nhất 2 lựa chọn có nội dung.`,
+        interactionId: interaction.id,
+      });
+    }
+
+    if (choices.some((choice, index) => isDefaultChoiceLabel(choice.label, index))) {
+      issues.push({
+        code: 'placeholder_choice_label',
+        severity: 'warning',
+        message: `${interaction.type === 'branch' ? 'Rẽ nhánh' : 'Câu hỏi'} tại ${formatAuthoringTime(atSeconds)} còn lựa chọn dùng tên mẫu.`,
+        interactionId: interaction.id,
+      });
+    }
+
+    const normalizedLabels = filledChoices.map(choice => choice.label.trim().toLowerCase());
+    if (new Set(normalizedLabels).size < normalizedLabels.length) {
+      issues.push({
+        code: 'duplicate_choice_label',
+        severity: 'warning',
+        message: `${interaction.type === 'branch' ? 'Rẽ nhánh' : 'Câu hỏi'} tại ${formatAuthoringTime(atSeconds)} có lựa chọn trùng nội dung.`,
+        interactionId: interaction.id,
+      });
+    }
+
+    if (interaction.type === 'single_choice') {
+      const correctChoices = choices.filter(choice => choice.isCorrect === true);
+      if (correctChoices.length === 0) {
+        issues.push({
+          code: 'missing_correct_answer',
+          severity: 'error',
+          message: `Câu hỏi tại ${formatAuthoringTime(atSeconds)} cần một đáp án đúng.`,
+          interactionId: interaction.id,
+        });
+      } else if (correctChoices.some(choice => !choice.label.trim())) {
+        issues.push({
+          code: 'blank_correct_answer',
+          severity: 'error',
+          message: `Đáp án đúng tại ${formatAuthoringTime(atSeconds)} chưa có nội dung.`,
+          interactionId: interaction.id,
+          choiceId: correctChoices.find(choice => !choice.label.trim())?.id,
+        });
+      }
+    }
+
+    if (interaction.type === 'branch') {
+      for (const choice of choices) {
+        const targetTime = choice.targetTimeSeconds;
+        if (maxInteractiveSeconds != null && targetTime != null && targetTime > maxInteractiveSeconds) {
+          issues.push({
+            code: 'branch_target_after_duration',
+            severity: 'error',
+            message: `Một nhánh tại ${formatAuthoringTime(atSeconds)} đang tới sau thời lượng video.`,
+            interactionId: interaction.id,
+            choiceId: choice.id,
+          });
+        }
+
+        if (choice.targetInteractionId === interaction.id) {
+          issues.push({
+            code: 'branch_targets_self',
+            severity: 'error',
+            message: `Một nhánh tại ${formatAuthoringTime(atSeconds)} đang trỏ lại chính nó.`,
+            interactionId: interaction.id,
+            choiceId: choice.id,
+          });
+          continue;
+        }
+
+        const target = choice.targetInteractionId
+          ? timelineById.get(choice.targetInteractionId)
+          : null;
+        if (choice.targetInteractionId && !target) {
+          issues.push({
+            code: 'missing_branch_target',
+            severity: 'error',
+            message: `Một nhánh tại ${formatAuthoringTime(atSeconds)} đang trỏ tới điểm không còn tồn tại.`,
+            interactionId: interaction.id,
+            choiceId: choice.id,
+          });
+          continue;
+        }
+
+        const resolvedTargetSeconds = target?.atSeconds ?? targetTime ?? null;
+        if (resolvedTargetSeconds != null && resolvedTargetSeconds <= atSeconds) {
+          issues.push({
+            code: 'branch_rewinds',
+            severity: 'warning',
+            message: `Một nhánh tại ${formatAuthoringTime(atSeconds)} quay về ${formatAuthoringTime(resolvedTargetSeconds)}.`,
+            interactionId: interaction.id,
+            choiceId: choice.id,
+          });
+        }
+      }
+    }
+  }
+
+  for (const [seconds, count] of timeCounts) {
+    if (count > 1) {
+      const interaction = timeline.find(item => toNonNegativeNumber(item.atSeconds, 0) === seconds);
+      issues.push({
+        code: 'duplicate_timestamp',
+        severity: 'warning',
+        message: `Có ${count} điểm cùng ở ${formatAuthoringTime(seconds)}; học viên có thể thấy nhiều hộp liên tiếp.`,
+        interactionId: interaction?.id,
+      });
+    }
+  }
+
+  return issues;
+}
+
+export function hasBlockingInteractiveVideoAuthoringIssues(
+  enabled: boolean,
+  timeline: InteractiveVideoInteraction[],
+  options: InteractiveVideoAuthoringIssueOptions = {},
+): boolean {
+  return getInteractiveVideoAuthoringIssues(enabled, timeline, options)
+    .some(issue => issue.severity === 'error');
+}
+
+export function removeInteractiveVideoInteractionAndRetargetBranches(
+  timeline: InteractiveVideoInteraction[],
+  interactionId: string,
+): InteractiveVideoInteraction[] {
+  const removed = timeline.find(interaction => interaction.id === interactionId);
+  const fallbackTargetSeconds = removed?.atSeconds ?? null;
+
+  return timeline
+    .filter(interaction => interaction.id !== interactionId)
+    .map(interaction => {
+      if (!choiceTypeNeedsChoices(interaction.type)) {
+        return interaction;
+      }
+
+      const choices = (interaction.choices ?? []).map(choice => {
+        if (choice.targetInteractionId !== interactionId) {
+          return choice;
+        }
+
+        return {
+          ...choice,
+          targetInteractionId: null,
+          targetTimeSeconds: fallbackTargetSeconds,
+        };
+      });
+
+      return { ...interaction, choices };
+    });
 }
 
 export function choiceTypeNeedsChoices(type: InteractiveVideoInteractionType): boolean {
@@ -262,6 +481,11 @@ function normalizeDurationSeconds(value: number | null | undefined): number | nu
   return Math.max(1, Math.round(value));
 }
 
+function getMaxInteractiveSeconds(durationSeconds: number | null | undefined): number | null {
+  const duration = normalizeDurationSeconds(durationSeconds);
+  return duration == null ? null : Math.max(0, duration - 1);
+}
+
 function clampToVideoDuration(value: number, maxSeconds: number | null): number {
   const safe = toNonNegativeNumber(value, 0);
   if (maxSeconds == null) {
@@ -315,6 +539,17 @@ function findLargestTimelineGapMidpoint(sortedTimes: number[], maxSeconds: numbe
 
 function createAuthoringId(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function isDefaultChoiceLabel(label: string, index: number): boolean {
+  return label.trim().toLowerCase() === `lựa chọn ${index + 1}`;
+}
+
+function formatAuthoringTime(seconds: number): string {
+  const safeSeconds = toNonNegativeNumber(seconds, 0);
+  const minutes = Math.floor(safeSeconds / 60);
+  const rest = safeSeconds % 60;
+  return `${minutes}:${rest.toString().padStart(2, '0')}`;
 }
 
 function isInteraction(value: InteractiveVideoInteraction | null): value is InteractiveVideoInteraction {


### PR DESCRIPTION
﻿## Summary
- Add shared interactive-video authoring quality checks for blocking errors and teacher-facing warnings.
- Show an inline quality panel in the teacher authoring UI so non-technical teachers see what to fix before saving.
- Retarget branch choices when a referenced interaction is deleted, preserving the timestamp instead of leaving a broken branch target.
- Improve the timeline draggable dots with slider semantics and explicit value metadata for assistive technology.

## Research basis
- WCAG/WAI-ARIA: identify input errors in text, expose dynamic status, and treat draggable timeline thumbs as slider-like controls.
- GOV.UK/NNG UX heuristics: prefer prevention, specific messages, visible options, and plain-language recovery over late generic errors.
- xAPI/video tracking practice: keep timeline, choice, branch, and timestamp data clean so learner events remain meaningful.

## Validation
- `npm run build` passed.
- `git diff --check` passed.
- Pure helper assertions via Node/esbuild passed for short-video timing, blocking issues, warnings, and branch retargeting.
- Local `npm run test:ci -- --include src/app/features/teacher/course-editor/utils/interactive-video-authoring.spec.ts` built the spec bundle, but Karma could not capture Chrome locally after retries; no Jasmine assertions ran. This appears to be a local runner/browser-capture issue in the existing Angular/Karma setup.
