### PR TITLE
Hồng: fix(sidebar): mobile drawer footer visible + de-dup learning bottom nav

### DIFF
--- a/fe/src/app/features/learning/pages/course-learning.component.html
+++ b/fe/src/app/features/learning/pages/course-learning.component.html
@@ -378,12 +378,18 @@
           <span>{{ completeButtonLabel() }}</span>
         </button>
 
-        <button class="flex items-center gap-1 px-3 py-2 rounded text-slate-500 hover:text-[#0056D2] hover:bg-slate-50 transition-colors disabled:opacity-40 disabled:pointer-events-none"
-          [disabled]="isLearningItemTransitioning() || (!canGoNext() && (!currentLesson()?.sections || currentSectionIndex() >= (currentLesson()?.sections?.length || 0) - 1))"
-          (click)="nextLesson()">
-          <span class="hidden sm:inline text-sm font-medium">Bài tiếp theo</span>
-          <app-icon name="arrow-right" size="md"></app-icon>
-        </button>
+        @if (showSkipToNextLessonButton()) {
+          <button class="flex items-center gap-1 px-3 py-2 rounded text-slate-500 hover:text-[#0056D2] hover:bg-slate-50 transition-colors disabled:opacity-40 disabled:pointer-events-none"
+            [disabled]="isLearningItemTransitioning()"
+            (click)="nextLesson()"
+            aria-label="Bỏ qua bài hiện tại, đi tới bài tiếp theo">
+            <span class="hidden sm:inline text-sm font-medium">Bài tiếp theo</span>
+            <app-icon name="arrow-right" size="md"></app-icon>
+          </button>
+        } @else {
+          <!-- Spacer keeps the centre CTA visually centred when right link hides. -->
+          <span class="px-3 py-2" aria-hidden="true"></span>
+        }
       </div>
     </div>
     }

--- a/fe/src/app/features/learning/pages/course-learning.component.ts
+++ b/fe/src/app/features/learning/pages/course-learning.component.ts
@@ -427,6 +427,20 @@ export class CourseLearningComponent implements OnInit {
     return this.canGoNext() ? 'Bài tiếp theo' : 'Đã hoàn thành';
   });
 
