### PR TITLE
[codex] Stabilize iOS HLS playback

### DIFF
--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackController.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackController.java
@@ -72,8 +72,9 @@ public class AdaptiveVideoPlaybackController {
         if (object.contentRange() != null && !object.contentRange().isBlank()) {
             builder.header(HttpHeaders.CONTENT_RANGE, object.contentRange());
         }
-        if (object.contentType() != null && !object.contentType().isBlank()) {
-            builder.contentType(MediaType.parseMediaType(object.contentType()));
+        MediaType contentType = normalizePlaybackContentType(object.contentType());
+        if (contentType != null) {
+            builder.contentType(contentType);
         }
 
         return builder.body(object.bytes());
@@ -100,9 +101,23 @@ public class AdaptiveVideoPlaybackController {
                 .contentLength(meta.size())
                 .header(HttpHeaders.ACCEPT_RANGES, "bytes")
                 .header(HttpHeaders.CACHE_CONTROL, "private, max-age=30");
-        if (meta.contentType() != null && !meta.contentType().isBlank()) {
-            builder.contentType(MediaType.parseMediaType(meta.contentType()));
+        MediaType contentType = normalizePlaybackContentType(meta.contentType());
+        if (contentType != null) {
+            builder.contentType(contentType);
         }
         return builder.build();
+    }
+
+    private MediaType normalizePlaybackContentType(String rawContentType) {
+        if (rawContentType == null || rawContentType.isBlank()) {
+            return null;
+        }
+
+        MediaType mediaType = MediaType.parseMediaType(rawContentType);
+        String type = mediaType.getType() + "/" + mediaType.getSubtype();
+        if ("video/iso.segment".equalsIgnoreCase(type) || "video/mp4".equalsIgnoreCase(type)) {
+            return MediaType.parseMediaType(type);
+        }
+        return mediaType;
     }
 }

--- a/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackControllerTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackControllerTest.java
@@ -48,6 +48,47 @@ class AdaptiveVideoPlaybackControllerTest {
         assertThat(response.getHeaders().getFirst(HttpHeaders.ACCEPT_RANGES)).isEqualTo("bytes");
         assertThat(response.getHeaders().getFirst(HttpHeaders.CONTENT_RANGE)).isEqualTo("bytes 0-2/10");
         assertThat(response.getHeaders().getContentLength()).isEqualTo(bytes.length);
+        assertThat(response.getHeaders().getContentType().toString()).isEqualTo("video/iso.segment");
         assertThat(response.getBody()).containsExactly(bytes);
+    }
+
+    @Test
+    @DisplayName("object endpoint strips charset from binary video segment content type")
+    void objectEndpointStripsCharsetFromBinaryVideoSegmentContentType() throws Exception {
+        UUID assetId = UUID.randomUUID();
+        String token = "play-token";
+        String key = "video-packages/" + assetId + "/segments/saver/1.m4s";
+
+        when(adaptiveVideoPlaybackService.readObject(assetId, token, key, null))
+                .thenReturn(new R2VideoStorageService.ObjectBytes(
+                        new byte[]{1},
+                        1,
+                        "video/iso.segment;charset=UTF-8",
+                        null
+                ));
+
+        var response = controller.getObject(assetId, token, key, null);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getHeaders().getContentType().toString()).isEqualTo("video/iso.segment");
+    }
+
+    @Test
+    @DisplayName("head endpoint strips charset from binary video segment content type")
+    void headEndpointStripsCharsetFromBinaryVideoSegmentContentType() throws Exception {
+        UUID assetId = UUID.randomUUID();
+        String token = "play-token";
+        String key = "video-packages/" + assetId + "/segments/saver/init.mp4";
+
+        when(adaptiveVideoPlaybackService.headObject(assetId, token, key))
+                .thenReturn(new R2VideoStorageService.ObjectMetadata(
+                        10,
+                        "video/mp4;charset=UTF-8"
+                ));
+
+        var response = controller.headObject(assetId, token, key);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getHeaders().getContentType().toString()).isEqualTo("video/mp4");
     }
 }

