### PR TITLE
Suppress upstream technology headers

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,6 +4,8 @@
 # =============================================================================
 
 (edge_response_headers) {
+    header -Server
+    header -X-Powered-By
     header -X-XSS-Protection
 
     header {


### PR DESCRIPTION
## Summary
- strip upstream `Server` and `X-Powered-By` headers at the Caddy edge
- reduce production technology fingerprinting after CSP hardening smoke tests

## Verification
- docker run --rm -v ${PWD}\\Caddyfile:/etc/caddy/Caddyfile:ro caddy:2 caddy validate --config /etc/caddy/Caddyfile