### PR TITLE
[codex] refine video network hint accuracy

### DIFF
--- a/fe/src/app/core/services/network-status.service.spec.ts
+++ b/fe/src/app/core/services/network-status.service.spec.ts
@@ -25,6 +25,10 @@ describe('NetworkStatusService', () => {
     it('should have effectiveBandwidthMbps as a number', () => {
       expect(typeof service.effectiveBandwidthMbps()).toBe('number');
     });
+
+    it('should expose reportedDownlinkMbps as nullable browser telemetry', () => {
+      expect(service.reportedDownlinkMbps() === null || typeof service.reportedDownlinkMbps() === 'number').toBeTrue();
+    });
   });
 
   describe('connectionTier computed', () => {

--- a/fe/src/app/core/services/network-status.service.ts
+++ b/fe/src/app/core/services/network-status.service.ts
@@ -14,6 +14,7 @@ const TRANSPORT_FAILURE_PROBE_DELAY_MS = 250;
 export class NetworkStatusService implements OnDestroy {
   readonly online = signal(this.getBrowserOnlineHint());
   readonly effectiveBandwidthMbps = signal(2);
+  readonly reportedDownlinkMbps = signal<number | null>(null);
   readonly connectionTransport = signal<ConnectionTransport>('unknown');
   readonly saveDataEnabled = signal(false);
   readonly effectiveNetworkType = signal<string | null>(null);
@@ -189,6 +190,7 @@ export class NetworkStatusService implements OnDestroy {
     this.connectionTransport.set(this.normalizeConnectionTransport(conn?.type));
     this.saveDataEnabled.set(conn?.saveData === true);
     this.effectiveNetworkType.set(typeof conn?.effectiveType === 'string' ? conn.effectiveType : null);
+    this.reportedDownlinkMbps.set(this.readReportedDownlinkMbps(conn));
 
     if (!browserOnline) {
       this.markOfflineState();
@@ -240,8 +242,9 @@ export class NetworkStatusService implements OnDestroy {
   }
 
   private estimateBandwidthMbps(conn: any): number {
-    if (typeof conn?.downlink === 'number' && Number.isFinite(conn.downlink) && conn.downlink > 0) {
-      return Math.max(conn.downlink, 0.05);
+    const reportedDownlinkMbps = this.readReportedDownlinkMbps(conn);
+    if (reportedDownlinkMbps != null) {
+      return reportedDownlinkMbps;
     }
 
     switch (conn?.effectiveType) {
@@ -258,6 +261,14 @@ export class NetworkStatusService implements OnDestroy {
 
   private getBrowserOnlineHint(): boolean {
     return typeof navigator !== 'undefined' ? navigator.onLine : true;
+  }
+
+  private readReportedDownlinkMbps(conn: any): number | null {
+    if (typeof conn?.downlink === 'number' && Number.isFinite(conn.downlink) && conn.downlink > 0) {
+      return Math.max(conn.downlink, 0.05);
+    }
+
+    return null;
   }
 
   private ensureSuccessfulProbeResponse(response: Response): void {
@@ -282,6 +293,7 @@ export class NetworkStatusService implements OnDestroy {
   private markOfflineState(): void {
     this.online.set(false);
     this.effectiveBandwidthMbps.set(0);
+    this.reportedDownlinkMbps.set(null);
     this.recentOfflineSignalAt.set(Date.now());
   }
 }

--- a/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.spec.ts
+++ b/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.spec.ts
@@ -1,0 +1,59 @@
+import { shouldShowMediaNetworkHint, type MediaNetworkHintState } from './adaptive-video-player.component';
+
+describe('shouldShowMediaNetworkHint', () => {
+  const baseState: MediaNetworkHintState = {
+    online: true,
+    saveDataEnabled: false,
+    effectiveNetworkType: '4g',
+    reportedDownlinkMbps: 12,
+    appBandwidthMbps: 10,
+    rebufferCount: 0,
+    totalBufferTimeMs: 0,
+  };
+
+  function withState(overrides: Partial<MediaNetworkHintState>): MediaNetworkHintState {
+    return { ...baseState, ...overrides };
+  }
+
+  it('does not show a weak-network hint from a browser 3g label alone', () => {
+    expect(shouldShowMediaNetworkHint(withState({
+      effectiveNetworkType: '3g',
+      reportedDownlinkMbps: 8,
+      appBandwidthMbps: 10,
+    }))).toBeFalse();
+  });
+
+  it('shows the hint for explicit Save-Data mode', () => {
+    expect(shouldShowMediaNetworkHint(withState({ saveDataEnabled: true }))).toBeTrue();
+  });
+
+  it('shows the hint for severe browser network classes', () => {
+    expect(shouldShowMediaNetworkHint(withState({ effectiveNetworkType: '2g' }))).toBeTrue();
+    expect(shouldShowMediaNetworkHint(withState({ effectiveNetworkType: 'slow-2g' }))).toBeTrue();
+  });
+
+  it('shows the hint when 3g has a low reported downlink', () => {
+    expect(shouldShowMediaNetworkHint(withState({
+      effectiveNetworkType: '3g',
+      reportedDownlinkMbps: 0.8,
+    }))).toBeTrue();
+  });
+
+  it('shows the hint after repeated noticeable buffering on a low app-bandwidth path', () => {
+    expect(shouldShowMediaNetworkHint(withState({
+      effectiveNetworkType: '4g',
+      reportedDownlinkMbps: null,
+      appBandwidthMbps: 0.9,
+      rebufferCount: 2,
+      totalBufferTimeMs: 2_000,
+    }))).toBeTrue();
+  });
+
+  it('does not show the hint while offline because the offline banner owns that state', () => {
+    expect(shouldShowMediaNetworkHint(withState({
+      online: false,
+      effectiveNetworkType: '2g',
+      saveDataEnabled: true,
+    }))).toBeFalse();
+  });
+});

--- a/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
+++ b/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
@@ -21,6 +21,7 @@ import { SectionApi } from '../../../../api/client/section.api';
 import { LearningActivityApi } from '../../../../api/client/learning-activity.api';
 import { QoETrackerService } from '../../../../core/services/qoe-tracker.service';
 import { OfflineSyncService } from '../../../../core/services/offline-sync.service';
+import { NetworkStatusService } from '../../../../core/services/network-status.service';
 import { HeartbeatTracker } from '../../services/heartbeat-tracker.service';
 import { WatchedSegmentsTracker } from '../../services/watched-segments-tracker.service';
 import { InteractiveVideoLayerComponent } from '../../../../shared/blocks/video-block/interactive-video-layer.component';
@@ -48,6 +49,47 @@ import type {
 type ResolvedVideoSource =
   | { kind: 'native'; url: string }
   | { kind: 'adaptive'; url: string };
+
+export interface MediaNetworkHintState {
+  online: boolean;
+  saveDataEnabled: boolean;
+  effectiveNetworkType: string | null;
+  reportedDownlinkMbps: number | null;
+  appBandwidthMbps: number;
+  rebufferCount: number;
+  totalBufferTimeMs: number;
+}
+
+const NOTICEABLE_REBUFFER_COUNT = 2;
+const NOTICEABLE_BUFFER_MS = 1_500;
+const LOW_REPORTED_DOWNLINK_MBPS = 1.2;
+const LOW_APP_BANDWIDTH_MBPS = 1.5;
+
+export function shouldShowMediaNetworkHint(state: MediaNetworkHintState): boolean {
+  if (!state.online) {
+    return false;
+  }
+
+  if (state.saveDataEnabled) {
+    return true;
+  }
+
+  const effectiveType = state.effectiveNetworkType?.toLowerCase();
+  if (effectiveType === 'slow-2g' || effectiveType === '2g') {
+    return true;
+  }
+
+  const hasPlaybackPain =
+    state.rebufferCount >= NOTICEABLE_REBUFFER_COUNT
+    && state.totalBufferTimeMs >= NOTICEABLE_BUFFER_MS;
+
+  if (effectiveType === '3g') {
+    return hasPlaybackPain
+      || (state.reportedDownlinkMbps != null && state.reportedDownlinkMbps < LOW_REPORTED_DOWNLINK_MBPS);
+  }
+
+  return hasPlaybackPain && state.appBandwidthMbps < LOW_APP_BANDWIDTH_MBPS;
+}
 
 @Component({
   selector: 'app-adaptive-video-player',
@@ -151,8 +193,14 @@ type ResolvedVideoSource =
         (markerSelected)="seekToInteractiveSecond($event)" />
 
       @if (showNetworkHint()) {
-        <div class="absolute bottom-3 left-3 rounded-full bg-amber-500/90 px-3 py-1 text-[11px] font-semibold text-slate-950">
-          Mạng yếu, hệ thống đang ưu tiên phát ổn định
+        <div
+          class="pointer-events-none absolute left-3 z-10 rounded-full bg-amber-400/95 px-3 py-1 text-[11px] font-semibold text-slate-950 shadow-lg shadow-black/20"
+          [class.top-14]="qualityLabel()"
+          [class.top-3]="!qualityLabel()"
+          role="status"
+          aria-live="polite"
+          data-testid="adaptive-video-network-hint">
+          Đang ưu tiên phát ổn định
         </div>
       }
       @if (activeInteraction(); as interaction) {
@@ -175,6 +223,7 @@ export class AdaptiveVideoPlayerComponent {
   private readonly videoProgressApi = inject(VideoProgressApi);
   private readonly learningActivityApi = inject(LearningActivityApi);
   private readonly injector = inject(Injector);
+  private readonly network = inject(NetworkStatusService);
 
   readonly lessonId = input.required<string>();
   readonly sectionId = input<string | null>(null);
@@ -206,11 +255,15 @@ export class AdaptiveVideoPlayerComponent {
   readonly currentTimeSeconds = signal(0);
   readonly showNetworkHint = computed(() => {
     const metrics = this.qoe.metrics();
-    const rebufferCount = metrics?.rebufferCount ?? 0;
-    const effectiveType = typeof navigator !== 'undefined'
-      ? ((navigator as any)?.connection?.effectiveType as string | undefined)
-      : undefined;
-    return rebufferCount > 1 || effectiveType === 'slow-2g' || effectiveType === '2g' || effectiveType === '3g';
+    return shouldShowMediaNetworkHint({
+      online: this.network.online(),
+      saveDataEnabled: this.network.saveDataEnabled(),
+      effectiveNetworkType: this.network.effectiveNetworkType(),
+      reportedDownlinkMbps: this.network.reportedDownlinkMbps(),
+      appBandwidthMbps: this.network.effectiveBandwidthMbps(),
+      rebufferCount: metrics?.rebufferCount ?? 0,
+      totalBufferTimeMs: metrics?.totalBufferTimeMs ?? 0,
+    });
   });
 
   private shakaPlayer: any = null;


### PR DESCRIPTION
﻿## Summary
- Tighten adaptive-video weak-network hint logic so a browser `3g` label alone no longer shows a persistent warning.
- Track browser-reported downlink separately from app latency probes, then combine it with QoE buffering evidence for the media hint.
- Move the player hint away from the bottom control/progress area and make the copy less alarming.

## Root Cause
The player treated `navigator.connection.effectiveType === '3g'` as enough evidence to show "M?ng y?u". That browser value is only a coarse hint and can be stale or conservative, which made the badge appear even while playback was healthy and Shaka selected 1080p. The badge was also positioned at `bottom-3`, overlapping the native video controls and progress bar.

## Validation
- `npm run test:ci -- --include src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.spec.ts --include src/app/core/services/network-status.service.spec.ts`
- `npm run build`
- `npm run test:ci`
