### PR TITLE
Fix course deletion cleanup and navigation

### DIFF
--- a/backend/src/main/java/com/example/lms/course_authoring/application/service/CourseDeletionCleanupService.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/application/service/CourseDeletionCleanupService.java
@@ -1,0 +1,104 @@
+package com.example.lms.course_authoring.application.service;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Cleans course-related rows that are not fully covered by database cascades.
+ */
+@Service
+public class CourseDeletionCleanupService {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Transactional
+    public void cleanupBeforeDelete(UUID courseId) {
+        Set<String> tables = loadExistingTables();
+
+        deleteByCourseIfPresent(tables, "certificates",
+                "DELETE FROM certificates WHERE course_id = :courseId", courseId);
+        deleteByCourseIfPresent(tables, "student_notes",
+                "DELETE FROM student_notes WHERE course_id = :courseId", courseId);
+        deleteByCourseIfPresent(tables, "ai_alerts",
+                "DELETE FROM ai_alerts WHERE course_id = :courseId", courseId);
+        deleteByCourseIfPresent(tables, "quiz_assignments",
+                "DELETE FROM quiz_assignments WHERE course_id = :courseId", courseId);
+
+        deleteByLessonIfPresent(tables, "learning_events",
+                "DELETE FROM learning_events WHERE lesson_id IN (" + courseLessonSubquery() + ")", courseId);
+        deleteByLessonIfPresent(tables, "video_progress",
+                "DELETE FROM video_progress WHERE lesson_id IN (" + courseLessonSubquery() + ")", courseId);
+        deleteByLessonIfPresent(tables, "student_lesson_progress",
+                "DELETE FROM student_lesson_progress WHERE lesson_id IN (" + courseLessonSubquery() + ")", courseId);
+
+        deleteAssignmentsForCourse(tables, courseId);
+
+        // payment_transactions cascade from courses; revenue_splits references
+        // those payment rows and must be removed first for hard course deletion.
+        deleteByCourseIfPresent(tables, "revenue_splits",
+                "DELETE FROM revenue_splits WHERE course_id = :courseId", courseId);
+
+        entityManager.flush();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> loadExistingTables() {
+        List<Object> rows = entityManager.createNativeQuery(
+                        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'")
+                .getResultList();
+        Set<String> tables = new HashSet<>();
+        for (Object row : rows) {
+            if (row != null) {
+                tables.add(row.toString());
+            }
+        }
+        return tables;
+    }
+
+    private void deleteAssignmentsForCourse(Set<String> tables, UUID courseId) {
+        if (!tables.contains("assignments")) {
+            return;
+        }
+        executeDelete(
+                "DELETE FROM assignments WHERE course_id = :courseId OR lesson_id IN (" + courseLessonSubquery() + ")",
+                courseId
+        );
+    }
+
+    private void deleteByCourseIfPresent(Set<String> tables, String tableName, String sql, UUID courseId) {
+        if (!tables.contains(tableName)) {
+            return;
+        }
+        executeDelete(sql, courseId);
+    }
+
+    private void deleteByLessonIfPresent(Set<String> tables, String tableName, String sql, UUID courseId) {
+        if (!tables.contains(tableName)) {
+            return;
+        }
+        executeDelete(sql, courseId);
+    }
+
+    private void executeDelete(String sql, UUID courseId) {
+        entityManager.createNativeQuery(sql)
+                .setParameter("courseId", courseId)
+                .executeUpdate();
+    }
+
+    private String courseLessonSubquery() {
+        return """
+                SELECT l.id
+                FROM lessons l
+                JOIN chapters ch ON ch.id = l.chapter_id
+                WHERE ch.course_id = :courseId
+                """;
+    }
+}

--- a/backend/src/main/java/com/example/lms/course_authoring/application/usecase/CourseAuthoringUseCase.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/application/usecase/CourseAuthoringUseCase.java
@@ -2,6 +2,7 @@ package com.example.lms.course_authoring.application.usecase;
 
 import com.example.lms.course_authoring.application.dto.AuthoringDTOs;
 import com.example.lms.course_authoring.application.dto.CourseDTOs;
+import com.example.lms.course_authoring.application.service.CourseDeletionCleanupService;
 import com.example.lms.course_authoring.domain.model.Course;
 import com.example.lms.course_authoring.domain.model.CourseCategory;
 import com.example.lms.course_authoring.domain.repository.ChapterRepositoryPort;
@@ -31,6 +32,7 @@ public class CourseAuthoringUseCase {
     private final ChapterRepositoryPort chapterRepository;
     private final GetCourseDraftUseCase getCourseDraftUseCase;
     private final CourseReviewEventJpaRepository reviewEventRepository;
+    private final CourseDeletionCleanupService courseDeletionCleanupService;
 
     private static final int MAX_CODE_RETRY = 3;
 
@@ -175,6 +177,10 @@ public class CourseAuthoringUseCase {
 
     @Transactional
     public void deleteCourse(UUID courseId) {
+        if (!courseRepository.existsById(courseId)) {
+            throw new EntityNotFoundException("Khóa học", courseId);
+        }
+        courseDeletionCleanupService.cleanupBeforeDelete(courseId);
         courseRepository.deleteById(courseId);
     }
 

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3.java
@@ -3,6 +3,7 @@ package com.example.lms.course_authoring.infrastructure.web;
 import com.example.lms.course_authoring.admin.application.dto.WindowedAnalyticsResponse;
 import com.example.lms.course_authoring.admin.application.usecase.GetWindowedAnalyticsUseCase;
 import com.example.lms.course_authoring.application.usecase.ApproveCourseUseCase;
+import com.example.lms.course_authoring.application.usecase.CourseAuthoringUseCase;
 import com.example.lms.course_authoring.application.usecase.RejectCourseUseCase;
 import com.example.lms.course_authoring.domain.model.Course;
 import com.example.lms.course_authoring.domain.repository.CourseRepository;
@@ -55,6 +56,7 @@ public class AdminCoursesControllerV3 {
     private final CourseCategoryJpaRepository categoryRepository;
     private final JpaEnrollmentRepository enrollmentRepository;
     private final PaymentTransactionJpaRepository paymentTransactionRepository;
+    private final CourseAuthoringUseCase courseAuthoringUseCase;
     private final ApproveCourseUseCase approveCourseUseCase;
     private final RejectCourseUseCase rejectCourseUseCase;
     private final CourseReviewEventJpaRepository reviewEventRepository;
@@ -449,7 +451,7 @@ public class AdminCoursesControllerV3 {
         if (!courseRepository.existsById(courseId)) {
             throw new EntityNotFoundException("Khóa học", courseId);
         }
-        courseRepository.deleteById(courseId);
+        courseAuthoringUseCase.deleteCourse(courseId);
         return ResponseEntity.ok(ApiResponse.success("Đã xóa", "Khóa học đã được xóa thành công"));
     }
 

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/TeacherCoursesControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/TeacherCoursesControllerV3.java
@@ -189,7 +189,7 @@ public class TeacherCoursesControllerV3 {
     public ResponseEntity<ApiResponse<Object>> deleteCourse(
             @PathVariable UUID courseId,
             @AuthenticationPrincipal UserJpaEntity user) {
-        verifyCourseOwnership(courseId, user);
+        verifyCourseOwner(courseId, user);
         courseAuthoringUseCase.deleteCourse(courseId);
         return ResponseEntity.ok(ApiResponse.success("Xóa thành công"));
     }
@@ -307,6 +307,16 @@ public class TeacherCoursesControllerV3 {
         if (!course.getTeacherId().equals(user.getId())
                 && !classTeacherJpaRepository.existsByTeacherIdAndCourseId(user.getId(), courseId)) {
             throw new org.springframework.security.access.AccessDeniedException("Bạn không có quyền truy cập khóa học này");
+        }
+    }
+
+    private void verifyCourseOwner(UUID courseId, UserJpaEntity user) {
+        if (isAdminRole(user)) return;
+        var course = jpaCourseRepository.findById(courseId)
+                .orElseThrow(() -> new com.example.lms.shared.exception.EntityNotFoundException("Course", courseId));
+        if (!course.getTeacherId().equals(user.getId())) {
+            throw new org.springframework.security.access.AccessDeniedException(
+                    "Chỉ chủ sở hữu khóa học mới có quyền xóa khóa học này");
         }
     }
 

--- a/backend/src/test/java/com/example/lms/course_authoring/application/service/CourseDeletionCleanupServiceTest.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/application/service/CourseDeletionCleanupServiceTest.java
@@ -1,0 +1,108 @@
+package com.example.lms.course_authoring.application.service;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CourseDeletionCleanupService Tests")
+class CourseDeletionCleanupServiceTest {
+
+    @Mock
+    private EntityManager entityManager;
+
+    @Mock
+    private Query tableQuery;
+
+    @Mock
+    private Query deleteQuery;
+
+    private CourseDeletionCleanupService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CourseDeletionCleanupService();
+        ReflectionTestUtils.setField(service, "entityManager", entityManager);
+
+        when(entityManager.createNativeQuery(anyString())).thenAnswer(invocation -> {
+            String sql = invocation.getArgument(0, String.class);
+            if (sql.startsWith("SELECT table_name FROM information_schema.tables")) {
+                return tableQuery;
+            }
+            return deleteQuery;
+        });
+        when(deleteQuery.setParameter(anyString(), any())).thenReturn(deleteQuery);
+    }
+
+    @Test
+    @DisplayName("Should cleanup non-cascading course dependents before hard delete")
+    void shouldCleanupNonCascadingCourseDependents() {
+        when(tableQuery.getResultList()).thenReturn(List.of(
+                "certificates",
+                "student_notes",
+                "ai_alerts",
+                "quiz_assignments",
+                "learning_events",
+                "video_progress",
+                "student_lesson_progress",
+                "assignments",
+                "revenue_splits"
+        ));
+
+        service.cleanupBeforeDelete(UUID.randomUUID());
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(entityManager, atLeastOnce()).createNativeQuery(sqlCaptor.capture());
+
+        assertThat(sqlCaptor.getAllValues())
+                .contains("DELETE FROM certificates WHERE course_id = :courseId")
+                .contains("DELETE FROM student_notes WHERE course_id = :courseId")
+                .contains("DELETE FROM ai_alerts WHERE course_id = :courseId")
+                .contains("DELETE FROM quiz_assignments WHERE course_id = :courseId")
+                .contains("DELETE FROM revenue_splits WHERE course_id = :courseId");
+
+        assertThat(sqlCaptor.getAllValues())
+                .anySatisfy(sql -> assertThat(sql)
+                        .startsWith("DELETE FROM learning_events WHERE lesson_id IN")
+                        .contains("JOIN chapters ch ON ch.id = l.chapter_id")
+                        .contains("WHERE ch.course_id = :courseId"))
+                .anySatisfy(sql -> assertThat(sql)
+                        .startsWith("DELETE FROM assignments WHERE course_id = :courseId OR lesson_id IN")
+                        .contains("WHERE ch.course_id = :courseId"));
+
+        verify(entityManager).flush();
+    }
+
+    @Test
+    @DisplayName("Should skip cleanup for tables missing in current schema")
+    void shouldSkipCleanupForMissingTables() {
+        when(tableQuery.getResultList()).thenReturn(List.of("student_notes"));
+
+        service.cleanupBeforeDelete(UUID.randomUUID());
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(entityManager, atLeastOnce()).createNativeQuery(sqlCaptor.capture());
+
+        assertThat(sqlCaptor.getAllValues())
+                .contains("DELETE FROM student_notes WHERE course_id = :courseId")
+                .doesNotContain("DELETE FROM ai_alerts WHERE course_id = :courseId")
+                .doesNotContain("DELETE FROM revenue_splits WHERE course_id = :courseId");
+    }
+}

--- a/backend/src/test/java/com/example/lms/course_authoring/application/usecase/CourseAuthoringUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/application/usecase/CourseAuthoringUseCaseTest.java
@@ -2,13 +2,16 @@ package com.example.lms.course_authoring.application.usecase;
 
 import com.example.lms.course_authoring.application.dto.AuthoringDTOs;
 import com.example.lms.course_authoring.application.dto.CourseDTOs;
+import com.example.lms.course_authoring.application.service.CourseDeletionCleanupService;
 import com.example.lms.course_authoring.domain.model.Course;
 import com.example.lms.course_authoring.domain.model.CourseCategory;
 import com.example.lms.course_authoring.domain.repository.ChapterRepositoryPort;
 import com.example.lms.course_authoring.domain.repository.CourseCategoryRepository;
 import com.example.lms.course_authoring.domain.repository.CourseRepository;
+import com.example.lms.course_authoring.infrastructure.persistence.repository.CourseReviewEventJpaRepository;
 import com.example.lms.shared.domain.valueobject.CourseCode;
 import com.example.lms.shared.exception.BusinessRuleException;
+import com.example.lms.shared.exception.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +29,8 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +49,12 @@ class CourseAuthoringUseCaseTest {
 
     @Mock
     private GetCourseDraftUseCase getCourseDraftUseCase;
+
+    @Mock
+    private CourseReviewEventJpaRepository reviewEventRepository;
+
+    @Mock
+    private CourseDeletionCleanupService courseDeletionCleanupService;
 
     @InjectMocks
     private CourseAuthoringUseCase useCase;
@@ -129,5 +140,31 @@ class CourseAuthoringUseCaseTest {
         assertThatThrownBy(() -> useCase.createCourse(request, teacherId))
                 .isInstanceOf(BusinessRuleException.class)
                 .hasMessageContaining("0");
+    }
+
+    @Test
+    @DisplayName("Should cleanup course dependents before deleting course")
+    void shouldCleanupDependentsBeforeDeletingCourse() {
+        UUID courseId = UUID.randomUUID();
+        when(courseRepository.existsById(courseId)).thenReturn(true);
+
+        useCase.deleteCourse(courseId);
+
+        var ordered = inOrder(courseDeletionCleanupService, courseRepository);
+        ordered.verify(courseDeletionCleanupService).cleanupBeforeDelete(courseId);
+        ordered.verify(courseRepository).deleteById(courseId);
+    }
+
+    @Test
+    @DisplayName("Should fail fast when deleting missing course")
+    void shouldFailFastWhenDeletingMissingCourse() {
+        UUID courseId = UUID.randomUUID();
+        when(courseRepository.existsById(courseId)).thenReturn(false);
+
+        assertThatThrownBy(() -> useCase.deleteCourse(courseId))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        verify(courseDeletionCleanupService, never()).cleanupBeforeDelete(any());
+        verify(courseRepository, never()).deleteById(any());
     }
 }

--- a/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3Test.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/AdminCoursesControllerV3Test.java
@@ -44,6 +44,7 @@ class AdminCoursesControllerV3Test {
     @Mock private CourseCategoryJpaRepository categoryRepository;
     @Mock private JpaEnrollmentRepository enrollmentRepository;
     @Mock private PaymentTransactionJpaRepository paymentTransactionRepository;
+    @Mock private com.example.lms.course_authoring.application.usecase.CourseAuthoringUseCase courseAuthoringUseCase;
     @Mock private com.example.lms.course_authoring.application.usecase.ApproveCourseUseCase approveCourseUseCase;
     @Mock private com.example.lms.course_authoring.application.usecase.RejectCourseUseCase rejectCourseUseCase;
     @Mock private CourseReviewEventJpaRepository reviewEventRepository;
@@ -317,7 +318,7 @@ class AdminCoursesControllerV3Test {
 
             // Then
             assertThat(response.getStatusCode().value()).isEqualTo(200);
-            verify(courseRepository).deleteById(courseId);
+            verify(courseAuthoringUseCase).deleteCourse(courseId);
         }
 
         @Test
@@ -330,7 +331,7 @@ class AdminCoursesControllerV3Test {
             // When/Then
             assertThatThrownBy(() -> controller.deleteCourse(courseId))
                     .isInstanceOf(com.example.lms.shared.exception.EntityNotFoundException.class);
-            verify(courseRepository, never()).deleteById(any());
+            verify(courseAuthoringUseCase, never()).deleteCourse(any());
         }
     }
 }

--- a/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/TeacherCoursesSecurityTest.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/TeacherCoursesSecurityTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
 class TeacherCoursesSecurityTest {
 
     private static final String COURSE_ACCESS_DENIED_MESSAGE = "quyền truy cập khóa học";
+    private static final String COURSE_DELETE_DENIED_MESSAGE = "chủ sở hữu khóa học";
 
     @Mock private CourseAuthoringUseCase courseAuthoringUseCase;
     @Mock private GetCourseDraftUseCase getCourseDraftUseCase;
@@ -99,7 +100,27 @@ class TeacherCoursesSecurityTest {
 
         assertThatThrownBy(() -> controller.deleteCourse(courseId, otherTeacher))
                 .isInstanceOf(AccessDeniedException.class)
-                .hasMessageContaining(COURSE_ACCESS_DENIED_MESSAGE);
+                .hasMessageContaining(COURSE_DELETE_DENIED_MESSAGE);
+    }
+
+    @Test
+    @DisplayName("deleteCourse: rejects co-teacher")
+    void deleteCourse_rejectsCoTeacher() {
+        UUID coTeacherId = UUID.randomUUID();
+        otherTeacher = mock(UserJpaEntity.class);
+        when(otherTeacher.getId()).thenReturn(coTeacherId);
+        when(otherTeacher.getRole()).thenReturn(UserJpaEntity.UserRole.TEACHER);
+
+        course = mock(CourseJpaEntity.class);
+        when(course.getTeacherId()).thenReturn(teacherId);
+        when(jpaCourseRepository.findById(courseId)).thenReturn(Optional.of(course));
+        org.mockito.Mockito.lenient()
+                .when(classTeacherJpaRepository.existsByTeacherIdAndCourseId(coTeacherId, courseId))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> controller.deleteCourse(courseId, otherTeacher))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining(COURSE_DELETE_DENIED_MESSAGE);
     }
 
     @Test

--- a/fe/src/app/features/teacher/course-editor/pages/course-settings/course-settings.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-settings/course-settings.component.html
@@ -49,7 +49,11 @@
       </div>
       <div class="editor-card__body">
         <p class="settings-danger-card__warning">Toàn bộ nội dung, bài học, và dữ liệu học viên sẽ bị xóa vĩnh viễn. Hành động này không thể hoàn tác.</p>
-        <button type="button" (click)="deleteCourse()" class="settings-danger-card__button">
+        <button type="button"
+          (click)="deleteCourse()"
+          [disabled]="isLoading()"
+          [attr.aria-busy]="isLoading()"
+          class="settings-danger-card__button">
           Xóa vĩnh viễn
         </button>
       </div>

--- a/fe/src/app/features/teacher/course-editor/pages/course-settings/course-settings.component.scss
+++ b/fe/src/app/features/teacher/course-editor/pages/course-settings/course-settings.component.scss
@@ -118,3 +118,9 @@
 .settings-danger-card__button:hover {
   background: rgb(254 226 226);
 }
+
+.settings-danger-card__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background: #fff;
+}

--- a/fe/src/app/features/teacher/course-editor/pages/course-settings/course-settings.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-settings/course-settings.component.ts
@@ -24,6 +24,7 @@ export class CourseSettingsComponent {
   readonly isLoading = signal(false);
   readonly allowOfflineDownload = signal(true);
   private readonly initialAllowOfflineDownload = signal(true);
+  private readonly courseDeleted = signal(false);
   private hydratedKey: string | null = null;
 
   readonly hasPersistableChanges = computed(() =>
@@ -60,6 +61,7 @@ export class CourseSettingsComponent {
   }
 
   async canDeactivate(): Promise<boolean> {
+    if (this.courseDeleted()) return true;
     if (!this.hasPersistableChanges() && !this.isLoading()) return true;
 
     const shouldLeave = await this.confirmDialog.confirm({
@@ -112,8 +114,12 @@ export class CourseSettingsComponent {
     this.isLoading.set(true);
     this.courseApi.deleteCourse(courseId).subscribe({
       next: () => {
+        this.courseDeleted.set(true);
+        this.initialAllowOfflineDownload.set(this.allowOfflineDownload());
+        this.store.markSaved();
+        this.isLoading.set(false);
         this.toast.success('Đã xóa khóa học');
-        this.router.navigate(['/teacher/courses']);
+        this.router.navigate(['/teacher/courses'], { replaceUrl: true });
       },
       error: (err: any) => {
         this.toast.error(`Xóa thất bại: ${err?.error?.message || 'Lỗi không xác định'}`);


### PR DESCRIPTION
## Summary
- Fix teacher course settings navigation after successful delete by bypassing the dirty-state guard for deleted courses.
- Route admin and teacher course deletion through the same authoring use case.
- Add guarded backend cleanup for course-related rows not consistently covered by DB cascades.
- Restrict teacher hard delete to course owner/admin, not co-teachers.

## Tests
- `mvn -Dtest=CourseAuthoringUseCaseTest,CourseDeletionCleanupServiceTest,TeacherCoursesSecurityTest,AdminCoursesControllerV3Test test`
- `mvn -Dtest=CleanArchitectureTest test`
- `npm ci`
- `npm run build`

## Reviewer Notes
- Please review the hard-delete cleanup list carefully, especially payment/revenue related cleanup and owner-only delete semantics.