### PR TITLE
[codex] add learning sidebar toggle

### DIFF
--- a/fe/src/app/features/learning/pages/course-learning.component.html
+++ b/fe/src/app/features/learning/pages/course-learning.component.html
@@ -31,9 +31,11 @@
   }
 
   <!-- Sidebar -->
-  <aside class="learning-sidebar w-[320px] flex-col border-r border-gray-200 bg-white h-full z-10 shrink-0"
+  <aside id="course-learning-sidebar"
+    class="learning-sidebar flex-col border-r border-gray-200 bg-white h-full z-10 shrink-0"
     [class.hidden]="isMobileView() && !showMobileSidebar()"
     [class.!flex]="showMobileSidebar() || !isMobileView()"
+    [class.learning-sidebar--collapsed]="!isMobileView() && desktopSidebarCollapsed()"
     [class.fixed]="isMobileView()"
     [class.left-0]="isMobileView()"
     [class.top-0]="isMobileView()"
@@ -41,7 +43,9 @@
     [class.w-[85vw]]="isMobileView()"
     [class.max-w-[340px]]="isMobileView()"
     [class.z-50]="isMobileView()"
-    [class.shadow-lg]="isMobileView()">
+    [class.shadow-lg]="isMobileView()"
+    [attr.aria-hidden]="!isMobileView() && desktopSidebarCollapsed() ? 'true' : null"
+    [attr.inert]="!isMobileView() && desktopSidebarCollapsed() ? '' : null">
 
     <!-- Sidebar Header -->
     <div class="px-4 py-4 border-b border-gray-200">
@@ -239,8 +243,20 @@
     </div>
   </aside>
 
+  <button type="button"
+    class="learning-sidebar-toggle hidden md:inline-flex"
+    [class.learning-sidebar-toggle--collapsed]="desktopSidebarCollapsed()"
+    [attr.aria-expanded]="!desktopSidebarCollapsed()"
+    aria-controls="course-learning-sidebar"
+    [attr.aria-label]="desktopSidebarCollapsed() ? 'Mở mục lục khóa học' : 'Thu gọn mục lục khóa học'"
+    [attr.title]="desktopSidebarCollapsed() ? 'Mở mục lục' : 'Thu gọn mục lục'"
+    (click)="toggleDesktopSidebar()">
+    <app-icon [name]="desktopSidebarCollapsed() ? 'chevron-right' : 'chevron-left'" size="sm"></app-icon>
+  </button>
+
   <!-- Main Content Area -->
-  <main class="learning-main flex-1 flex flex-col h-full relative bg-white overflow-hidden">
+  <main class="learning-main flex-1 flex flex-col h-full relative bg-white overflow-hidden"
+    [class.learning-main--sidebar-collapsed]="!isMobileView() && desktopSidebarCollapsed()">
 
     <!-- Top Bar (desktop only) — minimal breadcrumb -->
     <div class="learning-topbar hidden md:flex h-[52px] items-center px-6 border-b border-gray-100 bg-white shrink-0">

--- a/fe/src/app/features/learning/pages/course-learning.component.scss
+++ b/fe/src/app/features/learning/pages/course-learning.component.scss
@@ -1,14 +1,72 @@
 :host {
+  --learning-sidebar-width: 20rem;
+
   display: block;
   height: 100vh;
 }
 
 .course-learning-layout {
+  position: relative;
   color: #0f172a;
 }
 
 .learning-sidebar {
+  width: var(--learning-sidebar-width);
+  overflow: hidden;
   scrollbar-gutter: stable;
+  transition:
+    width 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.learning-sidebar--collapsed {
+  width: 0;
+  min-width: 0;
+  border-right-color: transparent;
+  box-shadow: none;
+  pointer-events: none;
+}
+
+.learning-sidebar-toggle {
+  position: absolute;
+  top: 4.35rem;
+  left: var(--learning-sidebar-width);
+  z-index: 35;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  color: #475569;
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid #dbe5f2;
+  border-radius: 999px;
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.12);
+  transform: translateX(-50%);
+  transition:
+    left 180ms ease,
+    color 160ms ease,
+    background-color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 180ms ease;
+
+  &:hover {
+    color: #0056d2;
+    background: #ffffff;
+    border-color: rgba(0, 86, 210, 0.28);
+    box-shadow: 0 10px 26px rgba(0, 86, 210, 0.16);
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(0, 86, 210, 0.22);
+    outline-offset: 2px;
+  }
+}
+
+.learning-sidebar-toggle--collapsed {
+  left: 1rem;
+  transform: none;
 }
 
 .learning-chapter-toggle {
@@ -49,6 +107,10 @@
     linear-gradient(180deg, #ffffff 0%, #fbfdff 48%, #ffffff 100%);
 }
 
+.learning-main--sidebar-collapsed .learning-topbar {
+  padding-left: 4rem;
+}
+
 .learning-topbar {
   padding-inline: clamp(1.5rem, 4vw, 4rem);
 }
@@ -65,6 +127,11 @@
 @media (max-width: 767px) {
   .learning-sidebar {
     width: 88vw;
+  }
+
+  .learning-sidebar--collapsed {
+    width: 88vw;
+    pointer-events: auto;
   }
 
   .learning-bottom-nav {

--- a/fe/src/app/features/learning/pages/course-learning.component.ts
+++ b/fe/src/app/features/learning/pages/course-learning.component.ts
@@ -76,6 +76,7 @@ export class CourseLearningComponent implements OnInit {
   // Local UI state
   isMobileView = signal(false);
   showMobileSidebar = signal(false);
+  desktopSidebarCollapsed = signal(false);
   error = signal<string | null>(null);
 
   // (Removed `activeTab` — content is single-column inline now, notes drawer
@@ -532,6 +533,15 @@ export class CourseLearningComponent implements OnInit {
   // Sidebar actions
   toggleSidebar(): void {
     this.showMobileSidebar.update(show => !show);
+  }
+
+  toggleDesktopSidebar(): void {
+    if (this.isMobileView()) {
+      this.toggleSidebar();
+      return;
+    }
+
+    this.desktopSidebarCollapsed.update(collapsed => !collapsed);
   }
 
   closeMobileSidebar(): void {


### PR DESCRIPTION
﻿## Summary
- Adds a desktop-only icon toggle for the course curriculum sidebar in the student learning page.
- Keeps the existing mobile drawer behavior unchanged.
- Uses `aria-controls`, `aria-expanded`, contextual labels, and `inert` while collapsed so hidden sidebar controls are not reachable by focus.

## Rationale
Students sometimes need the full reading/video canvas after locating the current lesson. The new control follows common LMS/course-player behavior: keep curriculum navigation persistent by default, but allow it to collapse when the learner wants more workspace.

## Validation
- npx ng build --configuration=production
- node scripts/fix-ngsw.js
- git diff --check
- Local Angular dev server returned HTTP 200 at http://127.0.0.1:4200/

Notes: production build still reports existing Angular extended-diagnostics, Sass @import deprecation, and mammoth/CommonJS warnings unrelated to this PR.
