### PR TITLE
[codex] Align student pagination with teacher structure

### DIFF
--- a/backend/src/main/java/com/example/lms/course_authoring/domain/repository/CourseRepository.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/domain/repository/CourseRepository.java
@@ -161,6 +161,16 @@ public interface CourseRepository {
      */
     Page<Course> findByStatusAndTitleContaining(Course.CourseStatus status, String search, Pageable pageable);
 
+    /**
+     * Find courses by status and optional category, delivery mode, and search filters.
+     */
+    Page<Course> findByStatusAndFilters(
+            Course.CourseStatus status,
+            Set<UUID> categoryIds,
+            Course.DeliveryMode deliveryMode,
+            String search,
+            Pageable pageable);
+
     Page<Course> findByStatusAndCategoryId(Course.CourseStatus status, UUID categoryId, Pageable pageable);
 
     Page<Course> findByStatusAndCategoryIdAndTitleContaining(Course.CourseStatus status, UUID categoryId, String search, Pageable pageable);

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/CourseRepositoryImpl.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/CourseRepositoryImpl.java
@@ -187,11 +187,9 @@ public class CourseRepositoryImpl implements CourseRepository {
             Course.DeliveryMode deliveryMode,
             String search,
             Pageable pageable
-    ) {
-        CourseJpaEntity.CourseStatus entityStatus = mapStatusToEntity(status);
-        CourseJpaEntity.DeliveryMode entityDeliveryMode = deliveryMode != null
-                ? CourseJpaEntity.DeliveryMode.valueOf(deliveryMode.name())
-                : null;
+) {
+        String entityStatus = mapStatusToEntity(status).name();
+        String entityDeliveryMode = deliveryMode != null ? deliveryMode.name() : null;
         boolean categoryFilter = categoryIds != null && !categoryIds.isEmpty();
         List<UUID> effectiveCategoryIds = categoryFilter ? List.copyOf(categoryIds) : List.of(new UUID(0L, 0L));
         String normalizedSearch = search != null && !search.isBlank() ? search.trim() : null;

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/CourseRepositoryImpl.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/CourseRepositoryImpl.java
@@ -181,6 +181,31 @@ public class CourseRepositoryImpl implements CourseRepository {
     }
 
     @Override
+    public Page<Course> findByStatusAndFilters(
+            Course.CourseStatus status,
+            Set<UUID> categoryIds,
+            Course.DeliveryMode deliveryMode,
+            String search,
+            Pageable pageable
+    ) {
+        CourseJpaEntity.CourseStatus entityStatus = mapStatusToEntity(status);
+        CourseJpaEntity.DeliveryMode entityDeliveryMode = deliveryMode != null
+                ? CourseJpaEntity.DeliveryMode.valueOf(deliveryMode.name())
+                : null;
+        boolean categoryFilter = categoryIds != null && !categoryIds.isEmpty();
+        List<UUID> effectiveCategoryIds = categoryFilter ? List.copyOf(categoryIds) : List.of(new UUID(0L, 0L));
+        String normalizedSearch = search != null && !search.isBlank() ? search.trim() : null;
+        return jpaRepository.findByStatusAndFilters(
+                        entityStatus,
+                        effectiveCategoryIds,
+                        categoryFilter,
+                        entityDeliveryMode,
+                        normalizedSearch,
+                        pageable)
+                .map(mapper::toDomain);
+    }
+
+    @Override
     public long count() {
         return jpaRepository.count();
     }

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/JpaCourseRepository.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/JpaCourseRepository.java
@@ -112,18 +112,26 @@ public interface JpaCourseRepository extends JpaRepository<CourseJpaEntity, UUID
 
     Page<CourseJpaEntity> findByStatus(CourseJpaEntity.CourseStatus status, Pageable pageable);
 
-    @Query("""
-        SELECT c FROM CourseJpaEntity c
+    @Query(value = """
+        SELECT * FROM courses c
         WHERE c.status = :status
-          AND (:categoryFilter = false OR c.categoryId IN :categoryIds)
-          AND (:deliveryMode IS NULL OR c.deliveryMode = :deliveryMode)
-          AND (:search IS NULL OR LOWER(c.title) LIKE LOWER(CONCAT('%', :search, '%')))
-    """)
+          AND (:categoryFilter = false OR c.category_id IN (:categoryIds))
+          AND (:deliveryMode IS NULL OR c.delivery_mode = :deliveryMode)
+          AND (:search IS NULL OR unaccent(LOWER(c.title)) LIKE unaccent(LOWER(CONCAT('%', :search, '%'))))
+    """,
+    countQuery = """
+        SELECT COUNT(*) FROM courses c
+        WHERE c.status = :status
+          AND (:categoryFilter = false OR c.category_id IN (:categoryIds))
+          AND (:deliveryMode IS NULL OR c.delivery_mode = :deliveryMode)
+          AND (:search IS NULL OR unaccent(LOWER(c.title)) LIKE unaccent(LOWER(CONCAT('%', :search, '%'))))
+    """,
+    nativeQuery = true)
     Page<CourseJpaEntity> findByStatusAndFilters(
-            @Param("status") CourseJpaEntity.CourseStatus status,
+            @Param("status") String status,
             @Param("categoryIds") Collection<UUID> categoryIds,
             @Param("categoryFilter") boolean categoryFilter,
-            @Param("deliveryMode") CourseJpaEntity.DeliveryMode deliveryMode,
+            @Param("deliveryMode") String deliveryMode,
             @Param("search") String search,
             Pageable pageable);
 

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/JpaCourseRepository.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/JpaCourseRepository.java
@@ -112,6 +112,21 @@ public interface JpaCourseRepository extends JpaRepository<CourseJpaEntity, UUID
 
     Page<CourseJpaEntity> findByStatus(CourseJpaEntity.CourseStatus status, Pageable pageable);
 
+    @Query("""
+        SELECT c FROM CourseJpaEntity c
+        WHERE c.status = :status
+          AND (:categoryFilter = false OR c.categoryId IN :categoryIds)
+          AND (:deliveryMode IS NULL OR c.deliveryMode = :deliveryMode)
+          AND (:search IS NULL OR LOWER(c.title) LIKE LOWER(CONCAT('%', :search, '%')))
+    """)
+    Page<CourseJpaEntity> findByStatusAndFilters(
+            @Param("status") CourseJpaEntity.CourseStatus status,
+            @Param("categoryIds") Collection<UUID> categoryIds,
+            @Param("categoryFilter") boolean categoryFilter,
+            @Param("deliveryMode") CourseJpaEntity.DeliveryMode deliveryMode,
+            @Param("search") String search,
+            Pageable pageable);
+
     Page<CourseJpaEntity> findByStatusAndCategoryId(CourseJpaEntity.CourseStatus status, UUID categoryId, Pageable pageable);
 
     @Query(value = "SELECT * FROM courses c WHERE c.status = :status AND c.category_id = :categoryId AND unaccent(LOWER(c.title)) LIKE unaccent(LOWER(CONCAT('%', :search, '%')))", nativeQuery = true)

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
@@ -768,7 +768,7 @@ public class CourseQueryControllerV3 {
     }
 
     private Sort resolveCourseSort(String sort, String order) {
-        String sortField = "title".equals(sort) ? "title" : "createdAt";
+        String sortField = "title".equals(sort) ? "title" : "created_at";
         return "asc".equalsIgnoreCase(order) ? Sort.by(sortField).ascending() : Sort.by(sortField).descending();
     }
 

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
@@ -74,38 +75,27 @@ public class CourseQueryControllerV3 {
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String search,
             @RequestParam(required = false) String category,
+            @RequestParam(required = false) String deliveryMode,
             @RequestParam(required = false, defaultValue = "createdAt") String sort,
             @RequestParam(required = false, defaultValue = "desc") String order
     ) {
-        UUID categoryId = null;
-        if (category != null && !category.isBlank()) {
-            categoryId = courseCategoryJpaRepository.findByCode(category.toUpperCase(Locale.ROOT))
-                    .or(() -> courseCategoryJpaRepository.findBySlug(category.toLowerCase(Locale.ROOT)))
-                    .map(c -> c.getId())
-                    .orElse(null);
+        Set<UUID> categoryFilterIds = resolveCategoryFilterIds(category);
+        if (hasText(category) && categoryFilterIds.isEmpty()) {
+            return emptyPublicCoursePage(page, size);
         }
 
-        String sortField = sort != null && Set.of("createdAt", "title").contains(sort) ? sort : "createdAt";
-        Sort sortOrder = "asc".equalsIgnoreCase(order) ? Sort.by(sortField).ascending() : Sort.by(sortField).descending();
-        String nativeSortField = "title".equals(sortField) ? "title" : "created_at";
-        Sort nativeSortOrder = "asc".equalsIgnoreCase(order) ? Sort.by(nativeSortField).ascending() : Sort.by(nativeSortField).descending();
-
-        Page<Course> courses;
-        boolean hasSearch = search != null && !search.isBlank();
-
-        if (hasSearch && categoryId != null) {
-            PageRequest nativePageable = PageRequest.of(Math.max(0, page), Math.min(Math.max(1, size), 100), nativeSortOrder);
-            courses = courseRepository.findByStatusAndCategoryIdAndTitleContaining(Course.CourseStatus.APPROVED, categoryId, search, nativePageable);
-        } else if (hasSearch) {
-            PageRequest nativePageable = PageRequest.of(Math.max(0, page), Math.min(Math.max(1, size), 100), nativeSortOrder);
-            courses = courseRepository.findByStatusAndTitleContaining(Course.CourseStatus.APPROVED, search, nativePageable);
-        } else if (categoryId != null) {
-            PageRequest pageable = PageRequest.of(Math.max(0, page), Math.min(Math.max(1, size), 100), sortOrder);
-            courses = courseRepository.findByStatusAndCategoryId(Course.CourseStatus.APPROVED, categoryId, pageable);
-        } else {
-            PageRequest pageable = PageRequest.of(Math.max(0, page), Math.min(Math.max(1, size), 100), sortOrder);
-            courses = courseRepository.findByStatus(Course.CourseStatus.APPROVED, pageable);
-        }
+        PageRequest pageable = PageRequest.of(
+                Math.max(0, page),
+                Math.min(Math.max(1, size), 100),
+                resolveCourseSort(sort, order)
+        );
+        Page<Course> courses = courseRepository.findByStatusAndFilters(
+                Course.CourseStatus.APPROVED,
+                categoryFilterIds,
+                parseDeliveryMode(deliveryMode),
+                normalizeSearch(search),
+                pageable
+        );
         
         // Batch-fetch teacher names and category names to prevent N+1
         Set<UUID> teacherIds = courses.getContent().stream()
@@ -767,6 +757,52 @@ public class CourseQueryControllerV3 {
             }
         }
         return chapters;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String normalizeSearch(String search) {
+        return hasText(search) ? search.trim() : null;
+    }
+
+    private Sort resolveCourseSort(String sort, String order) {
+        String sortField = "title".equals(sort) ? "title" : "createdAt";
+        return "asc".equalsIgnoreCase(order) ? Sort.by(sortField).ascending() : Sort.by(sortField).descending();
+    }
+
+    private Course.DeliveryMode parseDeliveryMode(String value) {
+        if (!hasText(value)) return null;
+        try {
+            return Course.DeliveryMode.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private Set<UUID> resolveCategoryFilterIds(String category) {
+        if (!hasText(category)) return Set.of();
+        Optional<CourseCategoryJpaEntity> matchedCategory = courseCategoryJpaRepository
+                .findByCode(category.trim().toUpperCase(Locale.ROOT))
+                .or(() -> courseCategoryJpaRepository.findBySlug(category.trim().toLowerCase(Locale.ROOT)));
+        if (matchedCategory.isEmpty()) return Set.of();
+
+        CourseCategoryJpaEntity rootOrLeaf = matchedCategory.get();
+        Set<UUID> categoryIds = new LinkedHashSet<>();
+        categoryIds.add(rootOrLeaf.getId());
+        courseCategoryJpaRepository.findByParentIdOrderBySortOrder(rootOrLeaf.getId()).stream()
+                .map(CourseCategoryJpaEntity::getId)
+                .forEach(categoryIds::add);
+        return categoryIds;
+    }
+
+    private ResponseEntity<ApiResponse<Page<CourseSummaryResponse>>> emptyPublicCoursePage(int page, int size) {
+        PageRequest pageable = PageRequest.of(Math.max(0, page), Math.min(Math.max(1, size), 100));
+        return ResponseEntity.ok(ApiResponse.success(
+                new PageImpl<>(Collections.emptyList(), pageable, 0),
+                "Danh sách khóa học"
+        ));
     }
 
     private CourseSummaryResponse toSummary(Course course) {

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3.java
@@ -39,6 +39,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.text.Normalizer;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -1095,7 +1096,16 @@ private Map<String, Object> buildSectionCompletionResponse(
     }
 
     private String normalizeSearch(String search) {
-        return hasText(search) ? search.trim().toLowerCase(Locale.ROOT) : null;
+        return hasText(search) ? normalizeForSearch(search) : null;
+    }
+
+    private String normalizeForSearch(String value) {
+        if (value == null) return "";
+        String normalized = Normalizer.normalize(value.trim(), Normalizer.Form.NFD)
+                .replace('đ', 'd')
+                .replace('Đ', 'D')
+                .replaceAll("\\p{M}+", "");
+        return normalized.toLowerCase(Locale.ROOT);
     }
 
     private CourseJpaEntity.DeliveryMode parseDeliveryMode(String value) {
@@ -1139,7 +1149,7 @@ private Map<String, Object> buildSectionCompletionResponse(
             return false;
         }
         return normalizedSearch == null
-                || (course.getTitle() != null && course.getTitle().toLowerCase(Locale.ROOT).contains(normalizedSearch));
+                || normalizeForSearch(course.getTitle()).contains(normalizedSearch);
     }
 
     private void sortEnrolledCourseResponses(List<EnrolledCourseResponse> courseResponses, String sort, String order) {

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3.java
@@ -75,7 +75,12 @@ public class StudentEnrollmentControllerV3 {
     public ResponseEntity<ApiResponse<Page<EnrolledCourseResponse>>> getEnrolledCourses(
             @AuthenticationPrincipal UserJpaEntity currentUser,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String deliveryMode,
+            @RequestParam(required = false, defaultValue = "recent") String sort,
+            @RequestParam(required = false, defaultValue = "desc") String order
     ) {
         if (currentUser == null) {
             return ResponseEntity.ok(ApiResponse.success(
@@ -99,6 +104,34 @@ public class StudentEnrollmentControllerV3 {
         Set<UUID> courseIds = courseEnrollments.keySet();
         Map<UUID, CourseJpaEntity> courseMap = courseJpaRepository.findAllById(courseIds).stream()
                 .collect(Collectors.toMap(CourseJpaEntity::getId, c -> c));
+
+        Set<UUID> categoryFilterIds = resolveCategoryFilterIds(category);
+        boolean categoryFilterRequested = hasText(category);
+        CourseJpaEntity.DeliveryMode deliveryModeFilter = parseDeliveryMode(deliveryMode);
+        String normalizedSearch = normalizeSearch(search);
+        if (categoryFilterRequested && categoryFilterIds.isEmpty()) {
+            courseEnrollments = Map.of();
+            courseMap = Map.of();
+        } else if (categoryFilterRequested || deliveryModeFilter != null || normalizedSearch != null) {
+            Map<UUID, List<Enrollment>> filteredEnrollments = new LinkedHashMap<>();
+            for (Map.Entry<UUID, List<Enrollment>> entry : courseEnrollments.entrySet()) {
+                CourseJpaEntity course = courseMap.get(entry.getKey());
+                if (matchesEnrolledCourseFilters(
+                        course,
+                        categoryFilterIds,
+                        categoryFilterRequested,
+                        deliveryModeFilter,
+                        normalizedSearch)) {
+                    filteredEnrollments.put(entry.getKey(), entry.getValue());
+                }
+            }
+            courseEnrollments = filteredEnrollments;
+            Set<UUID> filteredCourseIds = courseEnrollments.keySet();
+            courseMap = courseMap.entrySet().stream()
+                    .filter(entry -> filteredCourseIds.contains(entry.getKey()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+        courseIds = courseEnrollments.keySet();
 
         // Batch-load teacher names
         Set<UUID> teacherIds = courseMap.values().stream()
@@ -142,6 +175,7 @@ public class StudentEnrollmentControllerV3 {
                 : Set.of();
 
         // Build response with real course data
+        Map<UUID, CourseJpaEntity> finalCourseMap = courseMap;
         List<EnrolledCourseResponse> courseResponses = courseEnrollments.entrySet().stream()
                 .map(entry -> {
                     UUID courseId = entry.getKey();
@@ -151,7 +185,7 @@ public class StudentEnrollmentControllerV3 {
                                     e -> e.getEnrolledAt() != null ? e.getEnrolledAt() : Instant.EPOCH))
                             .orElse(entry.getValue().getFirst());
                     LearningClass lc = enrollment.getLearningClass();
-                    CourseJpaEntity course = courseMap.get(courseId);
+                    CourseJpaEntity course = finalCourseMap.get(courseId);
 
                     String description = course != null && course.getDescription() != null
                             ? course.getDescription() : "";
@@ -190,15 +224,7 @@ public class StudentEnrollmentControllerV3 {
                 })
                 .collect(Collectors.toList());
 
-        // Sort by lastAccessedAt DESC (SOTA: Canvas/Coursera "most recently accessed" pattern)
-        courseResponses.sort((a, b) -> {
-            String aTime = a.getLastAccessedAt();
-            String bTime = b.getLastAccessedAt();
-            if (aTime == null && bTime == null) return 0;
-            if (aTime == null) return 1;
-            if (bTime == null) return -1;
-            return bTime.compareTo(aTime);
-        });
+        sortEnrolledCourseResponses(courseResponses, sort, order);
         
         // Apply pagination manually (0-indexed, Spring Data standard)
         int safePage = Math.max(0, page);
@@ -1062,6 +1088,86 @@ private Map<String, Object> buildSectionCompletionResponse(
                 .count();
         int percent = (int) Math.min(100, Math.round((double) completedCount / totalLessons * 100));
         enrollment.updateCompletionPercent(percent);
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String normalizeSearch(String search) {
+        return hasText(search) ? search.trim().toLowerCase(Locale.ROOT) : null;
+    }
+
+    private CourseJpaEntity.DeliveryMode parseDeliveryMode(String value) {
+        if (!hasText(value)) return null;
+        try {
+            return CourseJpaEntity.DeliveryMode.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private Set<UUID> resolveCategoryFilterIds(String category) {
+        if (!hasText(category)) return Set.of();
+        Optional<CourseCategoryJpaEntity> matchedCategory = categoryJpaRepository
+                .findByCode(category.trim().toUpperCase(Locale.ROOT))
+                .or(() -> categoryJpaRepository.findBySlug(category.trim().toLowerCase(Locale.ROOT)));
+        if (matchedCategory.isEmpty()) return Set.of();
+
+        CourseCategoryJpaEntity rootOrLeaf = matchedCategory.get();
+        Set<UUID> categoryIds = new LinkedHashSet<>();
+        categoryIds.add(rootOrLeaf.getId());
+        categoryJpaRepository.findByParentIdOrderBySortOrder(rootOrLeaf.getId()).stream()
+                .map(CourseCategoryJpaEntity::getId)
+                .forEach(categoryIds::add);
+        return categoryIds;
+    }
+
+    private boolean matchesEnrolledCourseFilters(
+            CourseJpaEntity course,
+            Set<UUID> categoryFilterIds,
+            boolean categoryFilterRequested,
+            CourseJpaEntity.DeliveryMode deliveryModeFilter,
+            String normalizedSearch
+    ) {
+        if (course == null) return false;
+        if (categoryFilterRequested
+                && (course.getCategoryId() == null || !categoryFilterIds.contains(course.getCategoryId()))) {
+            return false;
+        }
+        if (deliveryModeFilter != null && course.getDeliveryMode() != deliveryModeFilter) {
+            return false;
+        }
+        return normalizedSearch == null
+                || (course.getTitle() != null && course.getTitle().toLowerCase(Locale.ROOT).contains(normalizedSearch));
+    }
+
+    private void sortEnrolledCourseResponses(List<EnrolledCourseResponse> courseResponses, String sort, String order) {
+        String sortKey = hasText(sort) ? sort.trim().toLowerCase(Locale.ROOT) : "recent";
+        boolean ascending = "asc".equalsIgnoreCase(order);
+        Comparator<EnrolledCourseResponse> comparator = switch (sortKey) {
+            case "az", "title" -> Comparator.comparing(
+                    response -> Optional.ofNullable(response.getTitle()).orElse(""),
+                    String.CASE_INSENSITIVE_ORDER
+            );
+            case "progress" -> Comparator.comparing(
+                    response -> Optional.ofNullable(response.getProgress()).orElse(0)
+            );
+            default -> this::compareLastAccessedAscending;
+        };
+        if (!ascending) {
+            comparator = comparator.reversed();
+        }
+        courseResponses.sort(comparator);
+    }
+
+    private int compareLastAccessedAscending(EnrolledCourseResponse a, EnrolledCourseResponse b) {
+        String aTime = a.getLastAccessedAt();
+        String bTime = b.getLastAccessedAt();
+        if (aTime == null && bTime == null) return 0;
+        if (aTime == null) return -1;
+        if (bTime == null) return 1;
+        return aTime.compareTo(bTime);
     }
 
     private long countTotalLessonsForCourse(UUID courseId) {

--- a/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3ContractTest.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3ContractTest.java
@@ -87,13 +87,17 @@ class CourseQueryControllerV3ContractTest {
         when(teacher.getId()).thenReturn(teacherId);
         when(teacher.getFullName()).thenReturn("Teacher Name");
 
-        when(courseRepository.findByStatus(any(), any())).thenReturn(new PageImpl<>(List.of(approvedPaidCourse)));
+        when(courseRepository.findByStatusAndFilters(eq(Course.CourseStatus.APPROVED), any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(approvedPaidCourse)));
         when(userJpaRepository.findAllById(any())).thenReturn(List.of(teacher));
         when(enrollmentJpaRepository.countEnrollmentsByCourseIds(any())).thenReturn(
                 java.util.Collections.singletonList(new Object[] {approvedPaidCourse.getId(), 7L})
         );
+        when(chapterRepository.countByCourseIds(any())).thenReturn(
+                java.util.Collections.singletonList(new Object[] {approvedPaidCourse.getId(), 3L})
+        );
 
-        var response = controller.getPublicCourses(0, 20, null, null, null, null);
+        var response = controller.getPublicCourses(0, 20, null, null, null, null, null);
 
         assertThat(response.getBody()).isNotNull();
         ApiResponse<?> body = response.getBody();

--- a/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3Test.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3Test.java
@@ -36,6 +36,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -107,6 +109,54 @@ class StudentEnrollmentControllerV3Test {
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().isSuccess()).isTrue();
         assertThat(response.getBody().getData()).isEqualTo(List.of());
+    }
+
+    @Test
+    @DisplayName("enrolled course search should match Vietnamese titles without diacritics")
+    void getEnrolledCoursesSearchMatchesVietnameseTitleWithoutDiacritics() {
+        UUID studentId = UUID.randomUUID();
+        UUID maritimeCourseId = UUID.randomUUID();
+        UUID logisticsCourseId = UUID.randomUUID();
+        UserJpaEntity student = student(studentId);
+
+        Enrollment maritimeEnrollment = enrollmentForCourse(studentId, maritimeCourseId);
+        Enrollment logisticsEnrollment = enrollmentForCourse(studentId, logisticsCourseId);
+        CourseJpaEntity maritimeCourse = CourseJpaEntity.builder()
+                .id(maritimeCourseId)
+                .title("Hàng hải căn bản")
+                .build();
+        CourseJpaEntity logisticsCourse = CourseJpaEntity.builder()
+                .id(logisticsCourseId)
+                .title("Port logistics")
+                .build();
+
+        when(enrollmentRepository.findActiveAndCompletedWithClass(studentId))
+                .thenReturn(List.of(maritimeEnrollment, logisticsEnrollment));
+        when(courseJpaRepository.findAllById(any()))
+                .thenReturn(List.of(maritimeCourse, logisticsCourse));
+        when(userJpaRepository.findAllById(any())).thenReturn(List.of());
+        when(chapterJpaRepository.findByCourseIdInOrderByOrderIndex(any())).thenReturn(List.of());
+        when(paymentTransactionJpaRepository.findPaidCourseIds(eq(studentId), any(), any()))
+                .thenReturn(List.of());
+
+        var response = controller.getEnrolledCourses(
+                student,
+                0,
+                20,
+                "hang hai",
+                null,
+                null,
+                "recent",
+                "desc"
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().isSuccess()).isTrue();
+        assertThat(response.getBody().getData().getTotalElements()).isEqualTo(1);
+        assertThat(response.getBody().getData().getContent())
+                .extracting(StudentEnrollmentControllerV3.EnrolledCourseResponse::getTitle)
+                .containsExactly("Hàng hải căn bản");
     }
 
     @Test
@@ -369,5 +419,20 @@ class StudentEnrollmentControllerV3Test {
         user.setEmail("student@maritime.edu");
         user.setFullName("Student");
         return user;
+    }
+
+    private Enrollment enrollmentForCourse(UUID studentId, UUID courseId) {
+        return Enrollment.builder()
+                .id(UUID.randomUUID())
+                .studentId(studentId)
+                .status(Enrollment.EnrollmentStatus.ACTIVE)
+                .completionPercent(0)
+                .learningClass(LearningClass.builder()
+                        .id(UUID.randomUUID())
+                        .courseId(courseId)
+                        .name("Class")
+                        .build())
+                .enrolledAt(Instant.now())
+                .build();
     }
 }

--- a/fe/src/app/api/client/course.api.ts
+++ b/fe/src/app/api/client/course.api.ts
@@ -1,12 +1,27 @@
 import { Injectable, inject } from '@angular/core';
 import { ApiClient } from './api-client';
 import { COURSE_ENDPOINTS } from '../endpoints/course.endpoints';
-import { ApiResponse } from '../types/common.types';
+import { ApiResponse, PaginationInfo } from '../types/common.types';
 import { CreateCourseRequest, CourseDetail, CourseSummary, CourseContentChapter, DeliveryMode } from '../types/course.types';
 import { EnrollStudentRequest } from '../types/enrollment.types';
 import { map, tap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { ApiCacheService } from '../../core/services/api-cache.service';
+
+function mapSpringPagePagination(page: any): PaginationInfo | undefined {
+  if (!page || typeof page !== 'object' || !Array.isArray(page.content)) {
+    return undefined;
+  }
+
+  return {
+    totalItems: page.totalElements ?? page.content.length ?? 0,
+    totalPages: page.totalPages ?? 0,
+    page: (page.number ?? 0) + 1,
+    limit: page.size ?? page.content.length ?? 0,
+    first: !!page.first,
+    last: !!page.last
+  };
+}
 
 @Injectable({ providedIn: 'root' })
 export class CourseApi {
@@ -58,10 +73,11 @@ export class CourseApi {
   publicCourses(params?: { page?: number; size?: number; search?: string; teacher?: string; category?: string; sort?: string; order?: string; deliveryMode?: DeliveryMode }): Observable<ApiResponse<CourseSummary[]>> {
     return this.api.getWithResponse<any>(COURSE_ENDPOINTS.BASE, { params }).pipe(
       map((res: ApiResponse<any>) => {
-        const content: CourseSummary[] = res?.data?.content ?? [];
+        const page = res?.data;
+        const content: CourseSummary[] = page?.content ?? [];
         return {
           data: content,
-          pagination: res?.pagination,
+          pagination: mapSpringPagePagination(page) ?? res?.pagination,
           message: res?.message
         } as ApiResponse<CourseSummary[]>;
       })
@@ -71,10 +87,11 @@ export class CourseApi {
   enrolledCourses(params?: { page?: number; size?: number; search?: string; category?: string; sort?: string; order?: string; deliveryMode?: DeliveryMode }): Observable<ApiResponse<CourseSummary[]>> {
     return this.api.getWithResponse<any>(COURSE_ENDPOINTS.STUDENT.ENROLLED, { params }).pipe(
       map((res: ApiResponse<any>) => {
-        const content: CourseSummary[] = res?.data?.content ?? [];
+        const page = res?.data;
+        const content: CourseSummary[] = page?.content ?? [];
         return {
           data: content,
-          pagination: res?.pagination,
+          pagination: mapSpringPagePagination(page) ?? res?.pagination,
           message: res?.message
         } as ApiResponse<CourseSummary[]>;
       })

--- a/fe/src/app/api/client/course.api.ts
+++ b/fe/src/app/api/client/course.api.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { ApiClient } from './api-client';
 import { COURSE_ENDPOINTS } from '../endpoints/course.endpoints';
 import { ApiResponse } from '../types/common.types';
-import { CreateCourseRequest, CourseDetail, CourseSummary, CourseContentChapter } from '../types/course.types';
+import { CreateCourseRequest, CourseDetail, CourseSummary, CourseContentChapter, DeliveryMode } from '../types/course.types';
 import { EnrollStudentRequest } from '../types/enrollment.types';
 import { map, tap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
@@ -55,7 +55,7 @@ export class CourseApi {
     );
   }
 
-  publicCourses(params?: { page?: number; size?: number; search?: string; teacher?: string; category?: string; sort?: string; order?: string }): Observable<ApiResponse<CourseSummary[]>> {
+  publicCourses(params?: { page?: number; size?: number; search?: string; teacher?: string; category?: string; sort?: string; order?: string; deliveryMode?: DeliveryMode }): Observable<ApiResponse<CourseSummary[]>> {
     return this.api.getWithResponse<any>(COURSE_ENDPOINTS.BASE, { params }).pipe(
       map((res: ApiResponse<any>) => {
         const content: CourseSummary[] = res?.data?.content ?? [];
@@ -68,7 +68,7 @@ export class CourseApi {
     );
   }
 
-  enrolledCourses(params?: { page?: number; size?: number }): Observable<ApiResponse<CourseSummary[]>> {
+  enrolledCourses(params?: { page?: number; size?: number; search?: string; category?: string; sort?: string; order?: string; deliveryMode?: DeliveryMode }): Observable<ApiResponse<CourseSummary[]>> {
     return this.api.getWithResponse<any>(COURSE_ENDPOINTS.STUDENT.ENROLLED, { params }).pipe(
       map((res: ApiResponse<any>) => {
         const content: CourseSummary[] = res?.data?.content ?? [];

--- a/fe/src/app/features/student/browse/student-course-browser.component.ts
+++ b/fe/src/app/features/student/browse/student-course-browser.component.ts
@@ -5,11 +5,21 @@ import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { Router, ActivatedRoute } from '@angular/router';
 import { CourseApi } from '../../../api/client/course.api';
-import { CourseSummary, CourseCategoryDTO } from '../../../api/types/course.types';
+import { CourseSummary, CourseCategoryDTO, DeliveryMode } from '../../../api/types/course.types';
 import { StudentEnrollmentService } from '../services/enrollment.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { environment } from '../../../../environments/environment';
 import { PaginationComponent } from '../../../shared/components/pagination/pagination.component';
+
+type CourseBrowserQueryParams = {
+  page: number;
+  size: number;
+  search?: string;
+  category?: string;
+  sort?: string;
+  order?: string;
+  deliveryMode?: DeliveryMode;
+};
 
 @Component({
   selector: 'app-student-course-browser',
@@ -190,7 +200,7 @@ import { PaginationComponent } from '../../../shared/components/pagination/pagin
             </svg>
             <h3 class="text-lg font-medium text-gray-700 mb-1">Không tìm thấy khóa học</h3>
             <p class="text-sm text-gray-500 mb-4">Thử thay đổi từ khóa tìm kiếm hoặc bộ lọc</p>
-            @if (searchQuery() || selectedRootCategory() || modeFilter()) {
+            @if (searchQuery() || selectedRootCategory() || modeFilter() || showEnrolledOnly()) {
               <button (click)="clearAllFilters()" class="px-4 py-2 text-sm font-medium text-[#0056D2] border border-[#0056D2] rounded-lg hover:bg-[#0056D2]/5 transition-colors">
                 Xóa bộ lọc
               </button>
@@ -359,54 +369,18 @@ export class StudentCourseBrowserComponent implements OnInit {
 
   private enrolledIds = computed(() => this.enrollmentService.enrolledCourseIds());
 
-  // Client-side filtered + sorted courses
+  // API-filtered courses for the current page.
   filteredCourses = computed(() => {
     let result = this.rawCourses();
 
-    // Category filter — match by categoryName (root or sub)
-    const root = this.selectedRootCategory();
-    if (root) {
-      const subId = this.selectedSubId();
-      if (subId) {
-        const sub = root.children?.find(c => c.id === subId);
-        if (sub) result = result.filter(c => c.categoryName === sub.name);
-      } else {
-        const names = new Set([root.name, ...(root.children?.map(c => c.name) || [])]);
-        result = result.filter(c => c.categoryName && names.has(c.categoryName));
-      }
-    }
-
-    // Mode filter
-    const mode = this.modeFilter();
-    if (mode) {
-      result = result.filter(c => c.deliveryMode === mode);
-    }
-
-    // Enrolled-only filter
-    if (this.showEnrolledOnly()) {
-      const ids = this.enrolledIds();
-      result = result.filter(c => ids.has(c.id));
-    }
-
-    // Sort
-    const sort = this.sortMode();
-    if (sort === 'az') {
-      result = [...result].sort((a, b) => a.title.localeCompare(b.title, 'vi'));
-    } else if (sort === 'popular') {
+    if (this.sortMode() === 'popular') {
       result = [...result].sort((a, b) => (b.enrolledCount || 0) - (a.enrolledCount || 0));
     }
-    // 'newest' = API default order
 
     return result;
   });
 
-  private hasLocalCourseFilter = computed(() =>
-    !!this.selectedRootCategory() || !!this.selectedSubId() || !!this.modeFilter() || this.showEnrolledOnly()
-  );
-
-  resultCount = computed(() =>
-    this.hasLocalCourseFilter() ? this.filteredCourses().length : this.totalItems()
-  );
+  resultCount = computed(() => this.totalItems());
 
   private readonly GRADIENTS = [
     'linear-gradient(135deg, #0056D2 0%, #4A90D9 100%)',
@@ -441,19 +415,51 @@ export class StudentCourseBrowserComponent implements OnInit {
     }, 300);
   }
 
+  private buildCourseQueryParams(): CourseBrowserQueryParams {
+    const params: CourseBrowserQueryParams = { page: this.currentPage(), size: this.PAGE_SIZE };
+    const q = this.searchQuery().trim();
+    if (q) params.search = q;
+
+    const category = this.selectedCategoryParam();
+    if (category) params.category = category;
+
+    const mode = this.modeFilter();
+    if (mode) params.deliveryMode = mode;
+
+    if (this.sortMode() === 'az') {
+      params.sort = 'title';
+      params.order = 'asc';
+    } else {
+      params.sort = this.showEnrolledOnly() ? 'recent' : 'createdAt';
+      params.order = 'desc';
+    }
+
+    return params;
+  }
+
+  private selectedCategoryParam(): string | undefined {
+    const root = this.selectedRootCategory();
+    if (!root) return undefined;
+    const subId = this.selectedSubId();
+    if (!subId) return root.slug || root.code;
+    const sub = root.children?.find(child => child.id === subId);
+    return sub ? sub.slug || sub.code : root.slug || root.code;
+  }
+
   loadCourses(): void {
     this.isLoading.set(true);
     this.errorMsg.set(null);
 
-    const params: any = { page: this.currentPage(), size: this.PAGE_SIZE };
-    const q = this.searchQuery().trim();
-    if (q) params.search = q;
+    const params = this.buildCourseQueryParams();
+    const request = this.showEnrolledOnly()
+      ? this.courseApi.enrolledCourses(params)
+      : this.courseApi.publicCourses(params);
 
-    this.courseApi.publicCourses(params).subscribe({
+    request.subscribe({
       next: (res) => {
         this.rawCourses.set(res.data ?? []);
         const pagination = res.pagination as any;
-        if (pagination?.totalPages) {
+        if (typeof pagination?.totalPages === 'number') {
           this.totalPages.set(pagination.totalPages);
           this.totalItems.set(pagination.totalItems ?? pagination.totalElements ?? this.rawCourses().length);
         } else {
@@ -514,7 +520,7 @@ export class StudentCourseBrowserComponent implements OnInit {
   }
 
   isEnrolled(courseId: string): boolean {
-    return this.enrolledIds().has(courseId);
+    return this.showEnrolledOnly() || this.enrolledIds().has(courseId);
   }
 
   isClassFull(course: CourseSummary): boolean {

--- a/fe/src/app/features/student/browse/student-course-browser.component.ts
+++ b/fe/src/app/features/student/browse/student-course-browser.component.ts
@@ -9,10 +9,11 @@ import { CourseSummary, CourseCategoryDTO } from '../../../api/types/course.type
 import { StudentEnrollmentService } from '../services/enrollment.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { environment } from '../../../../environments/environment';
+import { PaginationComponent } from '../../../shared/components/pagination/pagination.component';
 
 @Component({
   selector: 'app-student-course-browser',
-  imports: [CommonModule],
+  imports: [CommonModule, PaginationComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="min-h-screen bg-slate-50 px-4 sm:px-6 py-6 max-w-[1400px] mx-auto">
@@ -60,7 +61,7 @@ import { environment } from '../../../../environments/environment';
       <!-- Subcategory Chips -->
       @if (selectedRootCategory()?.children?.length) {
         <div class="flex items-center gap-1.5 mb-4 overflow-x-auto pb-1">
-          <button (click)="selectedSubId.set(null)"
+          <button (click)="selectSubCategory(null)"
             class="px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-colors"
             [class]="!selectedSubId()
               ? 'bg-[#0056D2]/10 text-[#0056D2]'
@@ -68,7 +69,7 @@ import { environment } from '../../../../environments/environment';
             Tất cả
           </button>
           @for (sub of selectedRootCategory()!.children; track sub.id) {
-            <button (click)="selectedSubId.set(sub.id)"
+            <button (click)="selectSubCategory(sub.id)"
               class="px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-colors"
               [class]="selectedSubId() === sub.id
                 ? 'bg-[#0056D2]/10 text-[#0056D2]'
@@ -86,21 +87,21 @@ import { environment } from '../../../../environments/environment';
         <!-- Mode Filter -->
         <div class="flex items-center gap-1.5">
           <span class="text-xs text-slate-500">Hình thức:</span>
-          <button (click)="modeFilter.set('')"
+          <button (click)="setModeFilter('')"
             class="px-2.5 py-1 rounded-full text-xs font-medium border transition-colors"
             [class]="!modeFilter()
               ? 'bg-[#0056D2] text-white border-[#0056D2]'
               : 'bg-white text-slate-600 border-slate-300 hover:border-slate-400'">
             Tất cả
           </button>
-          <button (click)="modeFilter.set('SELF_PACED')"
+          <button (click)="setModeFilter('SELF_PACED')"
             class="px-2.5 py-1 rounded-full text-xs font-medium border transition-colors"
             [class]="modeFilter() === 'SELF_PACED'
               ? 'bg-[#0056D2] text-white border-[#0056D2]'
               : 'bg-white text-slate-600 border-slate-300 hover:border-slate-400'">
             Tự học
           </button>
-          <button (click)="modeFilter.set('INSTRUCTOR_LED')"
+          <button (click)="setModeFilter('INSTRUCTOR_LED')"
             class="px-2.5 py-1 rounded-full text-xs font-medium border transition-colors"
             [class]="modeFilter() === 'INSTRUCTOR_LED'
               ? 'bg-emerald-600 text-white border-emerald-600'
@@ -130,7 +131,7 @@ import { environment } from '../../../../environments/environment';
       <div class="flex items-center justify-between mb-4">
         <span class="text-sm text-gray-600">
           @if (!isLoading()) {
-            Tìm thấy <strong class="text-gray-900">{{ filteredCourses().length }}</strong> khóa học
+            Tìm thấy <strong class="text-gray-900">{{ resultCount() }}</strong> khóa học
           }
         </span>
         <!-- "Đang học" quick toggle -->
@@ -312,29 +313,13 @@ import { environment } from '../../../../environments/environment';
 
           <!-- Pagination -->
           @if (totalPages() > 1) {
-            <div class="flex items-center justify-center gap-1.5 mt-8">
-              <button (click)="goToPage(currentPage() - 1)" [disabled]="currentPage() === 0"
-                class="px-3 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
-              </button>
-              @for (p of paginationPages(); track p) {
-                @if (p === -1) {
-                  <span class="px-2 py-2 text-sm text-gray-400">...</span>
-                } @else {
-                  <button (click)="goToPage(p)"
-                    class="w-11 h-11 sm:w-9 sm:h-9 text-sm rounded-lg border transition-colors"
-                    [class]="currentPage() === p
-                      ? 'bg-[#0056D2] text-white border-[#0056D2]'
-                      : 'border-gray-300 hover:bg-gray-50 text-gray-700'">
-                    {{ p + 1 }}
-                  </button>
-                }
-              }
-              <button (click)="goToPage(currentPage() + 1)" [disabled]="currentPage() >= totalPages() - 1"
-                class="px-3 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
-              </button>
-            </div>
+            <app-pagination
+              class="mt-8 block overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm"
+              [currentPage]="currentPage() + 1"
+              [totalPages]="totalPages()"
+              [totalItems]="totalItems()"
+              [itemsPerPage]="PAGE_SIZE"
+              (pageChange)="goToPage($event - 1)" />
           }
         }
       }
@@ -357,6 +342,7 @@ export class StudentCourseBrowserComponent implements OnInit {
   searchQuery = signal('');
   currentPage = signal(0);
   totalPages = signal(1);
+  totalItems = signal(0);
 
   // Category tree from API
   categoryTree = signal<CourseCategoryDTO[]>([]);
@@ -369,7 +355,7 @@ export class StudentCourseBrowserComponent implements OnInit {
   modeFilter = signal<'' | 'SELF_PACED' | 'INSTRUCTOR_LED'>('');
 
   private searchTimer: ReturnType<typeof setTimeout> | null = null;
-  private readonly PAGE_SIZE = 12;
+  readonly PAGE_SIZE = 12;
 
   private enrolledIds = computed(() => this.enrollmentService.enrolledCourseIds());
 
@@ -414,21 +400,13 @@ export class StudentCourseBrowserComponent implements OnInit {
     return result;
   });
 
-  // Pagination pages for numbered pagination
-  paginationPages = computed(() => {
-    const total = this.totalPages();
-    const current = this.currentPage();
-    if (total <= 7) return Array.from({ length: total }, (_, i) => i);
+  private hasLocalCourseFilter = computed(() =>
+    !!this.selectedRootCategory() || !!this.selectedSubId() || !!this.modeFilter() || this.showEnrolledOnly()
+  );
 
-    const pages: number[] = [0];
-    const start = Math.max(1, current - 1);
-    const end = Math.min(total - 2, current + 1);
-    if (start > 1) pages.push(-1); // ellipsis
-    for (let i = start; i <= end; i++) pages.push(i);
-    if (end < total - 2) pages.push(-1); // ellipsis
-    pages.push(total - 1);
-    return pages;
-  });
+  resultCount = computed(() =>
+    this.hasLocalCourseFilter() ? this.filteredCourses().length : this.totalItems()
+  );
 
   private readonly GRADIENTS = [
     'linear-gradient(135deg, #0056D2 0%, #4A90D9 100%)',
@@ -477,13 +455,16 @@ export class StudentCourseBrowserComponent implements OnInit {
         const pagination = res.pagination as any;
         if (pagination?.totalPages) {
           this.totalPages.set(pagination.totalPages);
+          this.totalItems.set(pagination.totalItems ?? pagination.totalElements ?? this.rawCourses().length);
         } else {
           this.totalPages.set((res.data?.length ?? 0) >= this.PAGE_SIZE ? this.currentPage() + 2 : this.currentPage() + 1);
+          this.totalItems.set((res.data?.length ?? 0) + (this.currentPage() * this.PAGE_SIZE));
         }
         this.isLoading.set(false);
       },
       error: () => {
         this.errorMsg.set('Không thể tải danh sách khóa học');
+        this.totalItems.set(0);
         this.isLoading.set(false);
         this.toast.error('Không thể tải danh sách khóa học');
       }
@@ -493,14 +474,27 @@ export class StudentCourseBrowserComponent implements OnInit {
   selectRootCategory(root: CourseCategoryDTO | null): void {
     this.selectedRootCategory.set(root);
     this.selectedSubId.set(null);
+    this.resetToFirstPage();
+  }
+
+  selectSubCategory(categoryId: string | null): void {
+    this.selectedSubId.set(categoryId);
+    this.resetToFirstPage();
+  }
+
+  setModeFilter(mode: '' | 'SELF_PACED' | 'INSTRUCTOR_LED'): void {
+    this.modeFilter.set(mode);
+    this.resetToFirstPage();
   }
 
   onSortChange(event: Event): void {
     this.sortMode.set((event.target as HTMLSelectElement).value);
+    this.resetToFirstPage();
   }
 
   toggleEnrolledFilter(): void {
     this.showEnrolledOnly.update(v => !v);
+    this.resetToFirstPage();
   }
 
   clearAllFilters(): void {
@@ -510,6 +504,11 @@ export class StudentCourseBrowserComponent implements OnInit {
     this.modeFilter.set('');
     this.showEnrolledOnly.set(false);
     this.sortMode.set('newest');
+    this.currentPage.set(0);
+    this.loadCourses();
+  }
+
+  private resetToFirstPage(): void {
     this.currentPage.set(0);
     this.loadCourses();
   }


### PR DESCRIPTION
## Summary
- Replaced the custom student course browser pagination with the shared `app-pagination` control used by teacher/admin/public list views.
- Added API-backed `totalItems` handling so the results count and pagination summary use the same total.
- Reset the student browser back to page 1 when category, mode, enrolled-only, or sort controls change to avoid stale page state.

## Validation
- `npm run build`
- `npx ng build --configuration development`
- Playwright visual smoke with mocked student session/data: desktop shows `Hiển thị 49 đến 60 trong tổng số 100 kết quả`; mobile shows `Trang 5 / 9`.