### PR TITLE
[codex] Harden public security and mobile UX

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -11,6 +11,8 @@
         >X-Frame-Options "SAMEORIGIN"
         >X-Content-Type-Options "nosniff"
         >Cross-Origin-Opener-Policy "same-origin-allow-popups"
+        >Cross-Origin-Resource-Policy "same-site"
+        >X-Permitted-Cross-Domain-Policies "none"
         >Strict-Transport-Security "max-age=31536000; includeSubDomains"
         >Referrer-Policy "strict-origin-when-cross-origin"
         >Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()"
@@ -19,6 +21,13 @@
 
 holilihu.online {
     @adaptivePlayback path /api/v3/video-assets/*/adaptive/*
+
+    # Defense-in-depth: never let hidden or repo metadata paths fall through to SSR.
+    @hiddenFiles path /.env /.env.* /.git/* /.svn/* /.hg/* /.DS_Store /Thumbs.db
+    handle @hiddenFiles {
+        import edge_response_headers
+        respond 404
+    }
 
     handle @adaptivePlayback {
         import edge_response_headers
@@ -37,6 +46,11 @@ holilihu.online {
     }
 
     # Backend API
+    handle /api/v3/api-docs* {
+        import edge_response_headers
+        respond 404
+    }
+
     handle /api/* {
         import edge_response_headers
         reverse_proxy backend:8080
@@ -46,6 +60,10 @@ holilihu.online {
     handle /actuator/health {
         import edge_response_headers
         reverse_proxy backend:8080
+    }
+    handle /actuator* {
+        import edge_response_headers
+        respond 404
     }
 
     # File uploads (LocalStorageService)

--- a/fe/nginx.conf
+++ b/fe/nginx.conf
@@ -26,6 +26,8 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "0" always;
     add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
+    add_header Cross-Origin-Resource-Policy "same-site" always;
+    add_header X-Permitted-Cross-Domain-Policies "none" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
     # CSP: Caddy is the sole CSP authority at the edge — do NOT add CSP here
@@ -71,6 +73,19 @@ server {
         add_header Service-Worker-Allowed "/";
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
+        try_files $uri =404;
+    }
+
+    # Web app manifest - nginx does not always know .webmanifest MIME by default.
+    location = /manifest.webmanifest {
+        default_type application/manifest+json;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Cross-Origin-Resource-Policy "same-site" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
         try_files $uri =404;
     }
 

--- a/fe/src/app/features/auth/login/login.component.html
+++ b/fe/src/app/features/auth/login/login.component.html
@@ -390,6 +390,10 @@
   }
 
   .auth-footer a {
+    display: inline-flex;
+    min-height: 32px;
+    align-items: center;
+    padding: 0 2px;
     color: var(--auth-primary);
     font-weight: 600;
     text-decoration: none;

--- a/fe/src/app/shared/components/layout/public-header.component.html
+++ b/fe/src/app/shared/components/layout/public-header.component.html
@@ -100,14 +100,18 @@
                 <input
                   type="text"
                   placeholder="Bạn muốn học gì hôm nay?"
+                  aria-label="Tìm kiếm khóa học"
+                  autocomplete="off"
+                  enterkeyhint="search"
                   [ngModel]="searchQuery()"
                   (ngModelChange)="onSearchInput($event)"
                   (focus)="onSearchFocus()"
                   (blur)="onSearchBlur()"
                   (keydown)="onSearchKeydown($event)"
-                  class="w-full h-12 pl-5 pr-12 text-sm border border-gray-200 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:border-[#0056D2] focus:ring-2 focus:ring-[#0056D2]/20 transition-all duration-200">
+                  class="w-full h-12 pl-5 pr-14 text-sm border border-gray-200 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:border-[#0056D2] focus:ring-2 focus:ring-[#0056D2]/20 transition-all duration-200">
                 <button (click)="onSearchSubmit()"
-                        class="absolute right-1.5 top-1/2 -translate-y-1/2 flex h-9 w-9 items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-[#0056D2]/5 hover:text-[#0056D2]">
+                        aria-label="Tìm kiếm khóa học"
+                        class="absolute right-1 top-1/2 -translate-y-1/2 flex h-10 w-10 items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-[#0056D2]/5 hover:text-[#0056D2] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
                   <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
                   </svg>
@@ -233,7 +237,7 @@
             <div class="flex items-center justify-between gap-3 h-16">
               <!-- Mobile Logo -->
               <div class="min-w-0 flex-shrink">
-                <a routerLink="/" class="flex min-w-0 items-center">
+                <a routerLink="/" class="flex min-h-11 min-w-0 items-center">
                   <img src="/icons/logo-master.png" alt="LMS Maritime" class="w-8 h-8 rounded-lg mr-2 flex-shrink-0">
                   <span class="truncate text-base font-bold text-gray-900">LMS Maritime</span>
                 </a>
@@ -280,13 +284,16 @@
             <div class="pb-3">
               <div class="relative">
                 <input type="text" placeholder="Tìm kiếm khóa học..."
+                       aria-label="Tìm kiếm khóa học"
+                       autocomplete="off"
+                       enterkeyhint="search"
                        [ngModel]="searchQuery()" (ngModelChange)="searchQuery.set($event)"
                        (keydown)="onSearchKeydown($event)"
-                       class="w-full h-10 pl-4 pr-12 text-sm border border-gray-200 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:border-[#0056D2] focus:ring-2 focus:ring-[#0056D2]/20 transition-all">
+                       class="w-full h-11 pl-4 pr-14 text-sm border border-gray-200 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:border-[#0056D2] focus:ring-2 focus:ring-[#0056D2]/20 transition-all">
                 <button (click)="onSearchSubmit()"
                         aria-label="Tìm kiếm khóa học"
-                        class="absolute right-1 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-[#0056D2]/5 hover:text-[#0056D2] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
-                  <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
+                        class="absolute right-0.5 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-[#0056D2]/5 hover:text-[#0056D2] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
+                  <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
                 </button>
               </div>
             </div>

--- a/fe/src/index.html
+++ b/fe/src/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>LMS Maritime - Hệ thống quản lý học tập</title>
   <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="description" content="Hệ thống quản lý học tập chuyên về ngành hàng hải">
   <meta name="keywords" content="LMS, hàng hải, học tập, thủy thủ, maritime">
   <meta name="author" content="LMS Maritime Team">


### PR DESCRIPTION
﻿## What changed
- Allow mobile pinch zoom by removing `user-scalable=no` from the app viewport meta.
- Improve public header/search touch targets, keyboard hints, focus ring, and accessible names.
- Increase login legal-link tap area.
- Add additional edge security headers and hard 404 handling for hidden files, actuator fallthrough, and API docs.
- Serve `manifest.webmanifest` with `application/manifest+json` from nginx.

## Why
Production smoke showed strong baseline headers/RBAC/CORS, but mobile accessibility and a few edge hardening details were still below the bar: zoom was disabled, search controls were slightly under target size, `.env`/`.git` fell through to SPA, and the manifest MIME was `application/octet-stream`.

## Validation
- Chrome extension smoke on production home: no console errors.
- Clean mobile production smoke: guest home/courses/detail, route guards, RBAC API checks, CORS evil-origin check, source-map/sensitive-string probes.
- `npm run build` passed.
- `npx ng build` passed after final aria-label update.
- `git diff --check` passed.
- `docker run --rm -v <Caddyfile>:/etc/caddy/Caddyfile:ro caddy:2 caddy validate --config /etc/caddy/Caddyfile` passed.
- Local built-app mobile smoke confirmed viewport zoom is no longer locked and manifest MIME is `application/manifest+json`.

Known existing warnings remain in Angular/Sass/CommonJS areas outside this PR.
