### PR TITLE
Hùng: fix(learning): bottom nav stable on mobile via 100dvh viewport

### DIFF
--- a/fe/src/app/features/learning/pages/course-learning.component.scss
+++ b/fe/src/app/features/learning/pages/course-learning.component.scss
@@ -165,6 +165,20 @@
 }
 
 @media (max-width: 767px) {
+  /* Mobile fix: Tailwind `h-screen` resolves to `100vh` which on mobile
+     INCLUDES the browser URL-bar height. The learning-bottom-nav is
+     absolutely positioned at `bottom: 0` of <main>, so when the URL bar
+     is visible (initial page load, scroll-up) the layout was taller than
+     the visible viewport and the bottom nav got pushed below the fold —
+     reappearing only when the URL bar auto-hid during scroll-down.
+     Switching to `100dvh` (dynamic viewport height) keeps the layout
+     bounded to the actual visible viewport in real time. iOS 15.4+ /
+     Chrome 108+ / Firefox 105+ — covered by the project's browser
+     baseline (CLAUDE.md: latest two stable + iOS 15+). */
+  .course-learning-layout.h-screen {
+    height: 100dvh;
+  }
+
   .learning-sidebar {
     width: 88vw;
   }


### PR DESCRIPTION
## Summary

Follow-up fix for the same family of bug PR #389 closed for the sidebar drawer. On production `/student/learn/.../lesson/...` the **lesson bottom navigation** ("Bài trước · centre CTA · Bài tiếp theo") was reported as **"bị ẩn xuống và đôi khi trồi lên"** — sometimes hidden, sometimes appears when scrolling. Made the bar feel broken on mobile.

## Root cause

Same root cause family as PR #389:

- `.course-learning-layout.h-screen` uses Tailwind `h-screen` → `100vh`.
- On mobile browsers, **`100vh` includes the URL-bar height** (~56 px on iPhone). The layout was therefore ~56 px taller than the visible viewport when the URL bar was showing.
- `.learning-bottom-nav` is `position: absolute; bottom: 0` inside the layout's `<main>`, so it was anchored to the bottom of the over-tall layout — i.e. below the visible fold.
- When the user scrolls **down**, mobile browsers auto-hide the URL bar, the visible viewport grows, and the bottom nav comes back into view. Scroll back up → URL bar reappears → bottom nav goes off-screen again. That's the "đôi khi trồi lên" behaviour the user reported.

## Fix

`course-learning.component.scss`:

```scss
@media (max-width: 767px) {
  .course-learning-layout.h-screen {
    height: 100dvh;
  }
}
```

- **`100dvh`** (Dynamic Viewport Height) resizes in real time when the URL bar shows/hides. Layout stays bounded to the **actual visible viewport** → bottom nav stays at the actual viewport bottom and never overflows.
- Browser support: iOS Safari 15.4+ / Chrome 108+ / Edge 108+ / Firefox 105+ — fully covered by the project's CLAUDE.md baseline ("latest two stable versions + Safari iOS 15+").
- Desktop (≥768 px) keeps `100vh` semantics — desktop has no URL-bar collapse so static height is correct.

## Test plan

- [ ] Open `https://holilihu.online/student/learn/course/.../lesson/...` on a real iPhone / Android device (DevTools mobile emulator does NOT simulate URL-bar auto-hide so dvh behaviour can't be fully verified there).
- [ ] On page load with URL bar visible → bottom nav (Bài trước · centre CTA · Bài tiếp theo) IS at the bottom of the visible viewport, fully visible. ✅
- [ ] Scroll the lesson content down → URL bar auto-hides → bottom nav stays at viewport bottom (no jump, no flash). ✅
- [ ] Scroll back up → URL bar reappears → bottom nav stays at viewport bottom (the layout shrinks, but the nav anchor remains correct). ✅
- [ ] On desktop (≥768 px) — bottom nav unchanged from before. No visual delta.
- [ ] `cd fe && npm run build` → green (verified locally)

## References

- Related (sibling fix): PR #389 (sidebar drawer footer hidden — same `100vh` / mobile URL-bar root cause; `100dvh` was the right tool there too via `height: 100%` on bounded parent).
- Reported by: PO via prod URL `/student/learn/course/965ab0b8-.../lesson/bd56d600-...` on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)