### PR TITLE
[codex] Remove course detail section accent

### DIFF
--- a/fe/src/app/features/student/pages/course-detail.component.scss
+++ b/fe/src/app/features/student/pages/course-detail.component.scss
@@ -702,22 +702,12 @@ $gray-900: #111827;
 }
 
 .section-item {
-  position: relative;
-  border: 1px solid #DDE6F0;
+  border: 1px solid #E2E8F0;
   border-radius: 10px;
   overflow: hidden;
   min-width: 0;
   background: white;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
-
-  &::before {
-    content: '';
-    position: absolute;
-    inset: 0 auto 0 0;
-    width: 3px;
-    background: $primary;
-    opacity: 0.72;
-  }
 }
 
 .section-header {


### PR DESCRIPTION
﻿## Summary
- Remove the blue left accent pseudo-element from student course detail curriculum section cards.
- Keep the section card structure intact with a neutral border so the curriculum list stays aligned without the extra blue strip.

## Validation
- `npx tsc -p tsconfig.app.json --noEmit --pretty false`
- `npx ng build --configuration development --progress=false`

## Notes
- Existing Angular build warnings are unrelated to this SCSS-only change.
