### PR TITLE
[codex] Polish mobile touch targets and navigation UX

### DIFF
--- a/fe/src/app/features/auth/login/login.component.html
+++ b/fe/src/app/features/auth/login/login.component.html
@@ -391,9 +391,9 @@
 
   .auth-footer a {
     display: inline-flex;
-    min-height: 32px;
+    min-height: 44px;
     align-items: center;
-    padding: 0 2px;
+    padding: 0 6px;
     color: var(--auth-primary);
     font-weight: 600;
     text-decoration: none;

--- a/fe/src/app/features/home/home-simple.component.ts
+++ b/fe/src/app/features/home/home-simple.component.ts
@@ -94,7 +94,7 @@ interface FeaturedCourse {
             <h2 class="text-3xl font-bold tracking-tight text-gray-900 lg:text-4xl">Khóa học nổi bật</h2>
             <p class="mt-3 text-lg text-gray-500">Được thiết kế bởi chuyên gia hàng hải hàng đầu</p>
           </div>
-          <a routerLink="/courses" class="hidden items-center text-[15px] font-medium text-[#0056D2] hover:text-[#004BB5] sm:flex">
+          <a routerLink="/courses" class="hidden min-h-11 items-center text-[15px] font-medium text-[#0056D2] hover:text-[#004BB5] sm:flex">
             Xem tất cả <svg class="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
           </a>
         </div>
@@ -151,7 +151,7 @@ interface FeaturedCourse {
           </div>
         }
         <div class="mt-8 text-center sm:hidden">
-          <a routerLink="/courses" class="text-[15px] font-medium text-[#0056D2]">Xem tất cả khóa học &rarr;</a>
+          <a routerLink="/courses" class="inline-flex min-h-11 items-center justify-center text-[15px] font-medium text-[#0056D2]">Xem tất cả khóa học &rarr;</a>
         </div>
       </div>
     </section>
@@ -188,7 +188,7 @@ interface FeaturedCourse {
               <p class="mt-3 leading-relaxed text-gray-600">{{ diff.desc }}</p>
               @if (diff.link) {
                 <a [href]="diff.link" target="_blank" rel="noopener noreferrer"
-                   class="mt-4 inline-flex items-center text-sm font-medium" [class]="diff.linkColor">
+                   class="mt-4 inline-flex min-h-11 items-center text-sm font-medium" [class]="diff.linkColor">
                   {{ diff.linkText }}
                   <svg class="ml-1 h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
                 </a>

--- a/fe/src/app/features/student/dashboard/student-dashboard.component.scss
+++ b/fe/src/app/features/student/dashboard/student-dashboard.component.scss
@@ -128,6 +128,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  min-height: 44px;
   padding: 10px 20px;
   background: $blue-primary;
   color: white;
@@ -177,6 +178,7 @@
 .tab-chip {
   display: inline-flex;
   align-items: center;
+  min-height: 44px;
   padding: 8px 16px;
   border: 1px solid #D1D5DB;
   border-radius: 20px;
@@ -223,6 +225,7 @@
 .view-all-link {
   display: flex;
   align-items: center;
+  min-height: 44px;
   gap: 4px;
   font-size: 12px;
   color: $blue-primary;
@@ -451,8 +454,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 44px;
+  height: 44px;
 
   &:hover {
     background: #F9FAFB;

--- a/fe/src/app/features/student/shared/student-layout-simple.component.ts
+++ b/fe/src/app/features/student/shared/student-layout-simple.component.ts
@@ -32,7 +32,11 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       <!-- Mobile sidebar overlay — always rendered, animated via CSS -->
       @if (!shouldHideSidebar()) {
         <div class="mobile-sidebar-overlay md:hidden"
-             [class.open]="isMobileSidebarOpen()">
+             [class.open]="isMobileSidebarOpen()"
+             [attr.aria-hidden]="!isMobileSidebarOpen()"
+             [attr.aria-modal]="isMobileSidebarOpen() ? 'true' : null"
+             [attr.inert]="isMobileSidebarOpen() ? null : ''"
+             role="dialog">
           <div class="mobile-sidebar-backdrop" (click)="toggleMobileSidebar()"></div>
           <div class="mobile-sidebar-panel">
             <app-sidebar [config]="studentSidebarConfig()"
@@ -59,7 +63,8 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
               <div class="flex justify-between items-center h-14">
                 <div class="flex items-center space-x-3">
                   <button (click)="toggleMobileSidebar()"
-                    class="p-2 rounded-xl text-gray-600 hover:text-gray-900 hover:bg-gray-100/80 focus:outline-none transition-all duration-200">
+                    aria-label="Mở menu điều hướng"
+                    class="inline-flex h-11 w-11 items-center justify-center rounded-xl text-gray-600 hover:text-gray-900 hover:bg-gray-100/80 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20 transition-all duration-200">
                     <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
                     </svg>
@@ -69,12 +74,12 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
                     <span class="text-base font-bold text-gray-900">Cổng Học viên</span>
                   </div>
                 </div>
-                <button (click)="toggleMobileSidebar()" class="p-1 rounded-full hover:bg-gray-100 transition-colors">
+                <button (click)="toggleMobileSidebar()" aria-label="Mở hồ sơ và menu" class="inline-flex h-11 w-11 items-center justify-center rounded-full hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
                   @if (userAvatarUrl()) {
                     <img [src]="userAvatarUrl()" [alt]="authService.currentUser()?.fullName || ''"
-                         class="w-8 h-8 rounded-full object-cover">
+                         class="w-9 h-9 rounded-full object-cover">
                   } @else {
-                    <div class="w-8 h-8 bg-[#0056D2] rounded-full flex items-center justify-center text-white text-xs font-semibold">
+                    <div class="w-9 h-9 bg-[#0056D2] rounded-full flex items-center justify-center text-white text-xs font-semibold">
                       {{ getUserInitials() }}
                     </div>
                   }
@@ -93,7 +98,7 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
                  [class.translate-y-full]="shouldHideMobileChrome()"
                  [class.opacity-0]="shouldHideMobileChrome()"
                  [class.pointer-events-none]="shouldHideMobileChrome()">
-              <div class="flex items-center justify-around px-1 py-1.5">
+              <div class="flex items-center justify-around px-1 py-1">
                 <a routerLink="/student/courses"
                   aria-label="Khóa học"
                   routerLinkActive="tab-active"
@@ -360,6 +365,12 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
       z-index: 51;
     }
+    .mobile-sidebar-panel .nav-item,
+    .mobile-sidebar-panel .sub-menu-item,
+    .mobile-sidebar-panel .user-menu-trigger,
+    .mobile-sidebar-panel .user-menu-item {
+      min-height: 44px;
+    }
     .mobile-sidebar-overlay.open .mobile-sidebar-panel {
       transform: translateX(0);
     }
@@ -408,7 +419,8 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      padding: 4px 0;
+      min-height: 48px;
+      padding: 6px 0;
       min-width: 0;
       flex: 1;
       color: #9ca3af;

--- a/fe/src/app/features/student/student-my-courses.component.scss
+++ b/fe/src/app/features/student/student-my-courses.component.scss
@@ -130,6 +130,7 @@
 .tab-chip {
   display: inline-flex;
   align-items: center;
+  min-height: 44px;
   padding: 8px 16px;
   border: 1px solid #D1D5DB;
   border-radius: 20px;
@@ -358,8 +359,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 44px;
+  height: 44px;
 
   &:hover {
     background: #F9FAFB;

--- a/fe/src/app/features/teacher/courses/course-management.component.ts
+++ b/fe/src/app/features/teacher/courses/course-management.component.ts
@@ -447,6 +447,7 @@ interface ReviewFeedback {
       display: inline-flex;
       align-items: center;
       gap: 8px;
+      min-height: 44px;
       padding: 10px 20px;
       background: #0056D2;
       color: white;
@@ -485,12 +486,20 @@ interface ReviewFeedback {
       margin-bottom: 24px;
     }
 
+    .desktop-tabs button[role='tab'] {
+      min-height: 44px;
+    }
+
     .mobile-toolbar {
       display: none;
       align-items: center;
       justify-content: space-between;
       gap: 8px;
       margin-bottom: 12px;
+    }
+
+    .mobile-toolbar select {
+      min-height: 44px;
     }
 
     /* ===== SIDEBAR FILTER (matching student) ===== */
@@ -740,6 +749,7 @@ interface ReviewFeedback {
 
     .submit-button {
       padding: 6px 14px;
+      min-height: 44px;
       border: 1px solid #059669;
       border-radius: 6px;
       background: white;
@@ -756,6 +766,7 @@ interface ReviewFeedback {
 
     .cancel-button {
       padding: 6px 14px;
+      min-height: 44px;
       border: 1px solid #D97706;
       border-radius: 6px;
       background: white;
@@ -772,6 +783,7 @@ interface ReviewFeedback {
 
     .edit-button {
       padding: 6px 16px;
+      min-height: 44px;
       border: 1px solid #0056D2;
       border-radius: 6px;
       background: white;

--- a/fe/src/app/features/teacher/dashboard/teacher-dashboard.component.scss
+++ b/fe/src/app/features/teacher/dashboard/teacher-dashboard.component.scss
@@ -52,6 +52,7 @@
   display: inline-flex;
   align-items: center;
   gap: $spacing-2;
+  min-height: 44px;
   padding: 10px 20px;
   background: $blue-primary;
   color: white;
@@ -91,10 +92,14 @@
 }
 
 /* Tabs: inline Tailwind (see template) — no SCSS needed */
+.section-header button[role='tab'] {
+  min-height: 44px;
+}
 
 .view-all-link {
   display: flex;
   align-items: center;
+  min-height: 44px;
   gap: 4px;
   font-size: $text-xs;
   color: $blue-primary;
@@ -293,6 +298,7 @@
 
 .edit-button {
   padding: 4px 12px;
+  min-height: 44px;
   border: 1px solid $blue-primary;
   border-radius: $radius-sm;
   background: white;

--- a/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
+++ b/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
@@ -29,7 +29,11 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       <!-- Mobile sidebar overlay — CSS animation (matching student layout) -->
       @if (!shouldHideSidebar()) {
         <div class="mobile-sidebar-overlay md:hidden"
-             [class.open]="isMobileSidebarOpen()">
+             [class.open]="isMobileSidebarOpen()"
+             [attr.aria-hidden]="!isMobileSidebarOpen()"
+             [attr.aria-modal]="isMobileSidebarOpen() ? 'true' : null"
+             [attr.inert]="isMobileSidebarOpen() ? null : ''"
+             role="dialog">
           <div class="mobile-sidebar-backdrop" (click)="toggleMobileSidebar()"></div>
           <div class="mobile-sidebar-panel">
             <app-sidebar [config]="teacherSidebarConfig()"
@@ -56,7 +60,8 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
               <div class="flex justify-between items-center h-14">
                 <div class="flex items-center space-x-3">
                   <button (click)="toggleMobileSidebar()"
-                    class="p-2 rounded-xl text-gray-600 hover:text-gray-900 hover:bg-gray-100/80 focus:outline-none transition-all duration-200">
+                    aria-label="Mở menu điều hướng"
+                    class="inline-flex h-11 w-11 items-center justify-center rounded-xl text-gray-600 hover:text-gray-900 hover:bg-gray-100/80 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20 transition-all duration-200">
                     <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
                     </svg>
@@ -66,8 +71,8 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
                     <span class="text-base font-bold text-gray-900">Cổng Giảng viên</span>
                   </div>
                 </div>
-                <button (click)="toggleMobileSidebar()" class="p-1 rounded-full hover:bg-gray-100 transition-colors">
-                  <div class="w-8 h-8 bg-[#0056D2] rounded-full flex items-center justify-center text-white text-xs font-semibold">
+                <button (click)="toggleMobileSidebar()" aria-label="Mở hồ sơ và menu" class="inline-flex h-11 w-11 items-center justify-center rounded-full hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
+                  <div class="w-9 h-9 bg-[#0056D2] rounded-full flex items-center justify-center text-white text-xs font-semibold">
                     {{ getUserInitials() }}
                   </div>
                 </button>
@@ -85,7 +90,7 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
                  [class.translate-y-full]="shouldHideMobileChrome()"
                  [class.opacity-0]="shouldHideMobileChrome()"
                  [class.pointer-events-none]="shouldHideMobileChrome()">
-              <div class="flex items-center justify-around px-1 py-1.5">
+              <div class="flex items-center justify-around px-1 py-1">
                 <a routerLink="/teacher/courses"
                   aria-label="Khóa học của tôi"
                   routerLinkActive="tab-active"
@@ -247,6 +252,12 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
       z-index: 51;
     }
+    .mobile-sidebar-panel .nav-item,
+    .mobile-sidebar-panel .sub-menu-item,
+    .mobile-sidebar-panel .user-menu-trigger,
+    .mobile-sidebar-panel .user-menu-item {
+      min-height: 44px;
+    }
     .mobile-sidebar-overlay.open .mobile-sidebar-panel {
       transform: translateX(0);
     }
@@ -259,7 +270,8 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      padding: 4px 0;
+      min-height: 48px;
+      padding: 6px 0;
       min-width: 0;
       flex: 1;
       color: #9ca3af;

--- a/fe/src/app/shared/components/course-download-button/course-download-button.component.ts
+++ b/fe/src/app/shared/components/course-download-button/course-download-button.component.ts
@@ -63,7 +63,7 @@ import { DownloadDialogComponent, DownloadOptions } from '../download-dialog/dow
         <button
           (click)="openDialog()"
           [disabled]="!isOnline()"
-          class="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs transition-colors"
+          class="inline-flex min-h-11 items-center gap-1.5 rounded-lg px-3 py-2 text-xs transition-colors"
           [class]="isOnline()
             ? 'bg-[#0056D2]/10 text-[#0056D2] hover:bg-[#0056D2]/20'
             : 'cursor-not-allowed bg-gray-100 text-gray-400'"

--- a/fe/src/app/shared/components/layout/footer/footer.component.ts
+++ b/fe/src/app/shared/components/layout/footer/footer.component.ts
@@ -107,5 +107,19 @@ import { RouterModule } from '@angular/router';
       </div>
     </footer>
   `,
+  styles: [`
+    :host footer a {
+      align-items: center;
+      display: inline-flex;
+      min-height: 44px;
+    }
+
+    :host footer a[aria-label] {
+      border-radius: 9999px;
+      height: 44px;
+      justify-content: center;
+      width: 44px;
+    }
+  `],
 })
 export class FooterComponent {}

--- a/fe/src/app/shared/components/layout/mega-menu/mega-menu.component.ts
+++ b/fe/src/app/shared/components/layout/mega-menu/mega-menu.component.ts
@@ -11,7 +11,7 @@ import { RouterModule } from '@angular/router';
           (mouseleave)="hideMenuWithDelay()">
 
       <button
-        class="flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:text-[#0056D2]"
+        class="flex min-h-11 items-center gap-1 rounded-lg px-3 text-sm font-medium text-gray-700 transition-colors hover:text-[#0056D2]"
         (click)="toggleMenu()"
         [class.text-[#0056D2]]="isMenuVisible()">
         <span>Khám phá</span>
@@ -41,7 +41,7 @@ import { RouterModule } from '@angular/router';
                     <a [routerLink]="['/courses']"
                        [queryParams]="{category: cat.slug}"
                        (click)="hideMenu()"
-                       class="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm text-gray-700 transition-colors hover:bg-[#0056D2]/5 hover:text-[#0056D2]">
+                       class="flex min-h-11 items-center gap-3 rounded-lg px-3 py-2.5 text-sm text-gray-700 transition-colors hover:bg-[#0056D2]/5 hover:text-[#0056D2]">
                       <svg class="h-4 w-4 flex-shrink-0 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
                         @switch (cat.icon) {
                           @case ('shield') { <path stroke-linecap="round" stroke-linejoin="round" d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/> }
@@ -68,7 +68,7 @@ import { RouterModule } from '@angular/router';
                     <a routerLink="/courses"
                        [queryParams]="{q: cert}"
                        (click)="hideMenu()"
-                       class="block rounded-lg px-3 py-2.5 text-sm text-gray-700 transition-colors hover:bg-[#0056D2]/5 hover:text-[#0056D2]">
+                       class="flex min-h-11 items-center rounded-lg px-3 py-2.5 text-sm text-gray-700 transition-colors hover:bg-[#0056D2]/5 hover:text-[#0056D2]">
                       {{ cert }}
                     </a>
                   </li>
@@ -90,7 +90,7 @@ import { RouterModule } from '@angular/router';
               </p>
               <a href="https://wiii.holilihu.online" target="_blank" rel="noopener noreferrer"
                  (click)="hideMenu()"
-                 class="inline-flex items-center rounded-lg bg-[#0056D2] px-4 py-2 text-sm font-semibold text-white transition-all hover:bg-[#004BB5]">
+                  class="inline-flex min-h-11 items-center rounded-lg bg-[#0056D2] px-4 text-sm font-semibold text-white transition-all hover:bg-[#004BB5]">
                 Hỏi Wiii AI
                 <svg class="ml-1.5 h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
               </a>

--- a/fe/src/app/shared/components/layout/public-header.component.html
+++ b/fe/src/app/shared/components/layout/public-header.component.html
@@ -6,12 +6,12 @@
       <div class="maritime-top-header hidden lg:block text-white transition-all duration-300 overflow-hidden"
            [class.max-h-0]="isScrolled()"
            [class.opacity-0]="isScrolled()"
-           [class.py-3]="!isScrolled()"
+           [class.py-1]="!isScrolled()"
            [class.transform]="isScrolled()"
            [class.-translate-y-full]="isScrolled()"
-           style="max-height: 50px;">
+           style="max-height: 56px;">
         <div class="max-w-7xl mx-auto px-8">
-          <div class="flex items-center justify-between h-9">
+          <div class="flex min-h-11 items-center justify-between">
             <!-- User Type Selector -->
             <div class="flex items-center space-x-6">
               <span class="text-xs font-medium text-slate-300">Đối tượng sử dụng:</span>
@@ -19,25 +19,25 @@
                 <button 
                   (click)="setUserType('personal')"
                   [class]="getUserTypeClass('personal')"
-                  class="text-xs font-medium px-3 py-1 rounded-full transition-all duration-200 hover:bg-white/10">
+                  class="min-h-11 rounded-full px-3 text-xs font-medium transition-all duration-200 hover:bg-white/10">
                   Cá nhân
                 </button>
                 <button 
                   (click)="setUserType('business')"
                   [class]="getUserTypeClass('business')"
-                  class="text-xs font-medium px-3 py-1 rounded-full transition-all duration-200 hover:bg-white/10">
+                  class="min-h-11 rounded-full px-3 text-xs font-medium transition-all duration-200 hover:bg-white/10">
                   Doanh nghiệp
                 </button>
                 <button 
                   (click)="setUserType('school')"
                   [class]="getUserTypeClass('school')"
-                  class="text-xs font-medium px-3 py-1 rounded-full transition-all duration-200 hover:bg-white/10">
+                  class="min-h-11 rounded-full px-3 text-xs font-medium transition-all duration-200 hover:bg-white/10">
                   Trường học
                 </button>
                 <button 
                   (click)="setUserType('government')"
                   [class]="getUserTypeClass('government')"
-                  class="text-xs font-medium px-3 py-1 rounded-full transition-all duration-200 hover:bg-white/10">
+                  class="min-h-11 rounded-full px-3 text-xs font-medium transition-all duration-200 hover:bg-white/10">
                   Chính phủ
                 </button>
               </div>
@@ -45,7 +45,7 @@
 
             <!-- Top Actions -->
             <div class="flex items-center space-x-4">
-              <a href="/contact" class="text-xs text-slate-300 hover:text-white transition-colors duration-200">
+              <a href="/contact" class="inline-flex min-h-11 min-w-11 items-center justify-center text-xs text-slate-300 transition-colors duration-200 hover:text-white">
                 Hỗ trợ
               </a>
             </div>
@@ -111,7 +111,7 @@
                   class="w-full h-12 pl-5 pr-14 text-sm border border-gray-200 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:border-[#0056D2] focus:ring-2 focus:ring-[#0056D2]/20 transition-all duration-200">
                 <button (click)="onSearchSubmit()"
                         aria-label="Tìm kiếm khóa học"
-                        class="absolute right-1 top-1/2 -translate-y-1/2 flex h-10 w-10 items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-[#0056D2]/5 hover:text-[#0056D2] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
+                        class="absolute right-0.5 top-1/2 -translate-y-1/2 flex h-11 w-11 items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-[#0056D2]/5 hover:text-[#0056D2] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
                   <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
                   </svg>
@@ -221,11 +221,11 @@
               } @else {
                 <!-- Guest: Login/Register Buttons -->
                 <a routerLink="/auth/login"
-                   class="text-gray-700 hover:text-[#0056D2] px-4 py-2 rounded-md text-sm font-medium transition-colors duration-200">
+                   class="inline-flex min-h-11 items-center justify-center rounded-md px-4 text-sm font-medium text-gray-700 transition-colors duration-200 hover:text-[#0056D2]">
                   Đăng nhập
                 </a>
                 <a routerLink="/auth/login"
-                   class="bg-[#0056D2] hover:bg-[#004BB5] text-white px-6 py-2 rounded-md text-sm font-semibold transition-all duration-200 hover:shadow-md">
+                   class="inline-flex min-h-11 items-center justify-center rounded-md bg-[#0056D2] px-6 text-sm font-semibold text-white transition-all duration-200 hover:bg-[#004BB5] hover:shadow-md">
                   Tham gia miễn phí
                 </a>
               }
@@ -247,7 +247,7 @@
                 @if (isLoggedIn()) {
                   <a [routerLink]="getDashboardRoute()"
                      aria-label="Mở bảng điều khiển"
-                     class="inline-flex h-10 w-10 items-center justify-center overflow-hidden rounded-full bg-[#0056D2] text-sm font-semibold text-white shadow-sm transition-colors duration-200 hover:bg-[#004BB5] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/30">
+                     class="inline-flex h-11 w-11 items-center justify-center overflow-hidden rounded-full bg-[#0056D2] text-sm font-semibold text-white shadow-sm transition-colors duration-200 hover:bg-[#004BB5] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/30">
                     @if (userAvatar()) {
                       <img [src]="userAvatar()" [alt]="userName()" class="h-full w-full object-cover">
                     } @else {
@@ -256,7 +256,7 @@
                   </a>
                 } @else {
                   <a routerLink="/auth/login"
-                     class="inline-flex h-10 min-w-[82px] items-center justify-center rounded-lg border border-[#0056D2]/20 bg-[#0056D2]/5 px-3 text-sm font-semibold text-[#0056D2] transition-colors duration-200 hover:border-[#0056D2]/30 hover:bg-[#0056D2]/10 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
+                     class="inline-flex h-11 min-w-[92px] items-center justify-center rounded-lg border border-[#0056D2]/20 bg-[#0056D2]/5 px-3 text-sm font-semibold text-[#0056D2] transition-colors duration-200 hover:border-[#0056D2]/30 hover:bg-[#0056D2]/10 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
                     Đăng nhập
                   </a>
                 }
@@ -268,7 +268,7 @@
                   [attr.aria-label]="isMobileMenuOpen() ? 'Đóng menu' : 'Mở menu'"
                   [attr.aria-expanded]="isMobileMenuOpen()"
                   aria-controls="mobile-navigation-panel"
-                  class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-gray-700 transition-colors duration-200 hover:bg-gray-100 hover:text-[#0056D2] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
+                  class="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-700 transition-colors duration-200 hover:bg-gray-100 hover:text-[#0056D2] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
                   <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     @if (isMobileMenuOpen()) {
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -289,10 +289,10 @@
                        enterkeyhint="search"
                        [ngModel]="searchQuery()" (ngModelChange)="searchQuery.set($event)"
                        (keydown)="onSearchKeydown($event)"
-                       class="w-full h-11 pl-4 pr-14 text-sm border border-gray-200 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:border-[#0056D2] focus:ring-2 focus:ring-[#0056D2]/20 transition-all">
+                       class="w-full h-12 pl-4 pr-14 text-sm border border-gray-200 rounded-xl bg-gray-50 focus:bg-white focus:outline-none focus:border-[#0056D2] focus:ring-2 focus:ring-[#0056D2]/20 transition-all">
                 <button (click)="onSearchSubmit()"
                         aria-label="Tìm kiếm khóa học"
-                        class="absolute right-0.5 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-[#0056D2]/5 hover:text-[#0056D2] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
+                        class="absolute right-0.5 top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-[#0056D2]/5 hover:text-[#0056D2] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
                   <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
                 </button>
               </div>
@@ -318,7 +318,7 @@
                 <button 
                   (click)="closeMobileMenu()"
                   aria-label="Đóng menu"
-                  class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-gray-400 transition-colors duration-200 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
+                  class="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-400 transition-colors duration-200 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20">
                   <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                   </svg>

--- a/fe/src/app/shared/components/layout/public-header.component.scss
+++ b/fe/src/app/shared/components/layout/public-header.component.scss
@@ -177,6 +177,13 @@
   .search-centerpiece {
     margin: 0 0.5rem;
   }
+
+  #mobile-navigation-panel {
+    a,
+    button {
+      min-height: 44px;
+    }
+  }
 }
 
 // Dark mode support

--- a/fe/src/app/shared/components/navigation/sidebar.component.css
+++ b/fe/src/app/shared/components/navigation/sidebar.component.css
@@ -92,6 +92,7 @@
 .nav-item {
   display: flex;
   align-items: center;
+  min-height: 44px;
   padding: 0.625rem 0.75rem;
   color: #374151;
   border-radius: 0.5rem;
@@ -185,6 +186,7 @@
 .sub-menu-item {
   display: flex;
   align-items: center;
+  min-height: 44px;
   padding: 0.5rem 1rem;
   font-size: 0.875rem;
   color: #6b7280;

--- a/fe/src/app/shared/components/ui/button/button.component.ts
+++ b/fe/src/app/shared/components/ui/button/button.component.ts
@@ -113,6 +113,14 @@ type ButtonSize = 'sm' | 'md' | 'lg';
     .btn-full {
       width: 100%;
     }
+
+    @media (max-width: 640px) {
+      .btn-sm,
+      .btn-md {
+        min-height: 44px;
+        height: auto;
+      }
+    }
   `]
 })
 export class ButtonComponent {


### PR DESCRIPTION
﻿## Summary
- Increase mobile and desktop tap targets across the public header, mega menu, footer, login footer links, student/teacher mobile layouts, dashboard chips, course management tabs/actions, and shared buttons.
- Keep login visible on the first mobile landing viewport and make mobile menu/profile controls accessible with explicit labels and focus rings.
- Harden mobile sidebars with dialog semantics, aria-hidden, aria-modal, and inert behavior when closed.

## Validation
- git diff --check
- npm run build
- Google Chrome audit via Playwright channel=chrome on:
  - / mobile and desktop
  - /auth/login mobile
  - /student/courses mobile after login
  - /teacher/courses mobile after login
- Final audit result: no horizontal overflow and no visible interactive target below 44px on audited routes.

## Notes
- The Chrome extension bridge diagnostics pass locally, but the direct extension bootstrap still reports a trust-bridge error in this Codex session. Browser verification used installed Google Chrome through Playwright instead.
- Local teacher audit still logs CSP blocking for a http://localhost:8088 avatar URL; production HTTPS avatar/media paths are not affected by this PR.
