### PR TITLE
Polish offline desktop UX

### DIFF
--- a/fe/src/app/shared/components/offline-fallback/offline-fallback.component.ts
+++ b/fe/src/app/shared/components/offline-fallback/offline-fallback.component.ts
@@ -1,5 +1,6 @@
 import { Component, ChangeDetectionStrategy, inject, computed } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { LucideAngularModule } from 'lucide-angular';
 import { CourseDownloadService } from '../../../core/services/course-download.service';
 import { StorageManagerService } from '../../../core/services/storage-manager.service';
 import { OfflineSyncService } from '../../../core/services/offline-sync.service';
@@ -9,117 +10,186 @@ export const OFFLINE_FALLBACK_COURSE_ROUTE_PREFIX = '/student/learn/course';
 @Component({
   selector: 'app-offline-fallback',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink],
+  imports: [RouterLink, LucideAngularModule],
   template: `
-    <div class="min-h-screen bg-slate-50 p-4">
-      <div class="max-w-lg mx-auto space-y-4 pt-8">
-
-        <!-- Header Card -->
-        <div class="bg-white rounded-xl border border-gray-200 shadow-sm p-6 text-center space-y-4">
-          <div class="mx-auto w-16 h-16 bg-red-50 rounded-full flex items-center justify-center">
-            <svg class="w-8 h-8 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 5.636a9 9 0 010 12.728M5.636 18.364a9 9 0 010-12.728" />
-              <line x1="4" y1="4" x2="20" y2="20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-          </div>
-
-          <div>
-            <h1 class="text-xl font-bold text-gray-900">Bạn đang ngoại tuyến</h1>
-            <p class="mt-1 text-sm text-gray-600">
-              Ứng dụng vẫn hoạt động với dữ liệu đã tải xuống.
-            </p>
-          </div>
-
-          <!-- Stats -->
-          <div class="grid grid-cols-2 gap-3 text-sm">
-            <div class="bg-slate-50 rounded-lg p-3">
-              <div class="font-semibold text-[#0056D2]">{{ downloadCount() }}</div>
-              <div class="text-gray-500">Khóa học đã tải</div>
-            </div>
-            <div class="bg-slate-50 rounded-lg p-3">
-              <div class="font-semibold text-[#0056D2]">{{ pendingSync() }}</div>
-              <div class="text-gray-500">Chờ đồng bộ</div>
-            </div>
-          </div>
-
-          <!-- Storage -->
-          <div class="text-xs text-gray-500">
-            Dung lượng: {{ usedStorage() }} / {{ totalStorage() }}
-          </div>
-
-          <button (click)="retry()"
-                  class="w-full py-2.5 border border-gray-300 text-gray-700 rounded-lg font-medium hover:bg-gray-50 transition-colors">
-            Thử kết nối lại
-          </button>
-        </div>
-
-        <!-- Downloaded Courses List -->
-        @if (downloadedCourses().length > 0) {
-          <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
-            <div class="px-4 py-3 border-b border-gray-100">
-              <h2 class="font-semibold text-gray-900">Khóa học đã tải xuống</h2>
-            </div>
-
-            @for (course of downloadedCourses(); track course.id) {
-              <a [routerLink]="[courseRoutePrefix, course.id]"
-                 class="flex items-center gap-3 px-4 py-3 hover:bg-slate-50 transition-colors border-b border-gray-50 last:border-b-0">
-                <div class="flex-shrink-0 w-10 h-10 bg-[#0056D2]/10 rounded-lg flex items-center justify-center">
-                  <svg class="w-5 h-5 text-[#0056D2]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-                  </svg>
+    <div class="min-h-screen bg-slate-50">
+      <main class="mx-auto flex min-h-screen max-w-6xl flex-col px-4 pb-8 pt-12 sm:px-6 sm:pt-14 lg:px-8 lg:pt-16">
+        <section class="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div class="grid lg:grid-cols-[minmax(0,1fr)_380px]">
+            <div class="p-5 sm:p-7 lg:p-8">
+              <div class="flex flex-col gap-5 sm:flex-row sm:items-start">
+                <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-amber-50 text-amber-700 ring-1 ring-amber-100">
+                  <lucide-icon name="wifi-off" [size]="24" aria-hidden="true"></lucide-icon>
                 </div>
-                <div class="flex-1 min-w-0">
-                  <div class="text-sm font-medium text-gray-900 truncate">{{ course.title }}</div>
-                  <div class="text-xs text-gray-500">{{ course.totalLessons }} bài học · {{ formatSize(course.sizeBytes) }}</div>
+
+                <div class="min-w-0 flex-1">
+                  <p class="text-xs font-semibold uppercase tracking-[0.12em] text-amber-700">Chế độ ngoại tuyến</p>
+                  <h1 class="mt-2 text-2xl font-bold text-slate-950 sm:text-3xl">Bạn đang ngoại tuyến</h1>
+                  <p class="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+                    Nội dung đã tải vẫn mở được. Bài làm, tiến độ và ghi chú mới sẽ được giữ trên thiết bị rồi đồng bộ khi kết nối ổn định trở lại.
+                  </p>
+
+                  <div class="mt-5 flex flex-col gap-3 sm:flex-row">
+                    <button
+                      type="button"
+                      (click)="retry()"
+                      class="inline-flex h-10 items-center justify-center gap-2 rounded-lg bg-[#0056D2] px-4 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#004BB5] focus:outline-none focus:ring-2 focus:ring-[#0056D2] focus:ring-offset-2"
+                    >
+                      <lucide-icon name="refresh-cw" [size]="16" aria-hidden="true"></lucide-icon>
+                      Thử kết nối lại
+                    </button>
+
+                    @if (downloadCount() > 0) {
+                      <a
+                        [routerLink]="[courseRoutePrefix, downloadedCourses()[0].id]"
+                        class="inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-[#0056D2] focus:ring-offset-2"
+                      >
+                        <lucide-icon name="book-open" [size]="16" aria-hidden="true"></lucide-icon>
+                        Mở khóa học gần nhất
+                      </a>
+                    }
+                  </div>
                 </div>
-                <svg class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-                </svg>
-              </a>
+              </div>
+            </div>
+
+            <div class="border-t border-slate-200 bg-slate-50/70 p-5 sm:p-7 lg:border-l lg:border-t-0">
+              <div class="grid grid-cols-2 gap-3">
+                <div class="rounded-lg border border-slate-200 bg-white p-4">
+                  <div class="text-2xl font-bold text-[#0056D2]">{{ downloadCount() }}</div>
+                  <div class="mt-1 text-xs font-medium text-slate-500">Khóa học đã tải</div>
+                </div>
+                <div class="rounded-lg border border-slate-200 bg-white p-4">
+                  <div class="text-2xl font-bold text-[#0056D2]">{{ pendingSync() }}</div>
+                  <div class="mt-1 text-xs font-medium text-slate-500">Chờ đồng bộ</div>
+                </div>
+              </div>
+
+              <div class="mt-4 rounded-lg border border-slate-200 bg-white p-4">
+                <div class="flex items-center justify-between gap-4">
+                  <div class="flex min-w-0 items-center gap-3">
+                    <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+                      <lucide-icon name="hard-drive" [size]="18" aria-hidden="true"></lucide-icon>
+                    </span>
+                    <div class="min-w-0">
+                      <div class="text-sm font-semibold text-slate-900">Dung lượng ngoại tuyến</div>
+                      <div class="mt-0.5 truncate text-xs text-slate-500">{{ usedStorage() }} / {{ totalStorage() }}</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="mt-6 grid min-w-0 gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
+          <div class="min-w-0 rounded-xl border border-slate-200 bg-white shadow-sm">
+            <div class="flex items-center justify-between gap-4 border-b border-slate-100 px-5 py-4">
+              <div>
+                <h2 class="text-base font-semibold text-slate-950">Nội dung đã tải</h2>
+                <p class="mt-0.5 text-xs text-slate-500">{{ downloadCount() }} khóa học có thể học khi mất mạng</p>
+              </div>
+              <span class="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600">
+                Offline
+              </span>
+            </div>
+
+            @if (downloadedCourses().length > 0) {
+              <div class="max-h-[560px] overflow-y-auto">
+                @for (course of downloadedCourses(); track course.id) {
+                  <a
+                    [routerLink]="[courseRoutePrefix, course.id]"
+                    class="group grid grid-cols-[2.5rem_minmax(0,1fr)_auto] items-center gap-3 border-b border-slate-100 px-5 py-4 transition-colors last:border-b-0 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-[#0056D2]"
+                    [attr.aria-label]="'Mở khóa học ' + course.title"
+                  >
+                    <span class="flex h-10 w-10 items-center justify-center rounded-lg bg-[#0056D2]/10 text-[#0056D2]">
+                      <lucide-icon name="book-open" [size]="18" aria-hidden="true"></lucide-icon>
+                    </span>
+                    <span class="min-w-0">
+                      <span class="block truncate text-sm font-semibold text-slate-900">{{ course.title }}</span>
+                      <span class="mt-1 block truncate text-xs text-slate-500">
+                        {{ course.totalLessons }} bài học · {{ formatSize(course.sizeBytes) }}
+                      </span>
+                    </span>
+                    <lucide-icon name="chevron-right" [size]="18" class="text-slate-300 transition-colors group-hover:text-[#0056D2]" aria-hidden="true"></lucide-icon>
+                  </a>
+                }
+              </div>
+            } @else {
+              <div class="px-5 py-12 text-center">
+                <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-xl bg-slate-100 text-slate-400">
+                  <lucide-icon name="download" [size]="24" aria-hidden="true"></lucide-icon>
+                </div>
+                <h3 class="mt-4 text-sm font-semibold text-slate-900">Chưa có khóa học nào được tải xuống</h3>
+                <p class="mx-auto mt-1 max-w-sm text-sm leading-6 text-slate-500">
+                  Khi có mạng, hãy tải khóa học cần học trước để dùng ổn định trong môi trường yếu hoặc mất kết nối.
+                </p>
+              </div>
             }
           </div>
-        } @else {
-          <div class="bg-white rounded-xl border border-gray-200 shadow-sm p-6 text-center">
-            <div class="mx-auto w-12 h-12 bg-slate-100 rounded-full flex items-center justify-center mb-3">
-              <svg class="w-6 h-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-              </svg>
-            </div>
-            <p class="text-sm text-gray-600">Chưa có khóa học nào được tải xuống.</p>
-            <p class="text-xs text-gray-400 mt-1">Kết nối mạng và tải khóa học để xem ngoại tuyến.</p>
-          </div>
-        }
 
-        <!-- Pending Sync Info -->
-        @if (pendingSync() > 0) {
-          <div class="bg-amber-50 border border-amber-200 rounded-xl p-4">
-            <div class="flex items-center gap-2 text-amber-800">
-              <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              <span class="text-sm font-medium">{{ pendingSync() }} thao tác đang chờ đồng bộ</span>
-            </div>
-            <p class="text-xs text-amber-600 mt-1">Dữ liệu sẽ tự động đồng bộ khi có kết nối mạng.</p>
-          </div>
-        }
+          <aside class="space-y-4">
+            <div class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+              <div class="flex items-center gap-3">
+                <span class="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 text-[#0056D2]">
+                  <lucide-icon name="folder-sync" [size]="18" aria-hidden="true"></lucide-icon>
+                </span>
+                <div>
+                  <h2 class="text-sm font-semibold text-slate-950">Đồng bộ</h2>
+                  <p class="text-xs text-slate-500">Trạng thái dữ liệu trên thiết bị này</p>
+                </div>
+              </div>
 
-        <!-- Failed Sync Warning -->
-        @if (failedSync() > 0) {
-          <div class="bg-red-50 border border-red-200 rounded-xl p-4">
-            <div class="flex items-center gap-2 text-red-800">
-              <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
-              </svg>
-              <span class="text-sm font-medium">{{ failedSync() }} thao tác đồng bộ thất bại</span>
+              @if (pendingSync() === 0 && failedSync() === 0) {
+                <div class="mt-5 rounded-lg border border-emerald-100 bg-emerald-50 px-4 py-3 text-sm font-medium text-emerald-800">
+                  Không có thao tác nào đang chờ.
+                </div>
+              }
+
+              @if (pendingSync() > 0) {
+                <div class="mt-5 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3">
+                  <div class="flex items-center gap-2 text-sm font-semibold text-amber-900">
+                    <lucide-icon name="clock" [size]="16" aria-hidden="true"></lucide-icon>
+                    {{ pendingSync() }} thao tác chờ đồng bộ
+                  </div>
+                  <p class="mt-1 text-xs leading-5 text-amber-700">Hệ thống sẽ tự thử lại khi kết nối đủ ổn định.</p>
+                </div>
+              }
+
+              @if (failedSync() > 0) {
+                <div class="mt-5 rounded-lg border border-red-200 bg-red-50 px-4 py-3">
+                  <div class="flex items-center gap-2 text-sm font-semibold text-red-800">
+                    <lucide-icon name="alert-triangle" [size]="16" aria-hidden="true"></lucide-icon>
+                    {{ failedSync() }} thao tác lỗi đồng bộ
+                  </div>
+                  <button
+                    type="button"
+                    (click)="retryFailed()"
+                    class="mt-3 inline-flex h-9 w-full items-center justify-center gap-2 rounded-lg bg-red-600 px-3 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+                  >
+                    <lucide-icon name="refresh-cw" [size]="15" aria-hidden="true"></lucide-icon>
+                    Thử lại đồng bộ
+                  </button>
+                </div>
+              }
             </div>
-            <p class="text-xs text-red-600 mt-1">Nhấn nút bên dưới để thử lại.</p>
-            <button (click)="retryFailed()"
-                    class="mt-2 w-full py-2 bg-red-600 text-white text-sm rounded-lg font-medium hover:bg-red-700 transition-colors">
-              Thử lại đồng bộ
-            </button>
-          </div>
-        }
-      </div>
+
+            <div class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+              <h2 class="text-sm font-semibold text-slate-950">Hoạt động khi ngoại tuyến</h2>
+              <div class="mt-4 space-y-3 text-sm text-slate-600">
+                <div class="flex gap-3">
+                  <lucide-icon name="check-circle" [size]="17" class="mt-0.5 shrink-0 text-emerald-600" aria-hidden="true"></lucide-icon>
+                  <span>Bài học đã tải, quiz hỗ trợ offline và ghi chú vẫn dùng được.</span>
+                </div>
+                <div class="flex gap-3">
+                  <lucide-icon name="clock" [size]="17" class="mt-0.5 shrink-0 text-amber-600" aria-hidden="true"></lucide-icon>
+                  <span>Các cập nhật mới trên server cần mạng để làm mới.</span>
+                </div>
+              </div>
+            </div>
+          </aside>
+        </section>
+      </main>
     </div>
   `,
 })