+  /** Hide the right "Bài tiếp theo →" link when the centre CTA already
+   *  points to the same action (label === 'Bài tiếp theo' or final state
+   *  'Đã hoàn thành'). Avoids two next-related buttons confusing the user.
+   *  When centre is 'Phần tiếp theo' / 'Hoàn thành phần này' / 'Hoàn thành
+   *  bài' the right link still surfaces a distinct skip-to-next-lesson
+   *  action so we keep it visible.
+   *  Pattern aligns with Coursera / edX single-primary-CTA but preserves
+   *  the existing skip-lesson escape hatch when it's actually distinct. */
+  readonly showSkipToNextLessonButton = computed(() => {
+    const label = this.completeButtonLabel();
+    if (label === 'Bài tiếp theo' || label === 'Đã hoàn thành') return false;
+    return this.canGoNext();
+  });
+
   readonly completeButtonDisabled = computed(() => {
     if (this.isCompletingCurrentItem() || this.isLearningItemTransitioning()) {
       return true;

--- a/fe/src/app/shared/components/navigation/sidebar.component.css
+++ b/fe/src/app/shared/components/navigation/sidebar.component.css
@@ -1,13 +1,37 @@
 /* Component-specific styles - avoiding Tailwind @apply conflicts */
+
+/* Host element MUST be a flex column with explicit height so the inner
+   nav-scroll + sticky footer layout works inside both the desktop wrapper
+   (lg:fixed lg:inset-y-0) and the mobile drawer panel (top:0; bottom:0).
+   `flex: 1; min-height: 0` covers flex-column parents (desktop wrapper);
+   `height: 100%` covers fixed-positioned parents (mobile drawer panel).
+   Both safely coexist — flex:1 is ignored if parent isn't flex. */
+app-sidebar {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  height: 100%;
+  min-height: 0;
+}
+
 .sidebar-container {
   background: white;
   box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-  height: 100vh;
+  /* Was `height: 100vh` — but on mobile 100vh INCLUDES the URL bar height,
+     so the footer (user account card) was pushed below the visible drawer.
+     Using 100% defers sizing to the parent which already constrains height. */
+  height: 100%;
   display: flex;
   flex-direction: column;
   border-right: 1px solid rgba(229, 231, 235, 0.5);
   transition: width 0.3s ease;
   overflow: hidden;
+}
+
+/* Sidebar footer must never be squeezed out of the flex column when the
+   nav has many items — `flex-shrink: 0` reserves its intrinsic height. */
+.sidebar-footer {
+  flex-shrink: 0;
 }
 
 .sidebar-header {


### PR DESCRIPTION
## Summary

Two reported UX bugs in production (https://holilihu.online/student/learn/...):

### Bug 1 — Mobile sidebar drawer footer hidden
The avatar + user account card at the bottom of the mobile drawer was hidden below the fold. The user had to scroll the nav up to reveal it.

**Root cause**: `.sidebar-container { height: 100vh }` includes the mobile URL-bar height. On a 375 × 667 iPhone the URL bar takes ~56 px, so the container was ~56 px taller than the visible drawer panel — the bottom 56 px (containing the user-account card) was pushed off-screen.

**Fix** (`sidebar.component.css`):
- `app-sidebar` host element now has explicit dimensions (`flex: 1; height: 100%; min-height: 0`) so the inner container can size to its bounded parent — works for both desktop (`lg:flex lg:flex-col` parent) and mobile drawer (`top: 0; bottom: 0` fixed parent).
- `.sidebar-container { height: 100% }` (was `100vh`) — defers sizing to parent which already constrains height. No more URL-bar overflow.
- `.sidebar-footer { flex-shrink: 0 }` — explicit guarantee, defence in depth against future flex churn.

### Bug 2 — Learning page bottom nav redundancy
3 buttons: `← Bài trước` | `Phần tiếp theo` (green CTA) | `Bài tiếp theo →`. The centre CTA cycles through 5 labels including `Bài tiếp theo`. When the centre says `Bài tiếp theo`, the right link said the same thing — visually inconsistent for the same action.

**Fix** (`course-learning.component.{ts,html}`):
- New computed `showSkipToNextLessonButton` hides the right link when centre label is `Bài tiếp theo` or `Đã hoàn thành` (redundant), keeps it visible when centre is `Phần tiếp theo` / `Hoàn thành phần này` / `Hoàn thành bài` (distinct skip-to-next-lesson).
- Transparent `<span>` spacer keeps the centre CTA visually centred when right link hides.
- Right link gets `aria-label="Bỏ qua bài hiện tại, đi tới bài tiếp theo"` so screen readers understand it's a skip action.

Pattern alignment: Coursera / edX / Khan Academy use a single primary "Next" CTA. This PR keeps the 3-button layout where it provides distinct value and de-dups where it doesn't.

## Test plan

- [ ] **Mobile sidebar (Bug 1)**: open `/student/...` on a 375 px viewport with URL bar visible → tap hamburger → user account card (avatar + email) IS visible at the bottom of the drawer without scrolling.
- [ ] Repeat on 412 × 915 (Pixel) and 320 × 568 (iPhone SE) — footer still visible.
- [ ] Desktop (≥1024 px) sidebar still renders correctly with `lg:fixed lg:inset-y-0` parent — no regression on layout.
- [ ] Sidebar collapsed mode on desktop still shows icon-rail + footer.
- [ ] **Learning bottom nav (Bug 2)** at `/student/learn/.../lesson/...`:
  - When current section incomplete → centre = `Hoàn thành phần này`/`Hoàn thành bài`, right `Bài tiếp theo →` IS visible (distinct skip).
  - When current section complete and not last → centre = `Phần tiếp theo`, right `Bài tiếp theo →` IS visible (distinct).
  - When all sections + lesson complete and there's a next lesson → centre = `Bài tiếp theo`, right link **HIDDEN** (would have been redundant).
  - When at last lesson of course → centre = `Đã hoàn thành`, right link HIDDEN.
  - Right link aria-label reads "Bỏ qua bài hiện tại, đi tới bài tiếp theo".
- [ ] `cd fe && npm run build` → green (verified locally)
- [ ] `cd fe && npm run test:ci -- --include='**/sidebar*.spec.ts' --include='**/focus-trap*.spec.ts'` → 28 SUCCESS (verified locally — no regression on existing sidebar suite incl. 8 axe-core a11y cases)

## References

- Production URL where bugs were reported: https://holilihu.online/student/learn/course/965ab0b8-0286-4517-a268-11169a5d45a0/lesson/bd56d600-d2da-43b8-b0f4-1e9846fcda3e
- Spec context: feature `001-sidebar-redesign` (post-merge polish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)