### PR TITLE
Hồng: feat(sidebar): unify state service + a11y hardening + bottom-nav alignment

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
@@ -5,6 +5,7 @@ import { Subscription, filter } from 'rxjs';
 import { AuthService } from '../../../../core/services/auth.service';
 import { SidebarStateService } from '../../../../shared/services/sidebar-state.service';
 import { SidebarComponent } from '../../../../shared/components/navigation/sidebar.component';
+import { SkipLinkComponent } from '../../../../shared/components/skip-link/skip-link.component';
 import { getSidebarConfig } from '../../../../shared/components/navigation/sidebar.config';
 import { ChatPanelComponent } from '../../../ai-chat/presentation/components/chat-panel/chat-panel.component';
 import { FloatingChatBubbleComponent } from '../../../ai-chat/presentation/components/floating-chat-bubble/floating-chat-bubble.component';
@@ -12,10 +13,12 @@ import { AiAvailabilityService } from '../../../ai-chat/application/services/ai-
 
 @Component({
   selector: 'app-admin-layout-simple',
-  imports: [RouterModule, RouterOutlet, SidebarComponent, ChatPanelComponent, FloatingChatBubbleComponent],
+  imports: [RouterModule, RouterOutlet, SidebarComponent, ChatPanelComponent, FloatingChatBubbleComponent, SkipLinkComponent],
   encapsulation: ViewEncapsulation.None,
   template: `
     <div class="min-h-screen flex">
+      <!-- WCAG 2.4.1 Bypass Blocks — first focusable element jumps to <main>. -->
+      <app-skip-link/>
       <!-- Desktop Sidebar -->
       @if (!shouldHideSidebar()) {
         <div class="hidden lg:flex lg:flex-col lg:fixed lg:inset-y-0 lg:z-50"
@@ -89,7 +92,7 @@ import { AiAvailabilityService } from '../../../ai-chat/application/services/ai-
           }
 
           <!-- Page content -->
-          <main class="flex-1">
+          <main id="main-content" tabindex="-1" class="flex-1">
             <router-outlet></router-outlet>
           </main>
         </div>

--- a/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
@@ -3,6 +3,7 @@ import { Component, ChangeDetectionStrategy, ViewEncapsulation, inject, signal, 
 import { RouterModule, RouterOutlet, Router, NavigationEnd } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { AuthService } from '../../../../core/services/auth.service';
+import { SidebarStateService } from '../../../../shared/services/sidebar-state.service';
 import { SidebarComponent } from '../../../../shared/components/navigation/sidebar.component';
 import { getSidebarConfig } from '../../../../shared/components/navigation/sidebar.config';
 import { ChatPanelComponent } from '../../../ai-chat/presentation/components/chat-panel/chat-panel.component';
@@ -18,11 +19,11 @@ import { AiAvailabilityService } from '../../../ai-chat/application/services/ai-
       <!-- Desktop Sidebar -->
       @if (!shouldHideSidebar()) {
         <div class="hidden lg:flex lg:flex-col lg:fixed lg:inset-y-0 lg:z-50"
-             [class.lg:w-16]="isSidebarCollapsed()"
-             [class.lg:w-72]="!isSidebarCollapsed()">
+             [class.lg:w-16]="sidebarState.collapsed()"
+             [class.lg:w-72]="!sidebarState.collapsed()">
           <app-sidebar [config]="adminSidebarConfig"
-                       [collapsed]="isSidebarCollapsed()"
-                       (toggleCollapse)="toggleSidebarCollapse()"></app-sidebar>
+                       [collapsed]="sidebarState.collapsed()"
+                       (toggleCollapse)="sidebarState.toggleCollapsed()"></app-sidebar>
         </div>
       }
 
@@ -54,8 +55,8 @@ import { AiAvailabilityService } from '../../../ai-chat/application/services/ai-
 
       <!-- Main content + AI Sidebar wrapper -->
       <div class="flex flex-1 min-w-0 min-h-screen"
-           [class.lg:pl-16]="!shouldHideSidebar() && isSidebarCollapsed()"
-           [class.lg:pl-72]="!shouldHideSidebar() && !isSidebarCollapsed()">
+           [class.lg:pl-16]="!shouldHideSidebar() && sidebarState.collapsed()"
+           [class.lg:pl-72]="!shouldHideSidebar() && !sidebarState.collapsed()">
 
         <!-- Main content column -->
         <div class="flex flex-col flex-1 min-w-0">
@@ -298,11 +299,11 @@ export class AdminLayoutSimpleComponent implements OnInit, OnDestroy {
   private router = inject(Router);
   protected isMobileSidebarOpen = signal(false);
 
-  // CC-04 — sidebar collapse parity với teacher / student. Persisted in
-  // localStorage under `admin_sidebar_collapsed` (separate key per portal
-  // so an admin's preference doesn't leak into other portals nếu cùng
-  // user role-switch).
-  protected isSidebarCollapsed = signal(false);
+  /** Sidebar collapsed/mobileOpen/hidden state — single source of truth shared
+   *  across all 4 portals via SidebarStateService (signals + localStorage +
+   *  cross-tab sync). Replaces the old per-portal `admin_sidebar_collapsed`
+   *  localStorage key. Per spec FR-005 — one storage entry across roles. */
+  protected sidebarState = inject(SidebarStateService);
 
   // Sidebar config — use shared config based on user role
   protected get adminSidebarConfig() {
@@ -341,7 +342,6 @@ export class AdminLayoutSimpleComponent implements OnInit, OnDestroy {
   });
 
   ngOnInit(): void {
-    this.loadSidebarCollapsed();
     this.loadAiSidebarState();
     this.loadAiSidebarWidth();
 
@@ -375,26 +375,6 @@ export class AdminLayoutSimpleComponent implements OnInit, OnDestroy {
    *  close button + Escape handler in the drawer template. Per spec FR-012. */
   closeMobileSidebar(): void {
     this.isMobileSidebarOpen.set(false);
-  }
-
-  toggleSidebarCollapse(): void {
-    this.isSidebarCollapsed.update(v => !v);
-    try {
-      localStorage?.setItem('admin_sidebar_collapsed', this.isSidebarCollapsed().toString());
-    } catch {
-      // Storage may be disabled in private mode — silently ignore.
-    }
-  }
-
-  private loadSidebarCollapsed(): void {
-    try {
-      const saved = localStorage?.getItem('admin_sidebar_collapsed');
-      if (saved !== null && saved !== undefined) {
-        this.isSidebarCollapsed.set(saved === 'true');
-      }
-    } catch {
-      // ignore
-    }
   }
 
   // --- AI Sidebar ---

--- a/fe/src/app/features/student/shared/student-layout-simple.component.ts
+++ b/fe/src/app/features/student/shared/student-layout-simple.component.ts
@@ -5,6 +5,7 @@ import { Subscription, filter } from 'rxjs';
 import { AuthService } from '../../../core/services/auth.service';
 import { SidebarStateService } from '../../../shared/services/sidebar-state.service';
 import { SidebarComponent, SidebarConfig } from '../../../shared/components/navigation/sidebar.component';
+import { SkipLinkComponent } from '../../../shared/components/skip-link/skip-link.component';
 import { studentSidebarConfig as baseStudentSidebarConfig } from '../../../shared/components/navigation/sidebar.config';
 import { NotificationService } from '../../../core/services/notification.service';
 import { MessagingService } from '../../../core/services/messaging.service';
@@ -16,10 +17,12 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
 
 @Component({
   selector: 'app-student-layout-simple',
-  imports: [RouterModule, RouterOutlet, SidebarComponent, ChatPanelComponent],
+  imports: [RouterModule, RouterOutlet, SidebarComponent, ChatPanelComponent, SkipLinkComponent],
   template: `
     <!-- Modern gradient background -->
     <div class="min-h-screen flex flex-col">
+      <!-- WCAG 2.4.1 Bypass Blocks — first focusable element jumps to <main>. -->
+      <app-skip-link/>
       <!-- Desktop Sidebar - Full Height -->
       @if (!shouldHideSidebar()) {
         <div [class]="'hidden md:flex md:flex-col md:fixed md:inset-y-0 md:z-40 transition-all duration-300 '
@@ -91,7 +94,7 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
           </header>
 
           <!-- Page content with modern spacing -->
-          <main class="flex-1 overflow-auto bg-transparent">
+          <main id="main-content" tabindex="-1" class="flex-1 overflow-auto bg-transparent">
             <router-outlet></router-outlet>
           </main>
 
@@ -434,6 +437,10 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
 
     .tab-item.tab-active {
       color: #0056D2;
+    }
+    /* Match sidebar active-item font weight (font-semibold = 600) per spec FR-037. */
+    .tab-item.tab-active .tab-label {
+      font-weight: 600;
     }
 
     .tab-label {

--- a/fe/src/app/features/student/shared/student-layout-simple.component.ts
+++ b/fe/src/app/features/student/shared/student-layout-simple.component.ts
@@ -3,6 +3,7 @@ import { Component, ChangeDetectionStrategy, inject, signal, computed, OnInit, O
 import { RouterModule, RouterOutlet, Router, NavigationEnd } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { AuthService } from '../../../core/services/auth.service';
+import { SidebarStateService } from '../../../shared/services/sidebar-state.service';
 import { SidebarComponent, SidebarConfig } from '../../../shared/components/navigation/sidebar.component';
 import { studentSidebarConfig as baseStudentSidebarConfig } from '../../../shared/components/navigation/sidebar.config';
 import { NotificationService } from '../../../core/services/notification.service';
@@ -22,10 +23,10 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       <!-- Desktop Sidebar - Full Height -->
       @if (!shouldHideSidebar()) {
         <div [class]="'hidden md:flex md:flex-col md:fixed md:inset-y-0 md:z-40 transition-all duration-300 '
-          + (sidebarCollapsed() ? 'md:w-16' : 'md:w-72')">
+          + (sidebarState.collapsed() ? 'md:w-16' : 'md:w-72')">
           <app-sidebar [config]="studentSidebarConfig()"
-            [collapsed]="sidebarCollapsed()"
-            (toggleCollapse)="toggleSidebarCollapse()"></app-sidebar>
+            [collapsed]="sidebarState.collapsed()"
+            (toggleCollapse)="sidebarState.toggleCollapsed()"></app-sidebar>
         </div>
       }
 
@@ -50,7 +51,7 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       <div [class]="shouldHideSidebar()
         ? 'flex flex-1 min-h-0'
         : 'flex flex-1 min-h-0 transition-all duration-300 '
-          + (sidebarCollapsed() ? 'md:pl-16' : 'md:pl-72')">
+          + (sidebarState.collapsed() ? 'md:pl-16' : 'md:pl-72')">
 
         <!-- Main content column -->
         <div class="flex flex-col flex-1 min-w-0">
@@ -468,7 +469,11 @@ export class StudentLayoutSimpleComponent implements OnInit, OnDestroy {
     const url = this.currentUrl();
     return url.startsWith('/student/tasks') || url.startsWith('/student/quiz');
   });
-  protected sidebarCollapsed = signal(false);
+  /** Sidebar collapsed/mobileOpen/hidden state — single source of truth shared
+   *  with teacher + admin portals via SidebarStateService (signals + localStorage
+   *  + cross-tab sync). Replaces the old per-portal `student_sidebar_collapsed`
+   *  localStorage key + duplicated signal/load/toggle methods. */
+  protected sidebarState = inject(SidebarStateService);
 
   // User avatar — show real avatar if exists, fallback to initials circle
   protected userAvatarUrl = computed(() => {
@@ -533,8 +538,8 @@ export class StudentLayoutSimpleComponent implements OnInit, OnDestroy {
     });
 
     // Load sidebar state from localStorage on initialization
+    // (sidebar collapsed state now hydrated by SidebarStateService)
     this.loadSidebarState();
-    this.loadCollapsedState();
     this.loadAiSidebarState();
     this.loadAiSidebarWidth();
 
@@ -592,19 +597,6 @@ export class StudentLayoutSimpleComponent implements OnInit, OnDestroy {
       if (saved !== null) {
         this.sidebarHidden.set(saved === 'true');
       }
-    }
-  }
-
-  toggleSidebarCollapse(): void {
-    this.sidebarCollapsed.update(v => !v);
-    if (typeof window !== 'undefined' && window.localStorage) {
-      localStorage.setItem('student_sidebar_collapsed', this.sidebarCollapsed().toString());
-    }
-  }
-
-  private loadCollapsedState(): void {
-    if (typeof window !== 'undefined' && window.localStorage) {
-      this.sidebarCollapsed.set(localStorage.getItem('student_sidebar_collapsed') === 'true');
     }
   }
 

--- a/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
+++ b/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
@@ -5,6 +5,7 @@ import { Subscription, filter } from 'rxjs';
 import { AuthService } from '../../../core/services/auth.service';
 import { SidebarStateService } from '../../../shared/services/sidebar-state.service';
 import { SidebarComponent, SidebarConfig } from '../../../shared/components/navigation/sidebar.component';
+import { SkipLinkComponent } from '../../../shared/components/skip-link/skip-link.component';
 import { teacherSidebarConfig as baseTeacherSidebarConfig } from '../../../shared/components/navigation/sidebar.config';
 import { NotificationService } from '../../../core/services/notification.service';
 import { MessagingService } from '../../../core/services/messaging.service';
@@ -13,10 +14,12 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
 
 @Component({
   selector: 'app-teacher-layout-simple',
-  imports: [RouterModule, RouterOutlet, SidebarComponent, ChatPanelComponent],
+  imports: [RouterModule, RouterOutlet, SidebarComponent, ChatPanelComponent, SkipLinkComponent],
   template: `
     <!-- Modern gradient background for teacher portal -->
     <div class="min-h-screen flex flex-col">
+      <!-- WCAG 2.4.1 Bypass Blocks — first focusable element jumps to <main>. -->
+      <app-skip-link/>
       <!-- Desktop Sidebar - Full Height (collapsible, matching student pattern) -->
       @if (!shouldHideSidebar()) {
         <div [class]="'hidden md:flex md:flex-col md:fixed md:inset-y-0 md:z-40 transition-all duration-300 '
@@ -83,7 +86,7 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
           </header>
 
           <!-- Page content -->
-          <main class="flex-1 overflow-auto bg-transparent">
+          <main id="main-content" tabindex="-1" class="flex-1 overflow-auto bg-transparent">
             <router-outlet></router-outlet>
           </main>
 
@@ -286,6 +289,10 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
 
     .tab-item.tab-active {
       color: #0056D2;
+    }
+    /* Match sidebar active-item font weight (font-semibold = 600) per spec FR-037. */
+    .tab-item.tab-active .tab-label {
+      font-weight: 600;
     }
 
     .tab-label {

--- a/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
+++ b/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
@@ -3,6 +3,7 @@ import { Component, ChangeDetectionStrategy, inject, signal, computed, OnInit, O
 import { RouterModule, RouterOutlet, Router, NavigationEnd } from '@angular/router';
 import { Subscription, filter } from 'rxjs';
 import { AuthService } from '../../../core/services/auth.service';
+import { SidebarStateService } from '../../../shared/services/sidebar-state.service';
 import { SidebarComponent, SidebarConfig } from '../../../shared/components/navigation/sidebar.component';
 import { teacherSidebarConfig as baseTeacherSidebarConfig } from '../../../shared/components/navigation/sidebar.config';
 import { NotificationService } from '../../../core/services/notification.service';
@@ -19,10 +20,10 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       <!-- Desktop Sidebar - Full Height (collapsible, matching student pattern) -->
       @if (!shouldHideSidebar()) {
         <div [class]="'hidden md:flex md:flex-col md:fixed md:inset-y-0 md:z-40 transition-all duration-300 '
-          + (sidebarCollapsed() ? 'md:w-16' : 'md:w-72')">
+          + (sidebarState.collapsed() ? 'md:w-16' : 'md:w-72')">
           <app-sidebar [config]="teacherSidebarConfig()"
-            [collapsed]="sidebarCollapsed()"
-            (toggleCollapse)="toggleSidebarCollapse()"></app-sidebar>
+            [collapsed]="sidebarState.collapsed()"
+            (toggleCollapse)="sidebarState.toggleCollapsed()"></app-sidebar>
         </div>
       }
 
@@ -47,7 +48,7 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       <div [class]="shouldHideSidebar()
         ? 'flex flex-1 min-h-0'
         : 'flex flex-1 min-h-0 transition-all duration-300 '
-          + (sidebarCollapsed() ? 'md:pl-16' : 'md:pl-72')">
+          + (sidebarState.collapsed() ? 'md:pl-16' : 'md:pl-72')">
 
         <!-- Main content column -->
         <div class="flex flex-col flex-1 min-w-0">
@@ -454,7 +455,11 @@ export class TeacherLayoutSimpleComponent implements OnInit, OnDestroy {
   private messagingService = inject(MessagingService);
   protected readonly enableAssistant = this.aiAvailability.isAvailable;
   protected isMobileSidebarOpen = signal(false);
-  protected sidebarCollapsed = signal(false);
+  /** Sidebar collapsed/mobileOpen/hidden state — single source of truth shared
+   *  with student + admin portals via SidebarStateService. Replaces the old
+   *  per-portal `teacher_sidebar_collapsed` localStorage key + duplicated
+   *  signal/load/toggle methods. */
+  protected sidebarState = inject(SidebarStateService);
 
   // Dynamic sidebar config with unread messages badge (matching student pattern)
   protected teacherSidebarConfig = computed<SidebarConfig>(() => {
@@ -502,7 +507,7 @@ export class TeacherLayoutSimpleComponent implements OnInit, OnDestroy {
       error: () => {} // Non-blocking init
     });
 
-    this.loadCollapsedState();
+    // Sidebar collapsed state now hydrated by SidebarStateService.
     this.loadAiSidebarState();
     this.loadAiSidebarWidth();
 
@@ -530,19 +535,6 @@ export class TeacherLayoutSimpleComponent implements OnInit, OnDestroy {
     // Chat: only hide mobile chrome, NOT desktop sidebar
     const isInConversation = /\/teacher\/messages\/[0-9a-f-]{36}/i.test(url) || url.includes('/teacher/messages/new');
     this.hideMobileChrome.set(isInConversation);
-  }
-
-  toggleSidebarCollapse(): void {
-    this.sidebarCollapsed.update(v => !v);
-    if (typeof window !== 'undefined' && window.localStorage) {
-      localStorage.setItem('teacher_sidebar_collapsed', this.sidebarCollapsed().toString());
-    }
-  }
-
-  private loadCollapsedState(): void {
-    if (typeof window !== 'undefined' && window.localStorage) {
-      this.sidebarCollapsed.set(localStorage.getItem('teacher_sidebar_collapsed') === 'true');
-    }
   }
 
   toggleMobileSidebar(): void {

--- a/fe/src/app/shared/components/navigation/sidebar.component.css
+++ b/fe/src/app/shared/components/navigation/sidebar.component.css
@@ -810,8 +810,21 @@
   .sidebar-container,
   .sidebar-toggle,
   .sidebar-org-context,
-  .sidebar-org-default-star {
+  .sidebar-org-default-star,
+  .nav-item,
+  .sub-menu-item {
     transition: none !important;
     animation: none !important;
   }
+}
+
+/* ===== Focus visible (WCAG 2.4.7) — every interactive sidebar element. ===== */
+.nav-item:focus-visible,
+.sub-menu-item:focus-visible,
+.sidebar-org-back:focus-visible,
+.user-menu-trigger:focus-visible,
+.user-menu-item:focus-visible {
+  outline: 2px solid #0056D2;
+  outline-offset: 2px;
+  border-radius: 0.5rem;
 }

--- a/fe/src/app/shared/components/navigation/sidebar.component.html
+++ b/fe/src/app/shared/components/navigation/sidebar.component.html
@@ -69,6 +69,7 @@
                 <div class="nav-item-container">
                     <a [routerLink]="item.route" [queryParams]="item.queryParams"
                        [class.active]="isOrgItemActive(item)"
+                       [attr.aria-current]="isOrgItemActive(item) ? 'page' : null"
                        (click)="itemClick.emit(item)"
                        class="nav-item">
                         <div class="nav-icon" [class]="getIconClasses(item)">
@@ -82,15 +83,18 @@
         </nav>
     } @else {
     <!-- Navigation Menu (system mode) -->
-    <nav class="sidebar-nav">
+    <nav class="sidebar-nav" role="navigation" aria-label="Điều hướng chính">
         @for (item of config().menuItems; track item.route; let i = $index) {
         @if (shouldShowGroupTitle(i)) {
             <div class="nav-group-title">{{ item.group }}</div>
         }
         <div class="nav-item-container">
-            <a [routerLink]="item.route" routerLinkActive="active"
+            <a [routerLink]="item.route" routerLinkActive="active" #rla="routerLinkActive"
                 [routerLinkActiveOptions]="{exact: item.exact ?? false}"
                 [class.force-active]="isItemActive(item)"
+                [attr.aria-current]="rla.isActive || isItemActive(item) ? 'page' : null"
+                [attr.aria-expanded]="item.children?.length ? isSubMenuOpen(item) : null"
+                [attr.aria-controls]="item.children?.length ? itemDomId(item) + '-submenu' : null"
                 (click)="onLeafClick(item)"
                 class="nav-item"
                 [class.has-children]="!!item.children?.length">
@@ -106,11 +110,14 @@
 
             <!-- Sub-menu items -->
             @if (item.children && isSubMenuOpen(item)) {
-            <div class="sub-menu">
+            <div class="sub-menu" [id]="itemDomId(item) + '-submenu'">
                 @for (child of item.children; track child.route) {
                 <div class="sub-menu-block">
-                    <a [routerLink]="child.route" routerLinkActive="active"
+                    <a [routerLink]="child.route" routerLinkActive="active" #childRla="routerLinkActive"
                         [routerLinkActiveOptions]="{exact: child.exact ?? false}"
+                        [attr.aria-current]="childRla.isActive ? 'page' : null"
+                        [attr.aria-expanded]="child.children?.length ? isSubMenuOpen(child) : null"
+                        [attr.aria-controls]="child.children?.length ? itemDomId(child) + '-submenu' : null"
                         (click)="onLeafClick(child)"
                         class="sub-menu-item"
                         [class.has-children]="!!child.children?.length">
@@ -121,10 +128,11 @@
                     </a>
 
                     @if (child.children && isSubMenuOpen(child)) {
-                    <div class="sub-menu sub-menu--nested">
+                    <div class="sub-menu sub-menu--nested" [id]="itemDomId(child) + '-submenu'">
                         @for (grandChild of child.children; track grandChild.route) {
-                        <a [routerLink]="grandChild.route" routerLinkActive="active"
+                        <a [routerLink]="grandChild.route" routerLinkActive="active" #gcRla="routerLinkActive"
                             [routerLinkActiveOptions]="{exact: grandChild.exact ?? false}"
+                            [attr.aria-current]="gcRla.isActive ? 'page' : null"
                             (click)="itemClick.emit(grandChild)"
                             class="sub-menu-item sub-menu-item--nested">
                             <div class="sub-icon" [class]="getIconClasses(grandChild)">

--- a/fe/src/app/shared/components/navigation/sidebar.component.ts
+++ b/fe/src/app/shared/components/navigation/sidebar.component.ts
@@ -302,4 +302,10 @@ export class SidebarComponent implements OnInit, OnDestroy {
     if (item.alsoActiveFor?.some(prefix => url.startsWith(prefix))) return true;
     return false;
   }
+
+  /** Stable, unique-per-item DOM id for aria-controls / id linkage. Routes
+   *  contain slashes which are not valid in HTML ids; this slugifies them. */
+  protected itemDomId(item: SidebarMenuItem): string {
+    return 'nav-' + (item.route || item.label).replace(/[^a-z0-9]/gi, '-').toLowerCase();
+  }
 }

--- a/fe/src/app/shared/components/skip-link/skip-link.component.spec.ts
+++ b/fe/src/app/shared/components/skip-link/skip-link.component.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { SkipLinkComponent } from './skip-link.component';
+
+describe('SkipLinkComponent', () => {
+  function build(targetId?: string, label?: string): { hostEl: HTMLElement; anchor: HTMLAnchorElement } {
+    TestBed.configureTestingModule({});
+    const fixture = TestBed.createComponent(SkipLinkComponent);
+    if (targetId !== undefined) {
+      fixture.componentRef.setInput('targetId', targetId);
+    }
+    if (label !== undefined) {
+      fixture.componentRef.setInput('label', label);
+    }
+    fixture.detectChanges();
+    const hostEl = fixture.nativeElement as HTMLElement;
+    const anchor = hostEl.querySelector('a.skip-link') as HTMLAnchorElement;
+    return { hostEl, anchor };
+  }
+
+  it('renders an anchor with default targetId "main-content" and Vietnamese label', () => {
+    const { anchor } = build();
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute('href')).toBe('#main-content');
+    expect(anchor.textContent?.trim()).toBe('Bỏ qua điều hướng');
+  });
+
+  it('respects custom targetId input', () => {
+    const { anchor } = build('app-main');
+    expect(anchor.getAttribute('href')).toBe('#app-main');
+  });
+
+  it('respects custom label input', () => {
+    const { anchor } = build(undefined, 'Skip to content');
+    expect(anchor.textContent?.trim()).toBe('Skip to content');
+  });
+
+  it('uses class "skip-link" so layout CSS can hide it off-screen until focused', () => {
+    const { anchor } = build();
+    expect(anchor.classList.contains('skip-link')).toBe(true);
+  });
+});

--- a/fe/src/app/shared/components/skip-link/skip-link.component.ts
+++ b/fe/src/app/shared/components/skip-link/skip-link.component.ts
@@ -1,0 +1,57 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+/**
+ * "Bỏ qua điều hướng" skip link — WCAG 2.4.1 Bypass Blocks (Level A).
+ *
+ * Visually hidden by default; appears when keyboard focus lands on it
+ * (typically the first Tab press after page load). Activating it jumps
+ * focus to the host page's main content landmark.
+ *
+ * Hosting layouts MUST render this as the first focusable element in the
+ * DOM and ensure their main content area has matching `id` (default
+ * `main-content`) and `tabindex="-1"` so the anchor can move focus there.
+ *
+ * Usage in a wrapper layout:
+ *   <app-skip-link/>
+ *   ...layout chrome...
+ *   <main id="main-content" tabindex="-1">
+ *     <router-outlet/>
+ *   </main>
+ */
+@Component({
+  selector: 'app-skip-link',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <a [href]="'#' + targetId()" class="skip-link">{{ label() }}</a>
+  `,
+  styles: [`
+    .skip-link {
+      position: absolute;
+      top: -100px;
+      left: 8px;
+      z-index: 100;
+      padding: 0.5rem 1rem;
+      background: #0056D2;
+      color: white;
+      font-weight: 600;
+      border-radius: 0.5rem;
+      text-decoration: none;
+      transition: top 0.15s ease;
+    }
+    .skip-link:focus,
+    .skip-link:focus-visible {
+      top: 8px;
+      outline: 2px solid white;
+      outline-offset: 2px;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .skip-link { transition: none; }
+    }
+  `],
+})
+export class SkipLinkComponent {
+  /** ID of the main-content landmark to jump to. Default 'main-content'. */
+  readonly targetId = input<string>('main-content');
+  /** Visible label. Vietnamese with diacritics per Constitution V. */
+  readonly label = input<string>('Bỏ qua điều hướng');
+}

--- a/fe/src/app/shared/directives/sidebar-tooltip.directive.spec.ts
+++ b/fe/src/app/shared/directives/sidebar-tooltip.directive.spec.ts
@@ -1,0 +1,87 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { SidebarTooltipDirective } from './sidebar-tooltip.directive';
+
+@Component({
+  selector: 'test-host',
+  imports: [SidebarTooltipDirective],
+  template: `
+    <button
+      data-testid="trigger"
+      [appSidebarTooltip]="label"
+      [tooltipEnabled]="enabled">Icon</button>
+  `,
+})
+class HostComponent {
+  label: string | null = 'Khóa học của tôi';
+  enabled = true;
+}
+
+describe('SidebarTooltipDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let trigger: HTMLButtonElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HostComponent],
+    });
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    trigger = fixture.nativeElement.querySelector('[data-testid="trigger"]');
+  });
+
+  afterEach(() => {
+    // Defensive cleanup — directive removes its popover on destroy, but
+    // ensure no orphan tooltip survives between tests.
+    document.querySelectorAll('[role="tooltip"]').forEach((el) => el.remove());
+  });
+
+  it('does not show tooltip immediately on mouse enter (waits for delay)', fakeAsync(() => {
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    tick(100);
+    expect(document.querySelector('[role="tooltip"]')).toBeNull();
+    tick(500); // total ~600 ms past
+    // Defensive: tooltip rendered or not depending on reduced-motion env.
+    // In test environment, prefers-reduced-motion typically false → 500 ms
+    // delay, so tooltip should be present by now.
+    const tooltip = document.querySelector('[role="tooltip"]');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip!.textContent).toBe('Khóa học của tôi');
+    // Cleanup before fakeAsync queue check
+    trigger.dispatchEvent(new MouseEvent('mouseleave'));
+  }));
+
+  it('removes tooltip and aria-describedby on mouse leave', fakeAsync(() => {
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    tick(600);
+    expect(trigger.getAttribute('aria-describedby')).toMatch(/sidebar-tooltip-/);
+
+    trigger.dispatchEvent(new MouseEvent('mouseleave'));
+    expect(document.querySelector('[role="tooltip"]')).toBeNull();
+    expect(trigger.getAttribute('aria-describedby')).toBeNull();
+  }));
+
+  it('does not render tooltip when tooltipEnabled is false', fakeAsync(() => {
+    fixture.componentInstance.enabled = false;
+    fixture.detectChanges();
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    tick(1000);
+    expect(document.querySelector('[role="tooltip"]')).toBeNull();
+  }));
+
+  it('does not render tooltip when label is empty', fakeAsync(() => {
+    fixture.componentInstance.label = '';
+    fixture.detectChanges();
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    tick(1000);
+    expect(document.querySelector('[role="tooltip"]')).toBeNull();
+  }));
+
+  it('cancels pending tooltip if mouse leaves before delay elapses', fakeAsync(() => {
+    trigger.dispatchEvent(new MouseEvent('mouseenter'));
+    tick(200); // less than 500 ms
+    trigger.dispatchEvent(new MouseEvent('mouseleave'));
+    tick(400); // would-be elapse; should not show
+    expect(document.querySelector('[role="tooltip"]')).toBeNull();
+  }));
+});

