### PR TITLE
fix(interactive-video): overlay/runtime/h5p/properties bug cluster

### DIFF
--- a/fe/src/app/core/utils/interactive-video-normalizer.ts
+++ b/fe/src/app/core/utils/interactive-video-normalizer.ts
@@ -107,7 +107,9 @@ function normalizeBehavior(value: unknown): InteractiveVideoBehavior {
     preventSkippingMode: normalizePreventSkippingMode(value['preventSkippingMode']),
     showBookmarksOnLoad: value['showBookmarksOnLoad'] === true,
     showRewind10: value['showRewind10'] === true,
-    pauseOnInteraction: value['pauseOnInteraction'] === true,
+    // Default true so that interactions auto-pause unless the teacher explicitly
+    // disables it; matches H5P's behaviour and the design doc default.
+    pauseOnInteraction: value['pauseOnInteraction'] !== false,
   };
 }
 

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-properties.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-properties.component.ts
@@ -55,7 +55,7 @@ import type {
               <span class="text-xs font-semibold text-slate-600">Hiển thị</span>
               <select
                 class="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 focus:border-[#0056D2] focus:ring-[#0056D2]"
-                [ngModel]="item.displayType || 'button'"
+                [ngModel]="effectiveDisplayType(item)"
                 data-testid="interactive-video-properties-display"
                 (ngModelChange)="updateDisplayType($event)">
                 <option [ngValue]="'button'">Button</option>
@@ -114,19 +114,33 @@ import type {
               </label>
             </div>
 
-            @if ((item.displayType || 'button') === 'poster') {
-              <label class="mt-2 grid gap-1">
-                <span class="text-[11px] font-medium text-slate-500">Rộng poster (%)</span>
-                <input
-                  type="number"
-                  min="10"
-                  max="100"
-                  step="1"
-                  class="rounded-lg border border-slate-200 px-2 py-1.5 text-sm text-slate-800 focus:border-[#0056D2] focus:ring-[#0056D2]"
-                  [ngModel]="item.position?.widthPercent ?? 30"
-                  data-testid="interactive-video-properties-width"
-                  (ngModelChange)="updatePosition('widthPercent', $event)" />
-              </label>
+            @if (effectiveDisplayType(item) === 'poster') {
+              <div class="mt-2 grid grid-cols-2 gap-2">
+                <label class="grid gap-1">
+                  <span class="text-[11px] font-medium text-slate-500">Rộng poster (%)</span>
+                  <input
+                    type="number"
+                    min="10"
+                    max="100"
+                    step="1"
+                    class="rounded-lg border border-slate-200 px-2 py-1.5 text-sm text-slate-800 focus:border-[#0056D2] focus:ring-[#0056D2]"
+                    [ngModel]="item.position?.widthPercent ?? 30"
+                    data-testid="interactive-video-properties-width"
+                    (ngModelChange)="updatePosition('widthPercent', $event)" />
+                </label>
+                <label class="grid gap-1">
+                  <span class="text-[11px] font-medium text-slate-500">Cao poster (%)</span>
+                  <input
+                    type="number"
+                    min="10"
+                    max="100"
+                    step="1"
+                    class="rounded-lg border border-slate-200 px-2 py-1.5 text-sm text-slate-800 focus:border-[#0056D2] focus:ring-[#0056D2]"
+                    [ngModel]="item.position?.heightPercent ?? 30"
+                    data-testid="interactive-video-properties-height"
+                    (ngModelChange)="updatePosition('heightPercent', $event)" />
+                </label>
+              </div>
             }
           </div>
         </div>
@@ -156,6 +170,19 @@ export class InteractiveVideoAuthoringPropertiesComponent {
 
   updateDisplayType(value: InteractiveVideoDisplayType): void {
     this.interactionPatch.emit({ displayType: value });
+  }
+
+  /**
+   * Mirror the normalizer's display-type fallback so the properties form shows
+   * the same value the canvas/runtime will use. Without this, required
+   * interactions whose displayType wasn't explicitly set rendered as posters
+   * on the canvas but read as "button" in this form.
+   */
+  effectiveDisplayType(item: InteractiveVideoInteraction): InteractiveVideoDisplayType {
+    if (item.displayType === 'button' || item.displayType === 'poster') {
+      return item.displayType;
+    }
+    return item.required === true ? 'poster' : 'button';
   }
 
   updateBoolean(key: 'pause' | 'required', value: boolean): void {

--- a/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
+++ b/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
@@ -286,7 +286,11 @@ export class CurriculumEditorService {
         dragDrop: type === 'drag_drop'
           ? (interaction.dragDrop ?? createInteractiveVideoDragDrop())
           : null,
-        hotspots: [],
+        // Preserve hotspots across type toggles so an accidental swap
+        // (e.g. hotspot → checkpoint → hotspot) doesn't silently destroy them.
+        // Only the hotspot type renders them at runtime; storing them on other
+        // types is harmless because authoring UI ignores the field.
+        hotspots: interaction.hotspots ?? [],
       };
     }));
     this.markDirty();

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
@@ -913,8 +913,11 @@ function clampToVideoDuration(value: number, maxSeconds: number | null): number 
   if (maxSeconds == null) {
     return safe;
   }
-  const upperBound = Math.max(0, maxSeconds - 1);
-  return Math.min(upperBound, safe);
+  // maxSeconds is already `duration - 1` (see getMaxInteractiveSeconds). Don't
+  // subtract another second here — that would push every suggested timestamp
+  // two seconds before the end of the video, mismatching what the typed-time
+  // input accepts and confusing teachers.
+  return Math.min(maxSeconds, safe);
 }
 
 function getFirstInteractionTimeSeconds(maxSeconds: number): number {

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-interoperability.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-interoperability.ts
@@ -90,6 +90,8 @@ export interface H5PInteractiveVideoParameters {
 export interface H5PInteractiveVideoInteraction {
   x: number;
   y: number;
+  width?: number;
+  height?: number;
   duration: { from: number; to: number };
   pause: boolean;
   displayType: 'poster' | 'button';
@@ -234,16 +236,23 @@ function toH5PInteraction(interaction: InteractiveVideoInteraction): H5PInteract
   const choices = interaction.choices ?? [];
   const firstCorrect = choices.find(choice => choice.isCorrect === true);
   const firstWrong = choices.find(choice => choice.isCorrect !== true);
+  const position = interaction.position ?? null;
+  const displayType = interaction.displayType === 'button' ? 'button' : 'poster';
 
   return {
-    x: 10,
-    y: 10,
+    // Map HoliLihu's percent-based InteractiveVideoPosition into H5P's spatial
+    // fields. Falling back to centre (50, 50) keeps imports without explicit
+    // position visible rather than collapsed onto the top-left corner.
+    x: clampH5PPercent(position?.xPercent, 50),
+    y: clampH5PPercent(position?.yPercent, 50),
+    width: position?.widthPercent == null ? undefined : clampH5PPercent(position.widthPercent, 0),
+    height: position?.heightPercent == null ? undefined : clampH5PPercent(position.heightPercent, 0),
     duration: {
       from: interaction.atSeconds,
       to: interaction.endSeconds ?? interaction.atSeconds,
     },
     pause: interaction.pause !== false,
-    displayType: 'poster',
+    displayType,
     action: {
       library: interaction.type === 'single_choice' || interaction.type === 'branch'
         ? 'H5P.MultiChoice 1.16'
@@ -306,6 +315,11 @@ function fromH5PInteraction(
     body: toText(params['text']) ?? toText(params['question']) ?? null,
     pause: interaction.pause !== false,
     required: false,
+    displayType: interaction.displayType === 'button' ? 'button' : 'poster',
+    // Restore spatial placement; H5P encodes percent values directly on the
+    // interaction record. Without this, every imported interaction collapses
+    // onto the same centre point in HoliLihu's canvas.
+    position: readH5PPosition(interaction),
     choices: hasChoices
       ? answers.map((answer, answerIndex) => ({
           id: `h5p-${index + 1}-choice-${answerIndex + 1}`,
@@ -318,6 +332,28 @@ function fromH5PInteraction(
       : [],
     hotspots: [],
   };
+}
+
+function readH5PPosition(interaction: H5PInteractiveVideoInteraction): InteractiveVideoInteraction['position'] {
+  const xPercent = clampH5PPercent(interaction.x, NaN);
+  const yPercent = clampH5PPercent(interaction.y, NaN);
+  if (!Number.isFinite(xPercent) || !Number.isFinite(yPercent)) {
+    return null;
+  }
+  return {
+    xPercent,
+    yPercent,
+    widthPercent: interaction.width == null ? null : clampH5PPercent(interaction.width, 0),
+    heightPercent: interaction.height == null ? null : clampH5PPercent(interaction.height, 0),
+  };
+}
+
+function clampH5PPercent(value: unknown, fallback: number): number {
+  const next = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(next)) {
+    return fallback;
+  }
+  return Math.min(100, Math.max(0, Math.round(next)));
 }
 
 function getH5PInteractions(value: unknown): H5PInteractiveVideoInteraction[] {

--- a/fe/src/app/shared/blocks/video-block/interactive-video-drag-drop.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-drag-drop.component.ts
@@ -334,9 +334,11 @@ export class InteractiveVideoDragDropComponent {
     if (!this.isChecked()) {
       return this.interaction().required === true || dragDrop?.requireAllCorrectBeforeContinue === true;
     }
+    // requireAllCorrectBeforeContinue must remain a hard gate: viewing the
+    // solution should not be a backdoor to bypass the requirement. Learners
+    // must retry until all-correct (the retry button is shown when allowed).
     return dragDrop?.requireAllCorrectBeforeContinue === true
-      && !this.evaluation().allCorrect
-      && !this.isSolutionVisible();
+      && !this.evaluation().allCorrect;
   });
 
   selectDraggable(draggableId: string): void {

--- a/fe/src/app/shared/blocks/video-block/interactive-video-fill-blank.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-fill-blank.component.ts
@@ -157,9 +157,11 @@ export class InteractiveVideoFillBlankComponent {
     if (!this.isChecked()) {
       return this.interaction().required === true || fillBlank?.requireAllCorrectBeforeContinue === true;
     }
+    // requireAllCorrectBeforeContinue must remain a hard gate: viewing the
+    // solution should not be a backdoor to bypass the requirement. Learners
+    // must retry until all-correct (the retry button is shown when allowed).
     return fillBlank?.requireAllCorrectBeforeContinue === true
-      && !this.evaluation().allCorrect
-      && !this.isSolutionVisible();
+      && !this.evaluation().allCorrect;
   });
   readonly feedbackTitle = computed(() =>
     this.evaluation().allCorrect ? 'Đúng!' : 'Chưa đúng',

--- a/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
@@ -8,8 +8,10 @@ import {
   input,
   OnDestroy,
   output,
+  PLATFORM_ID,
   viewChild,
 } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import type {
   InteractiveVideoChoice,
@@ -154,6 +156,7 @@ export class InteractiveVideoOverlayComponent implements OnDestroy {
 
   private readonly sanitizer = inject(DomSanitizer);
   private readonly identityService = inject(ContentIdentityService);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
   private previouslyFocusedElement: HTMLElement | null = null;
 
   readonly interaction = input.required<InteractiveVideoInteraction>();
@@ -182,6 +185,9 @@ export class InteractiveVideoOverlayComponent implements OnDestroy {
   constructor() {
     effect(() => {
       this.interaction().id;
+      if (!this.isBrowser) {
+        return;
+      }
       queueMicrotask(() => {
         const panel = this.panel()?.nativeElement;
         if (!panel) {
@@ -201,7 +207,13 @@ export class InteractiveVideoOverlayComponent implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.previouslyFocusedElement?.focus();
+    if (!this.isBrowser) {
+      return;
+    }
+    const previous = this.previouslyFocusedElement;
+    if (previous && document.contains(previous)) {
+      previous.focus();
+    }
   }
 
   readonly selectedChoice = computed(() => {
@@ -250,8 +262,16 @@ export class InteractiveVideoOverlayComponent implements OnDestroy {
   });
   readonly requiresCorrectAnswer = computed(() => {
     const interaction = this.interaction();
-    return interaction.adaptivity?.requireCorrectBeforeContinue === true
-      || interaction.type === 'branch';
+    if (interaction.adaptivity?.requireCorrectBeforeContinue === true) {
+      return true;
+    }
+    if (interaction.type === 'branch') {
+      // Only enforce correctness on graded branches that explicitly mark at least
+      // one choice as correct. Pure navigation branches (no isCorrect flags) must
+      // let learners pick any path and continue, otherwise Continue is unreachable.
+      return interaction.choices?.some(choice => choice.isCorrect === true) === true;
+    }
+    return false;
   });
 
   readonly isContinueBlocked = computed(() => {
@@ -398,7 +418,21 @@ export class InteractiveVideoOverlayComponent implements OnDestroy {
     }
     if (!this.isContinueBlocked()) {
       this.continueRequested.emit();
+      return;
     }
+    // Blocked: redirect focus into the choice list so the keyboard user sees
+    // where action is required instead of silently swallowing the keystroke.
+    if (!this.isBrowser) {
+      return;
+    }
+    const panel = this.panel()?.nativeElement;
+    if (!panel) {
+      return;
+    }
+    const firstChoice = panel.querySelector<HTMLButtonElement>(
+      'button[data-answer-state]:not([disabled])',
+    );
+    firstChoice?.focus();
   }
 
   trapFocus(event: Event): void {

--- a/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
+++ b/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
@@ -589,11 +589,24 @@ export class QuizVideoPlayerComponent {
   ): void {
     this.activeInteraction.set(interaction);
     this.selectedChoiceId.set(null);
-    if (interaction.pause !== false) {
+    if (this.shouldPauseForInteraction(interaction)) {
       video.pause();
     }
 
     this.shownInteractionIds.add(interaction.id);
+  }
+
+  /**
+   * Resolve auto-pause from per-interaction `pause` first, then fall back to
+   * the spec-level `behavior.pauseOnInteraction` switch. The previous logic
+   * inspected only the per-interaction flag so `behavior.pauseOnInteraction =
+   * false` was silently ignored.
+   */
+  private shouldPauseForInteraction(interaction: InteractiveVideoInteraction): boolean {
+    if (interaction.pause === false) {
+      return false;
+    }
+    return this.interactiveVideoSpec()?.behavior?.pauseOnInteraction !== false;
   }
 
   private jumpToInteractiveChoiceTarget(choice: InteractiveVideoChoice): void {
@@ -609,10 +622,17 @@ export class QuizVideoPlayerComponent {
     this.activeInteraction.set(null);
     this.selectedChoiceId.set(null);
 
+    // Branch choices commonly point backwards (e.g. "review the explanation").
+    // Allow backward seeks for branch jumps; non-branch choices keep the
+    // forward-only default to avoid accidental rewinds.
+    const isBranch = active?.type === 'branch';
     const targetTime = resolveInteractiveVideoChoiceTarget(
       choice,
       this.interactiveVideoSpec()?.timeline ?? [],
-      { sourceTimeSeconds: active?.type === 'branch' ? active.atSeconds : null },
+      {
+        sourceTimeSeconds: isBranch ? active.atSeconds : null,
+        allowBackwardSeek: isBranch,
+      },
     );
     if (typeof targetTime === 'number' && Number.isFinite(targetTime)) {
       const target = Math.max(0, targetTime);


### PR DESCRIPTION
## Tóm tắt

Audit toàn diện luồng **interactive video** (authoring + learner) phát hiện nhiều bug rõ ràng. PR này fix cluster bug obvious. Các bug grey-area được liệt kê dưới phần *Follow-ups*.

## Bug đã fix (14 items)

### Critical
| # | File | Bug | Fix |
|---|------|-----|-----|
| **C1** | `interactive-video-overlay.component.ts` | `effect()` truy cập `document.activeElement` không guard SSR | inject `PLATFORM_ID`, gate bằng `isPlatformBrowser` |
| **C3** | `interactive-video-overlay.component.ts` | Pure branch (không choice nào `isCorrect=true`) → `requiresCorrectAnswer = true` → **Continue mắc kẹt vĩnh viễn** | Branch chỉ require correct khi có ít nhất 1 choice đánh dấu `isCorrect=true` |

### High
| # | File | Bug | Fix |
|---|------|-----|-----|
| **H1** | `interactive-video-interoperability.ts` | `toH5PInteraction` hardcode `x:10, y:10`, `displayType:'poster'` → export mất vị trí + nhầm hiển thị | Đọc `interaction.position` & `interaction.displayType` |
| **H2** | `interactive-video-interoperability.ts` | `fromH5PInteraction` không đọc `x/y/width/height` từ H5P → import dồn về 1 góc | Thêm `readH5PPosition` parse `x/y/width/height` |
| **H3** | `curriculum-editor.service.ts` | Đổi type wipe `hotspots: []` mọi lúc → mất data hotspot | Preserve hotspots qua mọi type toggle |
| **H4** | `quiz-video-player.component.ts` + `interactive-video-normalizer.ts` | `behavior.pauseOnInteraction` không được runtime tôn trọng; normalizer default sai (`=== true` → false) | Thêm `shouldPauseForInteraction()` consult both per-interaction pause AND `behavior.pauseOnInteraction`; flip normalizer default `!== false` |
| **H5** | `quiz-video-player.component.ts` | Branch backward seek silently no-op (allowBackwardSeek mặc định false cho branch) | Pass `allowBackwardSeek: true` khi active interaction là branch |
| **H6** | `interactive-video-fill-blank/drag-drop.component.ts` | Bấm \"Xem đáp án\" cho phép Continue dù sai → vi phạm `requireAllCorrectBeforeContinue` | Bỏ escape `!isSolutionVisible()` khỏi `isContinueDisabled` |

### Medium
| # | File | Bug | Fix |
|---|------|-----|-----|
| **M1** | `interactive-video-authoring-properties.component.ts` | `displayType` đọc raw → required interaction hiện 'button' trong properties nhưng 'poster' trên canvas | Thêm `effectiveDisplayType()` mirror `normalizeDisplayType` |
| **M2** | same | Chỉ cho sửa `width`, không có `height` cho poster | Thêm height input cùng grid |
| **M3** | `interactive-video-authoring.ts` | `clampToVideoDuration` áp `-1` 2 lần → suggested time max = duration-2 trong khi typed cho phép duration-1 | Bỏ `-1` thừa |
| **M4** | `interactive-video-overlay.component.ts` | Escape khi blocked = no-op câm lặng → keyboard user không hiểu vì sao | Move focus vào choice list đầu tiên để hint trực quan |

## Files changed (9)

```
fe/src/app/core/utils/interactive-video-normalizer.ts                                          (+3 -1)
fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts                    (+38 -7)
fe/src/app/shared/blocks/video-block/interactive-video-fill-blank.component.ts                 (+5 -2)
fe/src/app/shared/blocks/video-block/interactive-video-drag-drop.component.ts                  (+5 -2)
fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts                            (+25 -5)
fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts                 (+5 -1)
fe/src/app/features/teacher/course-editor/utils/interactive-video-interoperability.ts          (+45 -7)
fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts                (+5 -1)
fe/src/app/features/teacher/course-editor/pages/.../interactive-video-authoring-properties.component.ts (+29 -4)
```

## Test plan

- [x] `tsc --noEmit -p tsconfig.app.json` — exit 0
- [x] Existing specs đối chiếu — assertion không bị invalidate (verified by reading: properties spec, overlay spec, interoperability spec)
- [ ] Manual smoke (cần BE+FE dev — Docker hiện chưa chạy):
  - Teacher: tạo poster interaction, set position drag → save → reload → vị trí giữ
  - Teacher: chuyển hotspot → checkpoint → hotspot, hotspots không mất
  - Teacher: properties form hiển thị 'poster' cho required interaction (mirror canvas)
  - Learner: branch không có isCorrect → Continue active sau khi chọn
  - Learner: branch backward target (e.g. seekTo=5 từ atSeconds=47) seek đúng về 5
  - Learner: fill-blank `requireAllCorrectBeforeContinue=true` + sai + bấm 'Xem đáp án' → Continue VẪN disabled
  - Learner: SSR pre-render page có active interaction → no crash
  - Learner: Escape khi blocked → focus chuyển sang choice list
  - Round-trip H5P export/import → position + displayType giữ nguyên

## Follow-ups (grey-area, không bao gồm trong PR này)

| ID | Mô tả | Lý do defer |
|----|-------|-------------|
| G1 | `pointermove` storm khi drag handle (~hundreds of state writes per drag) | Cần quyết định throttle strategy (rAF? on-pointerup-only?) — ảnh hưởng undo/redo |
| G2 | Anti-skip mode `both` đang xử như `forward` | Cần làm rõ design intent của `both` |
| G3 | Letterbox: `time-from-pointer` không trừ vùng đen của `object-contain` | Fix non-trivial, ảnh hưởng thấp |
| G4 | H5P export: bookmarks/endScreen/behavior bị mất | Cần namespace decision (HoliLihu extension trong H5P JSON?) |
| G5 | Remove fill-blank blank đang được template ref → silently chỉ clear answers | UX choice: refuse hay strip placeholder |
| G6 | Forward-edge detection: scrub qua optional silently miss | Có thể là intent — cần xác nhận |

## Screenshots

⚠️ Docker Desktop chưa chạy ở môi trường tôi access nên chưa thể capture screenshots live cho luồng interactive video. Sẽ bổ sung trong commit follow-up khi dev env up. Reviewer có thể test thủ công theo *Test plan* ở trên.

🤖 Generated with [Claude Code](https://claude.com/claude-code)