### PR TITLE
[codex] Polish interactive video drag/drop UX

### DIFF
--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
@@ -530,8 +530,8 @@
                     </p>
                   </div>
 
-                  <div class="grid gap-4 2xl:grid-cols-[minmax(0,1.1fr)_minmax(20rem,0.9fr)]">
-                    <section class="rounded-2xl border border-slate-200 bg-white p-3">
+                  <div class="grid gap-4">
+                    <section class="min-w-0 rounded-2xl border border-slate-200 bg-white p-3">
                       <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
                         <div>
                           <h6 class="text-sm font-bold text-slate-900">1. Vùng nhận đáp án đúng</h6>
@@ -555,7 +555,7 @@
 
                       <div
                         data-drag-drop-authoring-stage
-                        class="relative aspect-video overflow-hidden rounded-2xl border border-slate-200 bg-slate-950 shadow-inner"
+                        class="relative mx-auto aspect-video w-full max-w-[62rem] overflow-hidden rounded-2xl border border-slate-200 bg-slate-950 shadow-inner"
                         (pointermove)="onDragDropAuthoringPointerMove($event, interaction)"
                         (pointerup)="onDragDropAuthoringPointerUp($event)"
                         (pointercancel)="onDragDropAuthoringPointerCancel($event)">
@@ -619,7 +619,7 @@
                       </p>
                     </section>
 
-                    <section class="rounded-2xl border border-slate-200 bg-white p-3">
+                    <section class="min-w-0 rounded-2xl border border-slate-200 bg-white p-3">
                       <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
                         <div>
                           <h6 class="text-sm font-bold text-slate-900">2. Vật dụng để kéo</h6>
@@ -635,22 +635,22 @@
                         </button>
                       </div>
 