--- a/fe/src/app/core/utils/video-playback-platform.spec.ts
+++ b/fe/src/app/core/utils/video-playback-platform.spec.ts
@@ -1,0 +1,63 @@
+import {
+  canUseNativeHlsForManifest,
+  shouldPreferNativeHlsForManifest,
+} from './video-playback-platform';
+
+describe('video-playback-platform', () => {
+  const safariDesktop = {
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15',
+    vendor: 'Apple Computer, Inc.',
+    platform: 'MacIntel',
+    maxTouchPoints: 0,
+  };
+
+  it('prefers native HLS on iPadOS desktop-mode Safari', () => {
+    expect(shouldPreferNativeHlsForManifest('/api/video/master.m3u8', {
+      ...safariDesktop,
+      maxTouchPoints: 5,
+    })).toBeTrue();
+  });
+
+  it('prefers native HLS on iOS WebKit browsers', () => {
+    expect(shouldPreferNativeHlsForManifest('/api/video/master.m3u8', {
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/135.0.0.0 Mobile/15E148 Safari/604.1',
+      vendor: 'Apple Computer, Inc.',
+      platform: 'iPhone',
+      maxTouchPoints: 5,
+    })).toBeTrue();
+  });
+
+  it('keeps Shaka MSE for Android Chrome HLS', () => {
+    expect(shouldPreferNativeHlsForManifest('/api/video/master.m3u8', {
+      userAgent: 'Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Mobile Safari/537.36',
+      vendor: 'Google Inc.',
+      platform: 'Linux armv8l',
+      maxTouchPoints: 5,
+    })).toBeFalse();
+  });
+
+  it('keeps Shaka MSE for desktop macOS Safari', () => {
+    expect(shouldPreferNativeHlsForManifest('/api/video/master.m3u8', safariDesktop)).toBeFalse();
+  });
+
+  it('does not prefer native HLS for DASH manifests', () => {
+    expect(shouldPreferNativeHlsForManifest('/api/video/manifest.mpd', safariDesktop)).toBeFalse();
+  });
+
+  it('uses native HLS only when the iOS video element reports HLS support', () => {
+    const ios = {
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1',
+      vendor: 'Apple Computer, Inc.',
+      platform: 'iPhone',
+      maxTouchPoints: 5,
+    };
+
+    expect(canUseNativeHlsForManifest('/api/video/master.m3u8', {
+      canPlayType: type => type === 'application/vnd.apple.mpegurl' ? 'probably' : '',
+    }, ios)).toBeTrue();
+
+    expect(canUseNativeHlsForManifest('/api/video/master.m3u8', {
+      canPlayType: () => '',
+    }, ios)).toBeFalse();
+  });
+});

