### PR TITLE
Polish interactive video timeline UX

### DIFF
--- a/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
+++ b/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
@@ -24,6 +24,7 @@ import { OfflineSyncService } from '../../../../core/services/offline-sync.servi
 import { HeartbeatTracker } from '../../services/heartbeat-tracker.service';
 import { WatchedSegmentsTracker } from '../../services/watched-segments-tracker.service';
 import { InteractiveVideoOverlayComponent } from '../../../../shared/blocks/video-block/interactive-video-overlay.component';
+import { InteractiveVideoMarkersComponent } from '../../../../shared/blocks/video-block/interactive-video-markers.component';
 import { buildInteractiveVideoAnalyticsProjection } from '../../../../core/utils/interactive-video-analytics';
 import type {
   InteractiveVideoChoice,
@@ -39,7 +40,7 @@ type ResolvedVideoSource =
 @Component({
   selector: 'app-adaptive-video-player',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [InteractiveVideoOverlayComponent],
+  imports: [InteractiveVideoOverlayComponent, InteractiveVideoMarkersComponent],
   template: `
     <div class="relative h-full w-full bg-black" data-testid="adaptive-video-player"
          (click)="showQualityMenu() && showQualityMenu.set(false)">
@@ -121,6 +122,13 @@ type ResolvedVideoSource =
         }
       </div>
 
+      <app-interactive-video-markers
+        [timeline]="interactiveVideoSpec()?.enabled === false ? [] : (interactiveVideoSpec()?.timeline ?? [])"
+        [durationSeconds]="videoDurationSeconds()"
+        [currentTimeSeconds]="currentTimeSeconds()"
+        [activeInteractionId]="activeInteraction()?.id ?? null"
+        (markerSelected)="seekToInteractiveSecond($event)" />
+
       @if (showNetworkHint()) {
         <div class="absolute bottom-3 left-3 rounded-full bg-amber-500/90 px-3 py-1 text-[11px] font-semibold text-slate-950">
           Mạng yếu, hệ thống đang ưu tiên phát ổn định
@@ -171,6 +179,8 @@ export class AdaptiveVideoPlayerComponent {
   readonly availableQualities = signal<Array<{ height: number; bandwidth: number }>>([]);
   readonly activeInteraction = signal<InteractiveVideoInteraction | null>(null);
   readonly selectedChoiceId = signal<string | null>(null);
+  readonly videoDurationSeconds = signal<number | null>(null);
+  readonly currentTimeSeconds = signal(0);
   readonly showNetworkHint = computed(() => {
     const metrics = this.qoe.metrics();
     const rebufferCount = metrics?.rebufferCount ?? 0;
@@ -224,6 +234,11 @@ export class AdaptiveVideoPlayerComponent {
 
   onLoadedMetadata(event: Event): void {
     const video = event.target as HTMLVideoElement | null;
+    if (video) {
+      this.videoDurationSeconds.set(Number.isFinite(video.duration) && video.duration > 0 ? video.duration : null);
+      this.currentTimeSeconds.set(Number.isFinite(video.currentTime) ? video.currentTime : 0);
+    }
+
     const sectionId = this.getTrackingSectionId();
     if (!video || !sectionId) {
       return;
@@ -238,7 +253,20 @@ export class AdaptiveVideoPlayerComponent {
     if (!video) {
       return;
     }
+    this.currentTimeSeconds.set(video.currentTime);
     this.tracker.recordSecond(video.currentTime);
+    this.evaluateInteractiveTimeline(video);
+  }
+
+  seekToInteractiveSecond(seconds: number): void {
+    const video = this.videoElement()?.nativeElement;
+    if (!video || !Number.isFinite(seconds)) {
+      return;
+    }
+
+    const duration = Number.isFinite(video.duration) && video.duration > 0 ? video.duration : seconds;
+    video.currentTime = Math.max(0, Math.min(seconds, duration));
+    this.currentTimeSeconds.set(video.currentTime);
     this.evaluateInteractiveTimeline(video);
   }
 
@@ -294,6 +322,8 @@ export class AdaptiveVideoPlayerComponent {
     this.qualityLabel.set(null);
     this.startupRecorded = false;
     this.attemptedOfflineBlobFallback = false;
+    this.videoDurationSeconds.set(null);
+    this.currentTimeSeconds.set(0);
     this.resetInteractiveRuntime();
     this.revokeOfflineBlobUrl();
     this.qoe.startSession(this.lessonId());

--- a/fe/src/app/features/learning/components/youtube-player/youtube-player.component.ts
+++ b/fe/src/app/features/learning/components/youtube-player/youtube-player.component.ts
@@ -19,6 +19,7 @@ import { VideoProgressApi } from '../../../../api/client/video-progress.api';
 import { HeartbeatTracker } from '../../services/heartbeat-tracker.service';
 import { LearningActivityApi } from '../../../../api/client/learning-activity.api';
 import { InteractiveVideoOverlayComponent } from '../../../../shared/blocks/video-block/interactive-video-overlay.component';
+import { InteractiveVideoMarkersComponent } from '../../../../shared/blocks/video-block/interactive-video-markers.component';
 import { buildInteractiveVideoAnalyticsProjection } from '../../../../core/utils/interactive-video-analytics';
 import type {
   InteractiveVideoChoice,
@@ -72,16 +73,23 @@ function extractVideoId(url: string): string | null {
   selector: 'app-youtube-player',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  imports: [InteractiveVideoOverlayComponent],
+  imports: [InteractiveVideoOverlayComponent, InteractiveVideoMarkersComponent],
   template: `
     <div class="youtube-player-wrapper">
       <div #playerShell class="youtube-iframe-host">
         <div [id]="playerId"></div>
       </div>
+      <app-interactive-video-markers
+        [timeline]="interactiveVideoSpec()?.enabled === false ? [] : (interactiveVideoSpec()?.timeline ?? [])"
+        [durationSeconds]="videoDurationSeconds()"
+        [currentTimeSeconds]="currentTimeSeconds()"
+        [activeInteractionId]="activeInteraction()?.id ?? null"
+        (markerSelected)="seekToInteractiveSecond($event)" />
       @if (activeInteraction(); as interaction) {
         <app-interactive-video-overlay
           [interaction]="interaction"
           [selectedChoiceId]="selectedChoiceId()"
+          [density]="overlayDensity()"
           (choiceSelected)="onInteractiveChoice($event)"
           (continueRequested)="onInteractiveContinue()" />
       }
@@ -120,6 +128,7 @@ export class YouTubePlayerComponent implements OnDestroy {
   completionThreshold = input<number | undefined>(undefined);
   trackingEnabled = input(true);
   interactiveVideoSpec = input<InteractiveVideoSpec | null>(null);
+  overlayDensity = input<'comfortable' | 'compact'>('comfortable');
   videoEnded = output<void>();
   durationLoaded = output<number>();
   interactiveEvent = output<InteractiveVideoRuntimeEvent>();
@@ -135,6 +144,8 @@ export class YouTubePlayerComponent implements OnDestroy {
   private playerLoadToken = 0;
   readonly activeInteraction = signal<InteractiveVideoInteraction | null>(null);
   readonly selectedChoiceId = signal<string | null>(null);
+  readonly videoDurationSeconds = signal<number | null>(null);
+  readonly currentTimeSeconds = signal(0);
   private readonly shownInteractionIds = new Set<string>();
   private readonly completedInteractionIds = new Set<string>();
 
@@ -187,6 +198,8 @@ export class YouTubePlayerComponent implements OnDestroy {
 
     const videoId = extractVideoId(videoUrl);
     this.destroyPlayer();
+    this.videoDurationSeconds.set(null);
+    this.currentTimeSeconds.set(0);
     if (!videoId) {
       return;
     }
@@ -242,7 +255,10 @@ export class YouTubePlayerComponent implements OnDestroy {
 
     const duration = event.target.getDuration?.() || 0;
     if (duration > 0) {
-      this.zone.run(() => this.durationLoaded.emit(duration));
+      this.zone.run(() => {
+        this.videoDurationSeconds.set(duration);
+        this.durationLoaded.emit(duration);
+      });
     }
     if (duration > 0) {
       if (this.trackingEnabled()) {
@@ -258,6 +274,7 @@ export class YouTubePlayerComponent implements OnDestroy {
       next: (res: any) => {
         if (res?.success && res.data?.position > 0 && this.player?.seekTo) {
           this.player.seekTo(res.data.position, true);
+          this.zone.run(() => this.currentTimeSeconds.set(res.data.position));
         }
       },
       error: () => {}
@@ -301,7 +318,14 @@ export class YouTubePlayerComponent implements OnDestroy {
         if (this.trackingEnabled()) {
           this.tracker.recordSecond(currentTime);
         }
-        this.zone.run(() => this.evaluateInteractiveTimeline(currentTime));
+        this.zone.run(() => {
+          this.currentTimeSeconds.set(currentTime);
+          const duration = this.player?.getDuration?.() || 0;
+          if (duration > 0 && this.videoDurationSeconds() == null) {
+            this.videoDurationSeconds.set(duration);
+          }
+          this.evaluateInteractiveTimeline(currentTime);
+        });
       }
     }, 1000);
   }
@@ -346,6 +370,18 @@ export class YouTubePlayerComponent implements OnDestroy {
     this.activeInteraction.set(null);
     this.selectedChoiceId.set(null);
     this.player?.playVideo?.();
+  }
+
+  seekToInteractiveSecond(seconds: number): void {
+    if (!this.player?.seekTo || !Number.isFinite(seconds)) {
+      return;
+    }
+
+    const duration = this.player?.getDuration?.() || seconds;
+    const target = Math.max(0, Math.min(seconds, Number.isFinite(duration) && duration > 0 ? duration : seconds));
+    this.player.seekTo(target, true);
+    this.currentTimeSeconds.set(target);
+    this.evaluateInteractiveTimeline(target);
   }
 
   private evaluateInteractiveTimeline(currentTime: number): void {
@@ -473,6 +509,8 @@ export class YouTubePlayerComponent implements OnDestroy {
     this.playerLoadToken++;
     this.stopPolling();
     this.resetInteractiveRuntime();
+    this.videoDurationSeconds.set(null);
+    this.currentTimeSeconds.set(0);
     if (this.trackingEnabled()) {
       this.tracker.stopTracking();
       this.heartbeat.stop();

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
@@ -52,6 +52,12 @@
         <div class="flex flex-wrap items-center gap-2">
           <span class="mr-1 text-xs font-semibold uppercase tracking-wide text-slate-500">Tạo trực tiếp</span>
           <button type="button"
+            (click)="addSuggestedInteractions()"
+            class="inline-flex items-center gap-1.5 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700 hover:bg-emerald-100">
+            <lucide-icon name="wand-sparkles" [size]="13"></lucide-icon>
+            Tạo nhanh theo độ dài
+          </button>
+          <button type="button"
             (click)="addInteraction('checkpoint')"
             class="inline-flex items-center gap-1.5 rounded-lg bg-[#0056D2] px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-[#004BB5]">
             <lucide-icon name="pause" [size]="13"></lucide-icon>
@@ -293,7 +299,13 @@
         <div class="rounded-xl border border-dashed border-slate-200 bg-slate-50/70 p-4 text-center">
           <lucide-icon name="plus-circle" [size]="30" class="mx-auto text-slate-300"></lucide-icon>
           <p class="mt-2 text-sm font-semibold text-slate-600">Chưa có điểm tương tác</p>
-          <div class="mt-4 grid gap-2 sm:grid-cols-3">
+          <div class="mt-4 grid gap-2 sm:grid-cols-4">
+            <button type="button"
+              (click)="addSuggestedInteractions()"
+              class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs font-semibold text-emerald-700 hover:bg-emerald-100">
+              <lucide-icon name="wand-sparkles" [size]="13"></lucide-icon>
+              Tạo nhanh
+            </button>
             <button type="button"
               (click)="addInteraction('checkpoint')"
               class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5">

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
@@ -210,6 +210,10 @@ export class InteractiveVideoAuthoringPanelComponent {
     this.svc.addInteractiveVideoInteraction(type);
   }
 
+  addSuggestedInteractions(): void {
+    this.svc.addSuggestedInteractiveVideoInteractions();
+  }
+
   onInteractiveTypeChange(
     interactionId: string,
     type: InteractiveVideoInteractionType,

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
@@ -459,20 +459,26 @@ type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
               <!-- DONE: video attached with preview + actions -->
               @if (cfUploadStatus() === 'done') {
                 <div class="space-y-3">
-                  <!-- Video preview (compact, max 280px height for editor) -->
+                  <!-- Video preview -->
                   @if (svc.sectionVideoAssetId()) {
-                    <div class="overflow-hidden rounded-xl border border-slate-200 bg-black" style="max-height: 280px; aspect-ratio: 16/9;">
+                    <div
+                      [class]="videoPreviewFrameClass()"
+                      style="aspect-ratio: 16/9;">
                       <app-quiz-video-player
                         [videoAssetId]="svc.sectionVideoAssetId()"
                         [rawVideoUrl]="svc.sectionVideoUrl()"
-                        [interactiveVideoSpec]="interactiveVideoPreviewSpec()">
+                        [interactiveVideoSpec]="interactiveVideoPreviewSpec()"
+                        [overlayDensity]="'compact'">
                       </app-quiz-video-player>
                     </div>
                   } @else if (svc.sectionVideoUrl()) {
-                    <div class="overflow-hidden rounded-xl border border-slate-200 bg-black" style="max-height: 280px; aspect-ratio: 16/9;">
+                    <div
+                      [class]="videoPreviewFrameClass()"
+                      style="aspect-ratio: 16/9;">
                       <app-quiz-video-player
                         [rawVideoUrl]="svc.sectionVideoUrl()"
-                        [interactiveVideoSpec]="interactiveVideoPreviewSpec()">
+                        [interactiveVideoSpec]="interactiveVideoPreviewSpec()"
+                        [overlayDensity]="'compact'">
                       </app-quiz-video-player>
                     </div>
                   }
@@ -544,6 +550,7 @@ type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
                       [sectionId]="svc.editingSectionId() || 'preview'"
                       [trackingEnabled]="false"
                       [interactiveVideoSpec]="interactiveVideoPreviewSpec()"
+                      [overlayDensity]="'compact'"
                       (durationLoaded)="onYouTubeDurationLoaded($event)" />
                   </div>
                 }
@@ -1603,6 +1610,15 @@ export class SectionEditorComponent {
     this.svc.sectionInteractiveVideoEnabled(),
     this.svc.sectionInteractiveVideoTimeline(),
   ));
+  readonly hasInteractiveVideoPreview = computed(() =>
+    this.svc.sectionInteractiveVideoEnabled() && this.svc.sectionInteractiveVideoTimeline().length > 0,
+  );
+  readonly videoPreviewFrameClass = computed(() => {
+    const base = 'overflow-hidden rounded-xl border border-slate-200 bg-black';
+    return this.hasInteractiveVideoPreview()
+      ? `${base} mx-auto w-full max-w-4xl`
+      : `${base} mx-auto w-full max-w-3xl`;
+  });
   readonly isContentEmpty = computed(() => {
     const content = this.svc.sectionContent();
     if (!content) return true;

--- a/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
+++ b/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
@@ -28,9 +28,11 @@ import {
   choiceTypeNeedsChoices,
   createInteractiveVideoChoice,
   createInteractiveVideoInteraction,
+  createSuggestedInteractiveVideoInteractions,
   getInteractiveVideoAuthoringIssues,
   normalizeInteractiveVideoSpec,
   removeInteractiveVideoInteractionAndRetargetBranches,
+  sortInteractiveVideoTimeline,
 } from '../utils/interactive-video-authoring';
 import {
   probeVideoFile,
@@ -207,6 +209,26 @@ export class CurriculumEditorService {
     this.sectionInteractiveVideoTimeline.update(timeline => [...timeline, next]);
     this.sectionInteractiveVideoEnabled.set(true);
     this.markDirty();
+  }
+
+  addSuggestedInteractiveVideoInteractions(): number {
+    const suggestions = createSuggestedInteractiveVideoInteractions(
+      this.sectionInteractiveVideoTimeline(),
+      { durationSeconds: this.sectionVideoDurationSec() },
+    );
+
+    if (suggestions.length === 0) {
+      this.toast.info('Các mốc gợi ý đã có đủ gần trên timeline.');
+      return 0;
+    }
+
+    this.sectionInteractiveVideoTimeline.update(timeline =>
+      sortInteractiveVideoTimeline([...timeline, ...suggestions]),
+    );
+    this.sectionInteractiveVideoEnabled.set(true);
+    this.markDirty();
+    this.toast.success(`Đã tạo ${suggestions.length} mốc gợi ý theo độ dài video.`);
+    return suggestions.length;
   }
 
   updateInteractiveVideoInteraction(

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.spec.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.spec.ts
@@ -1,6 +1,7 @@
 import {
   buildInteractiveVideoSpec,
   createInteractiveVideoInteraction,
+  createSuggestedInteractiveVideoInteractions,
   getInteractiveVideoAuthoringIssues,
   normalizeInteractiveVideoSpec,
   removeInteractiveVideoInteractionAndRetargetBranches,
@@ -37,6 +38,38 @@ describe('interactive-video-authoring', () => {
     });
 
     expect(created.atSeconds).toBe(30);
+  });
+
+  it('creates one duration-aware quick scaffold for very short videos', () => {
+    const suggestions = createSuggestedInteractiveVideoInteractions([], {
+      durationSeconds: 15,
+    });
+
+    expect(suggestions.length).toBe(1);
+    expect(suggestions[0].atSeconds).toBe(8);
+    expect(suggestions[0].type).toBe('checkpoint');
+  });
+
+  it('creates spaced quick scaffolds for a 22 minute lecture', () => {
+    const suggestions = createSuggestedInteractiveVideoInteractions([], {
+      durationSeconds: 22 * 60,
+    });
+
+    expect(suggestions.map(item => item.atSeconds)).toEqual([106, 370, 686, 1003, 1214]);
+    expect(suggestions.some(item => item.type === 'single_choice')).toBeTrue();
+  });
+
+  it('skips quick scaffold points that are already covered nearby', () => {
+    const existing: InteractiveVideoInteraction[] = [
+      { id: 'near-intro', type: 'checkpoint', atSeconds: 100, pause: true, required: false },
+    ];
+
+    const suggestions = createSuggestedInteractiveVideoInteractions(existing, {
+      durationSeconds: 22 * 60,
+    });
+
+    expect(suggestions.map(item => item.atSeconds)).not.toContain(106);
+    expect(suggestions.length).toBe(4);
   });
 
   it('spreads later generated interactions into the largest remaining gap', () => {

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
@@ -18,6 +18,11 @@ export interface CreateInteractiveVideoInteractionOptions {
   preferredSeconds?: number | null;
 }
 
+export interface CreateSuggestedInteractiveVideoInteractionsOptions {
+  durationSeconds?: number | null;
+  maxSuggestions?: number;
+}
+
 export interface InteractiveVideoAuthoringIssue {
   code: string;
   severity: InteractiveVideoAuthoringIssueSeverity;
@@ -107,6 +112,37 @@ export function createInteractiveVideoChoice(index: number): InteractiveVideoCho
     targetTimeSeconds: null,
     targetInteractionId: null,
   };
+}
+
+export function createSuggestedInteractiveVideoInteractions(
+  timeline: InteractiveVideoInteraction[],
+  options: CreateSuggestedInteractiveVideoInteractionsOptions = {},
+): InteractiveVideoInteraction[] {
+  const durationSeconds = normalizeDurationSeconds(options.durationSeconds)
+    ?? inferDurationFromTimeline(timeline)
+    ?? 180;
+  const maxSuggestions = Math.max(1, Math.min(8, Math.round(options.maxSuggestions ?? 8)));
+  const minGapSeconds = getSuggestedMilestoneMinGapSeconds(durationSeconds);
+  const suggestions: InteractiveVideoInteraction[] = [];
+
+  for (const preferredSeconds of suggestInteractiveVideoMilestoneSeconds(durationSeconds)) {
+    if (suggestions.length >= maxSuggestions) {
+      break;
+    }
+
+    if (hasNearbyInteraction([...timeline, ...suggestions], preferredSeconds, minGapSeconds)) {
+      continue;
+    }
+
+    const type = getSuggestedInteractionType(suggestions.length);
+    const interaction = createInteractiveVideoInteraction([...timeline, ...suggestions], type, {
+      durationSeconds,
+      preferredSeconds,
+    });
+    suggestions.push(applySuggestedInteractionCopy(interaction, suggestions.length));
+  }
+
+  return suggestions;
 }
 
 export function sortInteractiveVideoTimeline(
@@ -535,6 +571,101 @@ function findLargestTimelineGapMidpoint(sortedTimes: number[], maxSeconds: numbe
     return latest + MIN_DURATION_AWARE_OFFSET_SECONDS;
   }
   return Math.round(bestStart + bestGap / 2);
+}
+
+function inferDurationFromTimeline(timeline: InteractiveVideoInteraction[]): number | null {
+  const latest = Math.max(0, ...timeline.map(interaction => toNonNegativeNumber(interaction.atSeconds, 0)));
+  return latest > 0 ? latest + DEFAULT_OFFSET_SECONDS : null;
+}
+
+function suggestInteractiveVideoMilestoneSeconds(durationSeconds: number): number[] {
+  const ratios = getSuggestedMilestoneRatios(durationSeconds);
+  return ratios
+    .map(ratio => clampToVideoDuration(Math.round(durationSeconds * ratio), durationSeconds))
+    .filter((seconds, index, all) => all.indexOf(seconds) === index);
+}
+
+function getSuggestedMilestoneRatios(durationSeconds: number): number[] {
+  if (durationSeconds <= 30) {
+    return [0.5];
+  }
+  if (durationSeconds <= 120) {
+    return [0.4, 0.75];
+  }
+  if (durationSeconds <= 600) {
+    return [0.15, 0.45, 0.75];
+  }
+  if (durationSeconds <= 1800) {
+    return [0.08, 0.28, 0.52, 0.76, 0.92];
+  }
+  return [0.05, 0.18, 0.32, 0.48, 0.64, 0.8, 0.93];
+}
+
+function getSuggestedMilestoneMinGapSeconds(durationSeconds: number): number {
+  if (durationSeconds <= 120) {
+    return 5;
+  }
+  if (durationSeconds <= 600) {
+    return 12;
+  }
+  if (durationSeconds <= 1800) {
+    return 30;
+  }
+  return 60;
+}
+
+function hasNearbyInteraction(
+  timeline: InteractiveVideoInteraction[],
+  preferredSeconds: number,
+  minGapSeconds: number,
+): boolean {
+  return timeline.some(interaction =>
+    Math.abs(toNonNegativeNumber(interaction.atSeconds, 0) - preferredSeconds) < minGapSeconds,
+  );
+}
+
+function getSuggestedInteractionType(index: number): InteractiveVideoInteractionType {
+  return index % 2 === 1 ? 'single_choice' : 'checkpoint';
+}
+
+function applySuggestedInteractionCopy(
+  interaction: InteractiveVideoInteraction,
+  index: number,
+): InteractiveVideoInteraction {
+  const ordinal = index + 1;
+  if (interaction.type === 'single_choice') {
+    return {
+      ...interaction,
+      title: `Kiểm tra nhanh ${ordinal}`,
+      body: 'Học viên đã nắm được ý chính của đoạn vừa xem chưa?',
+      required: false,
+      choices: [
+        {
+          id: createAuthoringId('choice'),
+          label: 'Đã hiểu ý chính',
+          feedback: 'Tốt. Tiếp tục sang đoạn kế tiếp.',
+          isCorrect: true,
+          targetTimeSeconds: null,
+          targetInteractionId: null,
+        },
+        {
+          id: createAuthoringId('choice'),
+          label: 'Cần xem lại đoạn này',
+          feedback: 'Hãy tua lại một chút để xem lại phần vừa học.',
+          isCorrect: false,
+          targetTimeSeconds: null,
+          targetInteractionId: null,
+        },
+      ],
+    };
+  }
+
+  return {
+    ...interaction,
+    title: `Điểm dừng ${ordinal}`,
+    body: 'Dừng lại một nhịp để học viên ghi nhớ ý quan trọng trước khi tiếp tục.',
+    required: false,
+  };
 }
 
 function createAuthoringId(prefix: string): string {

--- a/fe/src/app/shared/blocks/video-block/interactive-video-markers.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-markers.component.ts
@@ -1,0 +1,138 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import type { InteractiveVideoInteraction } from '../../../api/types/interactive-video.types';
+
+interface InteractiveVideoMarker {
+  interaction: InteractiveVideoInteraction;
+  percent: number;
+}
+
+@Component({
+  selector: 'app-interactive-video-markers',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [],
+  template: `
+    @if (visibleMarkers().length > 0) {
+      <div class="pointer-events-none absolute inset-x-3 bottom-10 z-10">
+        @if (upcomingInteraction(); as next) {
+          <div class="mb-2 flex justify-end">
+            <button
+              type="button"
+              class="pointer-events-auto inline-flex max-w-md items-center gap-2 rounded-full bg-slate-950/85 px-3 py-1.5 text-[11px] font-semibold text-white shadow-lg backdrop-blur transition-colors hover:bg-slate-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-200"
+              [attr.aria-label]="'Tới tương tác tại ' + formatTime(next.atSeconds)"
+              (click)="markerSelected.emit(next.atSeconds)">
+              <span class="h-2 w-2 shrink-0 rounded-full bg-sky-300"></span>
+              <span class="truncate">
+                Sắp tới: {{ interactionLabel(next) }} tại {{ formatTime(next.atSeconds) }}
+              </span>
+            </button>
+          </div>
+        }
+
+        <div class="pointer-events-auto relative h-3 rounded-full bg-slate-950/35 px-1 shadow-sm backdrop-blur">
+          <div class="absolute left-1 right-1 top-1/2 h-1 -translate-y-1/2 rounded-full bg-white/25"></div>
+          @for (marker of visibleMarkers(); track marker.interaction.id) {
+            <button
+              type="button"
+              class="absolute top-1/2 flex h-3 w-3 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-2 border-white bg-[#0056D2] shadow transition-transform hover:scale-125 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-200"
+              [class.ring-2]="activeInteractionId() === marker.interaction.id"
+              [class.ring-sky-200]="activeInteractionId() === marker.interaction.id"
+              [style.left.%]="marker.percent"
+              [attr.title]="interactionLabel(marker.interaction) + ' · ' + formatTime(marker.interaction.atSeconds)"
+              [attr.aria-label]="'Tới ' + interactionLabel(marker.interaction) + ' tại ' + formatTime(marker.interaction.atSeconds)"
+              (click)="markerSelected.emit(marker.interaction.atSeconds)">
+            </button>
+          }
+        </div>
+      </div>
+    }
+  `,
+})
+export class InteractiveVideoMarkersComponent {
+  readonly timeline = input<InteractiveVideoInteraction[]>([]);
+  readonly durationSeconds = input<number | null>(null);
+  readonly currentTimeSeconds = input(0);
+  readonly activeInteractionId = input<string | null>(null);
+  readonly markerSelected = output<number>();
+
+  readonly scaleSeconds = computed(() => {
+    const duration = this.toPositiveNumber(this.durationSeconds());
+    const timelineMax = Math.max(
+      0,
+      ...this.timeline().map(interaction => this.toNonNegativeNumber(interaction.atSeconds)),
+    );
+    return Math.max(duration ?? 0, timelineMax + 5, 1);
+  });
+
+  readonly visibleMarkers = computed<InteractiveVideoMarker[]>(() => {
+    const scale = this.scaleSeconds();
+    return [...this.timeline()]
+      .filter(interaction => Number.isFinite(interaction.atSeconds) && interaction.atSeconds >= 0)
+      .sort((a, b) => a.atSeconds - b.atSeconds)
+      .map(interaction => ({
+        interaction,
+        percent: Math.min(100, Math.max(0, (interaction.atSeconds / scale) * 100)),
+      }));
+  });
+
+  readonly upcomingInteraction = computed<InteractiveVideoInteraction | null>(() => {
+    if (this.activeInteractionId()) {
+      return null;
+    }
+
+    const current = this.toNonNegativeNumber(this.currentTimeSeconds());
+    const windowSeconds = this.getUpcomingWindowSeconds();
+    return this.visibleMarkers()
+      .map(marker => marker.interaction)
+      .find(interaction => {
+        const delta = interaction.atSeconds - current;
+        return delta > 0 && delta <= windowSeconds;
+      }) ?? null;
+  });
+
+  interactionLabel(interaction: InteractiveVideoInteraction): string {
+    switch (interaction.type) {
+      case 'single_choice':
+        return 'Câu hỏi';
+      case 'branch':
+        return 'Rẽ nhánh';
+      case 'hotspot':
+        return 'Hotspot';
+      default:
+        return 'Điểm dừng';
+    }
+  }
+
+  formatTime(seconds: number | null | undefined): string {
+    const safeSeconds = this.toNonNegativeNumber(seconds ?? 0);
+    const minutes = Math.floor(safeSeconds / 60);
+    const rest = safeSeconds % 60;
+    return `${minutes}:${rest.toString().padStart(2, '0')}`;
+  }
+
+  private getUpcomingWindowSeconds(): number {
+    const duration = this.toPositiveNumber(this.durationSeconds()) ?? this.scaleSeconds();
+    if (duration <= 30) {
+      return 8;
+    }
+    if (duration <= 120) {
+      return 15;
+    }
+    if (duration <= 600) {
+      return 30;
+    }
+    if (duration <= 1800) {
+      return 60;
+    }
+    return 90;
+  }
+
+  private toPositiveNumber(value: number | null | undefined): number | null {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0
+      ? value
+      : null;
+  }
+
+  private toNonNegativeNumber(value: number): number {
+    return Number.isFinite(value) ? Math.max(0, Math.round(value)) : 0;
+  }
+}

--- a/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
@@ -18,12 +18,12 @@ import type {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [],
   template: `
-    <div class="absolute inset-0 z-20 flex items-center justify-center bg-slate-950/70 px-4">
+    <div [class]="overlayClass()">
       <section
         #panel
         role="dialog"
         tabindex="-1"
-        class="w-full max-w-xl rounded-lg border border-white/10 bg-white p-4 text-slate-900 shadow-2xl sm:p-5"
+        [class]="panelClass()"
         aria-live="polite"
         aria-modal="true"
         [attr.aria-labelledby]="interaction().title ? titleId() : null"
@@ -101,6 +101,7 @@ import type {
 export class InteractiveVideoOverlayComponent {
   readonly interaction = input.required<InteractiveVideoInteraction>();
   readonly selectedChoiceId = input<string | null>(null);
+  readonly density = input<'comfortable' | 'compact'>('comfortable');
   private readonly panel = viewChild<ElementRef<HTMLElement>>('panel');
 
   readonly choiceSelected = output<InteractiveVideoChoice>();
@@ -131,6 +132,22 @@ export class InteractiveVideoOverlayComponent {
     return interaction.required === true
       && (interaction.type === 'single_choice' || interaction.type === 'branch')
       && !this.selectedChoiceId();
+  });
+
+  readonly overlayClass = computed(() => {
+    const base = 'absolute inset-0 z-20 flex bg-slate-950/70';
+    if (this.density() === 'compact') {
+      return `${base} items-end justify-center overflow-y-auto p-2 sm:items-center sm:p-3`;
+    }
+    return `${base} items-center justify-center px-4`;
+  });
+
+  readonly panelClass = computed(() => {
+    const base = 'w-full rounded-lg border border-white/10 bg-white text-slate-900 shadow-2xl';
+    if (this.density() === 'compact') {
+      return `${base} max-h-full max-w-lg overflow-y-auto p-3 sm:p-4`;
+    }
+    return `${base} max-w-xl p-4 sm:p-5`;
   });
 
   readonly interactionLabel = computed(() => {

--- a/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
+++ b/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
@@ -11,6 +11,7 @@ import {
 import { VideoAssetApi } from '../../../api/client/video-asset.api';
 import { firstValueFrom } from 'rxjs';
 import { InteractiveVideoOverlayComponent } from './interactive-video-overlay.component';
+import { InteractiveVideoMarkersComponent } from './interactive-video-markers.component';
 import type {
   InteractiveVideoChoice,
   InteractiveVideoInteraction,
@@ -31,9 +32,9 @@ type ResolvedSource =
 @Component({
   selector: 'app-quiz-video-player',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [InteractiveVideoOverlayComponent],
+  imports: [InteractiveVideoOverlayComponent, InteractiveVideoMarkersComponent],
   template: `
-    <div class="relative w-full bg-black rounded-lg overflow-hidden"
+    <div class="relative aspect-video w-full overflow-hidden rounded-lg bg-black"
          (click)="showQualityMenu() && showQualityMenu.set(false)">
       <video
         #videoElement
@@ -42,9 +43,10 @@ type ResolvedSource =
         playsinline
         preload="metadata"
         crossorigin="anonymous"
-        class="w-full"
-        style="max-height: 400px;"
+        class="h-full w-full object-contain"
         [class.opacity-0]="isLoading() && !error() && !isProcessing()"
+        (loadedmetadata)="onLoadedMetadata()"
+        (durationchange)="onLoadedMetadata()"
         (timeupdate)="onTimeUpdate()"
         (error)="onVideoError()">
         Trình duyệt không hỗ trợ phát video.
@@ -114,10 +116,18 @@ type ResolvedSource =
         }
       </div>
 
+      <app-interactive-video-markers
+        [timeline]="interactiveVideoSpec()?.enabled === false ? [] : (interactiveVideoSpec()?.timeline ?? [])"
+        [durationSeconds]="videoDurationSeconds()"
+        [currentTimeSeconds]="currentTimeSeconds()"
+        [activeInteractionId]="activeInteraction()?.id ?? null"
+        (markerSelected)="seekToInteractiveSecond($event)" />
+
       @if (activeInteraction(); as interaction) {
         <app-interactive-video-overlay
           [interaction]="interaction"
           [selectedChoiceId]="selectedChoiceId()"
+          [density]="overlayDensity()"
           (choiceSelected)="onInteractiveChoice($event)"
           (continueRequested)="onInteractiveContinue()" />
       }
@@ -130,6 +140,7 @@ export class QuizVideoPlayerComponent {
   readonly videoAssetId = input<string | null>(null);
   readonly rawVideoUrl = input<string | null>(null);
   readonly interactiveVideoSpec = input<InteractiveVideoSpec | null>(null);
+  readonly overlayDensity = input<'comfortable' | 'compact'>('comfortable');
 
   private readonly videoElement = viewChild<ElementRef<HTMLVideoElement>>('videoElement');
 
@@ -142,6 +153,8 @@ export class QuizVideoPlayerComponent {
   readonly availableQualities = signal<Array<{ height: number; bandwidth: number }>>([]);
   readonly activeInteraction = signal<InteractiveVideoInteraction | null>(null);
   readonly selectedChoiceId = signal<string | null>(null);
+  readonly videoDurationSeconds = signal<number | null>(null);
+  readonly currentTimeSeconds = signal(0);
 
   private shakaPlayer: any = null;
   private loadToken = 0;
@@ -180,11 +193,43 @@ export class QuizVideoPlayerComponent {
     }
   }
 
+  onLoadedMetadata(): void {
+    const video = this.videoElement()?.nativeElement;
+    if (!video) {
+      return;
+    }
+
+    this.videoDurationSeconds.set(Number.isFinite(video.duration) && video.duration > 0 ? video.duration : null);
+    this.currentTimeSeconds.set(Number.isFinite(video.currentTime) ? video.currentTime : 0);
+  }
+
   onTimeUpdate(): void {
     const video = this.videoElement()?.nativeElement;
     if (!video) {
       return;
     }
+    this.currentTimeSeconds.set(video.currentTime);
+    this.evaluateInteractiveTimeline(video);
+  }
+
+  seekToInteractiveSecond(seconds: number): void {
+    const video = this.videoElement()?.nativeElement;
+    if (!video || !Number.isFinite(seconds)) {
+      return;
+    }
+
+    const targetInteraction = this.interactiveVideoSpec()?.timeline
+      ?.find(interaction => Math.abs(interaction.atSeconds - seconds) <= 1);
+    if (targetInteraction) {
+      this.completedInteractionIds.delete(targetInteraction.id);
+      this.shownInteractionIds.delete(targetInteraction.id);
+      this.activeInteraction.set(null);
+      this.selectedChoiceId.set(null);
+    }
+
+    const duration = Number.isFinite(video.duration) && video.duration > 0 ? video.duration : seconds;
+    video.currentTime = Math.max(0, Math.min(seconds, duration));
+    this.currentTimeSeconds.set(video.currentTime);
     this.evaluateInteractiveTimeline(video);
   }
 
@@ -227,6 +272,8 @@ export class QuizVideoPlayerComponent {
     this.isProcessing.set(false);
     this.isLoading.set(true);
     this.qualityLabel.set(null);
+    this.videoDurationSeconds.set(null);
+    this.currentTimeSeconds.set(0);
 
     try {
       const source = await this.resolveSource(assetId, rawUrl);


### PR DESCRIPTION
## Summary
- Add a shared interactive-video marker rail with upcoming interaction pill and marker seek across uploaded/adaptive, offline-capable, YouTube, and teacher preview players.
- Improve teacher preview geometry and compact overlay density so interaction dialogs are no longer clipped in the editor preview.
- Add duration-aware quick scaffolding for non-technical teachers, with tests for short videos, 22-minute lectures, and duplicate-nearby avoidance.

## Verification
- `git diff --check`
- `npx tsc -p tsconfig.spec.json --noEmit`
- `npm run build`

## Notes
- Focused Karma/ChromeHeadless local runs timed out twice on this Windows workspace; stale Karma processes were cleaned up. CI should remain the authority for browser unit execution.
- YouTube interactive video remains online-only by platform constraint; uploaded/adaptive video keeps offline playback and queued interactive analytics behavior.