### PR TITLE
[codex] Fix course detail text wrapping

### DIFF
--- a/fe/src/app/features/student/pages/course-detail.component.scss
+++ b/fe/src/app/features/student/pages/course-detail.component.scss
@@ -621,16 +621,19 @@ $gray-900: #111827;
 .curriculum-card {
   position: sticky;
   top: 20px;
+  min-width: 0;
 }
 
 .curriculum-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 12px;
   margin-bottom: 8px;
 }
 
 .toggle-all-btn {
+  flex-shrink: 0;
   background: none;
   border: none;
   color: $primary;
@@ -656,12 +659,14 @@ $gray-900: #111827;
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-width: 0;
 }
 
 .section-item {
   border: 1px solid $gray-200;
   border-radius: 8px;
   overflow: hidden;
+  min-width: 0;
 }
 
 .section-header {
@@ -690,6 +695,7 @@ $gray-900: #111827;
   display: flex;
   flex-direction: column;
   gap: 2px;
+  min-width: 0;
 }
 
 .section-number {
@@ -706,6 +712,7 @@ $gray-900: #111827;
   color: $gray-900;
   margin: 0;
   line-height: 1.3;
+  overflow-wrap: anywhere;
 }
 
 .section-progress-text {
@@ -731,12 +738,13 @@ $gray-900: #111827;
 .lessons-list {
   background: $gray-50;
   padding: 6px 8px;
+  min-width: 0;
 }
 
 .lesson-row {
   width: 100%;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
   padding: 10px 12px;
   background: white;
@@ -780,6 +788,7 @@ $gray-900: #111827;
 
 .lesson-status {
   flex-shrink: 0;
+  padding-top: 1px;
 }
 
 .status-icon {
@@ -808,9 +817,10 @@ $gray-900: #111827;
   font-size: 0.875rem;
   font-weight: 500;
   color: $gray-900;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  line-height: 1.35;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .lesson-desc {
@@ -819,8 +829,13 @@ $gray-900: #111827;
   margin: 0;
   line-height: 1.4;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .lesson-tags {
@@ -901,6 +916,7 @@ $gray-900: #111827;
 // ============================================
 .lesson-wrapper {
   margin-bottom: 4px;
+  min-width: 0;
 
   &:last-child { margin-bottom: 0; }
 }
@@ -967,9 +983,9 @@ $gray-900: #111827;
   font-weight: 400;
   color: $gray-700;
   line-height: 1.3;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .section-sub-meta {


### PR DESCRIPTION
## Summary
- Fix curriculum text wrapping on the student course detail page.
- Allow long lesson titles, lesson descriptions, chapter names, and section item titles to wrap within the card instead of forcing a single overflowing line.
- Keep lesson descriptions compact with a two-line clamp and add flex `min-width: 0` safeguards so the curriculum card does not expand horizontally.

## Root cause
The curriculum rows used `white-space: nowrap` with ellipsis on long text. In the course detail layout, long Vietnamese lesson descriptions could remain on one line and appear to overflow beyond the visible content area.

## Validation
- `npx ng build --configuration development --no-progress`