### PR TITLE
Polish public mobile course UX

### DIFF
--- a/fe/src/app/features/auth/forgot-password/forgot-password.component.ts
+++ b/fe/src/app/features/auth/forgot-password/forgot-password.component.ts
@@ -300,8 +300,8 @@ type ForgotPasswordForm = {
           <a routerLink="/" class="auth-brand">
             <img src="/icons/logo-master.png" alt="LMS Maritime" class="h-11 w-11 rounded-2xl shadow-sm">
             <div>
-              <p class="auth-brand-kicker">LMS Maritime</p>
-              <p class="auth-brand-title">HoHoLiHu</p>
+              <p class="auth-brand-kicker">HoLiLiHu Online</p>
+              <p class="auth-brand-title">LMS Maritime</p>
             </div>
           </a>
 

--- a/fe/src/app/features/auth/login/login.component.html
+++ b/fe/src/app/features/auth/login/login.component.html
@@ -570,8 +570,8 @@
         <a routerLink="/" class="auth-brand">
           <img src="/icons/logo-master.png" alt="LMS Maritime" class="h-11 w-11 rounded-2xl shadow-sm">
           <div class="auth-brand-text">
-            <p class="auth-brand-kicker">LMS Maritime</p>
-            <p class="auth-brand-title">HoHoLiHu</p>
+            <p class="auth-brand-kicker">HoLiLiHu Online</p>
+            <p class="auth-brand-title">LMS Maritime</p>
           </div>
         </a>
 

--- a/fe/src/app/features/auth/reset-password/reset-password.component.ts
+++ b/fe/src/app/features/auth/reset-password/reset-password.component.ts
@@ -324,8 +324,8 @@ type ResetPasswordForm = {
           <a routerLink="/" class="auth-brand">
             <img src="/icons/logo-master.png" alt="LMS Maritime" class="h-11 w-11 rounded-2xl shadow-sm">
             <div>
-              <p class="auth-brand-kicker">LMS Maritime</p>
-              <p class="auth-brand-title">HoHoLiHu</p>
+              <p class="auth-brand-kicker">HoLiLiHu Online</p>
+              <p class="auth-brand-title">LMS Maritime</p>
             </div>
           </a>
 

--- a/fe/src/app/features/courses/course-detail.component.html
+++ b/fe/src/app/features/courses/course-detail.component.html
@@ -53,6 +53,50 @@
               }
             </div>
 
+            <div class="mb-6 rounded-xl border border-white/10 bg-white/10 p-3 shadow-sm backdrop-blur-sm lg:hidden">
+              <div class="mb-3 flex items-center justify-between gap-3">
+                <span class="text-xl font-bold text-white">{{ getPriceDisplay(getEffectivePrice()) }}</span>
+                @if (totalLessons()) {
+                  <span class="shrink-0 rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-blue-100">
+                    {{ totalLessons() }} bài học
+                  </span>
+                }
+              </div>
+
+              @if (hasLearningAccess()) {
+                <button
+                  (click)="continueLearning()"
+                  class="flex w-full items-center justify-center gap-2 rounded-lg bg-white px-5 py-3 text-sm font-semibold text-[#0a1628] transition-colors hover:bg-blue-50 active:bg-blue-100">
+                  <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path>
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                  </svg>
+                  <span>{{ getLearningCtaLabel() }}</span>
+                </button>
+              } @else if (isAwaitingManualActivation() || isAccessPending()) {
+                <a
+                  routerLink="/student/payments"
+                  class="flex w-full items-center justify-center gap-2 rounded-lg bg-white px-5 py-3 text-sm font-semibold text-[#0056D2]">
+                  Xem lịch sử thanh toán
+                </a>
+              } @else {
+                <button
+                  (click)="handleEnrollClick()"
+                  [disabled]="isEnrolling()"
+                  class="flex w-full items-center justify-center gap-2 rounded-lg bg-white px-5 py-3 text-sm font-semibold text-[#0a1628] transition-colors hover:bg-blue-50 active:bg-blue-100 disabled:opacity-50">
+                  @if (isEnrolling()) {
+                    <svg class="h-5 w-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    <span>Đang xử lý...</span>
+                  } @else {
+                    <span>{{ getEnrollmentCtaLabel() }}</span>
+                  }
+                </button>
+              }
+            </div>
+
             <div class="flex items-center gap-3">
               <div class="flex h-10 w-10 items-center justify-center rounded-full bg-[#0056D2] font-bold text-white">
                 {{ (course()?.instructor?.name || 'G')[0] }}
@@ -300,7 +344,7 @@
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path>
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                   </svg>
-                  <span>Tiếp tục học</span>
+                  <span>{{ getLearningCtaLabel() }}</span>
                 </button>
 
               } @else if (isAwaitingManualActivation() || isAccessPending()) {
@@ -333,10 +377,8 @@
                       <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                     </svg>
                     <span>Đang xử lý...</span>
-                  } @else if (isCoursePaid()) {
-                    <span>Đăng ký và thanh toán</span>
                   } @else {
-                    <span>Đăng ký miễn phí</span>
+                    <span>{{ getEnrollmentCtaLabel() }}</span>
                   }
                 </button>
               }

