### PR TITLE
[codex] fix complete button learning flow

### DIFF
--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
@@ -8,7 +8,7 @@
     @if (hasSections() && currentSection(); as section) {
     <header class="lesson-header">
       <p class="lesson-kicker">Chương {{ chapterIndex() + 1 }} / {{ currentSectionNumber() }}</p>
-      <h1 id="lesson-heading" class="lesson-title">
+      <h1 id="lesson-heading" class="lesson-title" tabindex="-1">
         {{ lesson().title }}
       </h1>
       <app-competency-badge [lessonId]="lesson().id" [courseId]="lesson().courseId" />
@@ -21,7 +21,7 @@
     } @else {
     <header class="lesson-header">
       <p class="lesson-kicker">{{ lessonNumber() }}</p>
-      <h1 id="lesson-heading" class="lesson-title">
+      <h1 id="lesson-heading" class="lesson-title" tabindex="-1">
         {{ lesson().title }}
       </h1>
       <app-competency-badge [lessonId]="lesson().id" [courseId]="lesson().courseId" />

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.scss
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.scss
@@ -38,6 +38,16 @@
   font-size: 2rem;
   font-weight: 800;
   line-height: 1.25;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgba(0, 86, 210, 0.22);
+    outline-offset: 0.35rem;
+    border-radius: 0.375rem;
+  }
 }
 
 .lesson-section-title {

--- a/fe/src/app/features/learning/pages/course-learning.component.html
+++ b/fe/src/app/features/learning/pages/course-learning.component.html
@@ -284,7 +284,7 @@
     </div>
 
     <!-- Scrollable Content -->
-    <div class="learning-scroll flex-1 overflow-y-auto scroll-smooth pb-20">
+    <div #learningScroll class="learning-scroll flex-1 overflow-y-auto scroll-smooth pb-20">
       @if (error()) {
       <div class="mx-4 mt-4 bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-lg flex justify-between items-center">
         <span>{{ error() }}</span>
@@ -340,7 +340,7 @@
         [isOfflinePackageStale]="course()?.isOfflinePackage === true && course()?.isStale === true"
         [staleReason]="course()?.staleReason ?? null"
         (sectionIndexChange)="onSectionIndexChange($event)"
-        (markComplete)="onMarkComplete()"
+        (markComplete)="onCompleteButtonClick()"
         (videoEnded)="onVideoEnded()"
         (sectionReadComplete)="onSectionReadComplete($event)">
       </app-lesson-content>
@@ -358,27 +358,28 @@
     <div class="learning-bottom-nav absolute bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-3 z-30 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]">
       <div class="max-w-[920px] mx-auto flex items-center justify-between">
         <button class="flex items-center gap-1 px-3 py-2 rounded text-slate-500 hover:text-[#0056D2] hover:bg-slate-50 transition-colors disabled:opacity-40 disabled:pointer-events-none"
-          [disabled]="!canGoPrevious() && currentSectionIndex() === 0"
+          [disabled]="isLearningItemTransitioning() || (!canGoPrevious() && currentSectionIndex() === 0)"
           (click)="previousLesson()">
           <app-icon name="arrow-left" size="md"></app-icon>
           <span class="hidden sm:inline text-sm font-medium">Bài trước</span>
         </button>
 
-        <button class="px-6 py-2.5 rounded-lg shadow-sm hover:shadow transition-all flex items-center gap-2 text-sm font-bold tracking-wide text-white hover:brightness-110"
+        <button class="px-6 py-2.5 rounded-lg shadow-sm hover:shadow transition-all flex items-center gap-2 text-sm font-bold tracking-wide text-white hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:brightness-100"
           [class.bg-green-600]="learningService.isLessonCompleted(currentLesson()!.id)()"
           [class.bg-[#0056D2]]="!learningService.isLessonCompleted(currentLesson()!.id)()"
-          (click)="onMarkComplete()">
-          @if (learningService.isLessonCompleted(currentLesson()!.id)()) {
-          <app-icon name="check" size="sm"></app-icon>
-          <span>Đã hoàn thành</span>
+          [disabled]="completeButtonDisabled()"
+          [attr.aria-busy]="(isCompletingCurrentItem() || isLearningItemTransitioning()) ? 'true' : null"
+          (click)="onCompleteButtonClick()">
+          @if (isCompletingCurrentItem() || isLearningItemTransitioning()) {
+          <app-icon name="refresh" size="sm" class="animate-spin"></app-icon>
           } @else {
-          <span>Đánh dấu hoàn thành</span>
           <app-icon name="check" size="sm"></app-icon>
           }
+          <span>{{ completeButtonLabel() }}</span>
         </button>
 
         <button class="flex items-center gap-1 px-3 py-2 rounded text-slate-500 hover:text-[#0056D2] hover:bg-slate-50 transition-colors disabled:opacity-40 disabled:pointer-events-none"
-          [disabled]="!canGoNext() && (!currentLesson()?.sections || currentSectionIndex() >= (currentLesson()?.sections?.length || 0) - 1)"
+          [disabled]="isLearningItemTransitioning() || (!canGoNext() && (!currentLesson()?.sections || currentSectionIndex() >= (currentLesson()?.sections?.length || 0) - 1))"
           (click)="nextLesson()">
           <span class="hidden sm:inline text-sm font-medium">Bài tiếp theo</span>
           <app-icon name="arrow-right" size="md"></app-icon>

--- a/fe/src/app/features/learning/pages/course-learning.component.scss
+++ b/fe/src/app/features/learning/pages/course-learning.component.scss
@@ -191,4 +191,8 @@
   .learning-mobile-sidebar-close {
     transition: none;
   }
+
+  .learning-scroll {
+    scroll-behavior: auto;
+  }
 }

--- a/fe/src/app/features/learning/pages/course-learning.component.ts
+++ b/fe/src/app/features/learning/pages/course-learning.component.ts
@@ -1,4 +1,17 @@
-import { Component, signal, computed, inject, OnInit, DestroyRef, ChangeDetectionStrategy, HostListener, effect, untracked } from '@angular/core';
+import {
+  Component,
+  signal,
+  computed,
+  inject,
+  OnInit,
+  DestroyRef,
+  ChangeDetectionStrategy,
+  HostListener,
+  effect,
+  untracked,
+  ElementRef,
+  viewChild,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { RouterModule, Router, ActivatedRoute } from '@angular/router';
@@ -78,9 +91,15 @@ export class CourseLearningComponent implements OnInit {
   showMobileSidebar = signal(false);
   desktopSidebarCollapsed = signal(false);
   error = signal<string | null>(null);
+  isCompletingCurrentItem = signal(false);
 
   // (Removed `activeTab` — content is single-column inline now, notes drawer
   // toggles inside `app-lesson-content`. No parent state to lift.)
+
+  private readonly hostElement: ElementRef<HTMLElement> = inject(ElementRef);
+  private readonly learningScrollRef = viewChild<ElementRef<HTMLElement>>('learningScroll');
+  private pendingLearningContentFocus = signal(false);
+  private pendingNavigationLessonId = signal<string | null>(null);
 
   // Video progress tracking for 75% rule
   canCompleteCurrentLesson = signal<boolean>(true); // Default true for non-video lessons
@@ -356,6 +375,85 @@ export class CourseLearningComponent implements OnInit {
     };
   });
 
+  readonly isLearningItemTransitioning = computed(() => {
+    const pendingLessonId = this.pendingNavigationLessonId();
+    return !!pendingLessonId
+      && (this.currentLesson()?.id !== pendingLessonId || this.isLoadingLesson());
+  });
+
+  readonly completeButtonLabel = computed(() => {
+    if (this.isCompletingCurrentItem()) {
+      return 'Đang lưu...';
+    }
+
+    if (this.isLearningItemTransitioning()) {
+      return 'Đang tải bài...';
+    }
+
+    const lesson = this.currentLesson();
+    if (!lesson) {
+      return 'Đánh dấu hoàn thành';
+    }
+
+    const lessonCompleted = this.learningService.isLessonCompleted(lesson.id)();
+    if (lesson.sections?.length) {
+      const sectionIndex = this.currentSectionIndex();
+      const currentSection = lesson.sections[sectionIndex];
+      const isLastSection = sectionIndex >= lesson.sections.length - 1;
+
+      if (!currentSection) {
+        return 'Đánh dấu hoàn thành';
+      }
+
+      if (!this.isSectionCompleted(currentSection.id)) {
+        return isLastSection ? 'Hoàn thành bài' : 'Hoàn thành phần này';
+      }
+
+      if (!isLastSection) {
+        return 'Phần tiếp theo';
+      }
+
+      if (!lessonCompleted) {
+        return 'Hoàn thành bài';
+      }
+
+      return this.canGoNext() ? 'Bài tiếp theo' : 'Đã hoàn thành';
+    }
+
+    if (!lessonCompleted) {
+      return 'Đánh dấu hoàn thành';
+    }
+
+    return this.canGoNext() ? 'Bài tiếp theo' : 'Đã hoàn thành';
+  });
+
+  readonly completeButtonDisabled = computed(() => {
+    if (this.isCompletingCurrentItem() || this.isLearningItemTransitioning()) {
+      return true;
+    }
+
+    const lesson = this.currentLesson();
+    if (!lesson) {
+      return true;
+    }
+
+    if (lesson.sections?.length) {
+      const sectionIndex = this.currentSectionIndex();
+      const currentSection = lesson.sections[sectionIndex];
+      const isLastSection = sectionIndex >= lesson.sections.length - 1;
+      if (!currentSection) {
+        return true;
+      }
+
+      return isLastSection
+        && this.isSectionCompleted(currentSection.id)
+        && this.learningService.isLessonCompleted(lesson.id)()
+        && !this.canGoNext();
+    }
+
+    return this.learningService.isLessonCompleted(lesson.id)() && !this.canGoNext();
+  });
+
   /** Index of the chapter (section) containing the current lesson */
   currentChapterIndex = computed(() => {
     const lesson = this.currentLesson();
@@ -382,6 +480,38 @@ export class CourseLearningComponent implements OnInit {
 
   // Filtered sections based on search
   filteredSections = computed(() => this.sections());
+
+  private clearPendingNavigationEffect = effect(() => {
+    const pendingLessonId = this.pendingNavigationLessonId();
+    if (!pendingLessonId || this.isLoadingLesson()) {
+      return;
+    }
+
+    if (this.lessonError()) {
+      untracked(() => this.pendingNavigationLessonId.set(null));
+      return;
+    }
+
+    if (this.currentLesson()?.id === pendingLessonId) {
+      untracked(() => this.pendingNavigationLessonId.set(null));
+    }
+  });
+
+  private focusPendingLearningContentEffect = effect(() => {
+    if (!this.pendingLearningContentFocus() || this.isLoadingLesson()) {
+      return;
+    }
+
+    if (this.lessonError()) {
+      untracked(() => this.pendingLearningContentFocus.set(false));
+      return;
+    }
+
+    void this.currentLesson()?.id;
+    void this.currentSectionIndex();
+
+    untracked(() => this.scheduleLearningContentFocus());
+  });
 
   ngOnInit(): void {
     this.isPreview.set(!!this.route.snapshot.data['preview']);
@@ -584,12 +714,11 @@ export class CourseLearningComponent implements OnInit {
       if (!this.isPreview()) {
         const courseId = this.course()?.id;
         if (courseId) {
-          this.router.navigate(
-            ['/student/learn/course', courseId, 'lesson', lessonId],
-            { replaceUrl: true }
-          );
+          this.updateUrlForLessonId(lessonId);
         }
       }
+
+      this.requestLearningContentFocus();
     }
   }
 
@@ -616,14 +745,15 @@ export class CourseLearningComponent implements OnInit {
     const currentLesson = this.currentLesson();
     if (currentLesson?.sections && currentLesson.sections.length > 0) {
       if (this.currentSectionIndex() > 0) {
-        this.currentSectionIndex.update(v => v - 1);
+        this.setCurrentSectionIndex(this.currentSectionIndex() - 1, { focus: true });
         return;
       }
     }
-    this.learningService.goToPreviousLesson();
-    // Reset section index for new lesson (handled in onLessonSelect/loadLesson but good to be explicit if needed)
-    this.currentSectionIndex.set(0);
-    this.updateUrlForCurrentLesson();
+
+    const previous = this.learningService.previousLesson();
+    if (previous) {
+      this.navigateToLessonId(previous.id, { focus: true });
+    }
   }
 
   async nextLesson(): Promise<void> {
@@ -633,14 +763,15 @@ export class CourseLearningComponent implements OnInit {
     if (currentLesson?.sections && currentLesson.sections.length > 0) {
       if (this.currentSectionIndex() < currentLesson.sections.length - 1) {
         const currentSection = currentLesson.sections[this.currentSectionIndex()];
+        const currentSectionCompleted = this.completedSections().has(currentSection.id);
 
         // 🔒 VIDEO: always check server-side threshold
-        if (isPlayableVideoSection(currentSection)) {
+        if (!currentSectionCompleted && isPlayableVideoSection(currentSection)) {
           const canProceed = await this.ensureVideoProgressThreshold(currentSection.id, 'next-section');
           if (!canProceed) return;
         }
         // 🔒 Required non-VIDEO sections: must be completed before proceeding
-        else if (currentSection.isRequired && !this.completedSections().has(currentSection.id)) {
+        else if (currentSection.isRequired && !currentSectionCompleted) {
           const messages: Record<string, string> = {
             'TEXT': 'Bạn cần đọc hết nội dung phần này trước khi chuyển tiếp.',
             'QUIZ': 'Bạn cần hoàn thành bài kiểm tra trước khi chuyển tiếp.',
@@ -651,27 +782,93 @@ export class CourseLearningComponent implements OnInit {
         }
 
         // All checks passed, proceed to next section
-        this.currentSectionIndex.update(v => v + 1);
+        this.setCurrentSectionIndex(this.currentSectionIndex() + 1, { focus: true });
         return;
       }
     }
 
     // No more sections, go to next lesson
-    this.learningService.goToNextLesson();
-    this.currentSectionIndex.set(0);
-    this.updateUrlForCurrentLesson();
+    const next = this.learningService.nextLesson();
+    if (next) {
+      if (this.isLessonLocked(next)) {
+        this.toast.warning('Cần thanh toán để xem bài này');
+        this.showPaymentModal.set(true);
+        return;
+      }
+
+      this.navigateToLessonId(next.id, { focus: true });
+    }
   }
 
-  private updateUrlForCurrentLesson(): void {
+  private setCurrentSectionIndex(index: number, options: { focus?: boolean } = {}): void {
+    this.currentSectionIndex.set(index);
+    if (options.focus) {
+      this.requestLearningContentFocus();
+    }
+  }
+
+  private navigateToLessonId(lessonId: string, options: { focus?: boolean } = {}): void {
+    this.pendingNavigationLessonId.set(lessonId);
+    this.learningService.loadLesson(lessonId);
+    this.pendingExpandLessonId.set(lessonId);
+    this.autoExpandChapterForLesson(lessonId);
+    this.currentSectionIndex.set(0);
+    this.closeMobileSidebar();
+    this.updateUrlForLessonId(lessonId);
+
+    if (options.focus) {
+      this.requestLearningContentFocus();
+    }
+  }
+
+  private updateUrlForLessonId(lessonId: string): void {
     if (this.isPreview()) return;
     const courseId = this.course()?.id;
-    const lessonId = this.currentLesson()?.id;
     if (courseId && lessonId) {
-      this.router.navigate(
+      void this.router.navigate(
         ['/student/learn/course', courseId, 'lesson', lessonId],
         { replaceUrl: true }
       );
     }
+  }
+
+  private requestLearningContentFocus(): void {
+    this.pendingLearningContentFocus.set(true);
+    this.scheduleLearningContentFocus();
+  }
+
+  private scheduleLearningContentFocus(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        if (this.focusLearningContentStart()) {
+          this.pendingLearningContentFocus.set(false);
+        }
+      });
+    });
+  }
+
+  private focusLearningContentStart(): boolean {
+    const scrollContainer = this.learningScrollRef()?.nativeElement;
+    const heading = this.hostElement.nativeElement.querySelector<HTMLElement>('#lesson-heading');
+
+    if (!scrollContainer || !heading) {
+      return false;
+    }
+
+    const behavior: ScrollBehavior = this.prefersReducedMotion() ? 'auto' : 'smooth';
+    scrollContainer.scrollTo({ top: 0, behavior });
+    heading.focus({ preventScroll: true });
+    return true;
+  }
+
+  private prefersReducedMotion(): boolean {
+    return typeof window !== 'undefined'
+      && typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   }
 
   private async ensureVideoProgressThreshold(
@@ -705,6 +902,67 @@ export class CourseLearningComponent implements OnInit {
   }
 
   // Progress
+  async onCompleteButtonClick(): Promise<void> {
+    if (this.isCompletingCurrentItem() || this.isLearningItemTransitioning()) {
+      return;
+    }
+
+    const lessonBeforeCompletion = this.currentLesson();
+    const sectionIndexBeforeCompletion = this.currentSectionIndex();
+
+    this.isCompletingCurrentItem.set(true);
+    try {
+      const completed = await this.onMarkComplete();
+      if (completed) {
+        this.continueAfterCompletion(lessonBeforeCompletion, sectionIndexBeforeCompletion);
+      }
+    } finally {
+      this.isCompletingCurrentItem.set(false);
+    }
+  }
+
+  private continueAfterCompletion(lesson: any, sectionIndexBeforeCompletion: number): void {
+    if (!lesson) {
+      this.requestLearningContentFocus();
+      return;
+    }
+
+    if (lesson.sections?.length) {
+      const completedLastSection = sectionIndexBeforeCompletion >= lesson.sections.length - 1;
+      if (completedLastSection && this.canGoNext()) {
+        this.navigateToNextLessonFromCompletion();
+        return;
+      }
+
+      this.requestLearningContentFocus();
+      return;
+    }
+
+    if (this.canGoNext()) {
+      this.navigateToNextLessonFromCompletion();
+      return;
+    }
+
+    this.requestLearningContentFocus();
+  }
+
+  private navigateToNextLessonFromCompletion(): void {
+    const next = this.learningService.nextLesson();
+    if (!next) {
+      this.requestLearningContentFocus();
+      return;
+    }
+
+    if (this.isLessonLocked(next)) {
+      this.toast.warning('Cần thanh toán để xem bài này');
+      this.showPaymentModal.set(true);
+      this.requestLearningContentFocus();
+      return;
+    }
+
+    this.navigateToLessonId(next.id, { focus: true });
+  }
+
   async onMarkComplete(): Promise<boolean> {
     if (this.isPreview()) {
       this.toast.info('Chế độ xem trước — không ghi nhận tiến độ.');
@@ -728,8 +986,10 @@ export class CourseLearningComponent implements OnInit {
       return false;
     }
 
+    const alreadyCompleted = this.completedSections().has(currentSection.id);
+
     // 🔒 VIDEO: always check server-side threshold
-    if (isPlayableVideoSection(currentSection)) {
+    if (!alreadyCompleted && isPlayableVideoSection(currentSection)) {
       const canProceed = await this.ensureVideoProgressThreshold(currentSection.id, 'complete-section');
       if (!canProceed) {
         return false;
@@ -737,7 +997,7 @@ export class CourseLearningComponent implements OnInit {
     }
 
     // 🔒 QUIZ: cannot be manually completed — must pass the quiz
-    if (currentSection.type === 'QUIZ' && currentSection.isRequired && !this.completedSections().has(currentSection.id)) {
+    if (!alreadyCompleted && currentSection.type === 'QUIZ' && currentSection.isRequired) {
       this.toast.warning('Bạn cần hoàn thành bài kiểm tra để đánh dấu phần này là hoàn thành.');
       return false;
     }
@@ -745,35 +1005,42 @@ export class CourseLearningComponent implements OnInit {
     const nextCompletedSections = new Set(this.completedSections());
     nextCompletedSections.add(currentSection.id);
     const allSectionsCompleted = lesson.sections.every((section: any) => nextCompletedSections.has(section.id));
-    await this.markSectionAsCompleted(currentSection.id, { persistBackend: true });
+    if (!alreadyCompleted) {
+      await this.markSectionAsCompleted(currentSection.id, { persistBackend: true });
+    }
 
     if (allSectionsCompleted) {
-      try {
-        await this.waitForSectionCompletionSync(lesson.id, currentSection.id);
-        await firstValueFrom(this.lessonApi.markLessonComplete(lesson.id, this.buildLessonCompletionPayload(lesson)));
-        await this.enrollmentService.refreshCourseProgress(lesson.courseId);
-        this.learningService.markCurrentLessonComplete();
-        this.toast.success(`Đã hoàn thành bài: ${lesson.title}`);
-      } catch {
-        if (!this.network.online()) {
+      const lessonAlreadyCompleted = this.learningService.isLessonCompleted(lesson.id)();
+      if (!lessonAlreadyCompleted) {
+        try {
+          await this.waitForSectionCompletionSync(lesson.id, currentSection.id);
+          await firstValueFrom(this.lessonApi.markLessonComplete(lesson.id, this.buildLessonCompletionPayload(lesson)));
+          await this.enrollmentService.refreshCourseProgress(lesson.courseId);
           this.learningService.markCurrentLessonComplete();
-          const courseId = lesson?.courseId ?? this.course()?.id;
-          if (courseId) {
-            const allSectionIds = lesson.sections.map((s: any) => s.id).filter(Boolean);
-            await this.courseDownload.mergeCompletedSectionsOffline(courseId, lesson.id, allSectionIds).catch(() => undefined);
+          this.toast.success(`Đã hoàn thành bài: ${lesson.title}`);
+        } catch {
+          if (!this.network.online()) {
+            this.learningService.markCurrentLessonComplete();
+            const courseId = lesson?.courseId ?? this.course()?.id;
+            if (courseId) {
+              const allSectionIds = lesson.sections.map((s: any) => s.id).filter(Boolean);
+              await this.courseDownload.mergeCompletedSectionsOffline(courseId, lesson.id, allSectionIds).catch(() => undefined);
+            }
+            this.toast.success(`Hoàn thành bài: ${lesson.title} (sẽ đồng bộ khi có mạng)`);
+          } else {
+            this.toast.error('Đã hoàn thành phần cuối nhưng chưa thể cập nhật tiến độ bài học. Vui lòng thử lại.');
+            return false;
           }
-          this.toast.success(`Hoàn thành bài: ${lesson.title} (sẽ đồng bộ khi có mạng)`);
-        } else {
-          this.toast.error('Đã hoàn thành phần cuối nhưng chưa thể cập nhật tiến độ bài học. Vui lòng thử lại.');
-          return false;
         }
+      } else if (!alreadyCompleted) {
+        this.toast.success(`Đã hoàn thành phần: ${currentSection.title}`);
       }
-    } else {
+    } else if (!alreadyCompleted) {
       this.toast.success(`Đã hoàn thành phần: ${currentSection.title}`);
     }
 
     if (this.currentSectionIndex() < lesson.sections.length - 1) {
-      this.currentSectionIndex.update((value) => value + 1);
+      this.setCurrentSectionIndex(this.currentSectionIndex() + 1, { focus: true });
     }
 
     return true;
@@ -807,6 +1074,7 @@ export class CourseLearningComponent implements OnInit {
       await this.enrollmentService.refreshCourseProgress(lesson.courseId);
       this.learningService.markCurrentLessonComplete();
       this.expandCurrentLessonSection();
+      this.toast.success(`Đã hoàn thành bài: ${lesson.title}`);
       return true;
     } catch {
       if (!this.network.online()) {
@@ -1067,12 +1335,13 @@ export class CourseLearningComponent implements OnInit {
       return;
     }
 
-    this.currentSectionIndex.set(sectionIndex);
+    this.setCurrentSectionIndex(sectionIndex, { focus: true });
+    this.closeMobileSidebar();
   }
 
   // Handle section index change from lesson-content component
   onSectionIndexChange(index: number): void {
-    this.currentSectionIndex.set(index);
+    this.setCurrentSectionIndex(index, { focus: true });
   }
 
   // === Payment / Paywall ===


### PR DESCRIPTION
## Summary
- Reworked the bottom `Đánh dấu hoàn thành` action into a guarded complete-and-continue flow.
- After a successful completion, the learner advances to the next section or next lesson, then the main content scrolls back to the top and programmatically focuses the lesson heading.
- Added button loading/transition states to prevent double-click progress mutations while completion or lesson loading is in flight.
- Made the lesson heading focusable with a visible focus style for keyboard/screen reader continuity.

## Root cause
The previous button only called the raw completion handler. Section completion sometimes advanced locally, but final-section and completed-lesson states did not consistently move to the next learning item. Route updates also read `currentLesson()` immediately after `loadLesson()`, which can still point at the old lesson while the next lesson API request is pending. The UI had no in-flight guard, so repeated clicks could resend completion requests or produce repeated toasts.

## UX/accessibility references
- W3C WCAG Focus Order: after a user-triggered context change, focus should keep a meaningful order and land on the new content context.
- WAI-ARIA Authoring Practices guidance for focus management patterns informed the decision to focus a real heading instead of a hidden sentinel.
- Material Design progress guidance informed the explicit busy/loading state on the primary completion action.

## Validation
- `git diff --check`
- `npx ng build --configuration=production`
- `node scripts/fix-ngsw.js`
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox` -> 379 success, 2 skipped
- Playwright mock flow:
  - complete section 1 -> section 2 opens, `.learning-scroll.scrollTop` returns to `0`, active element is `#lesson-heading`
  - complete final section -> URL moves to `/lesson/lesson-2`, scrollTop returns to `0`, active element is `#lesson-heading`

Build warnings are existing project warnings in admin/analytics/editor templates, Sass `@import`, and `mammoth` CommonJS dependencies; none were introduced by this PR.