--- a/fe/src/app/shared/directives/sidebar-tooltip.directive.ts
+++ b/fe/src/app/shared/directives/sidebar-tooltip.directive.ts
@@ -1,13 +1,11 @@
 import {
-  ChangeDetectorRef,
   Directive,
   ElementRef,
   HostListener,
-  Inject,
-  Input,
   OnDestroy,
   PLATFORM_ID,
   inject,
+  input,
 } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { SIDEBAR_TOOLTIP_DELAY_MS } from '../components/navigation/sidebar.tokens';
@@ -32,11 +30,11 @@ import { SIDEBAR_TOOLTIP_DELAY_MS } from '../components/navigation/sidebar.token
   selector: '[appSidebarTooltip]',
 })
 export class SidebarTooltipDirective implements OnDestroy {
-  /** Label text. Empty/null → no tooltip rendered. */
-  @Input('appSidebarTooltip') label: string | null = '';
+  /** Label text. Empty/null → no tooltip rendered. Bound as `[appSidebarTooltip]`. */
+  readonly label = input<string | null>('', { alias: 'appSidebarTooltip' });
 
   /** Enable flag — when false the directive is inert (no listeners fire). */
-  @Input() tooltipEnabled = true;
+  readonly tooltipEnabled = input(true);
 
   private readonly host = inject(ElementRef<HTMLElement>);
   private readonly platformId = inject(PLATFORM_ID);
@@ -73,10 +71,11 @@ export class SidebarTooltipDirective implements OnDestroy {
   }
 
   private shouldShow(): boolean {
+    const lbl = this.label();
     return (
-      this.tooltipEnabled &&
-      !!this.label &&
-      this.label.trim().length > 0 &&
+      this.tooltipEnabled() &&
+      !!lbl &&
+      lbl.trim().length > 0 &&
       isPlatformBrowser(this.platformId)
     );
   }
@@ -96,7 +95,7 @@ export class SidebarTooltipDirective implements OnDestroy {
     this.describedById = `sidebar-tooltip-${SidebarTooltipDirective.idCounter}`;
     popover.id = this.describedById;
     popover.setAttribute('role', 'tooltip');
-    popover.textContent = this.label!;
+    popover.textContent = this.label()!;
     Object.assign(popover.style, {
       position: 'fixed',
       zIndex: '60',

--- a/fe/src/app/shared/directives/sidebar-tooltip.directive.ts
+++ b/fe/src/app/shared/directives/sidebar-tooltip.directive.ts
@@ -1,0 +1,146 @@
+import {
+  ChangeDetectorRef,
+  Directive,
+  ElementRef,
+  HostListener,
+  Inject,
+  Input,
+  OnDestroy,
+  PLATFORM_ID,
+  inject,
+} from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { SIDEBAR_TOOLTIP_DELAY_MS } from '../components/navigation/sidebar.tokens';
+
+/**
+ * Sidebar icon-rail tooltip — shows the menu item label as a positioned
+ * popover after a 500 ms hover/focus delay when the sidebar is collapsed.
+ *
+ * Custom implementation (not native `title` attribute) because:
+ *   - Native `title` has uncontrollable browser-defined delay (~700 ms).
+ *   - Native `title` cannot be linked via `aria-describedby` reliably.
+ *   - We need design-token styling and reduced-motion support.
+ *
+ * Per spec FR-006 + clarify Q2.
+ *
+ * Usage:
+ *   <a [appSidebarTooltip]="item.label" [tooltipEnabled]="collapsed()">
+ *     <app-icon .../>
+ *   </a>
+ */
+@Directive({
+  selector: '[appSidebarTooltip]',
+})
+export class SidebarTooltipDirective implements OnDestroy {
+  /** Label text. Empty/null → no tooltip rendered. */
+  @Input('appSidebarTooltip') label: string | null = '';
+
+  /** Enable flag — when false the directive is inert (no listeners fire). */
+  @Input() tooltipEnabled = true;
+
+  private readonly host = inject(ElementRef<HTMLElement>);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private popoverEl: HTMLElement | null = null;
+  private static idCounter = 0;
+  private describedById: string | null = null;
+
+  @HostListener('mouseenter')
+  onMouseEnter(): void {
+    if (!this.shouldShow()) return;
+    this.scheduleShow();
+  }
+
+  @HostListener('focusin')
+  onFocusIn(): void {
+    if (!this.shouldShow()) return;
+    this.scheduleShow();
+  }
+
+  @HostListener('mouseleave')
+  onMouseLeave(): void {
+    this.cancelAndHide();
+  }
+
+  @HostListener('focusout')
+  onFocusOut(): void {
+    this.cancelAndHide();
+  }
+
+  ngOnDestroy(): void {
+    this.cancelAndHide();
+  }
+
+  private shouldShow(): boolean {
+    return (
+      this.tooltipEnabled &&
+      !!this.label &&
+      this.label.trim().length > 0 &&
+      isPlatformBrowser(this.platformId)
+    );
+  }
+
+  private scheduleShow(): void {
+    this.cancelTimer();
+    // Reduced-motion users still get the label, but instantly (no animation,
+    // no delay — they need the info, not the choreography).
+    const delay = this.prefersReducedMotion() ? 0 : SIDEBAR_TOOLTIP_DELAY_MS;
+    this.timer = setTimeout(() => this.show(), delay);
+  }
+
+  private show(): void {
+    if (this.popoverEl) return; // already showing
+    const popover = document.createElement('div');
+    SidebarTooltipDirective.idCounter += 1;
+    this.describedById = `sidebar-tooltip-${SidebarTooltipDirective.idCounter}`;
+    popover.id = this.describedById;
+    popover.setAttribute('role', 'tooltip');
+    popover.textContent = this.label!;
+    Object.assign(popover.style, {
+      position: 'fixed',
+      zIndex: '60',
+      padding: '6px 10px',
+      borderRadius: '6px',
+      background: '#111827',
+      color: 'white',
+      fontSize: '12px',
+      fontWeight: '500',
+      pointerEvents: 'none',
+      whiteSpace: 'nowrap',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+    } as CSSStyleDeclaration);
+    document.body.appendChild(popover);
+    this.popoverEl = popover;
+
+    const rect = (this.host.nativeElement as HTMLElement).getBoundingClientRect();
+    popover.style.top = `${rect.top + rect.height / 2 - popover.offsetHeight / 2}px`;
+    popover.style.left = `${rect.right + 8}px`;
+
+    this.host.nativeElement.setAttribute('aria-describedby', this.describedById);
+  }
+
+  private cancelTimer(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private cancelAndHide(): void {
+    this.cancelTimer();
+    if (this.popoverEl) {
+      this.popoverEl.remove();
+      this.popoverEl = null;
+    }
+    if (this.describedById) {
+      this.host.nativeElement.removeAttribute('aria-describedby');
+      this.describedById = null;
+    }
+  }
+
+  private prefersReducedMotion(): boolean {
+    if (!isPlatformBrowser(this.platformId)) return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
+}


### PR DESCRIPTION
## Summary

Wraps up the sidebar redesign foundation tracked under spec `001-sidebar-redesign` by landing **3 logically distinct slices** in a single review-friendly PR (per request from PO):

1. **US1 wiring** — refactor 3 wrapper layouts to inject the `SidebarStateService` introduced in PR #377, eliminating ~150 LOC of duplicated state plumbing and consolidating onto the single `sidebar:collapsed` localStorage key (FR-005).
2. **US4 accessibility hardening** (partial) — `SkipLinkComponent` (WCAG 2.4.1), `aria-current="page"` on every leaf, `aria-expanded`/`aria-controls` on parent items, `<nav>` landmarks with Vietnamese labels, focus-visible rules across every interactive sidebar element, expanded `prefers-reduced-motion` coverage.
3. **US6 bottom-nav alignment** — student & teacher mobile bottom nav active-tab font weight bumped to match the sidebar `font-semibold` token (FR-037). Color was already `#0056D2`; structure intact (5 tabs + Wiii AI center).
4. **US1 polish** — `SidebarTooltipDirective` ready to wire (custom popover with `aria-describedby`, 500 ms delay, reduced-motion aware) per spec FR-006 + clarify Q2.

This PR builds on PR #378 which is currently OPEN — when #378 merges, the diff here narrows to just my 4 new commits.

## Commits (4, alternating Hùng/Hồng)

```
cba7b9de Hồng: feat(sidebar): SidebarTooltipDirective + focus-visible rules (US1 + US4)
df9aa1da Hùng: feat(sidebar): WCAG 2.2 AA hardening + bottom-nav token alignment (US4 + US6)
10e4af1d Hồng: refactor(sidebar): wire SidebarStateService into 3 wrapper layouts (US1)
da6366e6 Hùng: feat(sidebar): mobile drawer auto-close on leaf nav + admin a11y parity   ← from PR #378
```

## What's in this PR

### `shared/services/` — already shipped in PR #377; consumed by all 3 wrappers here.

### `shared/components/skip-link/` (NEW)
- `SkipLinkComponent` — standalone, OnPush, signal inputs (`targetId`, `label`)
- `skip-link.component.spec.ts` — 4 unit tests (default/custom inputs, class hooks)

### `shared/directives/sidebar-tooltip.directive.ts` (NEW)
- `[appSidebarTooltip]` — 500 ms delayed popover, `aria-describedby`, SSR-safe, reduced-motion aware
- 5 unit tests (fakeAsync) — delay, removal, enabled flag, empty label, leave-cancels

### `shared/components/navigation/sidebar.component.{ts,html,css}`
- New `itemDomId(item)` helper for `aria-controls`/`id` linkage
- Template adds `aria-current="page"` (top-level + sub-menu + grandchild + org-scoped) via `routerLinkActive` exposed `isActive`
- Template adds `aria-expanded` + `aria-controls` on parent items with sub-menus
- System nav: `role="navigation" aria-label="Điều hướng chính"`
- CSS: `prefers-reduced-motion` expanded to nav items; new focus-visible rules (2 px brand outline + offset)

### 3 wrapper layouts (`student-`, `teacher-`, `admin-layout-simple.component.ts`)
- Inject `SidebarStateService`; expose as `protected sidebarState`
- Drop local `sidebarCollapsed`/`isSidebarCollapsed` signals (redundant)
- Drop `toggleSidebarCollapse()` methods (template calls service directly)
- Drop `loadCollapsedState()`/`loadSidebarCollapsed()` methods + ngOnInit calls (service hydrates)
- Drop the 3 legacy localStorage keys (`student_/teacher_/admin_sidebar_collapsed`)
- Add `<app-skip-link/>` as first focusable element
- Wrap routed content `<main id="main-content" tabindex="-1">` for skip-link target
- Student/teacher only: bottom-nav active-tab `.tab-label { font-weight: 600 }` (matches sidebar)

## Behaviour deltas

- **Cross-portal collapse state** — a user collapsing the sidebar on student portal now sees the same state on teacher/admin portals (was per-portal). Acceptable and aligned with FR-005.
- **Cross-tab live sync** — the SidebarStateService's `storage` event listener now powers all 3 wrappers (was: required reload).
- **Screen reader announcement** — sidebar now announces as "Điều hướng chính, navigation landmark"; current page item announces as "current page"; parent items announce expand/collapse state.
- **Keyboard navigation** — first Tab reveals "Bỏ qua điều hướng" skip link; every nav item shows visible focus ring on Tab.

## Test plan

- [ ] `cd fe && npm run build` → green (verified locally, no new warnings)
- [ ] `cd fe && npm run test:ci -- --include='**/sidebar*.spec.ts' --include='**/skip-link.component.spec.ts'` → 23 SUCCESS (10 service + 3 sidebar + 4 skip-link + 5 tooltip + 1 contract)
- [ ] On any role's logged-in page, press Tab once → "Bỏ qua điều hướng" link visible top-left → Enter → focus moves to main content ✅
- [ ] DevTools inspect a sidebar nav item on its current page → `aria-current="page"` present ✅
- [ ] DevTools inspect a parent item like "Khoá học của tôi" (student) → `aria-expanded="true|false"` + `aria-controls="nav-...-submenu"` present ✅
- [ ] Open student sidebar; collapse via toggle → log into admin in another tab → admin sidebar starts collapsed (cross-portal state shared) ✅
- [ ] Open student in two tabs; collapse in tab A → tab B updates without reload (cross-tab sync via storage event) ✅
- [ ] Tab through nav items keyboard-only → 2 px brand-color focus ring on every focusable element ✅
- [ ] Enable OS "Reduce motion" → toggle sidebar → no animation; hover collapsed icon → tooltip appears instantly (no 500 ms delay) ✅
- [ ] Mobile bottom nav (student + teacher) at 375 px → active tab text bold (font-semibold = 600) matching sidebar active style ✅

## Out of scope (deferred — clearly marked in tasks.md)

- **US3 cross-role breakpoint unification (md → lg for student/teacher)** — behavioural change for tablet users (768-1024 px); deserves a separate review with explicit user confirmation. Admin already at lg.
- **T013** wire `SidebarTooltipDirective` into sidebar.component.html — needs to remove the existing CSS-based `.nav-tooltip` span at the same time to avoid visual collision; deserves a focused review.
- **T015/T016** `FocusTrapDirective` for mobile drawer — focus management is delicate; want a real-device test pass.
- **T023** edge-swipe-left-to-close gesture — requires real-device testing.
- **T040** 48×48 touch targets bump (current 44 already meets WCAG 2.5.8 minimum; Material 48 is polish).
- **US5 Quay lại affordance** — already satisfied by the existing "Danh sách tổ chức" back link in the org context block (admin role); spec is functionally met.
- **Phase 9 axe-core + full smoke matrix** — scheduled for the final consolidation PR.

## References

- Spec: [`specs/001-sidebar-redesign/spec.md`](specs/001-sidebar-redesign/spec.md)
- Plan: [`specs/001-sidebar-redesign/plan.md`](specs/001-sidebar-redesign/plan.md) — Constitution Check 7/7
- Tasks: [`specs/001-sidebar-redesign/tasks.md`](specs/001-sidebar-redesign/tasks.md)
- Predecessors: PR #377 (foundation) + PR #378 (mobile auto-close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)