### PR TITLE
[codex] improve course learning layout

### DIFF
--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
@@ -1,23 +1,29 @@
-<div class="flex flex-col min-h-full">
+<div class="lesson-learning-shell">
 
 
   <!-- Reading Area -->
-  <div class="max-w-[1150px] mx-auto w-full pt-3 px-4 md:px-0">
+  <div class="lesson-reading-area" role="region" aria-labelledby="lesson-heading">
 
     <!-- Lesson Title (Always at top) -->
     @if (hasSections() && currentSection(); as section) {
-    <h1 class="text-xl md:text-2xl font-semibold text-gray-900 mb-2 leading-tight">
-      {{ lessonNumber() }}: {{ lesson().title }}
-    </h1>
+    <header class="lesson-header">
+      <p class="lesson-kicker">Chương {{ chapterIndex() + 1 }} / {{ lessonNumber() }}</p>
+      <h1 id="lesson-heading" class="lesson-title">
+        {{ lesson().title }}
+      </h1>
     @if (section.title) {
-    <h3 class="text-xl md:text-xl font-semibold text-gray-700 mb-2 leading-tight">
+      <h2 class="lesson-section-title">
       {{ section.title }}
-    </h3>
+      </h2>
     }
+    </header>
     } @else {
-    <h1 class="text-xl md:text-2xl font-semibold text-gray-900 mb-2 leading-tight">
-      {{ lesson().title }}
-    </h1>
+    <header class="lesson-header">
+      <p class="lesson-kicker">{{ lessonNumber() }}</p>
+      <h1 id="lesson-heading" class="lesson-title">
+        {{ lesson().title }}
+      </h1>
+    </header>
     }
 
     <!-- Single-column layout (Coursera/edX/Khan Academy hybrid) — no tab nav.
@@ -25,12 +31,12 @@
          by the floating button at bottom-right. The lesson-attachments tab
          was removed because section.type === 'FILE' already surfaces every
          attachment via the unified file card below. -->
