### PR TITLE
[codex] Harden weak-network learning sync

### DIFF
--- a/fe/src/app/api/interceptors/offline.interceptor.spec.ts
+++ b/fe/src/app/api/interceptors/offline.interceptor.spec.ts
@@ -1,5 +1,10 @@
 import type { OfflineCourse } from '../../core/db/lms-offline.db';
-import { buildOfflineCoursesListingResponse, shouldBypassOfflineInterception } from './offline.interceptor';
+import {
+  buildOfflineCoursesListingResponse,
+  isBackgroundLearningMutation,
+  shouldBypassOfflineInterception,
+  shouldQueueBeforeNetwork,
+} from './offline.interceptor';
 
 describe('buildOfflineCoursesListingResponse', () => {
   const cachedCourses: OfflineCourse[] = [
@@ -83,5 +88,33 @@ describe('shouldBypassOfflineInterception', () => {
 
   it('keeps course requests eligible for offline fallback', () => {
     expect(shouldBypassOfflineInterception('/api/v3/courses/11111111-1111-1111-1111-111111111111')).toBeFalse();
+  });
+});
+
+describe('background learning mutation queue policy', () => {
+  it('identifies learner telemetry and progress mutations as queue-safe', () => {
+    expect(isBackgroundLearningMutation('/api/v3/video-progress/track', 'POST')).toBeTrue();
+    expect(isBackgroundLearningMutation('/api/v3/learning-activity/heartbeat', 'POST')).toBeTrue();
+    expect(isBackgroundLearningMutation(
+      '/api/v3/student/progress/lessons/11111111-1111-1111-1111-111111111111/sections/intro/complete',
+      'POST',
+    )).toBeTrue();
+    expect(isBackgroundLearningMutation(
+      '/api/v3/student/progress/lessons/11111111-1111-1111-1111-111111111111/complete',
+      'PATCH',
+    )).toBeTrue();
+  });
+
+  it('does not preemptively queue reads, auth, sync, or destructive mutations', () => {
+    expect(isBackgroundLearningMutation('/api/v3/video-progress/track', 'GET')).toBeFalse();
+    expect(isBackgroundLearningMutation('/api/v3/auth/login', 'POST')).toBeFalse();
+    expect(isBackgroundLearningMutation('/api/v3/sync/push', 'POST')).toBeFalse();
+    expect(isBackgroundLearningMutation('/api/v3/video-progress/track', 'DELETE')).toBeFalse();
+  });
+
+  it('queues before network only when the network is constrained', () => {
+    expect(shouldQueueBeforeNetwork('/api/v3/video-progress/track', 'POST', true)).toBeTrue();
+    expect(shouldQueueBeforeNetwork('/api/v3/video-progress/track', 'POST', false)).toBeFalse();
+    expect(shouldQueueBeforeNetwork('/api/v3/auth/login', 'POST', true)).toBeFalse();
   });
 });

--- a/fe/src/app/api/interceptors/offline.interceptor.ts
+++ b/fe/src/app/api/interceptors/offline.interceptor.ts
@@ -1,5 +1,5 @@
 import { HttpRequest, HttpHandlerFn, HttpEvent, HttpResponse, HttpErrorResponse } from '@angular/common/http';
-import { Observable, from, of, throwError } from 'rxjs';
+import { Observable, from, of, throwError, timeout } from 'rxjs';
 import { catchError, switchMap, tap } from 'rxjs/operators';
 import { inject } from '@angular/core';
 import { ensureOfflineDbReady, offlineDb, getCurrentUserId, type OfflineCourse } from '../../core/db/lms-offline.db';
@@ -10,6 +10,7 @@ import { isOfflineCompatibleHttpError } from '../../core/utils/offline-http-erro
 /** Paths that must never be intercepted offline (auth, health checks) */
 const NEVER_INTERCEPT_PREFIXES = ['/api/v3/auth/', '/api/v3/sync/', '/actuator/'];
 const DEFAULT_OFFLINE_COURSES_PAGE_SIZE = 12;
+const BACKGROUND_MUTATION_NETWORK_TIMEOUT_MS = 2_000;
 
 /**
  * Offline interceptor — catches network errors and falls back to IndexedDB.
@@ -25,21 +26,28 @@ const DEFAULT_OFFLINE_COURSES_PAGE_SIZE = 12;
 export const offlineInterceptor = (req: HttpRequest<any>, next: HttpHandlerFn): Observable<HttpEvent<any>> => {
   const syncService = inject(OfflineSyncService);
   const networkStatus = inject(NetworkStatusService);
+  const path = extractApiPath(req.url) || req.url;
 
-  // If online, proceed normally but catch network failures
-  return next(req).pipe(
-    tap((event) => {
-      if (event instanceof HttpResponse) {
-        networkStatus.markOnlineFromHttpSuccess();
-      }
-    }),
-    catchError((error: HttpErrorResponse) => {
-      const path = extractApiPath(req.url) || req.url;
-      const isOfflineError = isOfflineCompatibleHttpError(error, req.url, {
-        navigatorOnline: typeof navigator === 'undefined' ? true : navigator.onLine,
-        appOnline: networkStatus.online(),
-        hasRecentOfflineSignal: networkStatus.hasRecentOfflineSignal(),
-      });
+  const forwardToNetwork = () => withBackgroundMutationTimeout(
+    next(req).pipe(
+      tap((event) => {
+        if (event instanceof HttpResponse) {
+          networkStatus.markOnlineFromHttpSuccess();
+        }
+      }),
+    ),
+    path,
+    req.method,
+  ).pipe(
+    catchError((error: unknown) => {
+      const isBackgroundTimeout = isNetworkTimeoutError(error)
+        && isBackgroundLearningMutation(path, req.method);
+      const isOfflineError = isBackgroundTimeout
+        || isOfflineCompatibleHttpError(error as HttpErrorResponse, req.url, {
+          navigatorOnline: typeof navigator === 'undefined' ? true : navigator.onLine,
+          appOnline: networkStatus.online(),
+          hasRecentOfflineSignal: networkStatus.hasRecentOfflineSignal(),
+        });
       if (!isOfflineError) {
         return throwError(() => error);
       }
@@ -76,27 +84,85 @@ export const offlineInterceptor = (req: HttpRequest<any>, next: HttpHandlerFn): 
 
       // For mutation requests → queue for later sync
       if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
-        return from(queueMutation(syncService, req)).pipe(
-          switchMap(async (queuedPayload) => {
-            const body = await buildOfflineMutationResponse(path, queuedPayload);
-            // Return a fake success response so the UI doesn't break
-            return new HttpResponse({
-              status: 202,
-              body,
-              url: req.url,
-            });
-          }),
-          catchError(() => throwError(() => error)),
-        );
+        return buildQueuedMutationResponse(syncService, req, path)
+          .pipe(catchError(() => throwError(() => error)));
       }
 
       return throwError(() => error);
     }),
   );
+
+  if (shouldQueueBeforeNetwork(path, req.method, networkStatus.shouldDeferNonCriticalSync())) {
+    return buildQueuedMutationResponse(syncService, req, path)
+      .pipe(catchError(() => forwardToNetwork()));
+  }
+
+  // If online, proceed normally but catch network failures
+  return forwardToNetwork();
 };
 
 export function shouldBypassOfflineInterception(path: string): boolean {
   return NEVER_INTERCEPT_PREFIXES.some(prefix => path.startsWith(prefix));
+}
+
+export function isBackgroundLearningMutation(path: string, method: string): boolean {
+  const normalizedMethod = method.toUpperCase();
+  if (!['POST', 'PUT', 'PATCH'].includes(normalizedMethod)) {
+    return false;
+  }
+
+  if (path === '/api/v3/video-progress/track') {
+    return normalizedMethod === 'POST';
+  }
+
+  if (path.startsWith('/api/v3/learning-activity/')) {
+    return normalizedMethod === 'POST';
+  }
+
+  return /^\/api\/v3\/student\/progress\/lessons\/[a-f0-9-]+\/sections\/[^/]+\/complete$/i.test(path)
+    || /^\/api\/v3\/student\/progress\/lessons\/[a-f0-9-]+\/complete$/i.test(path);
+}
+
+export function shouldQueueBeforeNetwork(path: string, method: string, shouldDeferSync: boolean): boolean {
+  return shouldDeferSync
+    && !shouldBypassOfflineInterception(path)
+    && isBackgroundLearningMutation(path, method);
+}
+
+function withBackgroundMutationTimeout(
+  source: Observable<HttpEvent<any>>,
+  path: string,
+  method: string,
+): Observable<HttpEvent<any>> {
+  if (!isBackgroundLearningMutation(path, method)) {
+    return source;
+  }
+
+  return source.pipe(timeout({ each: BACKGROUND_MUTATION_NETWORK_TIMEOUT_MS }));
+}
+
+function isNetworkTimeoutError(error: unknown): boolean {
+  return !!error
+    && typeof error === 'object'
+    && (error as { name?: string }).name === 'TimeoutError';
+}
+
+function buildQueuedMutationResponse(
+  syncService: OfflineSyncService,
+  req: HttpRequest<any>,
+  path: string,
+): Observable<HttpEvent<any>> {
+  return from(queueMutation(syncService, req)).pipe(
+    switchMap(async (queuedPayload) => {
+      const body = await buildOfflineMutationResponse(path, queuedPayload);
+      // Return a fake success response so the UI doesn't break
+      return new HttpResponse({
+        status: 202,
+        body,
+        url: req.url,
+      });
+    }),
+  );
 }
 
 // ─── Offline Fallback Logic ──────────────────────────────────────────
@@ -653,7 +719,7 @@ function toTimestampValue(value: Date | string | undefined): number {
 }
 
 type SyncDescriptor = {
-  entityType: 'progress' | 'submission' | 'quizAttempt' | 'videoProgress';
+  entityType: 'progress' | 'submission' | 'quizAttempt' | 'videoProgress' | 'learningEvent';
   metadata: {
     courseId?: string;
     publicationId?: string | null;
@@ -719,7 +785,7 @@ async function resolveSyncDescriptor(path: string, payload: unknown): Promise<Sy
       ? payloadRecord['sectionId']
       : (typeof payloadRecord['lessonId'] === 'string' ? payloadRecord['lessonId'] : undefined);
     return {
-      entityType: 'submission',
+      entityType: 'learningEvent',
       metadata: {
         courseId: courseId ?? undefined,
         publicationId,

--- a/fe/src/app/core/services/network-status.service.spec.ts
+++ b/fe/src/app/core/services/network-status.service.spec.ts
@@ -155,4 +155,35 @@ describe('NetworkStatusService', () => {
       expect(fetchSpy).not.toHaveBeenCalled();
     }));
   });
+
+  describe('non-critical sync deferral', () => {
+    it('should defer background sync while effectively offline', () => {
+      service.online.set(false);
+
+      expect(service.shouldDeferNonCriticalSync()).toBeTrue();
+    });
+
+    it('should defer background sync on slow connections', () => {
+      service.online.set(true);
+      service.effectiveBandwidthMbps.set(0.5);
+
+      expect(service.shouldDeferNonCriticalSync()).toBeTrue();
+    });
+
+    it('should defer background sync when Save-Data is enabled', () => {
+      service.online.set(true);
+      service.effectiveBandwidthMbps.set(10);
+      service.saveDataEnabled.set(true);
+
+      expect(service.shouldDeferNonCriticalSync()).toBeTrue();
+    });
+
+    it('should allow background sync on a stable fast connection', () => {
+      service.online.set(true);
+      service.effectiveBandwidthMbps.set(10);
+      service.saveDataEnabled.set(false);
+
+      expect(service.shouldDeferNonCriticalSync()).toBeFalse();
+    });
+  });
 });

--- a/fe/src/app/core/services/network-status.service.ts
+++ b/fe/src/app/core/services/network-status.service.ts
@@ -5,6 +5,7 @@ export type ConnectionTransport = 'wifi' | 'ethernet' | 'cellular' | 'unknown';
 
 const OFFLINE_GRACE_MS = 1_500;
 const RECENT_OFFLINE_WINDOW_MS = 5_000;
+const NON_CRITICAL_SYNC_DEFER_WINDOW_MS = 15_000;
 const PROBE_INTERVAL_MS = 120_000;
 const PROBE_TIMEOUT_MS = 4_000;
 const TRANSPORT_FAILURE_PROBE_DELAY_MS = 250;
@@ -133,6 +134,13 @@ export class NetworkStatusService implements OnDestroy {
       || !this.online();
   }
 
+  shouldDeferNonCriticalSync(windowMs = NON_CRITICAL_SYNC_DEFER_WINDOW_MS): boolean {
+    return this.isEffectivelyOffline()
+      || this.connectionTier() === 'slow'
+      || this.saveDataEnabled()
+      || this.hasRecentOfflineSignal(windowMs);
+  }
+
   markOfflineFromTransportFailure(): void {
     if (!this.getBrowserOnlineHint()) {
       this.markOfflineState();
@@ -188,11 +196,7 @@ export class NetworkStatusService implements OnDestroy {
     }
 
     this.online.set(true);
-    if (conn?.downlink != null) {
-      this.effectiveBandwidthMbps.set(Math.max(conn.downlink, 1.5));
-    } else {
-      this.effectiveBandwidthMbps.set(2);
-    }
+    this.effectiveBandwidthMbps.set(this.estimateBandwidthMbps(conn));
   }
 
   // Single-probe health check against /actuator/health. Previously used a
@@ -233,6 +237,23 @@ export class NetworkStatusService implements OnDestroy {
     }
 
     return 'unknown';
+  }
+
+  private estimateBandwidthMbps(conn: any): number {
+    if (typeof conn?.downlink === 'number' && Number.isFinite(conn.downlink) && conn.downlink > 0) {
+      return Math.max(conn.downlink, 0.05);
+    }
+
+    switch (conn?.effectiveType) {
+      case 'slow-2g':
+        return 0.1;
+      case '2g':
+        return 0.25;
+      case '3g':
+        return 0.75;
+      default:
+        return 2;
+    }
   }
 
   private getBrowserOnlineHint(): boolean {

--- a/fe/src/app/core/services/offline-sync.service.ts
+++ b/fe/src/app/core/services/offline-sync.service.ts
@@ -178,7 +178,7 @@ export class OfflineSyncService {
     if (!force && !this.offlineSettings.autoSyncWhenOnline()) {
       return { synced: 0, failed: 0, pending: await this.getPendingCount() };
     }
-    if (this.syncInProgress || !this.network.online()) {
+    if (this.syncInProgress || !this.network.online() || (!force && this.network.shouldDeferNonCriticalSync())) {
       return { synced: 0, failed: 0, pending: await this.getPendingCount() };
     }
 
@@ -268,7 +268,7 @@ export class OfflineSyncService {
    */
   async syncWithPriority(force = false): Promise<void> {
     if (!force && !this.offlineSettings.autoSyncWhenOnline()) return;
-    if (this.syncInProgress || !this.network.online()) return;
+    if (this.syncInProgress || !this.network.online() || (!force && this.network.shouldDeferNonCriticalSync())) return;
 
     // Step 1: Sync all queued operations (progress, submissions, quiz attempts)
     const result = await this.syncAll(force);


### PR DESCRIPTION
﻿## Summary
- Treat weak/constrained network as a local-first path for learner progress and learning telemetry.
- Queue interactive video events, heartbeat/reading progress, video progress, and lesson completion before network when the app detects slow/recently failed/Save-Data connections.
- Add a 2s watchdog for queue-safe learner mutations so an "online but hanging" request falls back to the offline sync queue instead of waiting for the transport to fail.

## Root Cause
Browsers can keep `navigator.onLine` true on poor or captive/partial networks. The old flow waited for a request failure before using IndexedDB/offline queue, so weak networks could feel slower than airplane mode because airplane mode failed immediately.

## Validation
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/core/services/network-status.service.spec.ts --include=src/app/api/interceptors/offline.interceptor.spec.ts` -> 28 SUCCESS
- `npx ng build --configuration production` -> success
- `npm run build` before final rebase -> success; `fix-ngsw` reported clean

## Notes
Build still reports existing unrelated Angular/Sass/CommonJS warnings in admin/analytics/tiptap/mammoth paths. This PR does not touch video playback/Shaka paths or upload/download flows.
