### PR TITLE
Fix interactive video quick create icon

### DIFF
--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
@@ -54,7 +54,7 @@
           <button type="button"
             (click)="addSuggestedInteractions()"
             class="inline-flex items-center gap-1.5 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700 hover:bg-emerald-100">
-            <lucide-icon name="wand-sparkles" [size]="13"></lucide-icon>
+            <lucide-icon name="plus-circle" [size]="13"></lucide-icon>
             Tạo nhanh theo độ dài
           </button>
           <button type="button"
@@ -303,7 +303,7 @@
             <button type="button"
               (click)="addSuggestedInteractions()"
               class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs font-semibold text-emerald-700 hover:bg-emerald-100">
-              <lucide-icon name="wand-sparkles" [size]="13"></lucide-icon>
+              <lucide-icon name="plus-circle" [size]="13"></lucide-icon>
               Tạo nhanh
             </button>
             <button type="button"


### PR DESCRIPTION
## Summary
- Replace the unsupported `wand-sparkles` lucide icon in the interactive video quick-create buttons with the already-provided `plus-circle` icon.
- Removes the production console error found during teacher-editor smoke after PR #353.

## Verification
- `git diff --check`
- `npx tsc -p tsconfig.spec.json --noEmit`
- `npm run build`