### PR TITLE
[codex] Harden offline UX and video downloads

### DIFF
--- a/fe/src/app/core/services/course-download.service.ts
+++ b/fe/src/app/core/services/course-download.service.ts
@@ -19,7 +19,11 @@ import {
 } from '../db/lms-offline.db';
 import { StorageManagerService } from './storage-manager.service';
 import { ToastService } from './toast.service';
-import { OfflineVideoService } from './offline-video.service';
+import {
+  OFFLINE_VIDEO_MAX_CACHE_BYTES,
+  OfflineVideoService,
+  isOfflineVideoTooLargeError,
+} from './offline-video.service';
 import { OfflineFileService } from './offline-file.service';
 import { OfflineSyncService } from './offline-sync.service';
 import { NetworkStatusService } from './network-status.service';
@@ -91,6 +95,15 @@ interface OfflineCourseSnapshot {
   lessons: OfflineLesson[];
   quizData: OfflineQuizData[];
 }
+
+interface OfflineVideoSkipSummary {
+  unsupported: number;
+  placeholder: number;
+  tooLarge: number;
+  failed: number;
+}
+
+type OfflineVideoSkipReason = keyof OfflineVideoSkipSummary;
 
 @Injectable({ providedIn: 'root' })
 export class CourseDownloadService {
@@ -174,6 +187,12 @@ export class CourseDownloadService {
     this.downloadCancelled = false;
     const userId = getCurrentUserId();
     const effectiveOptions = this.resolveEffectiveDownloadOptions(options);
+    const videoSkipSummary: OfflineVideoSkipSummary = {
+      unsupported: 0,
+      placeholder: 0,
+      tooLarge: 0,
+      failed: 0,
+    };
 
     try {
       await this.ensureOfflineReady();
@@ -324,6 +343,7 @@ export class CourseDownloadService {
             let downloadedVideoProfileId: OfflineVideoProfileId | null = null;
             let downloadedVideoProfileLabel: string | null = null;
             let downloadedVideoResolution: string | null = null;
+            let downloadedVideoFileSizeBytes: number | null = null;
             let videoSourceKind = vl.videoSourceKind ?? this.resolveVideoSourceKind(
               null,
               vl.videoManifestUrl,
@@ -343,6 +363,7 @@ export class CourseDownloadService {
                   descriptor.actualResolution,
                 );
                 downloadedVideoResolution = descriptor.actualResolution ?? null;
+                downloadedVideoFileSizeBytes = descriptor.fileSizeBytes ?? null;
                 videoSourceKind = 'STREAM';
               } catch {
                 // CF URL fetch failed — fall through to raw videoManifestUrl
@@ -351,6 +372,14 @@ export class CourseDownloadService {
               downloadedVideoProfileId = 'ORIGINAL';
               downloadedVideoProfileLabel = getOfflineVideoProfileLabel('ORIGINAL');
             }
+            const skipReason = this.getOfflineVideoSkipReason({
+              downloadUrl,
+              fileSizeBytes: downloadedVideoFileSizeBytes,
+            });
+            if (skipReason) {
+              this.recordVideoSkip(videoSkipSummary, skipReason);
+              continue;
+            }
             await this.videoService.downloadVideo(downloadUrl, vl.id);
             await offlineDb.lessons.update([userId, vl.id], {
               downloadedVideoProfileId,
@@ -358,8 +387,9 @@ export class CourseDownloadService {
               downloadedVideoResolution,
               videoSourceKind,
             });
-          } catch {
-            // Video download failure is non-fatal — skip and continue
+          } catch (videoErr) {
+            this.recordVideoDownloadError(videoSkipSummary, videoErr);
+            // Non-fatal: text, quiz, and progress data remain available offline.
           }
 
           this.downloadProgress.set(80 + Math.round(((vi + 1) / videoLessons.length) * 15));
@@ -387,6 +417,12 @@ export class CourseDownloadService {
               try {
                 const descriptor = await this.resolveSectionVideoDownloadDescriptor(section, videoPreference);
                 if (descriptor.downloadUrl) {
+                  const skipReason = this.getOfflineVideoSkipReason(descriptor);
+                  if (skipReason) {
+                    this.recordVideoSkip(videoSkipSummary, skipReason);
+                    continue;
+                  }
+
                   section.videoOfflineUri = await this.videoService.downloadSectionVideo(descriptor.downloadUrl, lesson.id, section.id);
                   section.downloadedVideoProfileId = this.normalizeDownloadedProfileId(descriptor.profile)
                     ?? (section.streamVideoUid ? null : 'ORIGINAL');
@@ -404,9 +440,9 @@ export class CourseDownloadService {
                   );
                   sectionsChanged = true;
                 } else {
-                  // descriptor.downloadUrl null → adaptive HLS hoặc no MP4 rendition
-                  // Log để user biết video này không support offline
-                  console.warn('[CourseDownload] Section video không có downloadUrl (likely adaptive HLS, no MP4 rendition):', {
+                  // Descriptor has no offline MP4 rendition; keep this as debug-only telemetry.
+                  this.recordVideoSkip(videoSkipSummary, 'unsupported');
+                  console.debug('[CourseDownload] Section video không có downloadUrl (likely adaptive HLS, no MP4 rendition):', {
                     sectionId: section.id,
                     sectionTitle: section.title,
                     videoSourceKind: section.videoSourceKind,
@@ -414,15 +450,7 @@ export class CourseDownloadService {
                   });
                 }
               } catch (videoErr) {
-                // Surface error để debug — silent swallow trước đây ẩn root cause
-                // (mobile vs PC behavior diff). User sẽ biết video nào fail + lý do.
-                console.error('[CourseDownload] Section video download FAILED:', {
-                  sectionId: section.id,
-                  sectionTitle: section.title,
-                  lessonId: lesson.id,
-                  error: videoErr instanceof Error ? videoErr.message : String(videoErr),
-                  stack: videoErr instanceof Error ? videoErr.stack : undefined,
-                });
+                this.recordVideoDownloadError(videoSkipSummary, videoErr);
               }
             }
 
@@ -603,6 +631,7 @@ export class CourseDownloadService {
       this.downloadProgress.set(100);
       if (!behavior.silentSuccessToast) {
         this.toast.success(`Đã tải khóa học "${courseData.title || courseData.name}" cho ngoại tuyến`);
+        this.showVideoSkipSummary(videoSkipSummary);
       }
 
       await this.refreshDownloadedCourses();
@@ -1216,6 +1245,76 @@ export class CourseDownloadService {
 
   private canDownloadQuizOffline(quizType: unknown): boolean {
     return this.normalizeQuizAssessmentType(quizType) === 'PRACTICE';
+  }
+
+  private getOfflineVideoSkipReason(
+    descriptor: Pick<OfflineVideoDownloadDescriptor, 'downloadUrl' | 'fileSizeBytes'>,
+  ): OfflineVideoSkipReason | null {
+    if ((descriptor.fileSizeBytes ?? 0) > OFFLINE_VIDEO_MAX_CACHE_BYTES) {
+      return 'tooLarge';
+    }
+
+    const downloadUrl = descriptor.downloadUrl?.trim();
+    if (!downloadUrl) {
+      return 'unsupported';
+    }
+
+    let parsedUrl: URL;
+    try {
+      const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://holilihu.online';
+      parsedUrl = new URL(downloadUrl, baseUrl);
+    } catch {
+      return 'unsupported';
+    }
+
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return 'unsupported';
+    }
+
+    const host = parsedUrl.hostname.toLowerCase();
+    if (
+      host === 'example.com'
+      || host === 'example.org'
+      || host === 'example.net'
+      || host.endsWith('.example.com')
+      || host.endsWith('.example.org')
+      || host.endsWith('.example.net')
+    ) {
+      return 'placeholder';
+    }
+
+    return null;
+  }
+
+  private recordVideoSkip(summary: OfflineVideoSkipSummary, reason: OfflineVideoSkipReason): void {
+    summary[reason] += 1;
+  }
+
+  private recordVideoDownloadError(summary: OfflineVideoSkipSummary, error: unknown): void {
+    if (isOfflineVideoTooLargeError(error)) {
+      this.recordVideoSkip(summary, 'tooLarge');
+      return;
+    }
+
+    this.recordVideoSkip(summary, 'failed');
+  }
+
+  private showVideoSkipSummary(summary: OfflineVideoSkipSummary): void {
+    const total = summary.unsupported + summary.placeholder + summary.tooLarge + summary.failed;
+    if (total === 0) {
+      return;
+    }
+
+    const details: string[] = [];
+    if (summary.tooLarge > 0) details.push(`${summary.tooLarge} video quá lớn`);
+    if (summary.unsupported > 0) details.push(`${summary.unsupported} video chỉ phát trực tuyến`);
+    if (summary.placeholder > 0) details.push(`${summary.placeholder} video chưa có nguồn thật`);
+    if (summary.failed > 0) details.push(`${summary.failed} video chưa tải được`);
+
+    this.toast.warning(
+      `Đã bỏ qua ${total} video khi tạo gói offline (${details.join(', ')}). Các nội dung này vẫn phát khi có mạng ổn định.`,
+      { duration: 6500 },
+    );
   }
 
   private async resolveSectionVideoDownloadDescriptor(

--- a/fe/src/app/core/services/network-status.service.spec.ts
+++ b/fe/src/app/core/services/network-status.service.spec.ts
@@ -132,7 +132,7 @@ describe('NetworkStatusService', () => {
       expect(service.hasRecentOfflineSignal()).toBeFalse();
     }));
 
-    it('should confirm offline when the follow-up probe fails', fakeAsync(() => {
+    it('should treat one failed probe as degraded instead of immediately offline', fakeAsync(() => {
       service.online.set(true);
       fetchSpy.and.callFake(async () => new Response('', { status: 503 }));
 
@@ -140,10 +140,36 @@ describe('NetworkStatusService', () => {
       tick(250);
       flushMicrotasks();
 
+      expect(service.online()).toBeTrue();
+      expect(service.connectionTier()).toBe('slow');
+      expect(service.hasRecentOfflineSignal()).toBeTrue();
+      expect(service.isEffectivelyOffline()).toBeFalse();
+    }));
+
+    it('should confirm offline after repeated failed probes', async () => {
+      service.online.set(true);
+      fetchSpy.and.callFake(async () => new Response('', { status: 503 }));
+
+      await service.probeNow();
+      await service.probeNow();
+
       expect(service.online()).toBeFalse();
       expect(service.hasRecentOfflineSignal()).toBeTrue();
       expect(service.isEffectivelyOffline()).toBeTrue();
-    }));
+    });
+
+    it('should let manual retry recover on a successful health probe', async () => {
+      service.online.set(true);
+      fetchSpy.calls.reset();
+      fetchSpy.and.callFake(async () => new Response('', { status: 200 }));
+
+      const recovered = await service.probeNow();
+
+      expect(recovered).toBeTrue();
+      expect(service.online()).toBeTrue();
+      expect(service.hasRecentOfflineSignal()).toBeFalse();
+      expect(fetchSpy.calls.count()).toBe(1);
+    });
 
     it('should clear a suspected offline signal after a successful HTTP response', fakeAsync(() => {
       service.online.set(true);

--- a/fe/src/app/core/services/network-status.service.ts
+++ b/fe/src/app/core/services/network-status.service.ts
@@ -9,6 +9,8 @@ const NON_CRITICAL_SYNC_DEFER_WINDOW_MS = 15_000;
 const PROBE_INTERVAL_MS = 120_000;
 const PROBE_TIMEOUT_MS = 4_000;
 const TRANSPORT_FAILURE_PROBE_DELAY_MS = 250;
+const OFFLINE_PROBE_FAILURE_THRESHOLD = 2;
+const DEGRADED_PROBE_BANDWIDTH_MBPS = 0.5;
 
 @Injectable({ providedIn: 'root' })
 export class NetworkStatusService implements OnDestroy {
@@ -52,6 +54,7 @@ export class NetworkStatusService implements OnDestroy {
   private offlineGraceTimer: ReturnType<typeof setTimeout> | null = null;
   private transportFailureProbeTimer: ReturnType<typeof setTimeout> | null = null;
   private probeInterval: ReturnType<typeof setInterval> | null = null;
+  private consecutiveProbeFailures = 0;
 
   private readonly onlineHandler = () => {
     if (this.offlineGraceTimer) {
@@ -163,10 +166,15 @@ export class NetworkStatusService implements OnDestroy {
     }
 
     this.online.set(true);
+    this.consecutiveProbeFailures = 0;
     this.recentOfflineSignalAt.set(null);
     if (this.effectiveBandwidthMbps() <= 0) {
       this.effectiveBandwidthMbps.set(2);
     }
+  }
+
+  async probeNow(): Promise<boolean> {
+    return this.runProbe();
   }
 
   private debouncedUpdate(): void {
@@ -201,36 +209,39 @@ export class NetworkStatusService implements OnDestroy {
     this.effectiveBandwidthMbps.set(this.estimateBandwidthMbps(conn));
   }
 
-  // Single-probe health check against /actuator/health. Previously used a
-  // two-step icon-HEAD + actuator-GET sequence which had a race condition where
-  // the icon succeeded but actuator timed out, showing false-offline state.
-  // In dev, /actuator is proxied to the Spring Boot backend at :8088.
   private probeLatency(): void {
+    void this.runProbe();
+  }
+
+  // Single-probe health check against /actuator/health. A single 504/timeout
+  // means "degraded" first, not "offline"; mobile networks and sleeping VMs can
+  // spike briefly while the browser still has usable connectivity.
+  private async runProbe(): Promise<boolean> {
     if (!this.getBrowserOnlineHint()) {
       this.markOfflineState();
-      return;
+      return false;
     }
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
     const start = performance.now();
 
-    fetch('/actuator/health', {
-      method: 'GET',
-      signal: controller.signal,
-      cache: 'no-store',
-      redirect: 'error',
-    })
-      .then((response) => {
-        clearTimeout(timeoutId);
-        this.ensureSuccessfulProbeResponse(response);
-        const rtt = performance.now() - start;
-        this.markMeasuredOnlineState(rtt);
-      })
-      .catch(() => {
-        clearTimeout(timeoutId);
-        this.markOfflineState();
+    try {
+      const response = await fetch(this.buildProbeUrl('/actuator/health'), {
+        method: 'GET',
+        signal: controller.signal,
+        cache: 'no-store',
+        redirect: 'error',
       });
+      this.ensureSuccessfulProbeResponse(response);
+      this.markMeasuredOnlineState(performance.now() - start);
+      return true;
+    } catch {
+      this.markProbeFailureState();
+      return false;
+    } finally {
+      clearTimeout(timeoutId);
+    }
   }
 
   private normalizeConnectionTransport(value: unknown): ConnectionTransport {
@@ -277,17 +288,42 @@ export class NetworkStatusService implements OnDestroy {
     }
   }
 
+  private buildProbeUrl(path: string): string {
+    const separator = path.includes('?') ? '&' : '?';
+    return `${path}${separator}offlineProbe=${Date.now()}`;
+  }
+
   private markMeasuredOnlineState(rtt: number): void {
     this.online.set(true);
+    this.consecutiveProbeFailures = 0;
     this.recentOfflineSignalAt.set(null);
 
-    if (rtt > 500) {
+    const reportedDownlink = this.reportedDownlinkMbps();
+    if (reportedDownlink != null) {
+      this.effectiveBandwidthMbps.set(reportedDownlink);
+      return;
+    }
+
+    if (rtt > 1200) {
       this.effectiveBandwidthMbps.set(0.5);
-    } else if (rtt > 200) {
+    } else if (rtt > 700) {
       this.effectiveBandwidthMbps.set(1.5);
     } else {
       this.effectiveBandwidthMbps.set(10);
     }
+  }
+
+  private markProbeFailureState(): void {
+    this.consecutiveProbeFailures += 1;
+    this.recentOfflineSignalAt.set(Date.now());
+
+    if (!this.getBrowserOnlineHint() || this.consecutiveProbeFailures >= OFFLINE_PROBE_FAILURE_THRESHOLD) {
+      this.markOfflineState();
+      return;
+    }
+
+    this.online.set(true);
+    this.effectiveBandwidthMbps.set(DEGRADED_PROBE_BANDWIDTH_MBPS);
   }
 
   private markOfflineState(): void {

--- a/fe/src/app/core/services/offline-video.service.spec.ts
+++ b/fe/src/app/core/services/offline-video.service.spec.ts
@@ -1,0 +1,20 @@
+import {
+  OFFLINE_VIDEO_MAX_CACHE_BYTES,
+  OfflineVideoTooLargeError,
+  isOfflineVideoTooLargeError,
+} from './offline-video.service';
+
+describe('OfflineVideoService download guards', () => {
+  it('classifies oversized video errors for non-fatal course downloads', () => {
+    const error = new OfflineVideoTooLargeError(OFFLINE_VIDEO_MAX_CACHE_BYTES + 1);
+
+    expect(isOfflineVideoTooLargeError(error)).toBeTrue();
+    expect(error.message).toContain('Video too large to cache');
+  });
+
+  it('recognizes the legacy oversized video error message', () => {
+    const error = new Error('Video too large to cache (720MB > 500MB). Reduce quality or skip download.');
+
+    expect(isOfflineVideoTooLargeError(error)).toBeTrue();
+  });
+});

--- a/fe/src/app/core/services/offline-video.service.ts
+++ b/fe/src/app/core/services/offline-video.service.ts
@@ -9,6 +9,27 @@ import {
 } from '../db/lms-offline.db';
 import type { OfflineVideoProfileId, VideoSourceKind } from '../models/video-quality';
 
+export const OFFLINE_VIDEO_MAX_CACHE_BYTES = 500 * 1024 * 1024;
+
+export class OfflineVideoTooLargeError extends Error {
+  override readonly name = 'OfflineVideoTooLargeError';
+
+  constructor(
+    readonly sizeBytes: number,
+    readonly maxBytes = OFFLINE_VIDEO_MAX_CACHE_BYTES,
+  ) {
+    super(
+      `Video too large to cache (${Math.round(sizeBytes / 1024 / 1024)}MB > ${Math.round(maxBytes / 1024 / 1024)}MB). ` +
+      'Reduce quality or skip download.',
+    );
+  }
+}
+
+export function isOfflineVideoTooLargeError(error: unknown): error is OfflineVideoTooLargeError {
+  return error instanceof OfflineVideoTooLargeError
+    || (error instanceof Error && /Video too large to cache/i.test(error.message));
+}
+
 export interface OfflineVideoEntry {
   cacheKey: string;
   lessonId: string;
@@ -50,8 +71,9 @@ export class OfflineVideoService {
 
     try {
       await this.ensureOfflineReady();
-      const response = await fetch(videoUrl);
+      const response = await fetch(videoUrl, { cache: 'no-store' });
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      this.assertResponseWithinOfflineLimit(response);
 
       await this.cacheVideoResponse(`/offline-video/${lessonId}`, response, lessonId);
 
@@ -86,8 +108,9 @@ export class OfflineVideoService {
     this.isDownloading.set(true);
     try {
       await this.ensureOfflineReady();
-      const response = await fetch(videoUrl);
+      const response = await fetch(videoUrl, { cache: 'no-store' });
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      this.assertResponseWithinOfflineLimit(response);
 
       await this.cacheVideoResponse(`/offline-video/${sectionId}`, response, sectionId);
       this.clearDownloadProgress(sectionId);
@@ -374,12 +397,8 @@ export class OfflineVideoService {
     // Buffer path: read chunks once with progress tracking, then cache.put as blob.
     // 1x network fetch, RAM peak ~ video size briefly. Used on Chromium desktop
     // where cache.put(ReadableStream) is unreliable.
-    const SAFE_BUFFER_LIMIT = 500 * 1024 * 1024;
-    if (contentLength > 0 && contentLength > SAFE_BUFFER_LIMIT) {
-      throw new Error(
-        `Video too large to cache (${Math.round(contentLength / 1024 / 1024)}MB > 500MB). ` +
-        `Reduce quality or skip download.`,
-      );
+    if (contentLength > 0 && contentLength > OFFLINE_VIDEO_MAX_CACHE_BYTES) {
+      throw new OfflineVideoTooLargeError(contentLength);
     }
 
     const reader = response.body!.getReader();
@@ -391,6 +410,10 @@ export class OfflineVideoService {
       if (done) break;
       chunks.push(value);
       received += value.length;
+      if (received > OFFLINE_VIDEO_MAX_CACHE_BYTES) {
+        await reader.cancel();
+        throw new OfflineVideoTooLargeError(received);
+      }
       if (contentLength > 0) {
         this.downloadProgress.update(map => {
           const next = new Map(map);
@@ -432,6 +455,11 @@ export class OfflineVideoService {
           return;
         }
         received += value.length;
+        if (received > OFFLINE_VIDEO_MAX_CACHE_BYTES) {
+          controller.error(new OfflineVideoTooLargeError(received));
+          await reader.cancel();
+          return;
+        }
         controller.enqueue(value);
         if (contentLength > 0) {
           this.downloadProgress.update(map => {
@@ -483,5 +511,15 @@ export class OfflineVideoService {
 
       return false;
     }
+  }
+
+  private assertResponseWithinOfflineLimit(response: Response): void {
+    const contentLength = Number(response.headers.get('content-length')) || 0;
+    if (contentLength <= OFFLINE_VIDEO_MAX_CACHE_BYTES) {
+      return;
+    }
+
+    void response.body?.cancel().catch(() => undefined);
+    throw new OfflineVideoTooLargeError(contentLength);
   }
 }

--- a/fe/src/app/shared/components/offline-fallback/offline-fallback.component.ts
+++ b/fe/src/app/shared/components/offline-fallback/offline-fallback.component.ts
@@ -1,9 +1,10 @@
-import { Component, ChangeDetectionStrategy, inject, computed } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Component, ChangeDetectionStrategy, inject, computed, signal } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
 import { LucideAngularModule } from 'lucide-angular';
 import { CourseDownloadService } from '../../../core/services/course-download.service';
 import { StorageManagerService } from '../../../core/services/storage-manager.service';
 import { OfflineSyncService } from '../../../core/services/offline-sync.service';
+import { NetworkStatusService } from '../../../core/services/network-status.service';
 
 export const OFFLINE_FALLBACK_COURSE_ROUTE_PREFIX = '/student/learn/course';
 
@@ -33,10 +34,13 @@ export const OFFLINE_FALLBACK_COURSE_ROUTE_PREFIX = '/student/learn/course';
                     <button
                       type="button"
                       (click)="retry()"
+                      [disabled]="isRetrying()"
                       class="inline-flex h-10 items-center justify-center gap-2 rounded-lg bg-[#0056D2] px-4 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[#004BB5] focus:outline-none focus:ring-2 focus:ring-[#0056D2] focus:ring-offset-2"
+                      [class.cursor-wait]="isRetrying()"
+                      [class.opacity-75]="isRetrying()"
                     >
-                      <lucide-icon name="refresh-cw" [size]="16" aria-hidden="true"></lucide-icon>
-                      Thử kết nối lại
+                      <lucide-icon name="refresh-cw" [size]="16" [class.animate-spin]="isRetrying()" aria-hidden="true"></lucide-icon>
+                      {{ isRetrying() ? 'Đang kiểm tra...' : 'Thử kết nối lại' }}
                     </button>
 
                     @if (downloadCount() > 0) {
@@ -49,6 +53,16 @@ export const OFFLINE_FALLBACK_COURSE_ROUTE_PREFIX = '/student/learn/course';
                       </a>
                     }
                   </div>
+
+                  @if (retryMessage()) {
+                    <p
+                      class="mt-3 max-w-xl rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      {{ retryMessage() }}
+                    </p>
+                  }
                 </div>
               </div>
             </div>
@@ -197,8 +211,12 @@ export class OfflineFallbackComponent {
   private readonly courseDownload = inject(CourseDownloadService);
   private readonly storageManager = inject(StorageManagerService);
   private readonly syncService = inject(OfflineSyncService);
+  private readonly networkStatus = inject(NetworkStatusService);
+  private readonly router = inject(Router);
 
   protected readonly courseRoutePrefix = OFFLINE_FALLBACK_COURSE_ROUTE_PREFIX;
+  protected readonly isRetrying = signal(false);
+  protected readonly retryMessage = signal<string | null>(null);
   protected readonly downloadedCourses = computed(() => this.courseDownload.downloadedCourses());
   protected readonly downloadCount = computed(() => this.downloadedCourses().length);
   protected readonly pendingSync = computed(() => this.syncService.pendingCount());
@@ -216,8 +234,25 @@ export class OfflineFallbackComponent {
     return this.storageManager.formatBytes(bytes);
   }
 
-  protected retry(): void {
-    window.location.reload();
+  protected async retry(): Promise<void> {
+    if (this.isRetrying()) {
+      return;
+    }
+
+    this.isRetrying.set(true);
+    this.retryMessage.set(null);
+
+    try {
+      const hasConnection = await this.networkStatus.probeNow();
+      if (hasConnection) {
+        await this.router.navigateByUrl('/student/courses');
+        return;
+      }
+
+      this.retryMessage.set('Chưa kết nối được. Nếu bạn vừa bật mạng, hãy đợi vài giây rồi thử lại.');
+    } finally {
+      this.isRetrying.set(false);
+    }
   }
 
   protected retryFailed(): void {

--- a/fe/src/app/shared/components/offline-indicator/offline-indicator.component.ts
+++ b/fe/src/app/shared/components/offline-indicator/offline-indicator.component.ts
@@ -14,43 +14,62 @@ import { SessionExpiredService } from '../../../core/services/session-expired.se
   template: `
     @if (isOffline() && !isOfflineRoute()) {
       <div
-        class="pointer-events-none fixed left-1/2 z-[1000] w-[calc(100vw-1.5rem)] max-w-xl -translate-x-1/2 transition-all duration-200 sm:w-[calc(100vw-2rem)]"
-        [class.top-3]="!hasExpiredBanner()"
-        [class.top-14]="hasExpiredBanner()"
+        class="pointer-events-none fixed bottom-20 right-3 z-[950] max-w-[calc(100vw-1.5rem)] transition-all duration-200 sm:bottom-4 sm:right-4 sm:max-w-sm"
         role="status"
         aria-live="polite"
       >
-        <div class="pointer-events-auto flex min-h-11 items-center justify-between gap-3 rounded-xl border border-amber-200 bg-amber-50/95 px-3 py-2 text-amber-950 shadow-lg shadow-amber-950/10 backdrop-blur sm:px-4">
-          <div class="flex min-w-0 items-center gap-3">
-            <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-700">
-              <lucide-icon name="wifi-off" [size]="15" aria-hidden="true"></lucide-icon>
-            </span>
-            <div class="min-w-0">
-              <div class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-                <span class="truncate text-sm font-semibold">Đang ngoại tuyến</span>
-                @if (pendingSyncCount() > 0) {
-                  <span class="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-semibold text-amber-800">
-                    {{ pendingSyncCount() }} mục chờ đồng bộ
-                  </span>
-                }
+        @if (showOfflineDetails()) {
+          <div class="pointer-events-auto rounded-xl border border-amber-200 bg-white/95 p-3 text-slate-900 shadow-lg shadow-slate-900/10 backdrop-blur">
+            <div class="flex items-start gap-3">
+              <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-50 text-amber-700 ring-1 ring-amber-100">
+                <lucide-icon name="wifi-off" [size]="18" aria-hidden="true"></lucide-icon>
+              </span>
+              <div class="min-w-0 flex-1">
+                <div class="flex min-w-0 items-center gap-2">
+                  <span class="truncate text-sm font-semibold">Đang ngoại tuyến</span>
+                  @if (pendingSyncCount() > 0) {
+                    <span class="shrink-0 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-800">
+                      {{ pendingSyncCount() }} chờ đồng bộ
+                    </span>
+                  }
+                </div>
+                <p class="mt-1 text-xs leading-5 text-slate-600">
+                  Nội dung đã tải vẫn dùng được. Tiến độ sẽ tự đồng bộ khi kết nối ổn định.
+                </p>
+                <div class="mt-3 flex items-center gap-2">
+                  <a
+                    routerLink="/offline"
+                    class="inline-flex h-8 items-center justify-center rounded-lg bg-[#0056D2] px-3 text-xs font-semibold text-white transition-colors hover:bg-[#004BB5] focus:outline-none focus:ring-2 focus:ring-[#0056D2] focus:ring-offset-2"
+                  >
+                    Kho offline
+                  </a>
+                  <button
+                    type="button"
+                    (click)="dismissOfflineBanner()"
+                    class="inline-flex h-8 items-center justify-center rounded-lg border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-600 transition-colors hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-[#0056D2] focus:ring-offset-2"
+                  >
+                    Thu gọn
+                  </button>
+                </div>
               </div>
-              <p class="hidden truncate text-xs text-amber-800 sm:block">
-                Bạn vẫn xem được nội dung đã tải. Tiến độ sẽ đồng bộ khi có mạng.
-              </p>
             </div>
           </div>
-
+        } @else {
           <a
             routerLink="/offline"
-            class="shrink-0 rounded-lg border border-amber-200 bg-white/80 px-3 py-1.5 text-xs font-semibold text-amber-900 transition-colors hover:bg-white focus:outline-none focus:ring-2 focus:ring-amber-400"
+            class="pointer-events-auto inline-flex h-10 items-center gap-2 rounded-full border border-amber-200 bg-white/95 px-3 text-xs font-semibold text-amber-900 shadow-md shadow-slate-900/10 backdrop-blur transition-colors hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-400"
+            aria-label="Mở kho offline"
           >
+            <lucide-icon name="wifi-off" [size]="15" aria-hidden="true"></lucide-icon>
             Kho offline
           </a>
-        </div>
+        }
       </div>
     } @else if (isSyncing()) {
       <div
-        class="pointer-events-none fixed left-1/2 top-3 z-[1000] w-[calc(100vw-1.5rem)] max-w-sm -translate-x-1/2 sm:w-auto"
+        class="pointer-events-none fixed left-1/2 z-[1000] w-[calc(100vw-1.5rem)] max-w-sm -translate-x-1/2 sm:w-auto"
+        [class.top-3]="!hasExpiredBanner()"
+        [class.top-14]="hasExpiredBanner()"
         role="status"
         aria-live="polite"
       >
@@ -61,7 +80,9 @@ import { SessionExpiredService } from '../../../core/services/session-expired.se
       </div>
     } @else if (isSlow()) {
       <div
-        class="pointer-events-none fixed left-1/2 top-3 z-[1000] w-[calc(100vw-1.5rem)] max-w-sm -translate-x-1/2 sm:w-auto"
+        class="pointer-events-none fixed left-1/2 z-[1000] w-[calc(100vw-1.5rem)] max-w-sm -translate-x-1/2 sm:w-auto"
+        [class.top-3]="!hasExpiredBanner()"
+        [class.top-14]="hasExpiredBanner()"
         role="status"
         aria-live="polite"
       >
@@ -80,6 +101,8 @@ export class OfflineIndicatorComponent {
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
   private readonly currentUrl = signal(this.router.url);
+  private readonly offlineBannerDismissed = signal(false);
+  private readonly compactViewport = signal(this.readCompactViewport());
 
   constructor() {
     this.router.events
@@ -88,6 +111,13 @@ export class OfflineIndicatorComponent {
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(event => this.currentUrl.set(event.urlAfterRedirects));
+
+    if (typeof window !== 'undefined') {
+      const media = window.matchMedia('(max-width: 640px)');
+      const handleViewportChange = () => this.compactViewport.set(media.matches);
+      media.addEventListener('change', handleViewportChange);
+      this.destroyRef.onDestroy(() => media.removeEventListener('change', handleViewportChange));
+    }
   }
 
   protected readonly isOffline = computed(() => {
@@ -96,9 +126,18 @@ export class OfflineIndicatorComponent {
     if (typeof navigator !== 'undefined' && !navigator.onLine) return true;
     return false;
   });
+  protected readonly showOfflineDetails = computed(() => !this.compactViewport() && !this.offlineBannerDismissed());
   protected readonly isSyncing = computed(() => !this.isOffline() && this.syncService.isSyncing());
   protected readonly isSlow = computed(() => this.network.connectionTier() === 'slow');
   protected readonly pendingSyncCount = computed(() => this.syncService.pendingCount());
   protected readonly hasExpiredBanner = computed(() => this.sessionService.showExpiredBanner());
   protected readonly isOfflineRoute = computed(() => this.currentUrl().startsWith('/offline'));
+
+  protected dismissOfflineBanner(): void {
+    this.offlineBannerDismissed.set(true);
+  }
+
+  private readCompactViewport(): boolean {
+    return typeof window !== 'undefined' && window.matchMedia('(max-width: 640px)').matches;
+  }
 }


### PR DESCRIPTION
﻿## Summary
- Make network state less noisy: one failed probe becomes degraded/slow instead of immediately offline; `/offline` retry now probes `/actuator/health` and routes back to the student course page when reachable.
- Replace the blocking offline banner with a compact, dismissible bottom indicator; mobile defaults to a small `Kho offline` pill.
- Harden offline video downloads by skipping placeholder `example.*` URLs, preempting videos above the 500 MB offline cache ceiling, and reporting skipped videos via a user-facing summary instead of console errors.

## Root Cause
The app mixed three different states: true offline, weak/degraded connection, and transient backend/API failures. That made the UI show persistent offline affordances too eagerly. The downloader also attempted to fetch seeded placeholder URLs and oversized videos, which produced CSP console noise and could overload mobile browsers.

## Validation
- `npm run test:ci -- --include src/app/core/services/network-status.service.spec.ts --include src/app/core/services/offline-video.service.spec.ts --include src/app/shared/components/offline-fallback/offline-fallback.component.spec.ts`
- `npm run build`
- Playwright local smoke:
  - `/offline` retry leaves the offline page after a successful health probe.
  - Mobile offline indicator renders as a small bottom pill.
  - Desktop offline indicator stays at the bottom and no longer blocks the top content.

## Notes
- Build still reports pre-existing Angular/Sass/CommonJS warnings outside this change set.
- This does not change the 500 MB offline video cache ceiling; it enforces it consistently before mobile devices do expensive work.
