### PR TITLE
[codex] Polish interactive video runtime UX

### DIFF
--- a/fe/src/app/features/learning/components/youtube-player/youtube-player.component.spec.ts
+++ b/fe/src/app/features/learning/components/youtube-player/youtube-player.component.spec.ts
@@ -1,0 +1,118 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { YouTubePlayerComponent } from './youtube-player.component';
+import { WatchedSegmentsTracker } from '../../services/watched-segments-tracker.service';
+import { VideoProgressApi } from '../../../../api/client/video-progress.api';
+import { HeartbeatTracker } from '../../services/heartbeat-tracker.service';
+import { LearningActivityApi } from '../../../../api/client/learning-activity.api';
+
+describe('YouTubePlayerComponent', () => {
+  let fixture: ComponentFixture<YouTubePlayerComponent>;
+  let players: Array<{ player: any; config: any }>;
+
+  beforeEach(async () => {
+    players = [];
+    (window as any).YT = {
+      PlayerState: { PLAYING: 1, PAUSED: 2, ENDED: 0 },
+      Player: function (_mount: HTMLElement, config: any) {
+        const iframe = document.createElement('iframe');
+        const player = {
+          destroy: jasmine.createSpy('destroy'),
+          getDuration: () => 0,
+          getCurrentTime: () => 0,
+          getIframe: () => iframe,
+          pauseVideo: jasmine.createSpy('pauseVideo'),
+          playVideo: jasmine.createSpy('playVideo'),
+          seekTo: jasmine.createSpy('seekTo'),
+        };
+        players.push({ player, config });
+        queueMicrotask(() => config.events.onReady({ target: player }));
+        return player;
+      },
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [YouTubePlayerComponent],
+      providers: [
+        {
+          provide: WatchedSegmentsTracker,
+          useValue: {
+            startTracking: jasmine.createSpy('startTracking'),
+            recordSecond: jasmine.createSpy('recordSecond'),
+            stopTracking: jasmine.createSpy('stopTracking'),
+          },
+        },
+        {
+          provide: VideoProgressApi,
+          useValue: {
+            getResumePosition: jasmine.createSpy('getResumePosition').and.returnValue(of({ success: false })),
+          },
+        },
+        {
+          provide: HeartbeatTracker,
+          useValue: {
+            start: jasmine.createSpy('start'),
+            stop: jasmine.createSpy('stop'),
+          },
+        },
+        {
+          provide: LearningActivityApi,
+          useValue: {
+            recordInteractiveVideoEvent: jasmine.createSpy('recordInteractiveVideoEvent').and.returnValue(of({})),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(YouTubePlayerComponent);
+    fixture.componentRef.setInput('lessonId', 'lesson-1');
+    fixture.componentRef.setInput('sectionId', 'section-1');
+    fixture.componentRef.setInput('videoUrl', 'https://www.youtube.com/watch?v=M7lc1UVf-VE');
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('recreates the iframe player and clears runtime state when the video source changes', async () => {
+    fixture.componentRef.setInput('interactiveVideoSpec', {
+      version: 1,
+      enabled: true,
+      timeline: [
+        {
+          id: 'checkpoint-1',
+          type: 'checkpoint',
+          atSeconds: 0,
+          title: 'Checkpoint',
+          pause: true,
+        },
+      ],
+    });
+    fixture.detectChanges();
+    (window as any).onYouTubeIframeAPIReady?.();
+    await fixture.whenStable();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(players.length).toBe(1);
+    const firstPlayer = players[0].player;
+
+    fixture.componentInstance.activeInteraction.set({
+      id: 'checkpoint-1',
+      type: 'checkpoint',
+      atSeconds: 0,
+      title: 'Checkpoint',
+      pause: true,
+    });
+    fixture.componentInstance.selectedChoiceId.set('choice-1');
+
+    fixture.componentRef.setInput('videoUrl', 'https://youtu.be/dQw4w9WgXcQ');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(firstPlayer.destroy).toHaveBeenCalled();
+    expect(players.length).toBe(2);
+    expect(fixture.componentInstance.activeInteraction()).toBeNull();
+    expect(fixture.componentInstance.selectedChoiceId()).toBeNull();
+  });
+});

--- a/fe/src/app/features/learning/components/youtube-player/youtube-player.component.ts
+++ b/fe/src/app/features/learning/components/youtube-player/youtube-player.component.ts
@@ -1,14 +1,17 @@
 import {
   Component,
+  computed,
+  effect,
+  ElementRef,
   input,
   output,
   inject,
   signal,
-  OnInit,
   OnDestroy,
   ChangeDetectionStrategy,
   ViewEncapsulation,
-  NgZone
+  NgZone,
+  viewChild
 } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { WatchedSegmentsTracker } from '../../services/watched-segments-tracker.service';
@@ -72,7 +75,9 @@ function extractVideoId(url: string): string | null {
   imports: [InteractiveVideoOverlayComponent],
   template: `
     <div class="youtube-player-wrapper">
-      <div [id]="playerId"></div>
+      <div #playerShell class="youtube-iframe-host">
+        <div [id]="playerId"></div>
+      </div>
       @if (activeInteraction(); as interaction) {
         <app-interactive-video-overlay
           [interaction]="interaction"
@@ -102,9 +107,13 @@ function extractVideoId(url: string): string | null {
       width: 100% !important;
       height: 100% !important;
     }
+    app-youtube-player .youtube-iframe-host {
+      position: absolute;
+      inset: 0;
+    }
   `]
 })
-export class YouTubePlayerComponent implements OnInit, OnDestroy {
+export class YouTubePlayerComponent implements OnDestroy {
   videoUrl = input.required<string>();
   lessonId = input.required<string>();
   sectionId = input.required<string>();
@@ -120,38 +129,105 @@ export class YouTubePlayerComponent implements OnInit, OnDestroy {
   private heartbeat = inject(HeartbeatTracker);
   private learningActivityApi = inject(LearningActivityApi);
   private zone = inject(NgZone);
+  private readonly playerShell = viewChild<ElementRef<HTMLElement>>('playerShell');
   private player: any = null;
   private pollInterval: ReturnType<typeof setInterval> | null = null;
+  private playerLoadToken = 0;
   readonly activeInteraction = signal<InteractiveVideoInteraction | null>(null);
   readonly selectedChoiceId = signal<string | null>(null);
   private readonly shownInteractionIds = new Set<string>();
   private readonly completedInteractionIds = new Set<string>();
 
   readonly playerId = 'yt-player-' + Math.random().toString(36).substring(2, 9);
+  private readonly playerSourceKey = computed(() => {
+    const spec = this.interactiveVideoSpec();
+    const timelineKey = (spec?.timeline ?? [])
+      .map(interaction => [
+        interaction.id,
+        interaction.type,
+        interaction.atSeconds,
+        interaction.endSeconds ?? '',
+        interaction.required === true ? 'required' : 'optional',
+        interaction.pause === false ? 'no-pause' : 'pause',
+        (interaction.choices ?? [])
+          .map(choice => `${choice.id}:${choice.targetTimeSeconds ?? ''}:${choice.targetInteractionId ?? ''}`)
+          .join('/'),
+      ].join(':'))
+      .join(',');
+    return [
+      this.videoUrl(),
+      this.lessonId(),
+      this.sectionId(),
+      this.completionThreshold() ?? '',
+      this.trackingEnabled(),
+      spec?.enabled === false ? 'off' : 'on',
+      timelineKey,
+    ].join('|');
+  });
 
-  ngOnInit(): void {
-    const videoId = extractVideoId(this.videoUrl());
-    if (!videoId) return;
+  constructor() {
+    effect(() => {
+      const shell = this.playerShell();
+      const videoUrl = this.videoUrl();
+      const sourceKey = this.playerSourceKey();
+      if (!shell || !sourceKey) {
+        return;
+      }
 
-    loadYouTubeApi().then(() => {
-      this.zone.runOutsideAngular(() => {
-        this.player = new window.YT.Player(this.playerId, {
-          videoId,
-          playerVars: {
-            rel: 0,
-            modestbranding: 1,
-            playsinline: 1
-          },
-          events: {
-            onReady: (event: any) => this.onPlayerReady(event),
-            onStateChange: (event: any) => this.onStateChange(event)
-          }
-        });
+      const token = ++this.playerLoadToken;
+      this.resetInteractiveRuntime();
+      void this.loadYouTubePlayer(videoUrl, token);
+    });
+  }
+
+  private async loadYouTubePlayer(videoUrl: string, token: number): Promise<void> {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+
+    const videoId = extractVideoId(videoUrl);
+    this.destroyPlayer();
+    if (!videoId) {
+      return;
+    }
+
+    await loadYouTubeApi();
+    if (token !== this.playerLoadToken) {
+      return;
+    }
+
+    const shell = this.playerShell()?.nativeElement;
+    if (!shell) {
+      return;
+    }
+
+    shell.replaceChildren();
+    const mount = document.createElement('div');
+    mount.id = this.playerId;
+    shell.appendChild(mount);
+
+    this.zone.runOutsideAngular(() => {
+      this.player = new window.YT.Player(mount, {
+        videoId,
+        playerVars: {
+          rel: 0,
+          modestbranding: 1,
+          playsinline: 1,
+          origin: window.location.origin,
+        },
+        events: {
+          onReady: (event: any) => this.onPlayerReady(event),
+          onStateChange: (event: any) => this.onStateChange(event)
+        }
       });
     });
   }
 
   private onPlayerReady(event: any): void {
+    if (event.target !== this.player) {
+      return;
+    }
+
     // Force iframe to fill wrapper (YouTube sets width="640" height="360" by default)
     const iframe = event.target?.getIframe?.();
     if (iframe) {
@@ -189,6 +265,10 @@ export class YouTubePlayerComponent implements OnInit, OnDestroy {
   }
 
   private onStateChange(event: any): void {
+    if (event.target !== this.player) {
+      return;
+    }
+
     const YT = window.YT;
     if (!YT) return;
 
@@ -331,6 +411,13 @@ export class YouTubePlayerComponent implements OnInit, OnDestroy {
       ?.atSeconds ?? null;
   }
 
+  private resetInteractiveRuntime(): void {
+    this.activeInteraction.set(null);
+    this.selectedChoiceId.set(null);
+    this.shownInteractionIds.clear();
+    this.completedInteractionIds.clear();
+  }
+
   private async recordInteractiveEvent(
     interaction: InteractiveVideoInteraction,
     action: InteractiveVideoRuntimeEvent['action'],
@@ -383,16 +470,25 @@ export class YouTubePlayerComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.playerLoadToken++;
     this.stopPolling();
-    this.activeInteraction.set(null);
-    this.selectedChoiceId.set(null);
+    this.resetInteractiveRuntime();
     if (this.trackingEnabled()) {
       this.tracker.stopTracking();
       this.heartbeat.stop();
     }
+    this.destroyPlayer();
+  }
+
+  private destroyPlayer(): void {
+    this.stopPolling();
     if (this.player?.destroy) {
-      this.player.destroy();
-      this.player = null;
+      try {
+        this.player.destroy();
+      } catch {
+        // Ignore teardown failures from stale YouTube iframes.
+      }
     }
+    this.player = null;
   }
 }

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
@@ -71,33 +71,41 @@
           </button>
           <span class="text-xs text-slate-500">{{ durationHint() }}</span>
         </div>
-        <div class="flex flex-wrap items-center gap-2 border-t border-slate-100 pt-3">
-          <span class="mr-1 text-xs font-semibold uppercase tracking-wide text-slate-400">Tệp H5P/JSON</span>
-          <input #interactiveImportInput type="file"
-            accept="application/json,.json,.h5p,application/h5p,application/zip"
-            class="hidden"
-            (change)="onInteractiveImportSelected($event)" />
-          <button type="button"
-            (click)="interactiveImportInput.click()"
-            class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5">
-            <lucide-icon name="upload" [size]="13"></lucide-icon>
-            Nhập từ file
-          </button>
-          <button type="button"
-            (click)="exportInteractiveVideoJson()"
-            [disabled]="!previewSpec()"
-            class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5 disabled:cursor-not-allowed disabled:opacity-50">
-            <lucide-icon name="download" [size]="13"></lucide-icon>
-            Xuất JSON
-          </button>
-          <button type="button"
-            (click)="exportInteractiveVideoH5P()"
-            [disabled]="!previewSpec()"
-            class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5 disabled:cursor-not-allowed disabled:opacity-50">
-            <lucide-icon name="archive" [size]="13"></lucide-icon>
-            Xuất H5P
-          </button>
-        </div>
+        <details class="group border-t border-slate-100 pt-3">
+          <summary class="inline-flex cursor-pointer select-none items-center gap-1.5 rounded-lg px-2 py-1 text-xs font-semibold text-slate-500 hover:bg-slate-50 hover:text-slate-700">
+            <lucide-icon name="chevron-right" [size]="13" class="transition-transform group-open:rotate-90"></lucide-icon>
+            Nâng cao: nhập/xuất gói tương tác
+          </summary>
+          <div class="mt-2 flex flex-wrap items-center gap-2">
+            <input #interactiveImportInput type="file"
+              accept="application/json,.json,.h5p,application/h5p,application/zip"
+              class="hidden"
+              (change)="onInteractiveImportSelected($event)" />
+            <button type="button"
+              (click)="interactiveImportInput.click()"
+              class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5">
+              <lucide-icon name="upload" [size]="13"></lucide-icon>
+              Nhập từ file
+            </button>
+            <button type="button"
+              (click)="exportInteractiveVideoJson()"
+              [disabled]="!previewSpec()"
+              class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5 disabled:cursor-not-allowed disabled:opacity-50">
+              <lucide-icon name="download" [size]="13"></lucide-icon>
+              Xuất JSON
+            </button>
+            <button type="button"
+              (click)="exportInteractiveVideoH5P()"
+              [disabled]="!previewSpec()"
+              class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5 disabled:cursor-not-allowed disabled:opacity-50">
+              <lucide-icon name="archive" [size]="13"></lucide-icon>
+              Xuất H5P
+            </button>
+            <span class="text-xs leading-relaxed text-slate-500">
+              Dành cho chuyển bài từ hệ thống khác; khi soạn mới chỉ cần dùng các nút tạo trực tiếp ở trên.
+            </span>
+          </div>
+        </details>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Move H5P/JSON import and export behind an advanced disclosure so non-technical teachers can focus on direct authoring first.
- Rework the YouTube interactive-video bridge so source/spec changes recreate the iframe player, reset interaction runtime state, and ignore stale callbacks.
- Add a focused component spec covering YouTube player recreation and runtime cleanup when the video source changes.

## Why
This follows the interactive-video polish pass: authoring should feel simple by default, while runtime logic should avoid stale player state when a student or preview session switches between YouTube video sections.

## Validation
- `npm run build` passes.
- `git diff --check` passes.
- Attempted focused Karma run for authoring + YouTube specs; local ChromeHeadless runner timed out before reporting assertions, and the stale Karma processes were cleaned up. CI should exercise the browser runner in the standard environment.