-    <div class="pt-6">
+    <div class="lesson-content-body">
       @if (currentSection(); as section) {
-      <div class="space-y-5 text-slate-800 text-[15px] leading-relaxed max-w-none pb-6">
+      <div class="lesson-content-flow text-slate-800 pb-6">
         @if (section.type === 'TEXT') {
           @if (section.content) {
-          <div class="prose prose-slate max-w-none" #textContent [innerHTML]="getSanitizedHtml(section.content)"></div>
+          <div class="lesson-prose prose prose-slate max-w-none" #textContent [innerHTML]="getSanitizedHtml(section.content)"></div>
           @if (readingProgress() > 0 && readingProgress() < 100) {
           <div class="flex items-center gap-2 text-xs text-slate-400 mt-4">
             <div class="flex-1 h-1 bg-slate-100 rounded-full">
@@ -95,13 +101,13 @@
           <app-icon name="edit" size="md" class="text-[#0056D2]"></app-icon>
           <h3 class="text-base font-bold text-slate-800">Bài tập{{ section.title ? ': ' + section.title : '' }}</h3>
         </div>
-        <div class="prose prose-slate max-w-none text-sm" [innerHTML]="getSanitizedHtml(section.content)"></div>
+        <div class="lesson-prose prose prose-slate max-w-none text-sm" [innerHTML]="getSanitizedHtml(section.content)"></div>
       </div>
       }
     </div>
     } @else {
     @if (lesson().content) {
-    <div class="prose prose-slate max-w-none text-[15px] leading-relaxed pb-6" [innerHTML]="getSafeHtmlContent()"></div>
+    <div class="lesson-prose prose prose-slate max-w-none pb-6" [innerHTML]="getSafeHtmlContent()"></div>
     }
     }
 
@@ -140,11 +146,11 @@
     }
 
     <!-- Media area: video / file unified card. Always visible — no tab gate. -->
-    <div class="mb-4 max-w-[920px] mx-auto w-full">
+    <div class="lesson-media-area mb-4 w-full">
       @if (currentSection(); as section) {
       <!-- VIDEO SECTION -->
       @if (section.type === 'VIDEO') {
-      <div class="relative aspect-video w-full rounded-lg overflow-hidden shadow-sm bg-black border border-gray-100 mb-6">
+      <div class="lesson-video-frame relative aspect-video w-full rounded-lg overflow-hidden shadow-sm bg-black border border-gray-100 mb-6">
         @if (!section.streamVideoUid && isYouTubeUrl(section.videoUrl || lesson().videoUrl)) {
         <app-youtube-player [videoUrl]="(section.videoUrl || lesson().videoUrl)!" [lessonId]="lesson().id" [sectionId]="section.id"
           [completionThreshold]="section.completionThreshold"
@@ -270,7 +276,7 @@
 
       <!-- Lesson-level video (legacy lessons may have text/file sections plus a single lesson video) -->
       @if (shouldShowLessonLevelVideo()) {
-      <div class="relative aspect-video w-full rounded-lg overflow-hidden shadow-sm bg-black border border-gray-100">
+      <div class="lesson-video-frame relative aspect-video w-full rounded-lg overflow-hidden shadow-sm bg-black border border-gray-100">
         @if (!lesson().streamVideoUid && isYouTubeUrl(lesson().videoUrl)) {
         <app-youtube-player [videoUrl]="lesson().videoUrl!" [lessonId]="lesson().id"
           [sectionId]="'lesson-' + lesson().id" (videoEnded)="onVideoEnd()" />
@@ -295,7 +301,6 @@
     </div>
 
   </div> <!-- end content container -->
-</div> <!-- end Reading Area -->
 
 <!-- Floating notes button (Coursera-style affordance) — anchored bottom-right.
      Sits ABOVE the page's bottom navigation bar (which uses bottom-0 + z-30):

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.scss
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.scss
@@ -4,8 +4,195 @@
   min-height: 100%;
 }
 
+.lesson-learning-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  padding: 0 2rem 7rem;
+}
+
+.lesson-reading-area {
+  width: 100%;
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 2rem 0 3rem;
+}
+
+.lesson-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.lesson-kicker {
+  margin: 0 0 0.65rem;
+  color: #64748b;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.lesson-title {
+  margin: 0;
+  color: #0f172a;
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1.25;
+}
+
+.lesson-section-title {
+  margin: 0.85rem 0 0;
+  color: #334155;
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.lesson-content-body {
+  padding-top: 0.25rem;
+}
+
+.lesson-content-flow {
+  font-size: 1rem;
+  line-height: 1.8;
+}
+
+.lesson-media-area {
+  max-width: 920px;
+  margin-inline: auto;
+}
+
+.lesson-video-frame {
+  border-radius: 0.75rem;
+}
+
 // ::ng-deep required because .prose content is injected via [innerHTML]
 // which doesn't get Angular's _ngcontent-xxx attribute scoping
 :host ::ng-deep .prose {
   @import '../../../../shared/components/tiptap-editor/prose-content';
+}
+
+:host ::ng-deep .lesson-prose {
+  color: #334155;
+  font-size: 1rem;
+  line-height: 1.85;
+
+  > *:first-child {
+    margin-top: 0;
+  }
+
+  p {
+    max-width: 75ch;
+    margin: 0 0 1rem;
+    color: #334155;
+    line-height: 1.85;
+    text-align: left;
+    overflow-wrap: anywhere;
+  }
+
+  p + p {
+    text-indent: 1.5rem;
+  }
+
+  li p,
+  blockquote p,
+  .callout p,
+  table p {
+    text-indent: 0;
+  }
+
+  h2 {
+    margin-top: 2.25rem;
+    margin-bottom: 0.85rem;
+    padding-bottom: 0.5rem;
+    color: #0f172a;
+    font-size: 1.35rem;
+    line-height: 1.35;
+    border-bottom: 1px solid #dbe5f2;
+  }
+
+  h3 {
+    margin-top: 1.75rem;
+    margin-bottom: 0.75rem;
+    color: #172033;
+    font-size: 1.12rem;
+    line-height: 1.4;
+  }
+
+  h4,
+  h5,
+  h6 {
+    margin-top: 1.4rem;
+    margin-bottom: 0.55rem;
+    color: #1e293b;
+    line-height: 1.45;
+  }
+
+  ul,
+  ol {
+    max-width: 75ch;
+    margin: 1rem 0 1.25rem;
+    padding-left: 1.75rem;
+  }
+
+  li {
+    margin: 0.45rem 0;
+    padding-left: 0.2rem;
+    line-height: 1.75;
+  }
+
+  li > ul,
+  li > ol {
+    margin: 0.45rem 0 0.65rem;
+    padding-left: 1.25rem;
+  }
+
+  blockquote,
+  .callout {
+    max-width: 78ch;
+  }
+
+  table {
+    line-height: 1.55;
+  }
+}
+
+@media (max-width: 767px) {
+  .lesson-learning-shell {
+    padding: 0 1rem 7.5rem;
+  }
+
+  .lesson-reading-area {
+    padding: 1.25rem 0 2.25rem;
+  }
+
+  .lesson-header {
+    margin-bottom: 1.5rem;
+  }
+
+  .lesson-title {
+    font-size: 1.5rem;
+  }
+
+  .lesson-section-title {
+    font-size: 1.1rem;
+  }
+
+  :host ::ng-deep .lesson-prose {
+    font-size: 0.96875rem;
+    line-height: 1.8;
+
+    p {
+      line-height: 1.8;
+    }
+
+    p + p {
+      text-indent: 0;
+    }
+
+    ul,
+    ol {
+      padding-left: 1.35rem;
+    }
+  }
 }

--- a/fe/src/app/features/learning/pages/course-learning.component.html
+++ b/fe/src/app/features/learning/pages/course-learning.component.html
@@ -12,7 +12,7 @@
   </div>
 }
 
-<div class="flex flex-col md:flex-row overflow-hidden bg-white" [class.h-screen]="!isPreview()" [style.height]="isPreview() ? 'calc(100vh - 40px)' : ''">
+<div class="course-learning-layout flex flex-col md:flex-row overflow-hidden bg-white" [class.h-screen]="!isPreview()" [style.height]="isPreview() ? 'calc(100vh - 40px)' : ''">
 
   <!-- Mobile Header (md:hidden) -->
   <header class="md:hidden flex items-center justify-between px-4 py-3 border-b border-gray-200 bg-white z-20 shrink-0">
@@ -31,7 +31,7 @@
   }
 
   <!-- Sidebar -->
-  <aside class="w-[300px] flex-col border-r border-gray-200 bg-white h-full z-10 shrink-0"
+  <aside class="learning-sidebar w-[320px] flex-col border-r border-gray-200 bg-white h-full z-10 shrink-0"
     [class.hidden]="isMobileView() && !showMobileSidebar()"
     [class.!flex]="showMobileSidebar() || !isMobileView()"
     [class.fixed]="isMobileView()"
@@ -39,7 +39,7 @@
     [class.top-0]="isMobileView()"
     [class.bottom-0]="isMobileView()"
     [class.w-[85vw]]="isMobileView()"
-    [class.max-w-[320px]]="isMobileView()"
+    [class.max-w-[340px]]="isMobileView()"
     [class.z-50]="isMobileView()"
     [class.shadow-lg]="isMobileView()">
 
@@ -114,13 +114,13 @@
       @for (section of filteredSections(); track section.id) {
       <div>
         <!-- Level 1: Chapter Header -->
-        <button class="flex items-center justify-between w-full px-4 py-3 border-b border-gray-100 cursor-pointer hover:bg-gray-100 transition-colors text-left"
+        <button class="learning-chapter-toggle flex items-center justify-between w-full px-4 py-3 border-b border-gray-100 cursor-pointer hover:bg-gray-100 transition-colors text-left"
           [class.bg-slate-100]="isSectionExpanded(section.id)"
           [class.bg-gray-50]="!isSectionExpanded(section.id)"
           (click)="toggleSection(section.id)"
           [attr.aria-expanded]="isSectionExpanded(section.id)">
           <div class="flex-1 min-w-0">
-            <h3 class="text-sm font-bold"
+            <h3 class="learning-chapter-title text-sm font-bold"
               [class.text-[#0056D2]]="isSectionExpanded(section.id)"
               [class.text-slate-800]="!isSectionExpanded(section.id)">
               <span class="text-[#0056D2] font-extrabold">Chương {{ $index + 1 }}:</span> {{ getChapterDisplayTitle(section.title, $index) }}
@@ -145,7 +145,7 @@
         <div>
           @for (lesson of section.lessons; track lesson.id; let lessonIdx = $index) {
           <!-- Level 2: Lesson Item -->
-          <button class="flex items-start gap-3 w-full px-4 py-2.5 cursor-pointer hover:bg-slate-50 transition-colors border-l-4 text-left"
+          <button class="learning-lesson-toggle flex items-start gap-3 w-full px-4 py-2.5 cursor-pointer hover:bg-slate-50 transition-colors border-l-4 text-left"
             [class.bg-[#E6F0FA]]="currentLesson()?.id === lesson.id"
             [class.border-[#0056D2]]="currentLesson()?.id === lesson.id && !learningService.isLessonCompleted(lesson.id)()"
             [class.border-green-500]="learningService.isLessonCompleted(lesson.id)()"
@@ -166,7 +166,7 @@
 
             <!-- Lesson Info -->
             <div class="flex-1 min-w-0">
-              <div class="text-sm font-medium truncate"
+              <div class="learning-lesson-title text-sm font-medium"
                 [class.font-bold]="currentLesson()?.id === lesson.id"
                 [class.text-[#0056D2]]="currentLesson()?.id === lesson.id"
                 [class.text-slate-700]="currentLesson()?.id !== lesson.id">
@@ -190,7 +190,7 @@
           <!-- Level 3: Sub-sections -->
           @if (lesson.sections && lesson.sections.length > 0 && isLessonExpanded(lesson.id)) {
           @for (sectionItem of lesson.sections; track sectionItem.id; let sectionIndex = $index) {
-          <button class="flex items-center gap-2 w-full pl-12 pr-4 py-1.5 text-xs cursor-pointer transition-colors text-left"
+          <button class="learning-section-toggle flex items-center gap-2 w-full pl-12 pr-4 py-1.5 text-xs cursor-pointer transition-colors text-left"
             [class.text-green-600]="isSectionCompleted(sectionItem.id)"
             [class.font-semibold]="currentLesson()?.id === lesson.id && currentSectionIndex() === sectionIndex"
             [class.text-[#0056D2]]="currentLesson()?.id === lesson.id && currentSectionIndex() === sectionIndex && !isSectionLockedByPrereqs(lesson, sectionIndex)"
@@ -214,7 +214,7 @@
               } @else {
               <app-icon name="paperclip" size="xs"></app-icon>
               }
-              <span class="truncate flex-1">{{ sectionItem.title }}</span>
+              <span class="learning-section-title flex-1">{{ sectionItem.title }}</span>
               @if (sectionItem.isRequired && !isSectionCompleted(sectionItem.id)) {
               <span class="text-[9px] font-bold text-amber-600 bg-amber-50 border border-amber-200 px-1 py-0.5 rounded shrink-0">Bắt buộc</span>
               }
@@ -240,15 +240,15 @@
   </aside>
 
   <!-- Main Content Area -->
-  <main class="flex-1 flex flex-col h-full relative bg-white overflow-hidden">
+  <main class="learning-main flex-1 flex flex-col h-full relative bg-white overflow-hidden">
 
     <!-- Top Bar (desktop only) — minimal breadcrumb -->
-    <div class="hidden md:flex h-[44px] items-center px-6 border-b border-gray-100 bg-white shrink-0">
+    <div class="learning-topbar hidden md:flex h-[52px] items-center px-6 border-b border-gray-100 bg-white shrink-0">
       <span class="text-xs text-slate-400 truncate">{{ course()?.title }}</span>
     </div>
 
     <!-- Scrollable Content -->
-    <div class="flex-1 overflow-y-auto scroll-smooth pb-20">
+    <div class="learning-scroll flex-1 overflow-y-auto scroll-smooth pb-20">
       @if (error()) {
       <div class="mx-4 mt-4 bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg flex justify-between items-center">
         <span>{{ error() }}</span>
@@ -319,8 +319,8 @@
 
     <!-- Bottom Navigation Bar -->
     @if (currentLesson()) {
-    <div class="absolute bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-3 z-30 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]">
-      <div class="max-w-5xl mx-auto flex items-center justify-between">
+    <div class="learning-bottom-nav absolute bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-3 z-30 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]">
+      <div class="max-w-[920px] mx-auto flex items-center justify-between">
         <button class="flex items-center gap-1 px-3 py-2 rounded text-slate-500 hover:text-[#0056D2] hover:bg-slate-50 transition-colors disabled:opacity-40 disabled:pointer-events-none"
           [disabled]="!canGoPrevious() && currentSectionIndex() === 0"
           (click)="previousLesson()">

--- a/fe/src/app/features/learning/pages/course-learning.component.scss
+++ b/fe/src/app/features/learning/pages/course-learning.component.scss
@@ -2,3 +2,72 @@
   display: block;
   height: 100vh;
 }
+
+.course-learning-layout {
+  color: #0f172a;
+}
+
+.learning-sidebar {
+  scrollbar-gutter: stable;
+}
+
+.learning-chapter-toggle {
+  min-height: 4.5rem;
+}
+
+.learning-chapter-title {
+  line-height: 1.45;
+}
+
+.learning-lesson-toggle {
+  min-height: 3.25rem;
+}
+
+.learning-lesson-title,
+.learning-section-title {
+  display: -webkit-box;
+  overflow: hidden;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+}
+
+.learning-lesson-title {
+  -webkit-line-clamp: 2;
+}
+
+.learning-section-title {
+  -webkit-line-clamp: 2;
+}
+
+.learning-section-toggle {
+  align-items: flex-start;
+}
+
+.learning-main {
+  background:
+    linear-gradient(180deg, #ffffff 0%, #fbfdff 48%, #ffffff 100%);
+}
+
+.learning-topbar {
+  padding-inline: clamp(1.5rem, 4vw, 4rem);
+}
+
+.learning-scroll {
+  scrollbar-gutter: stable;
+}
+
+.learning-bottom-nav {
+  backdrop-filter: blur(12px);
+  background: rgba(255, 255, 255, 0.96);
+}
+
+@media (max-width: 767px) {
+  .learning-sidebar {
+    width: 88vw;
+  }
+
+  .learning-bottom-nav {
+    padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+  }
+}


### PR DESCRIPTION
﻿## Summary
- Refines the student course learning layout into a centered reading rail with stable desktop/mobile margins.
- Improves lesson heading hierarchy, section labeling, paragraph rhythm, first-line indentation, nested list indentation, and media sizing.
- Lets long chapter/lesson/section titles wrap cleanly in the curriculum sidebar instead of hard truncating the learning path.

## Rationale
The previous desktop layout allowed lesson text to start too close to the main content edge and used a very wide reading area. The update follows common course-player patterns from Udemy and Coursera: persistent curriculum navigation, chunked module/lesson hierarchy, and a constrained reading column for long-form lesson content.

References:
- Udemy course player curriculum/resource navigation: https://support.udemy.com/hc/articles/229603648-How-to-Access-And-Use-The-Course-Player
- Udemy course overview/learning experience notes: https://support.udemy.com/hc/en-us/sections/206457187-Course-player
- Coursera module/course content structure examples: https://www.coursera.org/learn/instructional-design-foundations-applications

## Validation
- npx ng build --configuration=production

Notes: the build still reports existing Angular extended-diagnostics, Sass @import deprecation, and mammoth/CommonJS warnings unrelated to this PR.