--- a/fe/src/app/shared/components/offline-indicator/offline-indicator.component.ts
+++ b/fe/src/app/shared/components/offline-indicator/offline-indicator.component.ts
@@ -1,5 +1,8 @@
-import { Component, ChangeDetectionStrategy, inject, computed } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Component, ChangeDetectionStrategy, DestroyRef, inject, computed, signal } from '@angular/core';
+import { Router, RouterLink, NavigationEnd } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { LucideAngularModule } from 'lucide-angular';
+import { filter } from 'rxjs';
 import { NetworkStatusService } from '../../../core/services/network-status.service';
 import { OfflineSyncService } from '../../../core/services/offline-sync.service';
 import { SessionExpiredService } from '../../../core/services/session-expired.service';
@@ -7,39 +10,65 @@ import { SessionExpiredService } from '../../../core/services/session-expired.se
 @Component({
   selector: 'app-offline-indicator',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink],
+  imports: [RouterLink, LucideAngularModule],
   template: `
-    @if (isOffline()) {
-      <div class="bg-red-600 text-white px-4 py-2 flex items-center justify-between shadow-md"
-           role="alert"
-           aria-live="assertive">
-        <div class="flex items-center gap-3">
-          <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-300 animate-pulse"></span>
-          <span class="text-sm font-semibold">Ngoại tuyến</span>
-          @if (pendingSyncCount() > 0) {
-            <span class="text-xs bg-red-700 px-2 py-0.5 rounded-full">
-              {{ pendingSyncCount() }} mục chờ đồng bộ
+    @if (isOffline() && !isOfflineRoute()) {
+      <div
+        class="pointer-events-none fixed left-1/2 z-[1000] w-[calc(100vw-1.5rem)] max-w-xl -translate-x-1/2 transition-all duration-200 sm:w-[calc(100vw-2rem)]"
+        [class.top-3]="!hasExpiredBanner()"
+        [class.top-14]="hasExpiredBanner()"
+        role="status"
+        aria-live="polite"
+      >
+        <div class="pointer-events-auto flex min-h-11 items-center justify-between gap-3 rounded-xl border border-amber-200 bg-amber-50/95 px-3 py-2 text-amber-950 shadow-lg shadow-amber-950/10 backdrop-blur sm:px-4">
+          <div class="flex min-w-0 items-center gap-3">
+            <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-700">
+              <lucide-icon name="wifi-off" [size]="15" aria-hidden="true"></lucide-icon>
             </span>
-          }
+            <div class="min-w-0">
+              <div class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                <span class="truncate text-sm font-semibold">Đang ngoại tuyến</span>
+                @if (pendingSyncCount() > 0) {
+                  <span class="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-semibold text-amber-800">
+                    {{ pendingSyncCount() }} mục chờ đồng bộ
+                  </span>
+                }
+              </div>
+              <p class="hidden truncate text-xs text-amber-800 sm:block">
+                Bạn vẫn xem được nội dung đã tải. Tiến độ sẽ đồng bộ khi có mạng.
+              </p>
+            </div>
+          </div>
+
+          <a
+            routerLink="/offline"
+            class="shrink-0 rounded-lg border border-amber-200 bg-white/80 px-3 py-1.5 text-xs font-semibold text-amber-900 transition-colors hover:bg-white focus:outline-none focus:ring-2 focus:ring-amber-400"
+          >
+            Kho offline
+          </a>
         </div>
-        <a routerLink="/offline"
-           class="text-xs underline hover:text-red-200 transition-colors">
-          Khóa học đã tải
-        </a>
       </div>
     } @else if (isSyncing()) {
-      <div class="flex items-center justify-center gap-2 px-3 py-1 bg-blue-50 border-b border-blue-200 text-blue-700"
-           role="status"
-           aria-live="polite">
-        <span class="inline-block w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse"></span>
-        <span class="text-xs font-medium">Đang đồng bộ dữ liệu...</span>
+      <div
+        class="pointer-events-none fixed left-1/2 top-3 z-[1000] w-[calc(100vw-1.5rem)] max-w-sm -translate-x-1/2 sm:w-auto"
+        role="status"
+        aria-live="polite"
+      >
+        <div class="pointer-events-auto flex items-center justify-center gap-2 rounded-full border border-blue-200 bg-blue-50/95 px-3 py-2 text-blue-700 shadow-md shadow-blue-900/10 backdrop-blur">
+          <lucide-icon name="refresh-cw" [size]="14" class="animate-spin" aria-hidden="true"></lucide-icon>
+          <span class="text-xs font-semibold">Đang đồng bộ dữ liệu...</span>
+        </div>
       </div>
     } @else if (isSlow()) {
-      <div class="flex items-center justify-center gap-2 px-3 py-1 bg-amber-50 border-b border-amber-200 text-amber-700"
-           role="status"
-           aria-live="polite">
-        <span class="inline-block w-1.5 h-1.5 rounded-full bg-amber-500 animate-pulse"></span>
-        <span class="text-xs font-medium">{{ network.connectionLabel() }}</span>
+      <div
+        class="pointer-events-none fixed left-1/2 top-3 z-[1000] w-[calc(100vw-1.5rem)] max-w-sm -translate-x-1/2 sm:w-auto"
+        role="status"
+        aria-live="polite"
+      >
+        <div class="pointer-events-auto flex items-center justify-center gap-2 rounded-full border border-amber-200 bg-amber-50/95 px-3 py-2 text-amber-800 shadow-md shadow-amber-950/10 backdrop-blur">
+          <lucide-icon name="alert-triangle" [size]="14" aria-hidden="true"></lucide-icon>
+          <span class="text-xs font-semibold">{{ network.connectionLabel() }}</span>
+        </div>
       </div>
     }
   `,
@@ -48,6 +77,18 @@ export class OfflineIndicatorComponent {
   protected readonly network = inject(NetworkStatusService);
   private readonly syncService = inject(OfflineSyncService);
   private readonly sessionService = inject(SessionExpiredService);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly currentUrl = signal(this.router.url);
+
+  constructor() {
+    this.router.events
+      .pipe(
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(event => this.currentUrl.set(event.urlAfterRedirects));
+  }
 
   protected readonly isOffline = computed(() => {
     const tier = this.network.connectionTier();
@@ -59,4 +100,5 @@ export class OfflineIndicatorComponent {
   protected readonly isSlow = computed(() => this.network.connectionTier() === 'slow');
   protected readonly pendingSyncCount = computed(() => this.syncService.pendingCount());
   protected readonly hasExpiredBanner = computed(() => this.sessionService.showExpiredBanner());
+  protected readonly isOfflineRoute = computed(() => this.currentUrl().startsWith('/offline'));
 }


### PR DESCRIPTION
## Summary
- Replace the red full-width offline strip with a compact amber connectivity status overlay that is not hidden behind page headers.
- Redesign `/offline` as a responsive recovery dashboard for desktop/wide screens with downloaded content, sync state, and storage status.
- Hide the global offline overlay on the `/offline` route to avoid duplicate offline messaging.

## Verification
- `npm run build`
- `npm run test:ci -- --include=src/app/shared/components/offline-fallback/offline-fallback.component.spec.ts`
- Playwright local visual checks: 1440, 1920, 2560 wide offline states; 390px mobile no horizontal overflow.