--- a/fe/src/app/features/courses/course-detail.component.ts
+++ b/fe/src/app/features/courses/course-detail.component.ts
@@ -80,6 +80,18 @@ export class CourseDetailComponent implements OnInit {
   async continueLearning(): Promise<void> {
     const courseId = this.course()?.id;
     if (courseId) {
+      if (!this.authService.isAuthenticated()) {
+        this.router.navigate(['/auth/login'], {
+          queryParams: { returnUrl: `/student/learn/course/${courseId}` }
+        });
+        return;
+      }
+
+      if (this.authService.userRole() !== 'student') {
+        this.toast.warning('Chỉ tài khoản học viên mới có thể vào khu vực học.');
+        return;
+      }
+
       if (this.courseDownload.isDownloadedSync(courseId)) {
         const offlineLessonId = await this.courseDownload.getOfflineResumeLessonId(courseId);
         if (offlineLessonId) {
@@ -246,10 +258,9 @@ export class CourseDetailComponent implements OnInit {
       this.course.set(course);
       if (course) {
         this.updateSeo(course);
-        if (course.benefits) {
-          const lines = course.benefits.split('\n').map((l: string) => l.trim()).filter((l: string) => l.length > 0);
-          this.parsedBenefits.set(lines);
-        }
+        this.parsedBenefits.set(this.parseBenefits(course.benefits));
+      } else {
+        this.parsedBenefits.set([]);
       }
 
       this.loadCurriculum(id);
@@ -315,6 +326,22 @@ export class CourseDetailComponent implements OnInit {
     return this.isEnrolled() || this.hasReadyPaidAccess() || !this.isCoursePaid();
   }
 
+  getLearningCtaLabel(): string {
+    if (!this.authService.isAuthenticated()) {
+      return this.isCoursePaid() ? 'Đăng nhập để tiếp tục' : 'Đăng nhập để học miễn phí';
+    }
+
+    return this.isCoursePaid() ? 'Tiếp tục học' : 'Bắt đầu học';
+  }
+
+  getEnrollmentCtaLabel(): string {
+    if (this.isCoursePaid()) {
+      return this.authService.isAuthenticated() ? 'Đăng ký và thanh toán' : 'Đăng nhập để đăng ký';
+    }
+
+    return this.authService.isAuthenticated() ? 'Đăng ký miễn phí' : 'Đăng nhập để học miễn phí';
+  }
+
   toggleChapter(chapterId: string): void {
     this.expandedChapters.update(set => {
       const newSet = new Set(set);
@@ -364,6 +391,35 @@ export class CourseDetailComponent implements OnInit {
     return this.getEffectivePrice() > 0;
   }
 
+  private parseBenefits(raw?: string | null): string[] {
+    const source = raw?.trim();
+    if (!source) {
+      return [];
+    }
+
+    const withLineBreaks = source
+      .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+      .replace(/<\s*\/(p|div|li)\s*>/gi, '\n')
+      .replace(/<\s*li[^>]*>/gi, '\n');
+
+    const decoded = this.decodeBasicHtmlEntities(withLineBreaks.replace(/<[^>]*>/g, ' '));
+    return decoded
+      .split('\n')
+      .map(item => item.replace(/\s+/g, ' ').replace(/^[•*·-]\s*/, '').trim())
+      .filter((item, index, all) => item.length > 0 && all.indexOf(item) === index)
+      .slice(0, 8);
+  }
+
+  private decodeBasicHtmlEntities(value: string): string {
+    return value
+      .replace(/&nbsp;/gi, ' ')
+      .replace(/&amp;/gi, '&')
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>')
+      .replace(/&quot;/gi, '"')
+      .replace(/&#39;/gi, "'");
+  }
+
   private scrollToCurriculumPreview(): void {
     if (typeof window === 'undefined') {
       return;
@@ -373,7 +429,7 @@ export class CourseDetailComponent implements OnInit {
     curriculum?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
 
-  private getEffectivePrice(course: ExtendedCourse | null = this.course()): number {
+  getEffectivePrice(course: ExtendedCourse | null = this.course()): number {
     if (!course) {
       return 0;
     }

--- a/fe/src/app/features/courses/courses.component.ts
+++ b/fe/src/app/features/courses/courses.component.ts
@@ -33,7 +33,35 @@ import { SeoService } from '../../core/services/seo.service';
         <div class="flex flex-col gap-8 lg:flex-row">
           <!-- Filters Sidebar -->
           <div class="lg:w-1/4" role="region" aria-label="Bộ lọc khóa học">
-            <div class="sticky top-24 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <button
+              type="button"
+              (click)="toggleMobileFilters()"
+              class="mb-3 flex w-full items-center justify-between rounded-xl border border-gray-200 bg-white px-4 py-3 text-left shadow-sm lg:hidden"
+              aria-controls="courses-filter-panel"
+              [attr.aria-expanded]="showMobileFilters()">
+              <span>
+                <span class="block text-sm font-semibold text-gray-900">Lọc và sắp xếp</span>
+                <span class="block text-xs text-gray-500">
+                  {{ paginationInfo().totalItems }} khóa học
+                  @if (activeFilterCount() > 0) {
+                    · {{ activeFilterCount() }} bộ lọc đang dùng
+                  }
+                </span>
+              </span>
+              <svg
+                class="h-5 w-5 text-gray-400 transition-transform"
+                [class.rotate-180]="showMobileFilters()"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+              </svg>
+            </button>
+
+            <div
+              id="courses-filter-panel"
+              class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm lg:sticky lg:top-24 lg:block"
+              [class.hidden]="!showMobileFilters()">
               <h3 class="mb-5 text-sm font-bold uppercase tracking-wide text-gray-900">Bộ lọc</h3>
 
               <!-- Search -->
@@ -133,6 +161,13 @@ import { SeoService } from '../../core/services/seo.service';
                       class="w-full rounded-lg border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-700">
                 Xóa bộ lọc
               </button>
+
+              <button
+                type="button"
+                (click)="showMobileFilters.set(false)"
+                class="mt-3 w-full rounded-lg bg-[#0056D2] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#004BB5] lg:hidden">
+                Xem {{ paginationInfo().totalItems }} khóa học
+              </button>
             </div>
           </div>
 
@@ -205,6 +240,7 @@ export class CoursesComponent implements OnInit {
 
   courses = signal<ExtendedCourse[]>([]);
   isLoading = signal<boolean>(false);
+  showMobileFilters = signal(false);
   paginationInfo = signal<PaginationInfo>({
     currentPage: 1,
     totalPages: 1,
@@ -419,6 +455,21 @@ export class CoursesComponent implements OnInit {
       },
       queryParamsHandling: 'merge'
     });
+    this.showMobileFilters.set(false);
+  }
+
+  activeFilterCount(): number {
+    let count = 0;
+    if (this.filters.search?.trim()) count++;
+    if (this.filters.category) count++;
+    if (this.filters.level) count++;
+    if (this.filters.priceRange) count++;
+    if (this.filters.rating) count++;
+    return count;
+  }
+
+  toggleMobileFilters(): void {
+    this.showMobileFilters.update(open => !open);
   }
 
   onSearchChange(value: string): void {

--- a/fe/src/app/features/home/home-simple.component.ts
+++ b/fe/src/app/features/home/home-simple.component.ts
@@ -53,22 +53,22 @@ interface FeaturedCourse {
         </svg>
       </div>
 
-      <div class="relative z-20 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-32 pt-20 md:pt-28 lg:pt-32">
+      <div class="relative z-20 mx-auto max-w-7xl px-4 pb-24 pt-14 sm:px-6 sm:pb-28 sm:pt-20 md:pt-28 lg:px-8 lg:pb-32 lg:pt-32">
         <div class="max-w-3xl">
           <p class="hero-enter hero-enter-1 mb-5 text-sm font-medium uppercase tracking-[0.2em] text-blue-300/70">
             Nền tảng đào tạo hàng hải Việt Nam
           </p>
-          <h1 class="hero-enter hero-enter-2 text-4xl font-bold leading-[1.1] tracking-tight text-white sm:text-5xl lg:text-6xl">
+          <h1 class="hero-enter hero-enter-2 text-3xl font-bold leading-[1.1] tracking-tight text-white sm:text-5xl lg:text-6xl">
             Học Hàng hải mọi lúc
             <span class="mt-1 block bg-gradient-to-r from-blue-300 to-blue-300 bg-clip-text text-transparent">
               kể cả trên biển.
             </span>
           </h1>
-          <p class="hero-enter hero-enter-3 mt-6 max-w-xl text-lg leading-relaxed text-blue-100/70 sm:text-xl">
+          <p class="hero-enter hero-enter-3 mt-5 max-w-xl text-base leading-relaxed text-blue-100/70 sm:mt-6 sm:text-xl">
             Nền tảng đầu tiên tại Việt Nam tích hợp trí tuệ nhân tạo và
             hoạt động ngoại tuyến — được thiết kế cho người đi biển.
           </p>
-          <div class="hero-enter hero-enter-4 mt-10 flex flex-col gap-4 sm:flex-row">
+          <div class="hero-enter hero-enter-4 mt-8 flex flex-col gap-3 sm:mt-10 sm:flex-row sm:gap-4">
             <a routerLink="/courses"
                class="inline-flex items-center justify-center rounded-lg bg-white px-7 py-3.5 text-[15px] font-semibold text-[#0a1628] shadow-lg shadow-white/10 transition-all hover:bg-blue-50 hover:shadow-xl">
               Khám phá khóa học
@@ -370,7 +370,11 @@ interface FeaturedCourse {
 
   `,
   styles: [`
-    .hero-section { min-height: 85vh; }
+    .hero-section { min-height: 72vh; }
+
+    @media (min-width: 768px) {
+      .hero-section { min-height: 85vh; }
+    }
 
     /* ── Hero entrance (CSS-only, no GSAP needed) ── */
     .hero-enter {


### PR DESCRIPTION
## Summary
- Collapse the public course listing filters behind a mobile-friendly toggle so course cards are visible sooner.
- Reduce the home hero mobile height while keeping the login CTA visible in the first viewport.
- Clean course detail benefits from HTML/list markup, clarify guest/student CTA labels, and add a mobile hero quick action.
- Align auth brand text across login, forgot password, and reset password screens.

## Verification
- `npm run build`
- Playwright smoke on production bundle served locally:
  - mobile home first viewport shows login and next-section hint
  - mobile `/courses` filter is collapsed by default and expands correctly
  - mocked course detail no longer shows raw HTML from benefits and shows the learning CTA before the fold

## Notes
- Build still reports existing Angular/Sass/CommonJS warnings outside this change set.
