### PR TITLE
[codex] fix learning section number heading

### DIFF
--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
@@ -7,7 +7,7 @@
     <!-- Lesson Title (Always at top) -->
     @if (hasSections() && currentSection(); as section) {
     <header class="lesson-header">
-      <p class="lesson-kicker">Chương {{ chapterIndex() + 1 }} / {{ lessonNumber() }}</p>
+      <p class="lesson-kicker">Chương {{ chapterIndex() + 1 }} / {{ currentSectionNumber() }}</p>
       <h1 id="lesson-heading" class="lesson-title">
         {{ lesson().title }}
       </h1>

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
@@ -195,6 +195,11 @@ export class LessonContentComponent implements AfterViewInit {
   // Two-way binding with model (Angular v20+)
   readonly sectionIndex = model(0);
 
+  /** Numbered section label that matches the sidebar section numbering, e.g. "BÃ i 1.5". */
+  readonly currentSectionNumber = computed(() =>
+    `BÃ i ${this.lessonIndex() + 1}.${this.sectionIndex() + 1}`
+  );
+
   // Output functions (Angular v20+)
   readonly markComplete = output<void>();
   readonly videoEnded = output<void>();

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
@@ -195,9 +195,9 @@ export class LessonContentComponent implements AfterViewInit {
   // Two-way binding with model (Angular v20+)
   readonly sectionIndex = model(0);
 
-  /** Numbered section label that matches the sidebar section numbering, e.g. "BÃ i 1.5". */
+  /** Numbered section label that matches the sidebar section numbering, e.g. "Bài 1.5". */
   readonly currentSectionNumber = computed(() =>
-    `BÃ i ${this.lessonIndex() + 1}.${this.sectionIndex() + 1}`
+    `Bài ${this.lessonIndex() + 1}.${this.sectionIndex() + 1}`
   );
 
   // Output functions (Angular v20+)


### PR DESCRIPTION
﻿## Summary
- Fixes the lesson header kicker so section-based lessons display the currently selected sidebar section number.
- Keeps the existing lesson-level number for lessons that do not have sections.

## Root Cause
`LessonContentComponent` always rendered `lessonNumber()` in the header, even when the student was viewing a specific lesson section. For a lesson with sections, `lessonNumber()` describes the parent lesson position, so the header stayed at `Bài 1.1` while the sidebar and content had advanced to section `1.5`.

## Validation
- npx ng build --configuration=production
- node scripts/fix-ngsw.js
- git diff --check
- Local Angular dev server returned HTTP 200 at http://127.0.0.1:4200/

Notes: production build still reports existing Angular extended-diagnostics, Sass @import deprecation, and mammoth/CommonJS warnings unrelated to this PR.