-                      <div class="grid gap-2">
+                      <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
                         @for (draggable of getDragDrop(interaction).draggables; track draggable.id; let dragIndex = $index) {
-                          <div class="rounded-2xl border border-slate-200 bg-slate-50/70 p-2">
-                            <div class="grid gap-2 sm:grid-cols-[4.5rem_minmax(0,1fr)]">
-                              <div class="flex h-16 items-center justify-center rounded-xl border border-slate-200 bg-white">
+                          <div class="min-w-0 rounded-xl border border-slate-200 bg-slate-50/70 p-2.5">
+                            <div class="grid gap-2 sm:grid-cols-[3.75rem_minmax(0,1fr)]">
+                              <div class="flex h-14 items-center justify-center rounded-xl border border-slate-200 bg-white">
                                 @if (getDragDropMediaPreviewUrl(draggable.image); as itemUrl) {
                                   <img [src]="itemUrl"
                                     width="72"
                                     height="56"
                                     [alt]="draggable.label || 'Vật dụng kéo thả'"
-                                    class="max-h-14 max-w-full object-contain" />
+                                    class="max-h-12 max-w-full object-contain" />
                                 } @else {
                                   <span class="text-[10px] font-semibold text-slate-400">Ảnh</span>
                                 }
                               </div>
-                              <div class="grid gap-2">
+                              <div class="grid min-w-0 gap-2">
                                 <div class="flex items-start gap-2">
                                   <label class="min-w-0 flex-1">
                                     <span class="mb-1 block text-[10px] font-semibold uppercase text-slate-400">Tên vật dụng</span>
@@ -685,14 +685,14 @@
                               </div>
                             </div>
 
-                            <div class="mt-2 flex flex-wrap items-center gap-2">
+                            <div class="mt-2 grid gap-2 sm:grid-cols-[auto_minmax(0,1fr)]">
                               <input #dragDropItemFile type="file"
                                 accept="image/*"
                                 class="hidden"
                                 (change)="onDragDropDraggableFileSelected(interaction, draggable.id, $event)" />
                               <button type="button"
                                 (click)="dragDropItemFile.click()"
-                                class="inline-flex h-9 items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5">
+                                class="inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-700 hover:border-[#0056D2]/40 hover:bg-[#0056D2]/5">
                                 <lucide-icon name="upload" [size]="13" aria-hidden="true"></lucide-icon>
                                 Tải ảnh vật dụng
                               </button>
@@ -700,7 +700,7 @@
                                 [ngModel]="draggable.image?.idOrUrl ?? ''"
                                 (ngModelChange)="onDragDropDraggableImageChange(interaction, draggable.id, $event)"
                                 placeholder="Hoặc nhập URL/mã ảnh…"
-                                class="min-w-[14rem] flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:border-[#0056D2] focus:ring-[#0056D2]" />
+                                class="min-w-0 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:border-[#0056D2] focus:ring-[#0056D2]" />
                             </div>
                           </div>
                         }

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
@@ -462,8 +462,7 @@ type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
                   <!-- Video preview -->
                   @if (svc.sectionVideoAssetId()) {
                     <div
-                      [class]="videoPreviewFrameClass()"
-                      style="aspect-ratio: 16/9;">
+                      [class]="videoPreviewFrameClass()">
                       <app-quiz-video-player
                         [videoAssetId]="svc.sectionVideoAssetId()"
                         [rawVideoUrl]="svc.sectionVideoUrl()"
@@ -473,8 +472,7 @@ type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
                     </div>
                   } @else if (svc.sectionVideoUrl()) {
                     <div
-                      [class]="videoPreviewFrameClass()"
-                      style="aspect-ratio: 16/9;">
+                      [class]="videoPreviewFrameClass()">
                       <app-quiz-video-player
                         [rawVideoUrl]="svc.sectionVideoUrl()"
                         [interactiveVideoSpec]="interactiveVideoPreviewSpec()"

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
@@ -137,7 +137,7 @@ export function createInteractiveVideoDragDrop(): InteractiveVideoDragDrop {
   const distractorDraggable = createInteractiveVideoDragDropDraggable(1);
 
   return {
-    instruction: 'Kéo những đáp án đúng vào vùng ảnh. Để nguyên đáp án sai ở ngoài.',
+    instruction: 'Chọn các vật dụng phù hợp rồi kéo vào vùng trên hình.',
     backgroundImage: null,
     dropZones: [
       { ...answerZone, correctDraggableIds: [correctDraggable.id] },

--- a/fe/src/app/shared/blocks/video-block/interactive-video-drag-drop.component.spec.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-drag-drop.component.spec.ts
@@ -16,7 +16,7 @@ describe('InteractiveVideoDragDropComponent', () => {
       atSeconds: 32,
       required: true,
       dragDrop: {
-        instruction: 'Keo dap an dung vao vung anh.',
+        instruction: 'Kéo những đáp án đúng vào vùng ảnh. Để nguyên đáp án sai ở ngoài.',
         backgroundImage: { idOrUrl: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==' },
         dropZones: [
           {
@@ -80,6 +80,15 @@ describe('InteractiveVideoDragDropComponent', () => {
       .querySelector('[data-testid="interactive-video-drag-drop-continue"]') as HTMLButtonElement;
 
     expect(continueButton.disabled).toBeTrue();
+  });
+
+  it('hides answer-role wording in student preview instructions', () => {
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.textContent).toContain('Chọn các vật dụng phù hợp rồi kéo vào vùng trên hình.');
+    expect(element.textContent).not.toContain('Kéo những đáp án đúng');
+    expect(element.textContent).not.toContain('Để nguyên đáp án sai');
   });
 
   function click(selector: string): void {

--- a/fe/src/app/shared/blocks/video-block/interactive-video-drag-drop.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-drag-drop.component.ts
@@ -59,17 +59,17 @@ interface DragDropResultState {
   `],
   template: `
     <div class="mt-3 grid gap-3" data-testid="interactive-video-drag-drop">
-      <section class="rounded-2xl border border-slate-200 bg-white p-3 shadow-sm">
-        @if (dragDrop()?.instruction) {
+      <section class="rounded-2xl border border-slate-200 bg-white p-3 shadow-sm sm:p-4">
+        @if (visibleInstruction(); as instruction) {
           <p class="mb-3 text-sm font-semibold leading-relaxed text-slate-700">
-            {{ dragDrop()?.instruction }}
+            {{ instruction }}
           </p>
         }
 
-        <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_18rem]">
+        <div [class]="layoutClass()">
           <div class="min-w-0">
             <div
-              class="drag-drop-stage relative aspect-video overflow-hidden rounded-2xl border border-slate-200 bg-slate-950 shadow-inner"
+              [class]="stageClass()"
               data-testid="interactive-video-drag-drop-canvas"
               (dragover)="onStageDragOver($event)">
               @if (backgroundUrl(); as bgUrl) {
@@ -151,7 +151,7 @@ interface DragDropResultState {
 
             <div class="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500">
               <span>
-                Kéo đáp án đúng vào vùng ảnh; giữ đáp án sai ở ngoài.
+                Bấm hoặc kéo vật dụng bạn chọn vào vùng trên hình.
               </span>
               <span class="font-semibold tabular-nums text-slate-700">
                 {{ placedCount() }}/{{ draggables().length }} đã chọn
@@ -159,7 +159,7 @@ interface DragDropResultState {
             </div>
           </div>
 
-          <aside class="flex max-h-[min(31rem,calc(100vh-12rem))] min-h-0 flex-col rounded-2xl border border-slate-200 bg-slate-50/90 p-3">
+          <aside class="min-w-0 rounded-2xl border border-slate-200 bg-slate-50/90 p-3">
             <div class="flex items-start justify-between gap-2">
               <div>
                 <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Vật dụng</p>
@@ -174,7 +174,7 @@ interface DragDropResultState {
               }
             </div>
 
-            <div class="mt-3 grid min-h-0 flex-1 gap-2 overflow-y-auto pr-1">
+            <div [class]="draggableGridClass()">
               @for (draggable of draggables(); track draggable.id) {
                 <button
                   type="button"
@@ -187,32 +187,19 @@ interface DragDropResultState {
                   (click)="selectDraggable(draggable.id)"
                   (dragstart)="onDragStart($event, draggable.id)"
                   (dragend)="onDragEnd()">
-                  <span class="flex h-16 w-20 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+                  <span [class]="draggableMediaClass()">
                     @if (mediaUrl(draggable.image); as imageUrl) {
                       <img [src]="imageUrl"
-                        width="96"
+                        width="72"
                         height="72"
                         [alt]="draggable.image?.alt || draggable.label"
-                        class="max-h-14 max-w-full object-contain" />
+                        [class]="draggableImageClass()" />
                     } @else {
                       <span class="px-1 text-[10px] font-bold uppercase text-slate-400">Text</span>
                     }
                   </span>
                   <span class="min-w-0 flex-1 text-left">
-                    <span class="block truncate text-sm font-extrabold">{{ draggable.label }}</span>
-                    @if (placementLabel(draggable); as zoneLabel) {
-                      <span class="mt-0.5 block truncate text-[11px] font-semibold opacity-75">
-                        Đã chọn: {{ zoneLabel }}
-                      </span>
-                    } @else if (shouldStayOutside(draggable)) {
-                      <span class="mt-0.5 block text-[11px] font-semibold opacity-70">
-                        Để ngoài nếu là đáp án sai
-                      </span>
-                    } @else {
-                      <span class="mt-0.5 block text-[11px] font-semibold opacity-70">
-                        Kéo vào vùng đúng
-                      </span>
-                    }
+                    <span class="block text-sm font-extrabold leading-snug text-slate-800">{{ draggable.label }}</span>
                   </span>
                   @if (isChecked()) {
                     <span [class]="draggableStatusClass(draggable)" aria-hidden="true">
@@ -283,6 +270,7 @@ export class InteractiveVideoDragDropComponent {
   private readonly contentIdentity = inject(ContentIdentityService);
 
   readonly interaction = input.required<InteractiveVideoInteraction>();
+  readonly density = input<'comfortable' | 'compact'>('comfortable');
   readonly continueRequested = output<void>();
 
   private readonly answerState = signal<DragDropAnswerState>({ interactionId: '', placements: {} });
@@ -297,6 +285,16 @@ export class InteractiveVideoDragDropComponent {
   readonly dragDrop = computed(() => this.interaction().dragDrop ?? null);
   readonly dropZones = computed(() => this.dragDrop()?.dropZones ?? []);
   readonly draggables = computed(() => this.dragDrop()?.draggables ?? []);
+  readonly visibleInstruction = computed(() => {
+    const instruction = this.dragDrop()?.instruction?.trim() ?? '';
+    if (!instruction) {
+      return '';
+    }
+
+    return this.isAnswerRoleLeakingInstruction(instruction)
+      ? 'Chọn các vật dụng phù hợp rồi kéo vào vùng trên hình.'
+      : instruction;
+  });
   readonly placements = computed(() => {
     const state = this.answerState();
     return state.interactionId === this.interaction().id ? state.placements : {};
@@ -457,13 +455,21 @@ export class InteractiveVideoDragDropComponent {
     return this.contentIdentity.resolveUrl(idOrUrl);
   }
 
-  placedDraggablesForZone(zoneId: string): InteractiveVideoDragDropDraggable[] {
-    return this.draggables().filter(draggable => this.placements()[draggable.id] === zoneId);
+  private isAnswerRoleLeakingInstruction(instruction: string): boolean {
+    const normalized = instruction
+      .toLocaleLowerCase('vi-VN')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/đ/g, 'd');
+
+    return normalized.includes('dap an dung')
+      || normalized.includes('dap an sai')
+      || normalized.includes('vung dung')
+      || normalized.includes('vung dap an dung');
   }
 
-  placementLabel(draggable: InteractiveVideoDragDropDraggable): string | null {
-    const zoneId = this.placements()[draggable.id];
-    return zoneId ? this.dropZones().find(zone => zone.id === zoneId)?.label ?? null : null;
+  placedDraggablesForZone(zoneId: string): InteractiveVideoDragDropDraggable[] {
+    return this.draggables().filter(draggable => this.placements()[draggable.id] === zoneId);
   }
 
   solutionLabelsForZone(zoneId: string): string {
@@ -472,10 +478,6 @@ export class InteractiveVideoDragDropComponent {
       .map(draggable => draggable.label)
       .filter(Boolean);
     return labels.join(', ');
-  }
-
-  shouldStayOutside(draggable: InteractiveVideoDragDropDraggable): boolean {
-    return this.getCorrectZoneIds(draggable).length === 0;
   }
 
   draggableState(draggable: InteractiveVideoDragDropDraggable): 'idle' | 'placed' | 'selected' | 'correct' | 'wrong' {
@@ -533,8 +535,41 @@ export class InteractiveVideoDragDropComponent {
       : `${base} bg-slate-950/75 text-white`;
   }
 
+  layoutClass(): string {
+    return this.density() === 'compact'
+      ? 'grid gap-4 lg:grid-cols-[minmax(0,1.05fr)_minmax(22rem,0.95fr)] lg:items-center'
+      : 'grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(22rem,0.72fr)] xl:items-start';
+  }
+
+  stageClass(): string {
+    const base = 'drag-drop-stage relative mx-auto aspect-video w-full overflow-hidden rounded-2xl border border-slate-200 bg-slate-950 shadow-inner';
+    return this.density() === 'compact'
+      ? `${base} max-w-[36rem]`
+      : `${base} max-w-[46rem]`;
+  }
+
+  draggableGridClass(): string {
+    return this.density() === 'compact'
+      ? 'mt-3 grid gap-2 grid-cols-[repeat(auto-fit,minmax(13.5rem,1fr))]'
+      : 'mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2';
+  }
+
+  draggableMediaClass(): string {
+    return this.density() === 'compact'
+      ? 'flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm'
+      : 'flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm';
+  }
+
+  draggableImageClass(): string {
+    return this.density() === 'compact'
+      ? 'max-h-[5.25rem] max-w-full object-contain'
+      : 'max-h-12 max-w-full object-contain';
+  }
+
   draggableCardClass(draggable: InteractiveVideoDragDropDraggable): string {
-    const base = 'drag-drop-item flex w-full cursor-grab items-center gap-3 rounded-2xl border px-3 py-2.5 text-left disabled:cursor-not-allowed';
+    const base = this.density() === 'compact'
+      ? 'drag-drop-item flex min-h-[6.5rem] w-full min-w-0 cursor-grab items-center gap-3 rounded-2xl border px-3 py-2.5 text-left disabled:cursor-not-allowed'
+      : 'drag-drop-item flex w-full min-w-0 cursor-grab items-center gap-2 rounded-xl border px-2.5 py-2 text-left disabled:cursor-not-allowed';
     switch (this.draggableState(draggable)) {
       case 'selected':
         return `${base} border-[#0056D2] bg-white text-[#0056D2] shadow-sm ring-2 ring-[#0056D2]/15`;

--- a/fe/src/app/shared/blocks/video-block/interactive-video-markers.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-markers.component.ts
@@ -12,12 +12,12 @@ interface InteractiveVideoMarker {
   imports: [],
   template: `
     @if (visibleMarkers().length > 0) {
-      <div class="pointer-events-none absolute inset-x-3 bottom-10 z-10">
+      <div class="pointer-events-none border-t border-white/10 bg-slate-950/95 px-3 py-2 text-white">
         @if (upcomingInteraction(); as next) {
-          <div class="mb-2 flex justify-end">
+          <div class="mb-1.5 flex justify-end">
             <button
               type="button"
-              class="pointer-events-auto inline-flex max-w-md items-center gap-2 rounded-full bg-slate-950/85 px-3 py-1.5 text-[11px] font-semibold text-white shadow-lg backdrop-blur transition-colors hover:bg-slate-950 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-200"
+              class="pointer-events-auto inline-flex max-w-md items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white shadow-sm transition-colors hover:bg-white/15 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-200"
               [attr.aria-label]="'Tới tương tác tại ' + formatTime(next.atSeconds)"
               (click)="markerSelected.emit(next.atSeconds)">
               <span class="h-2 w-2 shrink-0 rounded-full bg-sky-300"></span>
@@ -28,12 +28,12 @@ interface InteractiveVideoMarker {
           </div>
         }
 
-        <div class="pointer-events-auto relative h-3 rounded-full bg-slate-950/35 px-1 shadow-sm backdrop-blur">
+        <div class="pointer-events-auto relative h-4 rounded-full bg-white/10 px-1 shadow-inner">
           <div class="absolute left-1 right-1 top-1/2 h-1 -translate-y-1/2 rounded-full bg-white/25"></div>
           @for (marker of visibleMarkers(); track marker.interaction.id) {
             <button
               type="button"
-              class="absolute top-1/2 flex h-3 w-3 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-2 border-white bg-[#0056D2] shadow transition-transform hover:scale-125 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-200"
+              class="absolute top-1/2 flex h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-2 border-white bg-[#0056D2] shadow transition-transform hover:scale-125 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-200"
               [class.ring-2]="activeInteractionId() === marker.interaction.id"
               [class.ring-sky-200]="activeInteractionId() === marker.interaction.id"
               [style.left.%]="marker.percent"

--- a/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
@@ -67,6 +67,7 @@ type ChoiceAnswerState = 'idle' | 'selected' | 'selected-correct' | 'selected-wr
         @if (isDragDropInteraction()) {
           <app-interactive-video-drag-drop
             [interaction]="interaction()"
+            [density]="density()"
             (continueRequested)="continueRequested.emit()" />
         } @else if (isFillBlankInteraction()) {
           <app-interactive-video-fill-blank
@@ -291,7 +292,7 @@ export class InteractiveVideoOverlayComponent implements OnDestroy {
     const base = 'w-full rounded-lg border border-white/10 bg-white text-slate-900 shadow-2xl';
     if (this.density() === 'compact') {
       return this.isDragDropInteraction()
-        ? `${base} max-h-full max-w-3xl overflow-y-auto p-3 sm:p-4`
+        ? `${base} max-h-full max-w-[72rem] overflow-y-auto p-3 sm:p-4`
         : this.isFillBlankInteraction()
         ? `${base} max-h-full max-w-xl overflow-y-auto p-3 sm:p-4`
         : `${base} max-h-full max-w-lg overflow-y-auto p-3 sm:p-4`;

--- a/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
+++ b/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
@@ -44,10 +44,12 @@ type ResolvedSource =
 @Component({
   selector: 'app-quiz-video-player',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'block w-full' },
   imports: [InteractiveVideoLayerComponent, InteractiveVideoOverlayComponent, InteractiveVideoMarkersComponent],
   template: `
-    <div class="relative aspect-video w-full overflow-hidden rounded-lg bg-black"
-         (click)="showQualityMenu() && showQualityMenu.set(false)">
+    <div class="overflow-hidden rounded-lg bg-black">
+      <div class="relative aspect-video w-full bg-black"
+           (click)="showQualityMenu() && showQualityMenu.set(false)">
       <video
         #videoElement
         controls
@@ -63,36 +65,9 @@ type ResolvedSource =
         (timeupdate)="onTimeUpdate()"
         (seeking)="onSeeking()"
         (seeked)="onSeeked()"
-        (play)="isPlaybackPaused.set(false)"
-        (pause)="isPlaybackPaused.set(true)"
-        (ended)="isPlaybackPaused.set(true)"
         (error)="onVideoError()">
         Trình duyệt không hỗ trợ phát video.
       </video>
-
-      @if (canShowPlaybackToggle()) {
-        <div class="pointer-events-none absolute bottom-14 left-4 z-20 flex items-center gap-2 rounded-full bg-slate-950/70 px-2 py-1 text-white shadow-lg ring-1 ring-white/10 backdrop-blur-sm">
-          <button
-            type="button"
-            class="pointer-events-auto flex h-6 w-6 items-center justify-center rounded-full bg-white/12 text-white transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-200"
-            data-testid="quiz-video-playback-toggle"
-            [attr.aria-label]="isPlaybackPaused() ? 'Phát video' : 'Tạm dừng video'"
-            (click)="togglePlayback($event)">
-            @if (isPlaybackPaused()) {
-              <svg class="ml-0.5 h-3 w-3" viewBox="0 0 12 12" aria-hidden="true">
-                <path d="M3 2.2v7.6L9 6 3 2.2Z" fill="currentColor" />
-              </svg>
-            } @else {
-              <svg class="h-3 w-3" viewBox="0 0 12 12" aria-hidden="true">
-                <path d="M3 2h2v8H3V2Zm4 0h2v8H7V2Z" fill="currentColor" />
-              </svg>
-            }
-          </button>
-          <span class="font-mono text-xs font-semibold tabular-nums text-white/95">
-            {{ formatPlaybackTime(currentTimeSeconds()) }} / {{ formatPlaybackTime(videoDurationSeconds()) }}
-          </span>
-        </div>
-      }
 
       @if (isLoading()) {
         <div class="absolute inset-0 flex items-center justify-center bg-slate-950/70 text-white">
@@ -166,13 +141,6 @@ type ResolvedSource =
         [activeInteractionId]="activeInteraction()?.id ?? null"
         (interactionSelected)="openInteractiveInteraction($event)" />
 
-      <app-interactive-video-markers
-        [timeline]="interactiveVideoSpec()?.enabled === false ? [] : (interactiveVideoSpec()?.timeline ?? [])"
-        [durationSeconds]="videoDurationSeconds()"
-        [currentTimeSeconds]="currentTimeSeconds()"
-        [activeInteractionId]="activeInteraction()?.id ?? null"
-        (markerSelected)="seekToInteractiveSecond($event)" />
-
       @if (activeInteraction(); as interaction) {
         <app-interactive-video-overlay
           [interaction]="interaction"
@@ -182,6 +150,14 @@ type ResolvedSource =
           (reviewRequested)="onInteractiveReviewRequested()"
           (continueRequested)="onInteractiveContinue()" />
       }
+      </div>
+
+      <app-interactive-video-markers
+        [timeline]="interactiveVideoSpec()?.enabled === false ? [] : (interactiveVideoSpec()?.timeline ?? [])"
+        [durationSeconds]="videoDurationSeconds()"
+        [currentTimeSeconds]="currentTimeSeconds()"
+        [activeInteractionId]="activeInteraction()?.id ?? null"
+        (markerSelected)="seekToInteractiveSecond($event)" />
     </div>
   `
 })
@@ -207,7 +183,6 @@ export class QuizVideoPlayerComponent {
   readonly videoDurationSeconds = signal<number | null>(null);
   readonly currentTimeSeconds = signal(0);
   readonly completedInteractionIdsSnapshot = signal<ReadonlySet<string>>(new Set<string>());
-  readonly isPlaybackPaused = signal(true);
 
   private shakaPlayer: any = null;
   private loadToken = 0;
@@ -256,7 +231,6 @@ export class QuizVideoPlayerComponent {
 
     this.videoDurationSeconds.set(Number.isFinite(video.duration) && video.duration > 0 ? video.duration : null);
     this.currentTimeSeconds.set(Number.isFinite(video.currentTime) ? video.currentTime : 0);
-    this.isPlaybackPaused.set(video.paused);
     this.markInteractiveVideoWatched(video.currentTime);
   }
 
@@ -387,7 +361,6 @@ export class QuizVideoPlayerComponent {
     this.error.set(null);
     this.isProcessing.set(false);
     this.isLoading.set(true);
-    this.isPlaybackPaused.set(true);
     this.qualityLabel.set(null);
     this.videoDurationSeconds.set(null);
     this.currentTimeSeconds.set(0);
@@ -581,47 +554,6 @@ export class QuizVideoPlayerComponent {
       this.shakaPlayer?.configure?.('abr.enabled', true);
       this.isAutoQuality.set(true);
     }
-  }
-
-  canShowPlaybackToggle(): boolean {
-    return !this.isLoading()
-      && !this.isProcessing()
-      && !this.error()
-      && !this.activeInteraction();
-  }
-
-  togglePlayback(event: Event): void {
-    event.preventDefault();
-    event.stopPropagation();
-
-    const video = this.videoElement()?.nativeElement;
-    if (!video) {
-      return;
-    }
-
-    if (video.paused) {
-      void video.play().catch(() => {
-        this.isPlaybackPaused.set(true);
-      });
-      return;
-    }
-
-    video.pause();
-  }
-
-  formatPlaybackTime(seconds: number | null | undefined): string {
-    const safeSeconds = Number.isFinite(seconds ?? Number.NaN)
-      ? Math.max(0, Math.floor(seconds as number))
-      : 0;
-    const hours = Math.floor(safeSeconds / 3600);
-    const minutes = Math.floor((safeSeconds % 3600) / 60);
-    const rest = safeSeconds % 60;
-
-    if (hours > 0) {
-      return `${hours}:${minutes.toString().padStart(2, '0')}:${rest.toString().padStart(2, '0')}`;
-    }
-
-    return `${minutes}:${rest.toString().padStart(2, '0')}`;
   }
 
   private evaluateInteractiveTimeline(


### PR DESCRIPTION
## Summary

This is a clean follow-up PR for the interactive video drag/drop UX work, rebuilt from the latest `origin/main` to address the stale/dirty branch blocker called out on #383.

- Keeps the PR scope limited to the interactive video UX files only.
- Preserves the new sidebar/spec/a11y files already merged into `main`; no `.claude`, `.specify`, sidebar, focus-trap, tooltip, or skip-link files are deleted by this branch.
- Polishes the drag/drop teacher preview and student-facing overlay layout so the background image and draggable answer cards are easier to use across desktop/mobile.
- Hides answer-role wording from student/preview runtime while keeping teacher authoring controls intact.
- Keeps browser-native video controls and simplifies marker/control presentation.

## Review Context

Supersedes #383. The previous PR was stale relative to `main` and showed deletion noise from recently merged sidebar/spec work. This branch was recreated from `origin/main` and cherry-picked only the UX polish commit.

## Validation

- `git diff --name-status origin/main..HEAD` shows only 8 interactive-video files changed.
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include src/app/shared/blocks/video-block/interactive-video-drag-drop.component.spec.ts`
- `npx ng build`

Build succeeds. Existing Angular/Sass/CommonJS warnings remain unrelated to this PR.