### PR TITLE
Hùng: feat(sidebar): unify lg breakpoint + tooltip wired + 48px touch + hamburger ARIA

### DIFF
--- a/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-layout-simple.component.ts
@@ -32,7 +32,8 @@ import { AiAvailabilityService } from '../../../ai-chat/application/services/ai-
 
       <!-- Mobile sidebar overlay — dialog semantics + auto-close on leaf nav -->
       @if (isMobileSidebarOpen() && !shouldHideSidebar()) {
-        <div class="fixed inset-0 z-50 lg:hidden"
+        <div id="mobile-sidebar-drawer"
+             class="fixed inset-0 z-50 lg:hidden"
              role="dialog"
              aria-modal="true"
              aria-label="Menu điều hướng"
@@ -71,7 +72,9 @@ import { AiAvailabilityService } from '../../../ai-chat/application/services/ai-
                   <div class="flex items-center">
                     <button (click)="toggleMobileSidebar()"
                       class="p-2 rounded-lg text-gray-500 hover:text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-500 transition-colors"
-                      aria-label="Open sidebar">
+                      [attr.aria-expanded]="isMobileSidebarOpen()"
+                      aria-controls="mobile-sidebar-drawer"
+                      aria-label="Mở menu điều hướng">
                       <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
                       </svg>

--- a/fe/src/app/features/student/shared/student-layout-simple.component.ts
+++ b/fe/src/app/features/student/shared/student-layout-simple.component.ts
@@ -25,8 +25,8 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       <app-skip-link/>
       <!-- Desktop Sidebar - Full Height -->
       @if (!shouldHideSidebar()) {
-        <div [class]="'hidden md:flex md:flex-col md:fixed md:inset-y-0 md:z-40 transition-all duration-300 '
-          + (sidebarState.collapsed() ? 'md:w-16' : 'md:w-72')">
+        <div [class]="'hidden lg:flex lg:flex-col lg:fixed lg:inset-y-0 lg:z-40 transition-all duration-300 '
+          + (sidebarState.collapsed() ? 'lg:w-16' : 'lg:w-72')">
           <app-sidebar [config]="studentSidebarConfig()"
             [collapsed]="sidebarState.collapsed()"
             (toggleCollapse)="sidebarState.toggleCollapsed()"></app-sidebar>
@@ -35,7 +35,8 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
 
       <!-- Mobile sidebar overlay — always rendered, animated via CSS -->
       @if (!shouldHideSidebar()) {
-        <div class="mobile-sidebar-overlay md:hidden"
+        <div id="mobile-sidebar-drawer"
+             class="mobile-sidebar-overlay lg:hidden"
              [class.open]="isMobileSidebarOpen()"
              [attr.aria-hidden]="!isMobileSidebarOpen()"
              [attr.aria-modal]="isMobileSidebarOpen() ? 'true' : null"
@@ -54,12 +55,12 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       <div [class]="shouldHideSidebar()
         ? 'flex flex-1 min-h-0'
         : 'flex flex-1 min-h-0 transition-all duration-300 '
-          + (sidebarState.collapsed() ? 'md:pl-16' : 'md:pl-72')">
+          + (sidebarState.collapsed() ? 'lg:pl-16' : 'lg:pl-72')">
 
         <!-- Main content column -->
         <div class="flex flex-col flex-1 min-w-0">
           <!-- Mobile top bar — sticky + collapses in full-screen views -->
-          <header class="sticky top-0 z-30 bg-white/80 backdrop-blur-xl border-b border-gray-200/50 md:hidden shadow-sm overflow-hidden transition-[max-height,opacity] duration-300 ease-out"
+          <header class="sticky top-0 z-30 bg-white/80 backdrop-blur-xl border-b border-gray-200/50 lg:hidden shadow-sm overflow-hidden transition-[max-height,opacity] duration-300 ease-out"
                   [class.max-h-14]="!shouldHideMobileChrome()"
                   [class.max-h-0]="shouldHideMobileChrome()"
                   [class.opacity-0]="shouldHideMobileChrome()"
@@ -69,6 +70,8 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
                 <div class="flex items-center space-x-3">
                   <button (click)="toggleMobileSidebar()"
                     aria-label="Mở menu điều hướng"
+                    [attr.aria-expanded]="isMobileSidebarOpen()"
+                    aria-controls="mobile-sidebar-drawer"
                     class="inline-flex h-11 w-11 items-center justify-center rounded-xl text-gray-600 hover:text-gray-900 hover:bg-gray-100/80 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20 transition-all duration-200">
                     <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
@@ -99,7 +102,7 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
           </main>
 
           <!-- Mobile Bottom Navigation — slides down in full-screen views -->
-            <nav class="mobile-bottom-nav md:hidden fixed bottom-0 left-0 right-0 z-40 bg-white border-t border-gray-200 shadow-lg transition-[transform,opacity] duration-300 ease-out"
+            <nav class="mobile-bottom-nav lg:hidden fixed bottom-0 left-0 right-0 z-40 bg-white border-t border-gray-200 shadow-lg transition-[transform,opacity] duration-300 ease-out"
                  [class.translate-y-full]="shouldHideMobileChrome()"
                  [class.opacity-0]="shouldHideMobileChrome()"
                  [class.pointer-events-none]="shouldHideMobileChrome()">
@@ -157,7 +160,7 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
             </nav>
 
           <!-- Bottom padding for mobile navigation — collapses when nav hidden -->
-            <div class="md:hidden transition-[height] duration-300 ease-out"
+            <div class="lg:hidden transition-[height] duration-300 ease-out"
                  [class.h-16]="!shouldHideMobileChrome()"
                  [class.h-0]="shouldHideMobileChrome()"></div>
         </div>

--- a/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
+++ b/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
@@ -22,8 +22,8 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       <app-skip-link/>
       <!-- Desktop Sidebar - Full Height (collapsible, matching student pattern) -->
       @if (!shouldHideSidebar()) {
-        <div [class]="'hidden md:flex md:flex-col md:fixed md:inset-y-0 md:z-40 transition-all duration-300 '
-          + (sidebarState.collapsed() ? 'md:w-16' : 'md:w-72')">
+        <div [class]="'hidden lg:flex lg:flex-col lg:fixed lg:inset-y-0 lg:z-40 transition-all duration-300 '
+          + (sidebarState.collapsed() ? 'lg:w-16' : 'lg:w-72')">
           <app-sidebar [config]="teacherSidebarConfig()"
             [collapsed]="sidebarState.collapsed()"
             (toggleCollapse)="sidebarState.toggleCollapsed()"></app-sidebar>
@@ -32,7 +32,8 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
 
       <!-- Mobile sidebar overlay — CSS animation (matching student layout) -->
       @if (!shouldHideSidebar()) {
-        <div class="mobile-sidebar-overlay md:hidden"
+        <div id="mobile-sidebar-drawer"
+             class="mobile-sidebar-overlay lg:hidden"
              [class.open]="isMobileSidebarOpen()"
              [attr.aria-hidden]="!isMobileSidebarOpen()"
              [attr.aria-modal]="isMobileSidebarOpen() ? 'true' : null"
@@ -51,12 +52,12 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       <div [class]="shouldHideSidebar()
         ? 'flex flex-1 min-h-0'
         : 'flex flex-1 min-h-0 transition-all duration-300 '
-          + (sidebarState.collapsed() ? 'md:pl-16' : 'md:pl-72')">
+          + (sidebarState.collapsed() ? 'lg:pl-16' : 'lg:pl-72')">
 
         <!-- Main content column -->
         <div class="flex flex-col flex-1 min-w-0">
           <!-- Mobile top bar — minimal: [☰] [Logo] [Avatar] (matching student layout) -->
-          <header class="sticky top-0 z-30 bg-white/80 backdrop-blur-xl border-b border-gray-200/50 md:hidden shadow-sm overflow-hidden transition-[max-height,opacity] duration-300 ease-out"
+          <header class="sticky top-0 z-30 bg-white/80 backdrop-blur-xl border-b border-gray-200/50 lg:hidden shadow-sm overflow-hidden transition-[max-height,opacity] duration-300 ease-out"
                   [class.max-h-14]="!shouldHideMobileChrome()"
                   [class.max-h-0]="shouldHideMobileChrome()"
                   [class.opacity-0]="shouldHideMobileChrome()"
@@ -66,6 +67,8 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
                 <div class="flex items-center space-x-3">
                   <button (click)="toggleMobileSidebar()"
                     aria-label="Mở menu điều hướng"
+                    [attr.aria-expanded]="isMobileSidebarOpen()"
+                    aria-controls="mobile-sidebar-drawer"
                     class="inline-flex h-11 w-11 items-center justify-center rounded-xl text-gray-600 hover:text-gray-900 hover:bg-gray-100/80 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/20 transition-all duration-200">
                     <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
@@ -91,7 +94,7 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
           </main>
 
           <!-- Mobile Bottom Navigation — 4 nav + 1 center AI (matching student + UX Guidelines) -->
-            <nav class="mobile-bottom-nav md:hidden fixed bottom-0 left-0 right-0 z-40 bg-white border-t border-gray-200 shadow-lg transition-[transform,opacity] duration-300 ease-out"
+            <nav class="mobile-bottom-nav lg:hidden fixed bottom-0 left-0 right-0 z-40 bg-white border-t border-gray-200 shadow-lg transition-[transform,opacity] duration-300 ease-out"
                  [class.translate-y-full]="shouldHideMobileChrome()"
                  [class.opacity-0]="shouldHideMobileChrome()"
                  [class.pointer-events-none]="shouldHideMobileChrome()">
@@ -149,7 +152,7 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
             </nav>
 
           <!-- Bottom padding — collapses when nav hidden -->
-            <div class="md:hidden transition-[height] duration-300 ease-out"
+            <div class="lg:hidden transition-[height] duration-300 ease-out"
                  [class.h-16]="!shouldHideMobileChrome()"
                  [class.h-0]="shouldHideMobileChrome()"></div>
         </div>

--- a/fe/src/app/shared/components/navigation/sidebar.component.css
+++ b/fe/src/app/shared/components/navigation/sidebar.component.css
@@ -163,25 +163,8 @@
   color: #dc2626;
 }
 
-/* Tooltip - hidden by default */
-.nav-tooltip {
-  display: none;
-  position: absolute;
-  left: calc(100% + 8px);
-  top: 50%;
-  transform: translateY(-50%);
-  opacity: 0;
-  pointer-events: none;
-  z-index: 100;
-  background: #1f2937;
-  color: white;
-  font-size: 12px;
-  font-weight: 500;
-  padding: 6px 10px;
-  border-radius: 6px;
-  white-space: nowrap;
-  transition: opacity 0.15s ease;
-}
+/* Legacy .nav-tooltip removed — now handled by SidebarTooltipDirective
+   (custom popover with aria-describedby, 500 ms delay, reduced-motion aware). */
 
 .sub-menu {
   margin-left: 1rem;
@@ -531,12 +514,6 @@
   }
 }
 
-/* Show tooltip on hover in collapsed state */
-.sidebar-collapsed .nav-item:hover .nav-tooltip {
-  display: block;
-  opacity: 1;
-}
-
 /* Active state in collapsed mode */
 .sidebar-collapsed .nav-item.active {
   background-color: #EFF6FF;
@@ -827,4 +804,14 @@
   outline: 2px solid #0056D2;
   outline-offset: 2px;
   border-radius: 0.5rem;
+}
+
+/* ===== Touch target size (WCAG 2.5.8 + Material 48 dp) on mobile. ===== */
+@media (max-width: 1023px) {
+  .nav-item,
+  .sub-menu-item {
+    min-height: 48px;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
 }

--- a/fe/src/app/shared/components/navigation/sidebar.component.html
+++ b/fe/src/app/shared/components/navigation/sidebar.component.html
@@ -70,13 +70,14 @@
                     <a [routerLink]="item.route" [queryParams]="item.queryParams"
                        [class.active]="isOrgItemActive(item)"
                        [attr.aria-current]="isOrgItemActive(item) ? 'page' : null"
+                       [appSidebarTooltip]="item.label"
+                       [tooltipEnabled]="collapsed()"
                        (click)="itemClick.emit(item)"
                        class="nav-item">
                         <div class="nav-icon" [class]="getIconClasses(item)">
                             <app-icon [name]="item.icon" size="sm"/>
                         </div>
                         <span class="nav-label">{{ item.label }}</span>
-                        <span class="nav-tooltip" aria-hidden="true">{{ item.label }}</span>
                     </a>
                 </div>
             }
@@ -95,6 +96,8 @@
                 [attr.aria-current]="rla.isActive || isItemActive(item) ? 'page' : null"
                 [attr.aria-expanded]="item.children?.length ? isSubMenuOpen(item) : null"
                 [attr.aria-controls]="item.children?.length ? itemDomId(item) + '-submenu' : null"
+                [appSidebarTooltip]="item.label"
+                [tooltipEnabled]="collapsed()"
                 (click)="onLeafClick(item)"
                 class="nav-item"
                 [class.has-children]="!!item.children?.length">
@@ -105,7 +108,6 @@
                 @if (item.badge) {
                 <span class="nav-badge">{{ item.badge }}</span>
                 }
-                <span class="nav-tooltip" aria-hidden="true">{{ item.label }}</span>
             </a>
 
             <!-- Sub-menu items -->

--- a/fe/src/app/shared/components/navigation/sidebar.component.ts
+++ b/fe/src/app/shared/components/navigation/sidebar.component.ts
@@ -6,6 +6,7 @@ import { AuthService } from '../../../core/services/auth.service';
 import { OrganizationContextService } from '../../../core/services/organization-context.service';
 import { Organization, OrganizationType, UserRole } from '../../../shared/types/user.types';
 import { IconComponent, IconName } from '../icon/icon.component';
+import { SidebarTooltipDirective } from '../../directives/sidebar-tooltip.directive';
 import { getPortalLandingRoute } from '../../../core/utils/portal-route.util';
 import { initialsAvatar } from '../../utils/avatar.util';
 
@@ -33,7 +34,7 @@ export interface SidebarConfig {
 
 @Component({
   selector: 'app-sidebar',
-  imports: [RouterModule, RouterLinkActive, IconComponent],
+  imports: [RouterModule, RouterLinkActive, IconComponent, SidebarTooltipDirective],
   encapsulation: ViewEncapsulation.None,
   templateUrl: './sidebar.component.html',
   styleUrl: './sidebar.component.css',


### PR DESCRIPTION
## Summary

- **US3 — single breakpoint at 1024 px** across all 4 role portals (FR-018). Student/teacher migrated `md:` → `lg:` on the main sidebar surface; admin already at `lg:`. AI sidebar untouched (separate component, separate scope).
- **T013 — tooltip directive wired** in `sidebar.component`. Replaces the legacy CSS `<span class="nav-tooltip">` hover-only span with the SidebarTooltipDirective shipped in PR #379 (custom popover, 500 ms delay, `aria-describedby`, reduced-motion aware).
- **T036 — hamburger ARIA parity**. All 3 wrapper layouts now expose `aria-expanded` + `aria-controls` on the mobile-menu toggle button; admin's English `aria-label="Open sidebar"` corrected to Vietnamese "Mở menu điều hướng".
- **T040 — 48 × 48 touch targets on mobile** (Material Design baseline; clears WCAG 2.5.8 by 2x margin).

Continues spec `001-sidebar-redesign`. Net diff: **6 files, -1 LOC** (legacy CSS span + rules removed; new ARIA attrs + 48 px media query added).

## What's in this PR

### `student-layout-simple.component.ts` + `teacher-layout-simple.component.ts`
- Every `md:` Tailwind class on the main sidebar surface → `lg:`:
  - desktop sidebar container `hidden md:flex md:flex-col md:fixed md:inset-y-0 md:z-40 md:w-16/72`
  - content area padding `md:pl-16/72`
  - mobile sidebar overlay `md:hidden`
  - mobile header chrome `md:hidden`
  - mobile bottom nav `md:hidden`
  - inline mobile chrome wrapper `md:hidden`
- AI sidebar lines (`<aside class="ai-sidebar md:flex">`, `mobile-ai-overlay md:hidden`, `ai-sidebar-toggle md:flex`) kept at `md:` — out of this spec's scope, separate component, separate contract.
- Mobile drawer container gets `id="mobile-sidebar-drawer"`.
- Hamburger button: `[attr.aria-expanded]="isMobileSidebarOpen()" aria-controls="mobile-sidebar-drawer"`.

### `admin-layout-simple.component.ts`
- Mobile drawer container `id="mobile-sidebar-drawer"`.
- Hamburger button: `[attr.aria-expanded]` + `aria-controls` + Vietnamese `aria-label="Mở menu điều hướng"` (was English "Open sidebar").

### `sidebar.component.{ts,html,css}`
- Imports `SidebarTooltipDirective`; adds to `imports: [...]`.
- Top-level nav-item links + org-scoped items bind `[appSidebarTooltip]="item.label" [tooltipEnabled]="collapsed()"`.
- Legacy `<span class="nav-tooltip" aria-hidden="true">` removed (2 instances).
- CSS `.nav-tooltip` rules + `.sidebar-collapsed .nav-item:hover .nav-tooltip` removed (~25 LOC).
- New `@media (max-width: 1023px)` block: `.nav-item, .sub-menu-item { min-height: 48px; padding: 0.75rem 0.75rem; }`.

## Test plan

- [ ] At 1023 px viewport, all 4 portals show the mobile drawer pattern + bottom nav (no desktop sidebar peek). Was: student/teacher showed desktop sidebar at 768-1023 px ✅
- [ ] At 1024 px, all 4 portals show the desktop fixed sidebar. ✅
- [ ] Collapse the desktop sidebar in any role; hover an icon → tooltip popover appears after ~500 ms with `aria-describedby` linkage (DevTools inspect) ✅
- [ ] Hover an icon while reduce-motion is enabled → tooltip appears instantly (no delay). ✅
- [ ] DevTools inspect any hamburger button → `aria-expanded`, `aria-controls="mobile-sidebar-drawer"`, Vietnamese `aria-label`. ✅
- [ ] DevTools inspect any nav item on mobile (≤1023 px) → height ≥ 48 px. ✅
- [ ] `cd fe && npm run build` → green
- [ ] `cd fe && npm run test:ci -- --include='**/sidebar*.spec.ts' --include='**/skip-link*.spec.ts'` → 23 SUCCESS (verified locally)

## Out of scope (final PR #5 will close)

- **T015/T016** `FocusTrapDirective` + spec (focus containment when drawer open)
- **T023** edge-swipe-left-to-close gesture
- **Phase 9** axe-core run + full smoke matrix verification (4 viewports × 4 roles × 12+ checks per quickstart.md)

## References

- Spec: [`specs/001-sidebar-redesign/spec.md`](specs/001-sidebar-redesign/spec.md)
- Predecessors: PR #377 + #378 + #379 (all merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)