### PR TITLE
[codex] Improve app update UX orchestration

### DIFF
--- a/fe/src/app/app.ts
+++ b/fe/src/app/app.ts
@@ -5,6 +5,7 @@ import { ToastContainerComponent } from './shared/components/toast-container/toa
 import { ConfirmDialogComponent } from './shared/components/confirm-dialog/confirm-dialog.component';
 import { OfflineIndicatorComponent } from './shared/components/offline-indicator/offline-indicator.component';
 import { SessionExpiredBannerComponent } from './shared/components/session-expired-banner/session-expired-banner.component';
+import { AppUpdateBannerComponent } from './shared/components/app-update-banner/app-update-banner.component';
 import { SessionExpiredService } from './core/services/session-expired.service';
 import { WebMcpService } from './core/services/webmcp.service';
 import { OfflineStorageTelemetryIngestService } from './core/services/offline-storage-telemetry-ingest.service';
@@ -14,10 +15,18 @@ import { MessagingService } from './core/services/messaging.service';
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-root',
-  imports: [RouterOutlet, ToastContainerComponent, ConfirmDialogComponent, OfflineIndicatorComponent, SessionExpiredBannerComponent],
+  imports: [
+    RouterOutlet,
+    ToastContainerComponent,
+    ConfirmDialogComponent,
+    OfflineIndicatorComponent,
+    SessionExpiredBannerComponent,
+    AppUpdateBannerComponent,
+  ],
   template: `
     <app-session-expired-banner />
     <app-offline-indicator />
+    <app-update-banner />
     <router-outlet></router-outlet>
     <app-toast-container />
     <app-confirm-dialog />

--- a/fe/src/app/core/services/app-update-state.service.spec.ts
+++ b/fe/src/app/core/services/app-update-state.service.spec.ts
@@ -1,0 +1,114 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+import {
+  AppUpdateStateService,
+  AppUpdateVersionInfo,
+  buildAppUpdatePromptCopy,
+  classifyAppUpdateContext,
+} from './app-update-state.service';
+
+const version: AppUpdateVersionInfo = {
+  currentHash: 'old',
+  latestHash: 'new',
+  detectedAt: 1,
+  severity: 'normal',
+  releaseNote: null,
+};
+
+describe('classifyAppUpdateContext', () => {
+  it('defers updates while learners are inside a lesson', () => {
+    const blocker = classifyAppUpdateContext('/student/learn/course/course-1/lesson/lesson-1');
+
+    expect(blocker?.kind).toBe('learning');
+    expect(blocker?.label).toBe('Đang học');
+  });
+
+  it('defers updates while a learner is taking a quiz', () => {
+    const blocker = classifyAppUpdateContext('/student/quiz/take/quiz-1');
+
+    expect(blocker?.kind).toBe('assessment');
+  });
+
+  it('defers updates while teachers are authoring content', () => {
+    const blocker = classifyAppUpdateContext('/teacher/courses/course-1/editor/curriculum');
+
+    expect(blocker?.kind).toBe('authoring');
+  });
+
+  it('defers updates during payment flows', () => {
+    const blocker = classifyAppUpdateContext('/payment/checkout');
+
+    expect(blocker?.kind).toBe('transaction');
+  });
+
+  it('uses offline as the highest priority blocker', () => {
+    const blocker = classifyAppUpdateContext('/student/quiz/take/quiz-1', { online: false });
+
+    expect(blocker?.kind).toBe('offline');
+  });
+});
+
+describe('buildAppUpdatePromptCopy', () => {
+  it('creates calm ready copy for safe routes', () => {
+    const copy = buildAppUpdatePromptCopy({
+      status: 'ready',
+      version,
+      blocker: null,
+      reason: null,
+      dismissedUntil: 0,
+    });
+
+    expect(copy?.title).toBe('Có bản cập nhật mới');
+    expect(copy?.primaryText).toBe('Cập nhật');
+    expect(copy?.secondaryText).toBe('Để sau');
+  });
+
+  it('explains the safe point when the update is deferred', () => {
+    const blocker = classifyAppUpdateContext('/teacher/courses/course-1/editor/curriculum');
+    const copy = buildAppUpdatePromptCopy({
+      status: 'deferred',
+      version,
+      blocker,
+      reason: null,
+      dismissedUntil: 0,
+    });
+
+    expect(copy?.title).toBe('Bản cập nhật đã sẵn sàng');
+    expect(copy?.message).toContain('Hãy lưu bản nháp');
+  });
+});
+
+describe('AppUpdateStateService', () => {
+  let service: AppUpdateStateService;
+
+  beforeEach(() => {
+    service = new AppUpdateStateService();
+  });
+
+  it('switches between ready and deferred as blockers change', () => {
+    service.markReady(version, null);
+
+    expect(service.state().status).toBe('ready');
+    expect(service.shouldShowPrompt()).toBeTrue();
+
+    service.updateBlocker(classifyAppUpdateContext('/student/quiz/take/quiz-1'));
+
+    expect(service.state().status).toBe('deferred');
+    expect(service.state().blocker?.kind).toBe('assessment');
+
+    service.updateBlocker(null);
+
+    expect(service.state().status).toBe('ready');
+  });
+
+  it('temporarily hides non-critical prompts when the user chooses later', fakeAsync(() => {
+    service.markReady(version, null);
+
+    service.dismissFor(1000);
+
+    expect(service.shouldShowPrompt()).toBeFalse();
+
+    tick(1300);
+
+    expect(service.shouldShowPrompt()).toBeTrue();
+  }));
+});

--- a/fe/src/app/core/services/app-update-state.service.ts
+++ b/fe/src/app/core/services/app-update-state.service.ts
@@ -1,0 +1,296 @@
+import { computed, Injectable, signal } from '@angular/core';
+
+export type AppUpdateStatus =
+  | 'idle'
+  | 'checking'
+  | 'ready'
+  | 'deferred'
+  | 'applying'
+  | 'failed'
+  | 'unrecoverable';
+
+export type AppUpdateSeverity = 'normal' | 'important' | 'critical';
+
+export type AppUpdateBlockerKind =
+  | 'learning'
+  | 'assessment'
+  | 'authoring'
+  | 'transaction'
+  | 'offline'
+  | 'background';
+
+export interface AppUpdateBlocker {
+  kind: AppUpdateBlockerKind;
+  label: string;
+  reason: string;
+  safePoint: string;
+}
+
+export interface AppUpdateVersionInfo {
+  currentHash: string | null;
+  latestHash: string | null;
+  detectedAt: number;
+  severity: AppUpdateSeverity;
+  releaseNote: string | null;
+}
+
+export interface AppUpdateState {
+  status: AppUpdateStatus;
+  version: AppUpdateVersionInfo | null;
+  blocker: AppUpdateBlocker | null;
+  reason: string | null;
+  dismissedUntil: number;
+}
+
+export interface AppUpdatePromptCopy {
+  title: string;
+  message: string;
+  primaryText: string;
+  secondaryText: string | null;
+  tone: 'info' | 'warning' | 'danger';
+  compactLabel: string;
+}
+
+export interface AppUpdateContextOptions {
+  online?: boolean;
+  visibilityState?: DocumentVisibilityState | 'visible' | 'hidden';
+}
+
+const INITIAL_STATE: AppUpdateState = {
+  status: 'idle',
+  version: null,
+  blocker: null,
+  reason: null,
+  dismissedUntil: 0,
+};
+
+const DEFAULT_DISMISS_MS = 30 * 60 * 1000;
+
+export function classifyAppUpdateContext(
+  url: string,
+  options: AppUpdateContextOptions = {},
+): AppUpdateBlocker | null {
+  if (options.online === false) {
+    return {
+      kind: 'offline',
+      label: 'Ngoại tuyến',
+      reason: 'Thiết bị đang ngoại tuyến.',
+      safePoint: 'Bản mới sẽ cập nhật khi có mạng ổn định.',
+    };
+  }
+
+  if (options.visibilityState === 'hidden') {
+    return {
+      kind: 'background',
+      label: 'Đang chạy nền',
+      reason: 'Trang đang chạy nền.',
+      safePoint: 'Bản mới sẽ hiện khi bạn quay lại ứng dụng.',
+    };
+  }
+
+  const pathname = getPathname(url);
+
+  if (pathname.startsWith('/student/learn/course/') && pathname.includes('/lesson/')) {
+    return {
+      kind: 'learning',
+      label: 'Đang học',
+      reason: 'Bạn đang xem bài học.',
+      safePoint: 'Nên cập nhật khi video tạm dừng hoặc sau khi chuyển bài.',
+    };
+  }
+
+  if (pathname.startsWith('/student/quiz/take') || pathname.includes('/quiz/take/')) {
+    return {
+      kind: 'assessment',
+      label: 'Đang làm bài',
+      reason: 'Bạn đang làm bài kiểm tra.',
+      safePoint: 'Nên cập nhật sau khi nộp bài để tránh mất nhịp làm bài.',
+    };
+  }
+
+  if (
+    (pathname.startsWith('/teacher/courses/') && pathname.includes('/editor')) ||
+    pathname.startsWith('/teacher/quiz') ||
+    pathname.startsWith('/teacher/assessments') ||
+    pathname.startsWith('/teacher/assignments')
+  ) {
+    return {
+      kind: 'authoring',
+      label: 'Đang soạn',
+      reason: 'Bạn đang chỉnh sửa nội dung.',
+      safePoint: 'Hãy lưu bản nháp rồi cập nhật.',
+    };
+  }
+
+  if (pathname.startsWith('/payment')) {
+    return {
+      kind: 'transaction',
+      label: 'Thanh toán',
+      reason: 'Bạn đang ở bước thanh toán.',
+      safePoint: 'Nên hoàn tất hoặc rời khỏi bước này rồi cập nhật.',
+    };
+  }
+
+  return null;
+}
+
+export function buildAppUpdatePromptCopy(state: AppUpdateState): AppUpdatePromptCopy | null {
+  if (state.status === 'idle' || state.status === 'checking' || state.status === 'failed') {
+    return null;
+  }
+
+  if (state.status === 'applying') {
+    return {
+      title: 'Đang cập nhật',
+      message: 'Ứng dụng sẽ tải lại trong giây lát.',
+      primaryText: 'Đang cập nhật',
+      secondaryText: null,
+      tone: 'info',
+      compactLabel: 'Đang cập nhật',
+    };
+  }
+
+  if (state.status === 'unrecoverable') {
+    return {
+      title: 'Cần tải lại ứng dụng',
+      message: 'Một phần ứng dụng đã cũ hoặc bị mất khi tải. Tải lại sẽ khôi phục phiên học.',
+      primaryText: 'Tải lại',
+      secondaryText: null,
+      tone: 'danger',
+      compactLabel: 'Cần tải lại',
+    };
+  }
+
+  const isImportant = state.version?.severity === 'important' || state.version?.severity === 'critical';
+  const title = state.blocker ? 'Bản cập nhật đã sẵn sàng' : 'Có bản cập nhật mới';
+  const releaseNote = state.version?.releaseNote ? ` ${state.version.releaseNote}` : '';
+  const message = state.blocker
+    ? `${state.blocker.reason} ${state.blocker.safePoint}${releaseNote}`
+    : `Mất vài giây để làm mới giao diện và dữ liệu.${releaseNote}`;
+
+  return {
+    title,
+    message,
+    primaryText: 'Cập nhật',
+    secondaryText: 'Để sau',
+    tone: isImportant ? 'warning' : 'info',
+    compactLabel: state.blocker?.label ?? 'Bản mới',
+  };
+}
+
+@Injectable({ providedIn: 'root' })
+export class AppUpdateStateService {
+  private readonly status = signal<AppUpdateStatus>('idle');
+  private readonly version = signal<AppUpdateVersionInfo | null>(null);
+  private readonly blocker = signal<AppUpdateBlocker | null>(null);
+  private readonly reason = signal<string | null>(null);
+  private readonly dismissedUntil = signal(0);
+  private readonly clock = signal(Date.now());
+
+  readonly state = computed<AppUpdateState>(() => ({
+    status: this.status(),
+    version: this.version(),
+    blocker: this.blocker(),
+    reason: this.reason(),
+    dismissedUntil: this.dismissedUntil(),
+  }));
+
+  readonly promptCopy = computed(() => buildAppUpdatePromptCopy(this.state()));
+
+  readonly shouldShowPrompt = computed(() => {
+    const state = this.state();
+    if (!['ready', 'deferred', 'applying', 'unrecoverable'].includes(state.status)) {
+      return false;
+    }
+
+    if (state.status === 'unrecoverable' || state.status === 'applying') {
+      return true;
+    }
+
+    return state.dismissedUntil <= this.clock();
+  });
+
+  markChecking(): void {
+    if (this.status() === 'ready' || this.status() === 'deferred') {
+      return;
+    }
+
+    this.status.set('checking');
+    this.reason.set(null);
+    this.tick();
+  }
+
+  markReady(version: AppUpdateVersionInfo, blocker: AppUpdateBlocker | null): void {
+    this.version.set(version);
+    this.blocker.set(blocker);
+    this.status.set(blocker ? 'deferred' : 'ready');
+    this.reason.set(null);
+    this.tick();
+  }
+
+  updateBlocker(blocker: AppUpdateBlocker | null): void {
+    if (this.status() !== 'ready' && this.status() !== 'deferred') {
+      return;
+    }
+
+    this.blocker.set(blocker);
+    this.status.set(blocker ? 'deferred' : 'ready');
+    this.tick();
+  }
+
+  markApplying(): void {
+    this.status.set('applying');
+    this.reason.set(null);
+    this.dismissedUntil.set(0);
+    this.tick();
+  }
+
+  markFailed(reason: string): void {
+    if (this.status() === 'ready' || this.status() === 'deferred') {
+      return;
+    }
+
+    this.status.set('failed');
+    this.reason.set(reason);
+    this.tick();
+  }
+
+  markUnrecoverable(reason: string, blocker: AppUpdateBlocker | null = null): void {
+    this.status.set('unrecoverable');
+    this.reason.set(reason);
+    this.blocker.set(blocker);
+    this.dismissedUntil.set(0);
+    this.tick();
+  }
+
+  dismissFor(durationMs = DEFAULT_DISMISS_MS): void {
+    if (this.status() === 'unrecoverable' || this.status() === 'applying') {
+      return;
+    }
+
+    this.dismissedUntil.set(Date.now() + durationMs);
+    this.tick();
+    setTimeout(() => this.tick(), durationMs + 250);
+  }
+
+  clear(): void {
+    this.status.set(INITIAL_STATE.status);
+    this.version.set(INITIAL_STATE.version);
+    this.blocker.set(INITIAL_STATE.blocker);
+    this.reason.set(INITIAL_STATE.reason);
+    this.dismissedUntil.set(INITIAL_STATE.dismissedUntil);
+    this.tick();
+  }
+
+  private tick(): void {
+    this.clock.set(Date.now());
+  }
+}
+
+function getPathname(url: string): string {
+  try {
+    return new URL(url, 'https://holilihu.local').pathname.toLowerCase();
+  } catch {
+    return url.split('?')[0]?.split('#')[0]?.toLowerCase() ?? '';
+  }
+}

--- a/fe/src/app/core/services/sw-update.service.ts
+++ b/fe/src/app/core/services/sw-update.service.ts
@@ -1,12 +1,17 @@
 import { Injectable, inject } from '@angular/core';
-import { Router } from '@angular/router';
+import { NavigationEnd, Router } from '@angular/router';
 import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
-import { filter, interval, switchMap } from 'rxjs';
-import { from } from 'rxjs';
+import { filter, timer } from 'rxjs';
 import { ToastService } from './toast.service';
 import { StorageManagerService } from './storage-manager.service';
-import { ConfirmDialogService } from './confirm-dialog.service';
 import { NetworkStatusService } from './network-status.service';
+import {
+  AppUpdateBlocker,
+  AppUpdateSeverity,
+  AppUpdateStateService,
+  AppUpdateVersionInfo,
+  classifyAppUpdateContext,
+} from './app-update-state.service';
 
 const RUNTIME_CHUNK_FAILURE_MARKERS = [
   'ChunkLoadError',
@@ -15,6 +20,18 @@ const RUNTIME_CHUNK_FAILURE_MARKERS = [
   'Importing a module script failed',
   'error loading dynamically imported module',
 ] as const;
+
+const INITIAL_UPDATE_CHECK_DELAY_MS = 30 * 1000;
+const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const UPDATE_REMIND_LATER_MS = 30 * 60 * 1000;
+const APP_UPDATE_BROADCAST_CHANNEL = 'holilihu-app-update';
+const APP_UPDATE_STARTED_AT_KEY = 'holilihu-app-update-started-at';
+const APP_UPDATE_RETURN_URL_KEY = 'holilihu-app-update-return-url';
+
+type AppUpdateBroadcastMessage = {
+  type: 'version-ready';
+  version: AppUpdateVersionInfo;
+};
 
 export function isRuntimeChunkLoadFailure(errorLike: unknown): boolean {
   const message = getRuntimeFailureMessage(errorLike).toLowerCase();
@@ -59,17 +76,22 @@ export class SwUpdateService {
   private readonly router = inject(Router);
   private readonly toast = inject(ToastService);
   private readonly storage = inject(StorageManagerService);
-  private readonly confirmDialog = inject(ConfirmDialogService);
   private readonly networkStatus = inject(NetworkStatusService);
+  private readonly updateState = inject(AppUpdateStateService);
+
   private initialized = false;
   private runtimeRecoveryTriggered = false;
+  private pendingVersion: AppUpdateVersionInfo | null = null;
+  private updateChannel: BroadcastChannel | null = null;
+
   private readonly visibilityChangeHandler = async () => {
     if (document.visibilityState !== 'visible') return;
 
     this.storage.requestPersistence();
 
     if (this.swUpdate?.isEnabled) {
-      this.swUpdate.checkForUpdate().catch(() => {});
+      void this.checkForUpdate('visible');
+      this.syncPendingUpdateContext();
       return;
     }
 
@@ -77,7 +99,7 @@ export class SwUpdateService {
 
     try {
       const reg = await navigator.serviceWorker.getRegistration();
-      if (!reg?.active && navigator.onLine) {
+      if (reg && !reg.active && navigator.onLine) {
         console.warn('[PWA] Service worker evicted by iOS, re-registering...');
         document.location.reload();
       }
@@ -85,6 +107,7 @@ export class SwUpdateService {
       // Ignore errors (e.g., SW API not available)
     }
   };
+
   private readonly windowErrorHandler = (event: ErrorEvent) => {
     if (!isRuntimeChunkLoadFailure(event)) {
       return;
@@ -92,6 +115,7 @@ export class SwUpdateService {
 
     this.handleRuntimeChunkFailure(event);
   };
+
   private readonly unhandledRejectionHandler = (event: PromiseRejectionEvent) => {
     if (!isRuntimeChunkLoadFailure(event.reason)) {
       return;
@@ -105,9 +129,12 @@ export class SwUpdateService {
     if (this.initialized) {
       return;
     }
+
     this.initialized = true;
     this.setupChunkErrorHandler();
     this.setupVisibilityHandler();
+    this.setupUpdateBroadcastChannel();
+    this.announceCompletedUpdateIfNeeded();
 
     if (this.shouldDisableServiceWorkerRuntime()) {
       void this.disableServiceWorkerForLocalRuntime();
@@ -117,49 +144,34 @@ export class SwUpdateService {
     if (!this.swUpdate?.isEnabled) return;
     const sw = this.swUpdate;
 
-    interval(6 * 60 * 60 * 1000).pipe(
-      switchMap(() => from(sw.checkForUpdate())),
-    ).subscribe();
+    timer(INITIAL_UPDATE_CHECK_DELAY_MS, UPDATE_CHECK_INTERVAL_MS)
+      .subscribe(() => void this.checkForUpdate('scheduled'));
 
     sw.versionUpdates.pipe(
       filter((evt): evt is VersionReadyEvent => evt.type === 'VERSION_READY'),
-    ).subscribe(async () => {
-      const confirmed = await this.confirmDialog.confirm({
-        title: 'Cập nhật ứng dụng',
-        message: 'Phiên bản mới đã sẵn sàng. Tải lại trang để cập nhật?',
-        variant: 'info',
-        confirmText: 'Cập nhật ngay',
-        cancelText: 'Để sau',
-      });
+    ).subscribe((event) => this.handleVersionReady(event));
 
-      if (confirmed) {
-        document.location.reload();
-      } else {
-        this.toast.info('Ứng dụng sẽ cập nhật khi bạn tải lại trang');
-      }
+    sw.unrecoverable.subscribe((event) => {
+      void this.handleUnrecoverableState(event.reason);
     });
 
-    sw.unrecoverable.subscribe(async (event) => {
-      console.error('[SW] Unrecoverable state:', event.reason);
-
-      if (navigator.onLine) {
-        await this.clearNgswCaches();
-        this.toast.error('Ứng dụng gặp lỗi. Đang tải lại...');
-        setTimeout(() => document.location.reload(), 1000);
-      } else {
-        this.toast.info('Ứng dụng sẽ cập nhật khi có kết nối mạng');
-        const onlineHandler = () => {
-          window.removeEventListener('online', onlineHandler);
-          fetch('/icons/icon-192x192.png', { method: 'HEAD' })
-            .then(() => document.location.reload())
-            .catch(() => {});
-        };
-        window.addEventListener('online', onlineHandler);
-      }
-    });
+    this.router.events.pipe(
+      filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+    ).subscribe(() => this.syncPendingUpdateContext());
 
     this.storage.requestPersistence();
     this.showOfflineReadyToast();
+  }
+
+  applyPendingUpdate(): void {
+    this.updateState.markApplying();
+    this.rememberUpdateReload();
+    setTimeout(() => document.location.reload(), 100);
+  }
+
+  remindLater(): void {
+    this.updateState.dismissFor(UPDATE_REMIND_LATER_MS);
+    this.toast.info('Sẽ nhắc lại khi phù hợp để cập nhật ứng dụng.');
   }
 
   private shouldDisableServiceWorkerRuntime(): boolean {
@@ -195,7 +207,7 @@ export class SwUpdateService {
     }
 
     navigator.serviceWorker.ready.then(() => {
-      this.toast.success('Sẵn sàng ngoại tuyến — trang web hoạt động kể cả khi mất mạng');
+      this.toast.success('Sẵn sàng ngoại tuyến - trang web vẫn mở được nội dung đã tải khi mất mạng');
       try {
         localStorage.setItem('pwa-ready-shown', '1');
       } catch {}
@@ -213,6 +225,140 @@ export class SwUpdateService {
 
     window.addEventListener('error', this.windowErrorHandler);
     window.addEventListener('unhandledrejection', this.unhandledRejectionHandler);
+  }
+
+  private setupUpdateBroadcastChannel(): void {
+    if (typeof window === 'undefined' || typeof BroadcastChannel === 'undefined') {
+      return;
+    }
+
+    this.updateChannel = new BroadcastChannel(APP_UPDATE_BROADCAST_CHANNEL);
+    this.updateChannel.onmessage = (event: MessageEvent<AppUpdateBroadcastMessage>) => {
+      if (event.data?.type !== 'version-ready') {
+        return;
+      }
+
+      this.pendingVersion = event.data.version;
+      this.publishUpdateState(event.data.version);
+    };
+  }
+
+  private async checkForUpdate(_reason: 'scheduled' | 'visible'): Promise<void> {
+    if (!this.swUpdate?.isEnabled || !this.canCheckForUpdate()) {
+      return;
+    }
+
+    this.updateState.markChecking();
+    try {
+      await this.swUpdate.checkForUpdate();
+    } catch {
+      this.updateState.markFailed('Không thể kiểm tra cập nhật lúc này.');
+    } finally {
+      if (this.updateState.state().status === 'checking') {
+        this.updateState.clear();
+      }
+    }
+  }
+
+  private canCheckForUpdate(): boolean {
+    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') {
+      return false;
+    }
+
+    if (typeof navigator !== 'undefined' && !navigator.onLine) {
+      return false;
+    }
+
+    return !this.networkStatus.isEffectivelyOffline();
+  }
+
+  private handleVersionReady(event: VersionReadyEvent): void {
+    const version = this.toVersionInfo(event);
+    this.pendingVersion = version;
+    this.publishUpdateState(version);
+    this.broadcastVersionReady(version);
+  }
+
+  private publishUpdateState(version: AppUpdateVersionInfo): void {
+    this.updateState.markReady(version, this.getCurrentUpdateBlocker());
+  }
+
+  private broadcastVersionReady(version: AppUpdateVersionInfo): void {
+    this.updateChannel?.postMessage({
+      type: 'version-ready',
+      version,
+    } satisfies AppUpdateBroadcastMessage);
+  }
+
+  private syncPendingUpdateContext(): void {
+    if (!this.pendingVersion) {
+      return;
+    }
+
+    this.updateState.updateBlocker(this.getCurrentUpdateBlocker());
+  }
+
+  private getCurrentUpdateBlocker(): AppUpdateBlocker | null {
+    const online = !(
+      (typeof navigator !== 'undefined' && !navigator.onLine) ||
+      this.networkStatus.isEffectivelyOffline()
+    );
+    const visibilityState = typeof document === 'undefined' ? 'visible' : document.visibilityState;
+
+    return classifyAppUpdateContext(this.router.url, {
+      online,
+      visibilityState,
+    });
+  }
+
+  private toVersionInfo(event: VersionReadyEvent): AppUpdateVersionInfo {
+    const appData = (event.latestVersion.appData ?? {}) as Record<string, unknown>;
+    return {
+      currentHash: event.currentVersion.hash ?? null,
+      latestHash: event.latestVersion.hash ?? null,
+      detectedAt: Date.now(),
+      severity: this.parseSeverity(appData['severity']),
+      releaseNote: this.readReleaseNote(appData),
+    };
+  }
+
+  private parseSeverity(value: unknown): AppUpdateSeverity {
+    if (value === 'important' || value === 'critical') {
+      return value;
+    }
+
+    return 'normal';
+  }
+
+  private readReleaseNote(appData: Record<string, unknown>): string | null {
+    const releaseNote = appData['releaseNote'] ?? appData['message'];
+    if (typeof releaseNote !== 'string') {
+      return null;
+    }
+
+    const trimmed = releaseNote.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  private async handleUnrecoverableState(reason: string): Promise<void> {
+    console.error('[SW] Unrecoverable state:', reason);
+    this.updateState.markUnrecoverable(reason, this.getCurrentUpdateBlocker());
+
+    if (navigator.onLine) {
+      await this.clearNgswCaches();
+      this.toast.error('Ứng dụng cần tải lại để khôi phục phiên hiện tại.');
+      setTimeout(() => this.applyPendingUpdate(), 1200);
+      return;
+    }
+
+    this.toast.info('Ứng dụng sẽ khôi phục khi có kết nối mạng.');
+    const onlineHandler = () => {
+      window.removeEventListener('online', onlineHandler);
+      fetch('/icons/icon-192x192.png', { method: 'HEAD' })
+        .then(() => this.applyPendingUpdate())
+        .catch(() => {});
+    };
+    window.addEventListener('online', onlineHandler);
   }
 
   private async clearNgswCaches(): Promise<void> {
@@ -245,13 +391,42 @@ export class SwUpdateService {
     }
 
     console.warn('[PWA] Runtime chunk load failure detected, reloading app shell.', reason);
+    this.updateState.markUnrecoverable('runtime chunk load failure', this.getCurrentUpdateBlocker());
 
     if (typeof navigator === 'undefined' || navigator.onLine) {
-      document.location.reload();
+      this.toast.info('Có bản ứng dụng mới. Đang tải lại để đồng bộ giao diện.');
+      setTimeout(() => this.applyPendingUpdate(), 500);
       return;
     }
 
     this.navigateToOfflineRecovery();
+  }
+
+  private rememberUpdateReload(): void {
+    try {
+      localStorage.setItem(APP_UPDATE_STARTED_AT_KEY, String(Date.now()));
+      localStorage.setItem(APP_UPDATE_RETURN_URL_KEY, this.router.url);
+    } catch {
+      // Ignore storage failures. Reload is still the source of truth.
+    }
+  }
+
+  private announceCompletedUpdateIfNeeded(): void {
+    try {
+      const startedAt = Number(localStorage.getItem(APP_UPDATE_STARTED_AT_KEY) ?? 0);
+      if (!startedAt) {
+        return;
+      }
+
+      localStorage.removeItem(APP_UPDATE_STARTED_AT_KEY);
+      localStorage.removeItem(APP_UPDATE_RETURN_URL_KEY);
+
+      if (Date.now() - startedAt < 2 * 60 * 1000) {
+        this.toast.success('Ứng dụng đã được cập nhật.');
+      }
+    } catch {
+      // Ignore storage failures.
+    }
   }
 
   private navigateToOfflineRecovery(): void {

--- a/fe/src/app/shared/components/app-update-banner/app-update-banner.component.html
+++ b/fe/src/app/shared/components/app-update-banner/app-update-banner.component.html
@@ -1,0 +1,58 @@
+@if (shouldShow() && prompt(); as copy) {
+  <section
+    class="pointer-events-none fixed left-1/2 top-3 z-[1001] w-[calc(100vw-1rem)] max-w-2xl -translate-x-1/2 sm:w-[calc(100vw-2rem)]"
+    role="status"
+    [attr.aria-live]="ariaLive()"
+    data-testid="app-update-banner"
+  >
+    <div [class]="containerClass()">
+      <div class="flex min-w-0 items-start gap-3">
+        <span [class]="iconClass()">
+          <lucide-icon
+            [name]="iconName()"
+            [size]="16"
+            [class.animate-spin]="state().status === 'applying'"
+            aria-hidden="true"
+          ></lucide-icon>
+        </span>
+
+        <div class="min-w-0">
+          <div class="flex min-w-0 flex-wrap items-center gap-2">
+            <p class="text-sm font-semibold leading-5">{{ copy.title }}</p>
+            <span class="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-semibold text-slate-600">
+              {{ copy.compactLabel }}
+            </span>
+          </div>
+          <p class="mt-1 text-sm leading-5 text-slate-600">{{ copy.message }}</p>
+        </div>
+      </div>
+
+      <div class="flex shrink-0 items-center justify-end gap-2 sm:justify-start">
+        @if (copy.secondaryText && state().status !== 'applying') {
+          <button
+            type="button"
+            class="inline-flex h-9 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-[#0056D2] focus:ring-offset-2"
+            (click)="remindLater()"
+          >
+            {{ copy.secondaryText }}
+          </button>
+        }
+
+        <button
+          type="button"
+          [class]="primaryButtonClass()"
+          [disabled]="state().status === 'applying'"
+          (click)="applyUpdate()"
+        >
+          <lucide-icon
+            [name]="state().status === 'applying' ? 'loader-2' : 'refresh-cw'"
+            [size]="14"
+            [class.animate-spin]="state().status === 'applying'"
+            aria-hidden="true"
+          ></lucide-icon>
+          <span>{{ copy.primaryText }}</span>
+        </button>
+      </div>
+    </div>
+  </section>
+}

--- a/fe/src/app/shared/components/app-update-banner/app-update-banner.component.spec.ts
+++ b/fe/src/app/shared/components/app-update-banner/app-update-banner.component.spec.ts
@@ -1,0 +1,70 @@
+import { importProvidersFrom } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AlertTriangle, Loader2, LucideAngularModule, RefreshCw } from 'lucide-angular';
+import { AppUpdateStateService, AppUpdateVersionInfo } from '../../../core/services/app-update-state.service';
+import { SwUpdateService } from '../../../core/services/sw-update.service';
+import { AppUpdateBannerComponent } from './app-update-banner.component';
+
+const version: AppUpdateVersionInfo = {
+  currentHash: 'old',
+  latestHash: 'new',
+  detectedAt: 1,
+  severity: 'normal',
+  releaseNote: null,
+};
+
+describe('AppUpdateBannerComponent', () => {
+  let fixture: ComponentFixture<AppUpdateBannerComponent>;
+  let state: AppUpdateStateService;
+  let swUpdate: jasmine.SpyObj<Pick<SwUpdateService, 'applyPendingUpdate' | 'remindLater'>>;
+
+  beforeEach(() => {
+    swUpdate = jasmine.createSpyObj('SwUpdateService', ['applyPendingUpdate', 'remindLater']);
+
+    TestBed.configureTestingModule({
+      imports: [AppUpdateBannerComponent],
+      providers: [
+        AppUpdateStateService,
+        { provide: SwUpdateService, useValue: swUpdate },
+        importProvidersFrom(LucideAngularModule.pick({ AlertTriangle, Loader2, RefreshCw })),
+      ],
+    });
+
+    fixture = TestBed.createComponent(AppUpdateBannerComponent);
+    state = TestBed.inject(AppUpdateStateService);
+  });
+
+  it('stays hidden when no update is ready', () => {
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="app-update-banner"]')).toBeNull();
+  });
+
+  it('shows a non-blocking update prompt and applies the update from the primary action', () => {
+    state.markReady(version, null);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.textContent).toContain('Có bản cập nhật mới');
+
+    const updateButton = Array.from(host.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('Cập nhật')) as HTMLButtonElement;
+
+    updateButton.click();
+
+    expect(swUpdate.applyPendingUpdate).toHaveBeenCalled();
+  });
+
+  it('lets users postpone non-critical updates', () => {
+    state.markReady(version, null);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const laterButton = Array.from(host.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('Để sau')) as HTMLButtonElement;
+
+    laterButton.click();
+
+    expect(swUpdate.remindLater).toHaveBeenCalled();
+  });
+});

--- a/fe/src/app/shared/components/app-update-banner/app-update-banner.component.ts
+++ b/fe/src/app/shared/components/app-update-banner/app-update-banner.component.ts
@@ -1,0 +1,82 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { LucideAngularModule } from 'lucide-angular';
+import { AppUpdateStateService } from '../../../core/services/app-update-state.service';
+import { SwUpdateService } from '../../../core/services/sw-update.service';
+
+@Component({
+  selector: 'app-update-banner',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [LucideAngularModule],
+  templateUrl: './app-update-banner.component.html',
+})
+export class AppUpdateBannerComponent {
+  private readonly swUpdate = inject(SwUpdateService);
+  protected readonly updateState = inject(AppUpdateStateService);
+
+  protected readonly state = this.updateState.state;
+  protected readonly prompt = this.updateState.promptCopy;
+  protected readonly shouldShow = this.updateState.shouldShowPrompt;
+
+  protected readonly iconName = computed(() => {
+    const status = this.state().status;
+    if (status === 'unrecoverable') return 'alert-triangle';
+    if (status === 'applying') return 'loader-2';
+    return 'refresh-cw';
+  });
+
+  protected readonly ariaLive = computed(() => (
+    this.prompt()?.tone === 'danger' ? 'assertive' : 'polite'
+  ));
+
+  protected readonly containerClass = computed(() => {
+    const tone = this.prompt()?.tone ?? 'info';
+    const toneClass = {
+      info: 'border-blue-200 bg-white/95 text-slate-950 shadow-blue-950/10',
+      warning: 'border-amber-200 bg-amber-50/95 text-amber-950 shadow-amber-950/10',
+      danger: 'border-red-200 bg-red-50/95 text-red-950 shadow-red-950/10',
+    }[tone];
+
+    return [
+      'pointer-events-auto flex min-h-14 flex-col gap-3 rounded-lg border px-3 py-3 shadow-lg backdrop-blur',
+      'sm:flex-row sm:items-center sm:justify-between sm:px-4',
+      toneClass,
+    ].join(' ');
+  });
+
+  protected readonly iconClass = computed(() => {
+    const tone = this.prompt()?.tone ?? 'info';
+    const toneClass = {
+      info: 'bg-blue-50 text-[#0056D2]',
+      warning: 'bg-amber-100 text-amber-700',
+      danger: 'bg-red-100 text-red-700',
+    }[tone];
+
+    return [
+      'flex h-8 w-8 shrink-0 items-center justify-center rounded-full',
+      toneClass,
+    ].join(' ');
+  });
+
+  protected readonly primaryButtonClass = computed(() => {
+    const tone = this.prompt()?.tone ?? 'info';
+    const toneClass = {
+      info: 'bg-[#0056D2] text-white hover:bg-[#004BB5] focus:ring-[#0056D2]',
+      warning: 'bg-amber-600 text-white hover:bg-amber-700 focus:ring-amber-500',
+      danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
+    }[tone];
+
+    return [
+      'inline-flex h-9 items-center justify-center gap-2 rounded-lg px-3 text-sm font-semibold',
+      'transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:cursor-wait disabled:opacity-75',
+      toneClass,
+    ].join(' ');
+  });
+
+  protected applyUpdate(): void {
+    this.swUpdate.applyPendingUpdate();
+  }
+
+  protected remindLater(): void {
+    this.swUpdate.remindLater();
+  }
+}


### PR DESCRIPTION
﻿## What changed
- Added an `AppUpdateStateService` state model for service-worker update readiness, blockers, severity, release notes, dismissal, and recovery states.
- Replaced the blocking `VERSION_READY` confirm dialog with a calm non-blocking `app-update-banner` mounted at the app shell.
- Deferred update prompts when the learner is in a lesson, taking a quiz, when teachers are authoring, during payment, while offline, or when the tab is backgrounded.
- Added multi-tab update notification via `BroadcastChannel`, delayed update polling, reload completion feedback, and controlled recovery for unrecoverable SW/chunk failures.
- Added focused unit/component coverage for update classification, state transitions, prompt copy, banner actions, and existing runtime chunk detection.

## Why
A production LMS update should not interrupt a student mid-video/quiz or a teacher mid-edit. This follows the common SOTA pattern from Angular/PWA update guidance: detect new app shell versions, wait for a safe user moment, then reload the full page rather than hot-swapping chunks in-place.

## Validation
- `npm run test:ci -- --include src/app/core/services/app-update-state.service.spec.ts --include src/app/shared/components/app-update-banner/app-update-banner.component.spec.ts --include src/app/core/services/sw-update.service.spec.ts` -> 15 passing
- `npm run test:ci` -> 449 passing, 2 skipped
- `npm run build` -> passing; only pre-existing Angular/Sass/CommonJS warnings remain
- Playwright smoke against `http://127.0.0.1:4200/` on desktop and mobile -> `app-root` rendered, update banner hidden by default, no console errors
