### PR TITLE
fix: prevent false student offline banner

### DIFF
--- a/fe/nginx.conf
+++ b/fe/nginx.conf
@@ -60,6 +60,20 @@ server {
         try_files $uri =404;
     }
 
+    location = /sw-wrapper.js {
+        if ($host = localhost) {
+            return 404;
+        }
+        if ($host = 127.0.0.1) {
+            return 404;
+        }
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Service-Worker-Allowed "/";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        try_files $uri =404;
+    }
+
     # PWA hard reset - standalone page that bypasses Angular and stale SW state.
     # Usage: /reset-sw?returnUrl=%2Fstudent%2Fstorage
     location = /reset-sw {

--- a/fe/src/app/api/interceptors/offline.interceptor.spec.ts
+++ b/fe/src/app/api/interceptors/offline.interceptor.spec.ts
@@ -1,5 +1,5 @@
 import type { OfflineCourse } from '../../core/db/lms-offline.db';
-import { buildOfflineCoursesListingResponse } from './offline.interceptor';
+import { buildOfflineCoursesListingResponse, shouldBypassOfflineInterception } from './offline.interceptor';
 
 describe('buildOfflineCoursesListingResponse', () => {
   const cachedCourses: OfflineCourse[] = [
@@ -71,5 +71,17 @@ describe('buildOfflineCoursesListingResponse', () => {
     expect(response.data.totalElements).toBe(0);
     expect(response.data.empty).toBeTrue();
     expect(response.pagination.totalItems).toBe(0);
+  });
+});
+
+describe('shouldBypassOfflineInterception', () => {
+  it('bypasses auth, sync, and health endpoints before changing offline state', () => {
+    expect(shouldBypassOfflineInterception('/api/v3/auth/login')).toBeTrue();
+    expect(shouldBypassOfflineInterception('/api/v3/sync/pending')).toBeTrue();
+    expect(shouldBypassOfflineInterception('/actuator/health')).toBeTrue();
+  });
+
+  it('keeps course requests eligible for offline fallback', () => {
+    expect(shouldBypassOfflineInterception('/api/v3/courses/11111111-1111-1111-1111-111111111111')).toBeFalse();
   });
 });

--- a/fe/src/app/api/interceptors/offline.interceptor.ts
+++ b/fe/src/app/api/interceptors/offline.interceptor.ts
@@ -1,6 +1,6 @@
 import { HttpRequest, HttpHandlerFn, HttpEvent, HttpResponse, HttpErrorResponse } from '@angular/common/http';
 import { Observable, from, of, throwError } from 'rxjs';
-import { catchError, switchMap } from 'rxjs/operators';
+import { catchError, switchMap, tap } from 'rxjs/operators';
 import { inject } from '@angular/core';
 import { ensureOfflineDbReady, offlineDb, getCurrentUserId, type OfflineCourse } from '../../core/db/lms-offline.db';
 import { OfflineSyncService } from '../../core/services/offline-sync.service';
@@ -28,6 +28,11 @@ export const offlineInterceptor = (req: HttpRequest<any>, next: HttpHandlerFn): 
 
   // If online, proceed normally but catch network failures
   return next(req).pipe(
+    tap((event) => {
+      if (event instanceof HttpResponse) {
+        networkStatus.markOnlineFromHttpSuccess();
+      }
+    }),
     catchError((error: HttpErrorResponse) => {
       const path = extractApiPath(req.url) || req.url;
       const isOfflineError = isOfflineCompatibleHttpError(error, req.url, {
@@ -39,12 +44,12 @@ export const offlineInterceptor = (req: HttpRequest<any>, next: HttpHandlerFn): 
         return throwError(() => error);
       }
 
-      networkStatus.markOfflineFromTransportFailure();
-
       // Never intercept auth or health-check endpoints
-      if (NEVER_INTERCEPT_PREFIXES.some(prefix => path.startsWith(prefix))) {
+      if (shouldBypassOfflineInterception(path)) {
         return throwError(() => error);
       }
+
+      networkStatus.markOfflineFromTransportFailure();
 
       // For GET requests → try offline fallback
       if (req.method === 'GET') {
@@ -89,6 +94,10 @@ export const offlineInterceptor = (req: HttpRequest<any>, next: HttpHandlerFn): 
     }),
   );
 };
+
+export function shouldBypassOfflineInterception(path: string): boolean {
+  return NEVER_INTERCEPT_PREFIXES.some(prefix => path.startsWith(prefix));
+}
 
 // ─── Offline Fallback Logic ──────────────────────────────────────────
 

--- a/fe/src/app/core/services/network-status.service.spec.ts
+++ b/fe/src/app/core/services/network-status.service.spec.ts
@@ -1,3 +1,4 @@
+import { fakeAsync, flushMicrotasks, tick } from '@angular/core/testing';
 import { NetworkStatusService } from './network-status.service';
 
 describe('NetworkStatusService', () => {
@@ -109,14 +110,49 @@ describe('NetworkStatusService', () => {
   });
 
   describe('offline signal tracking', () => {
-    it('should mark the app as effectively offline after a transport failure', () => {
+    it('should wait for a probe before showing offline after a transport failure', fakeAsync(() => {
       service.online.set(true);
+      fetchSpy.calls.reset();
 
       service.markOfflineFromTransportFailure();
+
+      expect(service.online()).toBeTrue();
+      expect(service.hasRecentOfflineSignal()).toBeTrue();
+      expect(service.isEffectivelyOffline()).toBeFalse();
+
+      tick(250);
+      flushMicrotasks();
+
+      expect(fetchSpy).toHaveBeenCalled();
+      expect(service.online()).toBeTrue();
+      expect(service.hasRecentOfflineSignal()).toBeFalse();
+    }));
+
+    it('should confirm offline when the follow-up probe fails', fakeAsync(() => {
+      service.online.set(true);
+      fetchSpy.and.callFake(async () => new Response('', { status: 503 }));
+
+      service.markOfflineFromTransportFailure();
+      tick(250);
+      flushMicrotasks();
 
       expect(service.online()).toBeFalse();
       expect(service.hasRecentOfflineSignal()).toBeTrue();
       expect(service.isEffectivelyOffline()).toBeTrue();
-    });
+    }));
+
+    it('should clear a suspected offline signal after a successful HTTP response', fakeAsync(() => {
+      service.online.set(true);
+      fetchSpy.calls.reset();
+      service.markOfflineFromTransportFailure();
+
+      service.markOnlineFromHttpSuccess();
+      tick(250);
+
+      expect(service.online()).toBeTrue();
+      expect(service.hasRecentOfflineSignal()).toBeFalse();
+      expect(service.isEffectivelyOffline()).toBeFalse();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    }));
   });
 });

--- a/fe/src/app/core/services/network-status.service.ts
+++ b/fe/src/app/core/services/network-status.service.ts
@@ -7,6 +7,7 @@ const OFFLINE_GRACE_MS = 1_500;
 const RECENT_OFFLINE_WINDOW_MS = 5_000;
 const PROBE_INTERVAL_MS = 120_000;
 const PROBE_TIMEOUT_MS = 4_000;
+const TRANSPORT_FAILURE_PROBE_DELAY_MS = 250;
 
 @Injectable({ providedIn: 'root' })
 export class NetworkStatusService implements OnDestroy {
@@ -47,6 +48,7 @@ export class NetworkStatusService implements OnDestroy {
   );
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private offlineGraceTimer: ReturnType<typeof setTimeout> | null = null;
+  private transportFailureProbeTimer: ReturnType<typeof setTimeout> | null = null;
   private probeInterval: ReturnType<typeof setInterval> | null = null;
 
   private readonly onlineHandler = () => {
@@ -116,6 +118,9 @@ export class NetworkStatusService implements OnDestroy {
     if (this.offlineGraceTimer) {
       clearTimeout(this.offlineGraceTimer);
     }
+    if (this.transportFailureProbeTimer) {
+      clearTimeout(this.transportFailureProbeTimer);
+    }
   }
 
   hasRecentOfflineSignal(windowMs = RECENT_OFFLINE_WINDOW_MS): boolean {
@@ -123,19 +128,50 @@ export class NetworkStatusService implements OnDestroy {
     return lastOfflineSignalAt != null && Date.now() - lastOfflineSignalAt <= windowMs;
   }
 
-  isEffectivelyOffline(windowMs = RECENT_OFFLINE_WINDOW_MS): boolean {
+  isEffectivelyOffline(): boolean {
     return !this.getBrowserOnlineHint()
-      || !this.online()
-      || this.hasRecentOfflineSignal(windowMs);
+      || !this.online();
   }
 
   markOfflineFromTransportFailure(): void {
-    this.markOfflineState();
+    if (!this.getBrowserOnlineHint()) {
+      this.markOfflineState();
+      return;
+    }
+
+    this.recentOfflineSignalAt.set(Date.now());
+    this.scheduleTransportFailureProbe();
+  }
+
+  markOnlineFromHttpSuccess(): void {
+    if (!this.getBrowserOnlineHint()) {
+      return;
+    }
+
+    if (this.transportFailureProbeTimer) {
+      clearTimeout(this.transportFailureProbeTimer);
+      this.transportFailureProbeTimer = null;
+    }
+
+    this.online.set(true);
+    this.recentOfflineSignalAt.set(null);
+    if (this.effectiveBandwidthMbps() <= 0) {
+      this.effectiveBandwidthMbps.set(2);
+    }
   }
 
   private debouncedUpdate(): void {
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     this.debounceTimer = setTimeout(() => this.updateStatus(), 150);
+  }
+
+  private scheduleTransportFailureProbe(): void {
+    if (this.transportFailureProbeTimer) return;
+
+    this.transportFailureProbeTimer = setTimeout(() => {
+      this.transportFailureProbeTimer = null;
+      this.probeLatency();
+    }, TRANSPORT_FAILURE_PROBE_DELAY_MS);
   }
 
   private updateStatus(): void {


### PR DESCRIPTION
## Summary
- prevent single transport failures from immediately flipping the global offline banner while the browser still reports online
- bypass auth/sync/health endpoints before offline fallback can mutate global network state
- clear suspected offline state on successful HTTP responses and keep `/sw-wrapper.js` from being cached immutably

## Verification
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/core/services/network-status.service.spec.ts --include=src/app/api/interceptors/offline.interceptor.spec.ts`
- `npx ng build --configuration=production`
- `node scripts/fix-ngsw.js`

## Notes
- Production build still reports existing Angular template/Sass/CommonJS warnings unrelated to this change.