--- a/fe/src/app/core/utils/video-playback-platform.ts
+++ b/fe/src/app/core/utils/video-playback-platform.ts
@@ -1,0 +1,55 @@
+export interface VideoPlaybackNavigatorLike {
+  userAgent?: string;
+  vendor?: string;
+  platform?: string;
+  maxTouchPoints?: number;
+}
+
+export interface NativeHlsCapableVideoLike {
+  canPlayType(type: string): string;
+}
+
+export function shouldPreferNativeHlsForManifest(
+  manifestUrl: string,
+  nav: VideoPlaybackNavigatorLike | null | undefined = getNavigator(),
+): boolean {
+  if (!isHlsManifestUrl(manifestUrl) || !nav) {
+    return false;
+  }
+
+  const userAgent = nav.userAgent ?? '';
+  const vendor = nav.vendor ?? '';
+  const platform = nav.platform ?? '';
+  const maxTouchPoints = nav.maxTouchPoints ?? 0;
+  const isIOS = /iPad|iPhone|iPod/i.test(userAgent);
+  const isIPadDesktopMode = vendor.includes('Apple')
+    && platform === 'MacIntel'
+    && maxTouchPoints > 1;
+
+  // All iOS/iPadOS browsers use WebKit and Apple's native HLS stack. On iPadOS
+  // 13+ MSE may also exist, but native HLS is still the smoother path for VOD.
+  return isIOS || isIPadDesktopMode;
+}
+
+export function canUseNativeHlsForManifest(
+  manifestUrl: string,
+  videoElement: NativeHlsCapableVideoLike | null | undefined,
+  nav: VideoPlaybackNavigatorLike | null | undefined = getNavigator(),
+): boolean {
+  if (!videoElement || !shouldPreferNativeHlsForManifest(manifestUrl, nav)) {
+    return false;
+  }
+
+  return Boolean(
+    videoElement.canPlayType('application/vnd.apple.mpegurl')
+      || videoElement.canPlayType('application/x-mpegURL')
+  );
+}
+
+function isHlsManifestUrl(url: string): boolean {
+  return /\.m3u8(?:[?#]|$)/i.test(url);
+}
+
+function getNavigator(): VideoPlaybackNavigatorLike | null {
+  return typeof navigator === 'undefined' ? null : navigator;
+}

--- a/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
+++ b/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
@@ -34,6 +34,10 @@ import {
   resolveInteractiveVideoReviewTarget,
   shouldBlockInteractiveVideoSeek,
 } from '../../../../core/utils/interactive-video-runtime';
+import {
+  canUseNativeHlsForManifest,
+  shouldPreferNativeHlsForManifest,
+} from '../../../../core/utils/video-playback-platform';
 import type {
   InteractiveVideoChoice,
   InteractiveVideoInteraction,
@@ -272,9 +276,6 @@ export class AdaptiveVideoPlayerComponent {
   onTimeUpdate(event: Event): void {
     const video = event.target as HTMLVideoElement | null;
     if (!video) {
-      return;
-    }
-    if (this.snapBlockedInteractiveSeek(video)) {
       return;
     }
     this.currentTimeSeconds.set(video.currentTime);
@@ -582,6 +583,11 @@ export class AdaptiveVideoPlayerComponent {
   }
 
   private async initializeShaka(videoElement: HTMLVideoElement, manifestUrl: string): Promise<void> {
+    if (canUseNativeHlsForManifest(manifestUrl, videoElement)) {
+      this.loadNativeHls(videoElement, manifestUrl);
+      return;
+    }
+
     const shakaNamespace = await import('shaka-player/dist/shaka-player.compiled');
     const shaka = (shakaNamespace as any).default ?? shakaNamespace;
     shaka.polyfill.installAll();
@@ -593,6 +599,7 @@ export class AdaptiveVideoPlayerComponent {
       return;
     }
 
+    const preferNativeHls = shouldPreferNativeHlsForManifest(manifestUrl);
     const player = new shaka.Player();
     await player.attach(videoElement);
     player.configure({
@@ -607,7 +614,9 @@ export class AdaptiveVideoPlayerComponent {
         bufferingGoal: 30,
         rebufferingGoal: 8,
         bufferBehind: 30,
-        segmentPrefetchLimit: 2,
+        lowLatencyMode: false,
+        preferNativeHls,
+        segmentPrefetchLimit: preferNativeHls ? 1 : 2,
         retryParameters: {
           baseDelay: 1_000,
           backoffFactor: 2,
@@ -655,6 +664,16 @@ export class AdaptiveVideoPlayerComponent {
     }
     this.shakaPlayer = player;
     this.syncActiveVariant(player);
+    this.isLoading.set(false);
+  }
+
+  private loadNativeHls(videoElement: HTMLVideoElement, manifestUrl: string): void {
+    this.shakaPlayer = null;
+    this.availableQualities.set([]);
+    this.isAutoQuality.set(true);
+    this.qualityLabel.set(null);
+    videoElement.src = manifestUrl;
+    videoElement.load();
     this.isLoading.set(false);
   }
 

--- a/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
+++ b/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
@@ -20,6 +20,10 @@ import {
   resolveInteractiveVideoReviewTarget,
   shouldBlockInteractiveVideoSeek,
 } from '../../../core/utils/interactive-video-runtime';
+import {
+  canUseNativeHlsForManifest,
+  shouldPreferNativeHlsForManifest,
+} from '../../../core/utils/video-playback-platform';
 import type {
   InteractiveVideoChoice,
   InteractiveVideoInteraction,
@@ -49,6 +53,7 @@ type ResolvedSource =
         controls
         controlsList="nodownload"
         playsinline
+        webkit-playsinline
         preload="metadata"
         crossorigin="anonymous"
         class="h-full w-full object-contain"
@@ -260,7 +265,7 @@ export class QuizVideoPlayerComponent {
     if (!video) {
       return;
     }
-    if (this.snapBlockedInteractiveSeek(video)) {
+    if (this.isSeeking && this.snapBlockedInteractiveSeek(video)) {
       return;
     }
     const previousTimeSeconds = this.isSeeking ? video.currentTime : this.currentTimeSeconds();
@@ -452,6 +457,11 @@ export class QuizVideoPlayerComponent {
   }
 
   private async initializeShaka(videoElement: HTMLVideoElement, manifestUrl: string): Promise<void> {
+    if (canUseNativeHlsForManifest(manifestUrl, videoElement)) {
+      this.loadNativeHls(videoElement, manifestUrl);
+      return;
+    }
+
     const shakaNamespace = await import('shaka-player/dist/shaka-player.compiled');
     const shaka = (shakaNamespace as any).default ?? shakaNamespace;
     shaka.polyfill.installAll();
@@ -464,6 +474,7 @@ export class QuizVideoPlayerComponent {
       return;
     }
 
+    const preferNativeHls = shouldPreferNativeHlsForManifest(manifestUrl);
     const player = new shaka.Player();
     await player.attach(videoElement);
     player.configure({
@@ -478,7 +489,9 @@ export class QuizVideoPlayerComponent {
         bufferingGoal: 30,
         rebufferingGoal: 8,
         bufferBehind: 30,
-        segmentPrefetchLimit: 2,
+        lowLatencyMode: false,
+        preferNativeHls,
+        segmentPrefetchLimit: preferNativeHls ? 1 : 2,
         // Conservative retry: dead/stale assets từng gây Chrome STATUS_BREAKPOINT
         // crash khi Shaka retry 4× × MediaSource reopen cycle. 2 attempts đủ cho
         // transient network errors, không hammer BE on permanent 4xx.
@@ -516,6 +529,16 @@ export class QuizVideoPlayerComponent {
     }
     this.shakaPlayer = player;
     this.syncQuality(player);
+    this.isLoading.set(false);
+  }
+
+  private loadNativeHls(videoElement: HTMLVideoElement, manifestUrl: string): void {
+    this.shakaPlayer = null;
+    this.availableQualities.set([]);
+    this.isAutoQuality.set(true);
+    this.qualityLabel.set(null);
+    videoElement.src = manifestUrl;
+    videoElement.load();
     this.isLoading.set(false);
   }
 


### PR DESCRIPTION
﻿## Summary
- route iOS/iPadOS HLS playback directly through the native `<video>` HLS stack instead of Shaka/MSE
- keep Android/Chrome/Desktop on Shaka, with conservative VOD streaming settings
- prevent interactive anti-seek logic from running during ordinary `timeupdate`
- normalize binary playback `Content-Type` headers so `.m4s`/MP4 responses do not include a text charset

## Root Cause
Recent interactive-video work in #370 added anti-skip handling into the playback loop and the players still initialized Shaka for HLS on every platform. iOS/iPadOS WebKit is much more sensitive around HLS segment boundaries and seek/timeupdate events than Android Chrome, so the combination could look like the video was stuttering chunk-by-chunk.

Production probing showed the uploaded video package itself was healthy: HLS master includes independent segments, playlists are 6s VOD segments, and segment range requests return `206 Partial Content`. The safer platform fix is to use Apple's native HLS path on iPhone/iPad and keep Shaka for the platforms where it is strongest.

## Validation
- `npm run test:ci -- --include src/app/core/utils/video-playback-platform.spec.ts --include src/app/core/utils/interactive-video-runtime.spec.ts` -> 19 SUCCESS
- `mvn -Dtest=AdaptiveVideoPlaybackControllerTest test` -> 3 tests, 0 failures
- `npx ng build --configuration development` -> success; existing unrelated Angular/Sass warnings remain
- `git diff --cached --check` before commit -> clean

## Notes
This still needs a real-device smoke on iPhone/iPad after deploy because desktop Chrome cannot emulate Safari's native HLS pipeline.
