### PR TITLE
feat: add Wiii Pointy LMS safe targets

### DIFF
--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
@@ -353,6 +353,8 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     const button = document.createElement('button');
     button.textContent = 'Bài tiếp theo';
     button.textContent = 'Bai tiep theo';
+    button.setAttribute('data-wiii-click-safe', 'true');
+    button.setAttribute('data-wiii-click-kind', 'navigation');
     const clickSpy = spyOn(button, 'click');
     document.body.appendChild(button);
 
@@ -372,6 +374,8 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     const button = document.createElement('button');
     button.textContent = 'BÃ i tiáº¿p theo';
     button.textContent = 'Bai tiep theo';
+    button.setAttribute('data-wiii-click-safe', 'true');
+    button.setAttribute('data-wiii-click-kind', 'navigation');
     const clickSpy = spyOn(button, 'click');
     document.body.appendChild(button);
 
@@ -389,6 +393,23 @@ describe('WiiiContextService - operator preview/apply flows', () => {
   });
 
   // ── Wiii Pointy V1 — read-only tutor primitives ──
+
+  it('refuses semantic navigation clicks when the host target is not marked safe', async () => {
+    const button = document.createElement('button');
+    button.textContent = 'Bai tiep theo';
+    const clickSpy = spyOn(button, 'click');
+    document.body.appendChild(button);
+
+    try {
+      await expectAsync((service as any).handleActionRequest('navigation.go_to', {
+        target: 'next_lesson',
+      })).toBeRejectedWithError(/Unsupported navigation target/);
+
+      expect(clickSpy).not.toHaveBeenCalled();
+    } finally {
+      button.remove();
+    }
+  });
 
   describe('Wiii Pointy actions', () => {
     afterEach(() => {
@@ -412,7 +433,7 @@ describe('WiiiContextService - operator preview/apply flows', () => {
       document.body.appendChild(target);
 
       const result = await (service as any).handleActionRequest('ui.highlight', {
-        selector: '[data-wiii-id="continue-lesson"]',
+        selector: 'continue-lesson',
         message: 'Đây là nút tiếp tục.',
         duration_ms: 1500,
       });
@@ -422,6 +443,43 @@ describe('WiiiContextService - operator preview/apply flows', () => {
       // The cursor SVG must have been mounted by the handler.
       expect(document.getElementById('wiii-pointy-cursor')).not.toBeNull();
       expect(document.getElementById('wiii-pointy-overlay')).not.toBeNull();
+    });
+
+    it('ui.click only clicks targets explicitly marked safe', async () => {
+      const target = document.createElement('button');
+      target.setAttribute('data-wiii-id', 'browse-courses');
+      target.setAttribute('data-wiii-click-safe', 'true');
+      target.setAttribute('data-wiii-click-kind', 'navigation');
+      target.setAttribute('data-wiii-test', 'pointy');
+      target.textContent = 'Browse';
+      const clickSpy = spyOn(target, 'click');
+      document.body.appendChild(target);
+
+      const result = await (service as any).handleActionRequest('ui.click', {
+        selector: 'browse-courses',
+      });
+
+      expect(result.success).toBeTrue();
+      expect(result.data?.clicked).toBeTrue();
+      expect(result.data?.click_kind).toBe('navigation');
+      expect(clickSpy).toHaveBeenCalled();
+    });
+
+    it('ui.click fails closed for unsafe targets', async () => {
+      const target = document.createElement('button');
+      target.setAttribute('data-wiii-id', 'submit-quiz');
+      target.setAttribute('data-wiii-test', 'pointy');
+      target.textContent = 'Submit';
+      const clickSpy = spyOn(target, 'click');
+      document.body.appendChild(target);
+
+      const result = await (service as any).handleActionRequest('ui.click', {
+        selector: 'submit-quiz',
+      });
+
+      expect(result.success).toBeFalse();
+      expect(result.error).toContain('unsafe_click_target');
+      expect(clickSpy).not.toHaveBeenCalled();
     });
 
     it('ui.highlight fails closed when the selector is missing', async () => {
@@ -462,8 +520,8 @@ describe('WiiiContextService - operator preview/apply flows', () => {
 
       const result = await (service as any).handleActionRequest('ui.show_tour', {
         steps: [
-          { selector: '[data-wiii-id="tour-a"]', message: 'A', duration_ms: 5 },
-          { selector: '[data-wiii-id="tour-b"]', message: 'B', duration_ms: 5 },
+          { selector: 'tour-a', message: 'A', duration_ms: 5 },
+          { selector: 'tour-b', message: 'B', duration_ms: 5 },
         ],
       });
 

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -24,6 +24,7 @@ import { LessonApi } from '../../../../api/client/lesson.api';
 import { QuizApi } from '../../../../api/endpoints/quiz.api';
 import { CurriculumSelectionService } from '../../../teacher/course-editor/services/curriculum-selection.service';
 import {
+  POINTY_ACTION_CLICK,
   POINTY_ACTION_HIGHLIGHT,
   POINTY_ACTION_SCROLL_TO,
   POINTY_ACTION_SHOW_TOUR,
@@ -34,6 +35,7 @@ import {
   resolvePointySelector,
   runTour,
   showSpotlight,
+  type ClickParams,
   type HighlightParams,
   type ScrollToParams,
   type ShowTourParams,
@@ -524,7 +526,8 @@ export class WiiiContextService implements OnDestroy {
         surface: 'host_page',
         result_schema: { type: 'object', properties: { image: { type: 'string' } } },
       },
-      // Wiii Pointy V1 — read-only tutor primitives. No auto-click, no auto-fill.
+      // Wiii Pointy V1.1 — tutor-safe primitives. Safe-click only works on
+      // host-marked navigation-like targets and remains fail-closed.
       // Vendored handlers in `../pointy/`. Quiz answer options must NOT be highlighted
       // (pedagogical guardrail enforced server-side via `lms-pointy-tutor` skill).
       {
@@ -586,6 +589,31 @@ export class WiiiContextService implements OnDestroy {
           properties: {
             completed_steps: { type: 'number' },
             total_steps: { type: 'number' },
+          },
+        },
+      },
+      {
+        name: POINTY_ACTION_CLICK,
+        input_schema: {
+          type: 'object',
+          properties: {
+            selector: { type: 'string' },
+            message: { type: 'string' },
+          },
+          required: ['selector'],
+        },
+        requires_confirmation: false,
+        mutates_state: false,
+        permission: 'use:tools',
+        description:
+          'Bấm một mục điều hướng an toàn đã được LMS đánh dấu data-wiii-click-safe="true". Từ chối mặc định với submit, delete, publish, enroll, grade, payment.',
+        roles: ['student', 'teacher', 'admin'],
+        surface: 'host_page',
+        result_schema: {
+          type: 'object',
+          properties: {
+            clicked: { type: 'boolean' },
+            click_kind: { type: 'string' },
           },
         },
       },
@@ -1501,7 +1529,10 @@ export class WiiiContextService implements OnDestroy {
     if (steps.length === 0) {
       return { success: false, error: 'invalid_tour_steps' };
     }
-    const result = await runTour(steps, { startAt: params.start_at });
+    const result = await runTour(steps, {
+      startAt: params.start_at,
+      resolveSelector: (selector) => resolvePointySelector(selector),
+    });
     // Defensive cleanup if the tour completed without a follow-up call.
     if (result.completed_steps === result.total_steps && !result.cancelled) {
       hideSpotlight();
@@ -1519,6 +1550,59 @@ export class WiiiContextService implements OnDestroy {
     };
   }
 
+  private handlePointyClick(
+    params: ClickParams,
+  ): { success: boolean; data?: Record<string, unknown>; error?: string } {
+    const selector = String(params?.selector || '').trim();
+    if (!selector) {
+      return { success: false, error: 'missing_selector' };
+    }
+    const target = resolvePointySelector(selector);
+    if (!target) {
+      return { success: false, error: `selector_not_found:${selector}` };
+    }
+    if (!(target instanceof HTMLElement) || target.getAttribute('data-wiii-click-safe') !== 'true') {
+      return { success: false, error: `unsafe_click_target:${selector}` };
+    }
+    if (
+      target.hasAttribute('disabled')
+      || target.getAttribute('aria-disabled') === 'true'
+      || (target instanceof HTMLButtonElement && target.disabled)
+    ) {
+      return { success: false, error: `disabled_click_target:${selector}` };
+    }
+    if (!target.isConnected || !this.isVisiblePointyTarget(target)) {
+      return { success: false, error: `target_not_visible:${selector}` };
+    }
+    if (typeof target.scrollIntoView === 'function') {
+      target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+    moveCursorToRect(target.getBoundingClientRect(), { duration_ms: 260 });
+    showSpotlight(target, {
+      message: params.message || 'Wiii đang mở mục này cho bạn.',
+      duration_ms: 900,
+    });
+    target.click();
+    return {
+      success: true,
+      data: {
+        summary: `Đã bấm ${describeTarget(target)}`,
+        clicked: true,
+        click_kind: target.getAttribute('data-wiii-click-kind') || 'safe',
+      },
+    };
+  }
+
+  private isVisiblePointyTarget(target: HTMLElement): boolean {
+    if (typeof window === 'undefined') {
+      return true;
+    }
+    const style = window.getComputedStyle(target);
+    return style.display !== 'none'
+      && style.visibility !== 'hidden'
+      && style.opacity !== '0';
+  }
+
   private async handleActionRequest(
     action: string,
     params: Record<string, unknown>,
@@ -1532,6 +1616,8 @@ export class WiiiContextService implements OnDestroy {
         return this.handlePointyScrollTo(params as unknown as ScrollToParams);
       case POINTY_ACTION_SHOW_TOUR:
         return this.handlePointyShowTour(params as unknown as ShowTourParams);
+      case POINTY_ACTION_CLICK:
+        return this.handlePointyClick(params as unknown as ClickParams);
       case 'navigation.go_to': {
         const target = String(params['target'] || '').trim();
         const route = String(params['route'] || '').trim();
@@ -1779,7 +1865,10 @@ export class WiiiContextService implements OnDestroy {
   }
 
   private clickButtonByText(candidates: string[]): boolean {
-    const button = Array.from(document.querySelectorAll('button')).find((node) => {
+    const button = Array.from(document.querySelectorAll('button[data-wiii-click-safe="true"]')).find((node) => {
+      if (node.getAttribute('data-wiii-click-kind') !== 'navigation') {
+        return false;
+      }
       const text = this.normalizeNavigationTarget(node.textContent || '');
       return candidates.some((candidate) => text.includes(this.normalizeNavigationTarget(candidate)));
     });

--- a/fe/src/app/features/ai-chat/infrastructure/pointy/helpers.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/pointy/helpers.ts
@@ -1,7 +1,7 @@
 /**
  * Wiii Pointy — small helpers shared between handler call sites.
  *
- * Vendored from `meiiie/wiii` PR #188.
+ * Vendored from `meiiie/wiii` PR #188 and updated to match PR #282 V1.1 ID resolution.
  */
 
 export function describeTarget(el: Element): string {
@@ -23,9 +23,21 @@ export function resolvePointySelector(selector: unknown): Element | null {
   const trimmed = selector.trim();
   if (!trimmed) return null;
   if (typeof document === 'undefined') return null;
+  if (/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+    try {
+      const semantic = document.querySelector(`[data-wiii-id="${escapeDataWiiiId(trimmed)}"]`);
+      if (semantic) return semantic;
+    } catch {
+      return null;
+    }
+  }
   try {
     return document.querySelector(trimmed);
   } catch {
     return null;
   }
+}
+
+function escapeDataWiiiId(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }

--- a/fe/src/app/features/ai-chat/infrastructure/pointy/types.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/pointy/types.ts
@@ -1,11 +1,12 @@
 /**
  * Wiii Pointy — type contracts for the LMS host integration.
  *
- * Vendored from `meiiie/wiii` PR #188 (Wiii Pointy V1, 2026-04-29).
+ * Vendored from `meiiie/wiii` PR #188 and updated to match PR #282 V1.1 safe-click.
  * Re-sync this folder when the upstream Pointy package bumps its version.
  *
- * V1 is read-only: highlight, scroll_to, show_tour. No auto-click, no
- * auto-fill. All actions are `mutates_state: false, requires_confirmation: false`.
+ * V1.1 is tutor-safe: highlight, scroll_to, show_tour, and safe-click. No
+ * auto-fill. Safe-click is fail-closed and only works on host-marked
+ * `data-wiii-click-safe="true"` navigation-like targets.
  *
  * Note: `ui.navigate` is intentionally NOT shipped here — LMS already
  * exposes `navigation.go_to` (with semantic targets + clickButtonByText)
@@ -15,11 +16,13 @@
 export const POINTY_ACTION_HIGHLIGHT = 'ui.highlight';
 export const POINTY_ACTION_SCROLL_TO = 'ui.scroll_to';
 export const POINTY_ACTION_SHOW_TOUR = 'ui.show_tour';
+export const POINTY_ACTION_CLICK = 'ui.click';
 
 export const POINTY_ACTIONS = [
   POINTY_ACTION_HIGHLIGHT,
   POINTY_ACTION_SCROLL_TO,
   POINTY_ACTION_SHOW_TOUR,
+  POINTY_ACTION_CLICK,
 ] as const;
 
 export type PointyAction = (typeof POINTY_ACTIONS)[number];
@@ -44,4 +47,9 @@ export interface TourStep {
 export interface ShowTourParams {
   steps: TourStep[];
   start_at?: number;
+}
+
+export interface ClickParams {
+  selector: string;
+  message?: string;
 }

--- a/fe/src/app/features/ai-chat/presentation/components/chat-panel/chat-panel.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/chat-panel/chat-panel.component.ts
@@ -81,6 +81,7 @@ import { environment } from '../../../../../../environments/environment';
           #wiiiIframe
           [src]="embedUrl()"
           class="wiii-embed-frame"
+          data-wiii-id="wiii-iframe"
           allow="clipboard-write"
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
           title="Wiii AI Chat"

--- a/fe/src/app/features/learning/pages/course-learning.component.html
+++ b/fe/src/app/features/learning/pages/course-learning.component.html
@@ -359,6 +359,9 @@
       <div class="max-w-[920px] mx-auto flex items-center justify-between">
         <button class="flex items-center gap-1 px-3 py-2 rounded text-slate-500 hover:text-[#0056D2] hover:bg-slate-50 transition-colors disabled:opacity-40 disabled:pointer-events-none"
           [disabled]="isLearningItemTransitioning() || (!canGoPrevious() && currentSectionIndex() === 0)"
+          data-wiii-id="previous-lesson"
+          data-wiii-click-safe="true"
+          data-wiii-click-kind="navigation"
           (click)="previousLesson()">
           <app-icon name="arrow-left" size="md"></app-icon>
           <span class="hidden sm:inline text-sm font-medium">Bài trước</span>
@@ -368,6 +371,7 @@
           [class.bg-green-600]="learningService.isLessonCompleted(currentLesson()!.id)()"
           [class.bg-[#0056D2]]="!learningService.isLessonCompleted(currentLesson()!.id)()"
           [disabled]="completeButtonDisabled()"
+          data-wiii-id="mark-lesson-complete"
           [attr.aria-busy]="(isCompletingCurrentItem() || isLearningItemTransitioning()) ? 'true' : null"
           (click)="onCompleteButtonClick()">
           @if (isCompletingCurrentItem() || isLearningItemTransitioning()) {
@@ -381,6 +385,9 @@
         @if (showSkipToNextLessonButton()) {
           <button class="flex items-center gap-1 px-3 py-2 rounded text-slate-500 hover:text-[#0056D2] hover:bg-slate-50 transition-colors disabled:opacity-40 disabled:pointer-events-none"
             [disabled]="isLearningItemTransitioning()"
+            data-wiii-id="continue-lesson"
+            data-wiii-click-safe="true"
+            data-wiii-click-kind="navigation"
             (click)="nextLesson()"
             aria-label="Bỏ qua bài hiện tại, đi tới bài tiếp theo">
             <span class="hidden sm:inline text-sm font-medium">Bài tiếp theo</span>

--- a/fe/src/app/features/teacher/course-editor/components/header/header.component.ts
+++ b/fe/src/app/features/teacher/course-editor/components/header/header.component.ts
@@ -18,6 +18,9 @@ import { getAdminPortalBase } from '../../../../../core/utils/portal-route.util'
         <!-- Left: Back + Title -->
         <div class="flex items-center gap-1 min-w-0">
             <button (click)="goBack()"
+                    data-wiii-id="back-to-courses"
+                    data-wiii-click-safe="true"
+                    data-wiii-click-kind="navigation"
                     class="flex items-center justify-center w-8 h-8 text-slate-400 hover:text-slate-700 hover:bg-slate-100 rounded-lg transition-colors flex-shrink-0"
                     title="Quay lại danh sách khóa học">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
@@ -63,6 +66,9 @@ import { getAdminPortalBase } from '../../../../../core/utils/portal-route.util'
 
                  <!-- Preview as Student -->
                  <a [href]="'/teacher/courses/' + courseId() + '/preview'" target="_blank"
+                    data-wiii-id="preview-course"
+                    data-wiii-click-safe="true"
+                    data-wiii-click-kind="preview"
                     class="h-8 px-3 rounded-lg border border-gray-200 text-xs font-semibold text-slate-600 hover:bg-slate-50 transition-colors flex items-center gap-1.5">
                      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -75,6 +81,7 @@ import { getAdminPortalBase } from '../../../../../core/utils/portal-route.util'
                  <div class="relative">
                      <button type="button"
                              id="editor-publish-trigger"
+                             data-wiii-id="open-publish-menu"
                              (click)="publishMenuOpen.set(!publishMenuOpen())"
                              [attr.aria-expanded]="publishMenuOpen()"
                              aria-haspopup="menu"
@@ -130,6 +137,9 @@ import { getAdminPortalBase } from '../../../../../core/utils/portal-route.util'
                              <div class="py-1">
                                  <button type="button"
                                          role="menuitem"
+                                         data-wiii-id="preview-course-from-publish-menu"
+                                         data-wiii-click-safe="true"
+                                         data-wiii-click-kind="preview"
                                          (click)="preview(); publishMenuOpen.set(false)"
                                          class="w-full text-left px-4 py-2.5 text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2.5 transition-colors">
                                      <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
@@ -141,6 +151,7 @@ import { getAdminPortalBase } from '../../../../../core/utils/portal-route.util'
                                  <div class="mx-3 border-t border-slate-100" role="separator" aria-hidden="true"></div>
                                  <button type="button"
                                          role="menuitem"
+                                         data-wiii-id="submit-course-for-approval"
                                          (click)="publish(); publishMenuOpen.set(false)"
                                          class="w-full text-left px-4 py-2.5 text-sm font-medium flex items-center gap-2.5 transition-colors"
                                          [class]="readinessChecklist().canPublish ? 'text-[#0056D2] hover:bg-[#0056D2]/5' : 'text-slate-300 cursor-not-allowed'"

--- a/fe/src/app/features/teacher/course-editor/components/sidebar/sidebar.component.ts
+++ b/fe/src/app/features/teacher/course-editor/components/sidebar/sidebar.component.ts
@@ -335,6 +335,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
   `],
   template: `
     <aside class="flex flex-col bg-white border-r border-slate-200 h-full overflow-hidden select-none"
+           data-wiii-id="course-editor-sidebar"
            role="tree"
            aria-label="Cấu trúc khóa học">
 
@@ -362,6 +363,9 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                 </button>
               }
               <button (click)="showAddChapterModal()"
+                      data-wiii-id="open-add-chapter-dialog"
+                      data-wiii-click-safe="true"
+                      data-wiii-click-kind="open_panel"
                       class="p-1.5 rounded-md hover:bg-[#E8F0FE] text-slate-400 hover:text-[#0056D2] transition-colors"
                       matTooltip="Thêm chương">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -402,6 +406,9 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                 <p class="text-sm font-semibold text-slate-700 mb-1">Chưa có chương nào</p>
                 <p class="text-xs text-slate-500 mb-4">Thêm chương đầu tiên để bắt đầu</p>
                 <button (click)="showAddChapterModal()"
+                        data-wiii-id="open-empty-add-chapter-dialog"
+                        data-wiii-click-safe="true"
+                        data-wiii-click-kind="open_panel"
                         class="px-4 py-2 bg-[#0056D2] text-white text-xs font-medium rounded-lg hover:bg-[#004BB5] transition-colors inline-flex items-center gap-1.5">
                   <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
@@ -423,6 +430,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
               @if (chapterMatchesSearch(chapter)) {
                   <div class="border-b border-slate-100 last:border-0"
                        role="treeitem"
+                       [attr.data-wiii-id]="'course-sidebar-chapter-' + chapter.id"
                        [attr.aria-expanded]="isChapterExpanded(chapter.id)"
                        cdkDrag [cdkDragData]="chapter"
                        [cdkDragStartDelay]="isTouchDevice ? 150 : 0"
@@ -450,6 +458,9 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
 
                           <!-- Expand Arrow -->
                           <button (click)="toggleChapter(chapter.id); $event.stopPropagation()"
+                                  [attr.data-wiii-id]="'toggle-chapter-' + chapter.id"
+                                  data-wiii-click-safe="true"
+                                  data-wiii-click-kind="open_panel"
                                   class="sidebar-expand" [class.rotate-90]="isChapterExpanded(chapter.id)">
                             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"></path>
@@ -458,6 +469,9 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
 
                           <!-- Title -->
                           <div class="flex-grow min-w-0 py-1.5 cursor-pointer"
+                               [attr.data-wiii-id]="'select-chapter-' + chapter.id"
+                               data-wiii-click-safe="true"
+                               data-wiii-click-kind="navigation"
                                (click)="toggleChapterSelection(chapter)">
                               @if (editingChapterId() === chapter.id) {
                                   <input [value]="editingValue"
@@ -476,6 +490,9 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                           <div class="flex items-center flex-shrink-0" (click)="$event.stopPropagation()">
                             <div class="relative">
                               <button (click)="toggleMenu('chapter', chapter.id)"
+                                      [attr.data-wiii-id]="'open-chapter-menu-' + chapter.id"
+                                      data-wiii-click-safe="true"
+                                      data-wiii-click-kind="open_panel"
                                       class="sidebar-kebab">
                                 <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 16 16">
                                   <circle cx="8" cy="3" r="1.5"/>
@@ -488,11 +505,15 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                                 <div class="absolute right-0 top-full mt-1 w-48 bg-white rounded-lg shadow-lg border border-slate-200 py-1.5 z-50"
                                      (click)="$event.stopPropagation()">
                                   <button (click)="startEditChapter(chapter, $event); closeMenu()"
+                                          [attr.data-wiii-id]="'edit-chapter-title-' + chapter.id"
                                           class="w-full text-left px-3.5 py-2.5 hover:bg-slate-50 text-[13px] text-slate-700 font-medium flex items-center gap-2.5">
                                     <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
                                     Đổi tên
                                   </button>
                                   <button (click)="requestAddLessonFromSidebar(chapter); closeMenu()"
+                                          [attr.data-wiii-id]="'open-lesson-composer-from-chapter-' + chapter.id"
+                                          data-wiii-click-safe="true"
+                                          data-wiii-click-kind="open_panel"
                                           class="w-full text-left px-3.5 py-2.5 hover:bg-slate-50 text-[13px] text-slate-700 font-medium flex items-center gap-2.5">
                                     <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
                                     Thêm bài học
@@ -515,6 +536,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                                   }
                                   <div class="border-t border-slate-100 my-1"></div>
                                   <button (click)="deleteChapter(chapter.id); closeMenu()"
+                                          [attr.data-wiii-id]="'delete-chapter-' + chapter.id"
                                           class="w-full text-left px-3.5 py-2.5 hover:bg-red-50 text-[13px] text-red-600 font-medium flex items-center gap-2.5">
                                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
                                     Xóa chương
@@ -539,6 +561,9 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                               <!-- Empty: no lessons in chapter -->
                               @if (chapter.lessons.length === 0) {
                                 <button (click)="requestAddLessonFromSidebar(chapter)"
+                                        [attr.data-wiii-id]="'open-empty-lesson-composer-' + chapter.id"
+                                        data-wiii-click-safe="true"
+                                        data-wiii-click-kind="open_panel"
                                         class="flex items-center gap-2 w-full pl-8 pr-4 py-2.5 text-[12px] text-slate-400 hover:text-[#0056D2] hover:bg-slate-50 transition-colors text-left">
                                   <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
@@ -550,6 +575,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                               @for (lesson of chapter.lessons; track lesson.id; let lessonIdx = $index) {
                                   <div class="relative group/ls"
                                        role="treeitem"
+                                       [attr.data-wiii-id]="'course-sidebar-lesson-' + lesson.id"
                                        cdkDrag [cdkDragData]="lesson"
                                        [cdkDragStartDelay]="isTouchDevice ? 150 : 0"
                                        (cdkDragStarted)="onLessonDragStart(lesson.id)">
@@ -576,6 +602,9 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
 
                                           <!-- Expand Arrow -->
                                           <button (click)="toggleLesson(lesson.id); $event.stopPropagation()"
+                                                  [attr.data-wiii-id]="'toggle-lesson-' + lesson.id"
+                                                  data-wiii-click-safe="true"
+                                                  data-wiii-click-kind="open_panel"
                                                   class="sidebar-expand sidebar-expand--sm" [class.rotate-90]="isLessonExpanded(lesson.id)">
                                             <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"></path>
@@ -584,6 +613,9 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
 
                                           <!-- Title -->
                                           <div class="flex-grow min-w-0 py-1.5 cursor-pointer"
+                                               [attr.data-wiii-id]="'select-lesson-' + lesson.id"
+                                               data-wiii-click-safe="true"
+                                               data-wiii-click-kind="navigation"
                                                (click)="toggleLessonSelection(chapter, lesson)">
                                             @if (editingLessonId() === lesson.id) {
                                                 <input [value]="editingValue"
@@ -602,6 +634,9 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                                           <div class="flex items-center flex-shrink-0" (click)="$event.stopPropagation()">
                                             <div class="relative">
                                               <button (click)="toggleMenu('lesson', lesson.id)"
+                                                      [attr.data-wiii-id]="'open-lesson-menu-' + lesson.id"
+                                                      data-wiii-click-safe="true"
+                                                      data-wiii-click-kind="open_panel"
                                                       class="sidebar-kebab">
                                                 <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 16 16">
                                                   <circle cx="8" cy="3" r="1.5"/>
@@ -613,11 +648,15 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                                                 <div class="absolute right-0 top-full mt-1 w-44 bg-white rounded-lg shadow-lg border border-slate-200 py-1.5 z-50"
                                                      (click)="$event.stopPropagation()">
                                                   <button (click)="startEditLesson(lesson, $event); closeMenu()"
+                                                          [attr.data-wiii-id]="'edit-lesson-title-' + lesson.id"
                                                           class="w-full text-left px-3.5 py-2.5 hover:bg-slate-50 text-[13px] text-slate-700 font-medium flex items-center gap-2.5">
                                                     <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
                                                     Đổi tên
                                                   </button>
                                                   <button (click)="selectLesson(chapter, lesson); closeMenu()"
+                                                          [attr.data-wiii-id]="'open-lesson-main-editor-' + lesson.id"
+                                                          data-wiii-click-safe="true"
+                                                          data-wiii-click-kind="navigation"
                                                           class="w-full text-left px-3.5 py-2.5 hover:bg-slate-50 text-[13px] text-slate-700 font-medium flex items-center gap-2.5">
                                                     <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
                                                     Mở vùng soạn chính
@@ -640,6 +679,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                                                   }
                                                   @if (store.chapters().length > 1) {
                                                     <button (click)="showMoveToChapterModal(chapter.id, lesson); closeMenu()"
+                                                            [attr.data-wiii-id]="'open-move-lesson-dialog-' + lesson.id"
                                                             class="w-full text-left px-3.5 py-2 hover:bg-slate-50 text-[13px] text-slate-700 font-medium flex items-center gap-2.5">
                                                       <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"></path></svg>
                                                       Chuyển sang chương...
@@ -647,6 +687,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                                                   }
                                                   <div class="border-t border-slate-100 my-1"></div>
                                                   <button (click)="deleteLesson(lesson.id); closeMenu()"
+                                                          [attr.data-wiii-id]="'delete-lesson-' + lesson.id"
                                                           class="w-full text-left px-3.5 py-2.5 hover:bg-red-50 text-[13px] text-red-600 font-medium flex items-center gap-2.5">
                                                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
                                                     Xóa bài học
@@ -674,6 +715,9 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
                                           @for (section of lesson.sections; track section.id; let secIdx = $index) {
                                             <div class="sidebar-section-row"
                                                  [class.sidebar-section-row--selected]="selectedSectionId() === section.id"
+                                                 [attr.data-wiii-id]="'select-sidebar-section-' + section.id"
+                                                 data-wiii-click-safe="true"
+                                                 data-wiii-click-kind="navigation"
                                                  cdkDrag [cdkDragData]="section"
                                                  [cdkDragStartDelay]="isTouchDevice ? 150 : 0"
                                                  (click)="selectSection(chapter, lesson, section); $event.stopPropagation()"
@@ -722,12 +766,14 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
       (close)="closeModals()">
       <label class="sidebar-field-label">Tên chương</label>
       <input type="text" [(ngModel)]="newChapterTitle"
+             data-wiii-id="new-chapter-title-input"
              (keydown.enter)="createChapter()"
              class="sidebar-field-input"
              placeholder="Nhập tên chương...">
       <div dialogFooter>
         <button type="button" (click)="closeModals()" class="sidebar-btn sidebar-btn--ghost">Hủy</button>
         <button type="button" (click)="createChapter()"
+                data-wiii-id="create-chapter"
                 [disabled]="isCreating()"
                 class="sidebar-btn sidebar-btn--primary">
           @if (isCreating()) {
@@ -750,6 +796,7 @@ import { getLessonReadinessState, lessonHasCanonicalContent } from '../../utils/
         @for (ch of store.chapters(); track ch.id) {
           @if (ch.id !== moveToFromChapterId()) {
             <button type="button" (click)="executeMoveToChapter(ch.id)"
+                    [attr.data-wiii-id]="'move-lesson-to-chapter-' + ch.id"
                     class="w-full text-left px-3.5 py-2.5 rounded-lg border border-slate-200 hover:border-[#0056D2] hover:bg-[#E8F0FE]/30 text-[13px] text-slate-700 font-medium transition-all flex items-center gap-2">
               <svg class="w-4 h-4 text-slate-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"></path></svg>
               <span class="line-clamp-2 break-words">{{ ch.title }}</span>

--- a/fe/src/app/features/teacher/course-editor/layouts/course-editor-layout/course-editor-layout.component.ts
+++ b/fe/src/app/features/teacher/course-editor/layouts/course-editor-layout/course-editor-layout.component.ts
@@ -17,7 +17,8 @@ import { distinctUntilChanged, filter, take, map } from 'rxjs/operators';
   imports: [RouterOutlet, RouterModule, CourseEditorSidebarComponent, CourseEditorHeaderComponent, CourseRejectionBannerComponent],
   styleUrl: './course-editor-layout.component.scss',
   template: `
-    <div class="relative flex h-screen w-full flex-col overflow-hidden font-sans bg-white text-slate-900">
+    <div class="relative flex h-screen w-full flex-col overflow-hidden font-sans bg-white text-slate-900"
+         data-wiii-id="course-editor-shell">
       <!-- Admin View-Only Mode Banner -->
       @if (isAdminViewMode()) {
         <div class="flex-shrink-0 bg-gradient-to-r from-amber-500 to-orange-500 text-white px-4 py-2 flex items-center justify-center gap-3 text-sm font-medium shadow-md z-30">
@@ -41,6 +42,9 @@ import { distinctUntilChanged, filter, take, map } from 'rxjs/operators';
       <nav aria-label="Editor tabs" role="tablist"
            class="flex items-center gap-1 border-b border-gray-200 flex-shrink-0 bg-white relative z-10 px-4 overflow-x-auto scrollbar-hide">
          <a routerLink="info"
+            data-wiii-id="course-editor-tab-info"
+            data-wiii-click-safe="true"
+            data-wiii-click-kind="navigation"
             role="tab"
             [attr.aria-selected]="activeTab() === 'info'"
             routerLinkActive="editor-tab--active"
@@ -48,6 +52,9 @@ import { distinctUntilChanged, filter, take, map } from 'rxjs/operators';
             Thông tin
          </a>
          <a routerLink="curriculum"
+            data-wiii-id="course-editor-tab-curriculum"
+            data-wiii-click-safe="true"
+            data-wiii-click-kind="navigation"
             role="tab"
             [attr.aria-selected]="activeTab() === 'curriculum'"
             routerLinkActive="editor-tab--active"
@@ -56,6 +63,9 @@ import { distinctUntilChanged, filter, take, map } from 'rxjs/operators';
          </a>
          @if (isInstructorLed()) {
            <a routerLink="classes"
+              data-wiii-id="course-editor-tab-classes"
+              data-wiii-click-safe="true"
+              data-wiii-click-kind="navigation"
               role="tab"
               [attr.aria-selected]="activeTab() === 'classes'"
               routerLinkActive="editor-tab--active"
@@ -64,6 +74,9 @@ import { distinctUntilChanged, filter, take, map } from 'rxjs/operators';
            </a>
          }
          <a routerLink="competency"
+            data-wiii-id="course-editor-tab-competency"
+            data-wiii-click-safe="true"
+            data-wiii-click-kind="navigation"
             role="tab"
             [attr.aria-selected]="activeTab() === 'competency'"
             routerLinkActive="editor-tab--active"
@@ -71,6 +84,9 @@ import { distinctUntilChanged, filter, take, map } from 'rxjs/operators';
             Tiêu chuẩn
          </a>
          <a routerLink="settings"
+            data-wiii-id="course-editor-tab-settings"
+            data-wiii-click-safe="true"
+            data-wiii-click-kind="navigation"
             role="tab"
             [attr.aria-selected]="activeTab() === 'settings'"
             routerLinkActive="editor-tab--active"

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload-modal.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/batch-video-upload/batch-video-upload-modal.component.ts
@@ -49,6 +49,7 @@ import {
           role="dialog"
           aria-modal="true"
           aria-labelledby="batch-upload-title"
+          data-wiii-id="batch-video-upload-dialog"
         >
           <!-- Header -->
           <div class="px-6 py-4 border-b border-gray-200 flex items-start justify-between flex-shrink-0">
@@ -61,6 +62,7 @@ import {
             <button
               type="button"
               (click)="requestClose()"
+              data-wiii-id="close-batch-video-upload"
               class="text-gray-400 hover:text-gray-600 p-1.5 rounded-md hover:bg-gray-100 flex-shrink-0 ml-4"
               aria-label="Đóng"
             >
@@ -126,11 +128,13 @@ import {
                 <button
                   type="button"
                   (click)="onBackToPick()"
+                  data-wiii-id="back-to-batch-video-picker"
                   class="px-4 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 rounded-lg"
                 >Chọn lại file</button>
                 <button
                   type="button"
                   (click)="onConfirmStart()"
+                  data-wiii-id="start-batch-video-upload"
                   [disabled]="svc.aggregateProgress().totalCount === 0"
                   class="px-4 py-1.5 text-sm font-semibold text-white bg-[#0056D2] hover:bg-[#004BB8] rounded-lg disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1.5"
                 >
@@ -157,6 +161,7 @@ import {
     <ng-template #pickStage>
       <div class="space-y-4">
         <div
+          data-wiii-id="batch-video-upload-dropzone"
           (drop)="onFileDrop($event)"
           (dragover)="$event.preventDefault()"
           (dragenter)="dragHover.set(true)"
@@ -173,6 +178,7 @@ import {
           <label class="inline-block mt-2 cursor-pointer">
             <input
               type="file"
+              data-wiii-id="batch-video-upload-input"
               multiple
               accept="video/*"
               (change)="onFilePickerChange($event)"

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/chapter-editor/chapter-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/chapter-editor/chapter-editor.component.ts
@@ -70,13 +70,20 @@ type LessonComposerType = 'LECTURE' | 'QUIZ' | 'ASSIGNMENT';
           <label class="editor-label">Bài học ({{ lessons().length }})</label>
           @if (lessons().length > 0 && !showLessonComposer()) {
             <div style="display: flex; gap: 0.5rem; align-items: center">
-              <button type="button" (click)="batchVideoUpload.emit()" class="add-lesson-header-btn add-lesson-header-btn--secondary" title="Tải lên nhiều video, tự động chia vào các bài">
+              <button type="button" (click)="batchVideoUpload.emit()" class="add-lesson-header-btn add-lesson-header-btn--secondary"
+                      data-wiii-id="upload-video-materials"
+                      data-wiii-click-safe="true"
+                      data-wiii-click-kind="open_panel"
+                      title="Tải lên nhiều video, tự động chia vào các bài">
                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"></path>
                 </svg>
                 Tải lên nhiều video
               </button>
-              <button type="button" (click)="addLesson.emit()" class="add-lesson-header-btn">
+              <button type="button" (click)="addLesson.emit()" class="add-lesson-header-btn"
+                      data-wiii-id="open-lesson-composer"
+                      data-wiii-click-safe="true"
+                      data-wiii-click-kind="open_panel">
                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
                 </svg>
@@ -102,6 +109,7 @@ type LessonComposerType = 'LECTURE' | 'QUIZ' | 'ASSIGNMENT';
                 <button
                   type="button"
                   class="lesson-type-btn"
+                  [attr.data-wiii-id]="'select-lesson-type-' + type"
                   [class.lesson-type-btn--active]="lessonDraftType() === type"
                   (click)="selectLessonDraftType($any(type))"
                 >
@@ -117,6 +125,7 @@ type LessonComposerType = 'LECTURE' | 'QUIZ' | 'ASSIGNMENT';
               </label>
               <input
                 id="lesson-draft-title"
+                data-wiii-id="lesson-draft-title-input"
                 type="text"
                 [ngModel]="lessonDraftTitle()"
                 (ngModelChange)="onLessonDraftTitleChange($event)"
@@ -133,6 +142,7 @@ type LessonComposerType = 'LECTURE' | 'QUIZ' | 'ASSIGNMENT';
               <button
                 type="button"
                 (click)="createLesson.emit()"
+                data-wiii-id="create-lesson-draft"
                 [disabled]="isCreatingLesson() || !lessonDraftTitle().trim()"
                 class="editor-primary-button"
               >
@@ -155,7 +165,10 @@ type LessonComposerType = 'LECTURE' | 'QUIZ' | 'ASSIGNMENT';
         @if (lessons().length > 0) {
           <div class="editor-stack" style="gap: 0.375rem">
             @for (lesson of lessons(); track lesson.id; let i = $index) {
-              <button type="button" (click)="lessonClicked.emit(lesson)" class="chapter-lesson-row">
+              <button type="button" (click)="lessonClicked.emit(lesson)" class="chapter-lesson-row"
+                      [attr.data-wiii-id]="'open-lesson-editor-' + lesson.id"
+                      data-wiii-click-safe="true"
+                      data-wiii-click-kind="navigation">
                 <span
                   class="chapter-lesson-row__dot"
                   [class.chapter-lesson-row__dot--ready]="lesson.sections.length > 0"
@@ -178,7 +191,10 @@ type LessonComposerType = 'LECTURE' | 'QUIZ' | 'ASSIGNMENT';
             <p style="font-size: 0.8125rem; color: rgb(100 116 139); margin-bottom: 0.75rem">
               Chưa có bài học trong chương này
             </p>
-            <button type="button" (click)="addLesson.emit()" class="editor-primary-button" style="font-size: 0.8125rem">
+            <button type="button" (click)="addLesson.emit()" class="editor-primary-button" style="font-size: 0.8125rem"
+                    data-wiii-id="open-first-lesson-composer"
+                    data-wiii-click-safe="true"
+                    data-wiii-click-kind="open_panel">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
               </svg>
@@ -198,6 +214,7 @@ type LessonComposerType = 'LECTURE' | 'QUIZ' | 'ASSIGNMENT';
         <button
           type="button"
           (click)="saveClicked.emit()"
+          data-wiii-id="save-chapter"
           [disabled]="isSaving() || !title().trim()"
           class="editor-primary-button"
         >

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lecture-sections-panel/lecture-sections-panel.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lecture-sections-panel/lecture-sections-panel.component.html
@@ -2,12 +2,19 @@
   <label class="editor-label">Nội dung ({{ sections().length }} mục)</label>
 
   <div style="display: flex; gap: 0.5rem; align-items: center">
-    <button type="button" class="add-content-btn add-content-btn--secondary" (click)="batchVideoUpload.emit()" title="Tải lên nhiều video, hệ thống tự phân bổ vào các bài">
+    <button type="button" class="add-content-btn add-content-btn--secondary" (click)="batchVideoUpload.emit()"
+            data-wiii-id="upload-video-materials-from-lesson"
+            data-wiii-click-safe="true"
+            data-wiii-click-kind="open_panel"
+            title="Tải lên nhiều video, hệ thống tự phân bổ vào các bài">
       <lucide-icon name="upload-cloud" [size]="14"></lucide-icon>
       Tải lên nhiều video
     </button>
   <div class="add-content-wrapper">
-    <button type="button" class="add-content-btn" (click)="toggleDropdown()">
+    <button type="button" class="add-content-btn" (click)="toggleDropdown()"
+            data-wiii-id="open-add-section-menu"
+            data-wiii-click-safe="true"
+            data-wiii-click-kind="open_panel">
       <lucide-icon name="plus" [size]="14"></lucide-icon>
       Thêm mục
       <lucide-icon name="chevron-down" [size]="12"></lucide-icon>
@@ -15,7 +22,8 @@
 
     @if (isDropdownOpen()) {
       <div class="add-content-dropdown">
-        <button type="button" class="add-content-option" (click)="onCreateSection('TEXT')">
+        <button type="button" class="add-content-option" (click)="onCreateSection('TEXT')"
+                data-wiii-id="add-text-section">
           <div class="add-content-option__icon" style="background: rgb(241 245 249)">
             <lucide-icon name="pilcrow" [size]="14" style="color: rgb(71 85 105)"></lucide-icon>
           </div>
@@ -25,7 +33,8 @@
           </div>
         </button>
 
-        <button type="button" class="add-content-option" (click)="onCreateSection('VIDEO')">
+        <button type="button" class="add-content-option" (click)="onCreateSection('VIDEO')"
+                data-wiii-id="add-video-section">
           <div class="add-content-option__icon" style="background: rgba(0, 86, 210, 0.08)">
             <lucide-icon name="play-circle" [size]="14" style="color: rgb(0 86 210)"></lucide-icon>
           </div>
@@ -35,7 +44,8 @@
           </div>
         </button>
 
-        <button type="button" class="add-content-option" (click)="onCreateSection('FILE')">
+        <button type="button" class="add-content-option" (click)="onCreateSection('FILE')"
+                data-wiii-id="upload-material">
           <div class="add-content-option__icon" style="background: rgba(245, 158, 11, 0.08)">
             <lucide-icon name="file-text" [size]="14" style="color: rgb(180 83 9)"></lucide-icon>
           </div>
@@ -45,7 +55,8 @@
           </div>
         </button>
 
-        <button type="button" class="add-content-option" (click)="onCreateSection('QUIZ')">
+        <button type="button" class="add-content-option" (click)="onCreateSection('QUIZ')"
+                data-wiii-id="add-quiz-section">
           <div class="add-content-option__icon" style="background: rgba(139, 92, 246, 0.08)">
             <lucide-icon name="help-circle" [size]="14" style="color: rgb(109 40 217)"></lucide-icon>
           </div>
@@ -74,7 +85,10 @@
     (cdkDropListDropped)="onDropSection($event)"
   >
     @for (section of sections(); track section.id; let idx = $index) {
-      <div class="section-row" [class.section-row--active]="activeSectionId() === section.id" (click)="onEditSection(section)" cdkDrag>
+      <div class="section-row"
+           [attr.data-wiii-id]="'edit-section-' + section.id"
+           [class.section-row--active]="activeSectionId() === section.id"
+           (click)="onEditSection(section)" cdkDrag>
         <div class="section-row__handle" cdkDragHandle>
           <lucide-icon name="grip-vertical" [size]="14"></lucide-icon>
         </div>
@@ -102,6 +116,7 @@
         <button
           type="button"
           (click)="onDeleteSection(section.id, $event)"
+          [attr.data-wiii-id]="'delete-section-' + section.id"
           class="section-row__delete"
           aria-label="Xóa"
         >

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lesson-editor/lesson-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/lesson-editor/lesson-editor.component.ts
@@ -109,10 +109,13 @@ import { CompetencyPanelComponent } from '../competency-panel/competency-panel.c
     }
   `],
   template: `
-    <div class="lesson-workspace">
+    <div class="lesson-workspace" data-wiii-id="lesson-editor">
       <div class="lesson-breadcrumb">
         @if (chapterTitle() || chapterLabel()) {
-          <button type="button" class="lesson-breadcrumb__back" (click)="backClicked.emit()">
+          <button type="button" class="lesson-breadcrumb__back" (click)="backClicked.emit()"
+                  data-wiii-id="back-to-chapter"
+                  data-wiii-click-safe="true"
+                  data-wiii-click-kind="navigation">
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
             </svg>
@@ -131,6 +134,7 @@ import { CompetencyPanelComponent } from '../competency-panel/competency-panel.c
         </label>
         <input
           id="lesson-title"
+          data-wiii-id="lesson-title-input"
           type="text"
           [value]="title()"
           (input)="onTitleChange($any($event.target).value)"
@@ -153,6 +157,7 @@ import { CompetencyPanelComponent } from '../competency-panel/competency-panel.c
               <button
                 type="button"
                 (click)="createSection.emit('VIDEO')"
+                data-wiii-id="add-video-section-from-legacy"
                 class="editor-secondary-button"
                 style="font-size: 0.75rem; min-height: 2rem; padding: 0.25rem 0.75rem"
               >
@@ -257,6 +262,7 @@ import { CompetencyPanelComponent } from '../competency-panel/competency-panel.c
         <button
           type="button"
           (click)="saveClicked.emit()"
+          data-wiii-id="save-lesson"
           [disabled]="isSaving() || !title().trim()"
           [title]="saveButtonTooltip()"
           class="editor-primary-button"

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
@@ -233,6 +233,7 @@ type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
               <!-- IDLE: drag-drop upload zone -->
               @if (cfUploadStatus() === 'idle') {
                 <div class="video-dropzone"
+                     data-wiii-id="upload-material-dropzone"
                      [class.video-dropzone--dragover]="isDragOver()"
                      (dragover)="onDragOver($event)"
                      (dragleave)="onDragLeave($event)"
@@ -646,6 +647,7 @@ type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
                      (dragleave)="onDragLeave($event)"
                      (drop)="onFileDrop($event)">
                   <input type="file"
+                         data-wiii-id="upload-material-input"
                          accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.csv,.rtf"
                          (change)="onFileSelected($event)"
                          class="absolute inset-0 h-full w-full cursor-pointer opacity-0" />
@@ -982,10 +984,12 @@ type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
 
       <!-- Footer — sticky bottom -->
       <div class="section-editor-footer">
-        <button type="button" (click)="onClose()" class="editor-secondary-button">
+        <button type="button" (click)="onClose()" class="editor-secondary-button"
+                data-wiii-id="close-section-editor">
           Hủy
         </button>
         <button type="button" (click)="onSave()"
+          data-wiii-id="save-section"
           [disabled]="svc.isSaving() || svc.sectionVideoIsUploading() || !svc.sectionTitle().trim()"
           class="editor-primary-button">
           @if (svc.isSaving()) {

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.html
@@ -3,6 +3,9 @@
   <!-- Sidebar toggle (visible when sidebar collapsed, e.g. mobile) -->
   @if (store.sidebarCollapsed()) {
     <button type="button" (click)="store.sidebarCollapsed.set(false)"
+      data-wiii-id="open-curriculum-sidebar"
+      data-wiii-click-safe="true"
+      data-wiii-click-kind="open_panel"
       class="sidebar-toggle-btn">
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
@@ -45,7 +48,10 @@
           </div>
 
           <p class="editor-hint" style="margin-bottom: 0.5rem">Hoặc tạo tự động từ tài liệu có sẵn</p>
-          <button type="button" (click)="openAiCourseGeneration()" class="editor-primary-button">
+          <button type="button" (click)="openAiCourseGeneration()" class="editor-primary-button"
+                  data-wiii-id="generate-course-from-document"
+                  data-wiii-click-safe="true"
+                  data-wiii-click-kind="open_panel">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
             </svg>

--- a/fe/src/app/features/teacher/dashboard/teacher-dashboard.component.html
+++ b/fe/src/app/features/teacher/dashboard/teacher-dashboard.component.html
@@ -1,4 +1,4 @@
-<div class="dashboard-container">
+<div class="dashboard-container" data-wiii-id="teacher-dashboard">
   <div class="main-content">
     <!-- Header — text-only greeting (Coursera pattern: avatar only in navigation) -->
     <div class="dashboard-header">
@@ -7,7 +7,10 @@
           <h1 class="greeting">{{ getGreeting() }}, {{ getUserFirstName() }}</h1>
           <p class="subtitle">Tổng quan hoạt động giảng dạy</p>
         </div>
-        <a routerLink="/teacher/course-creation" class="cta-button">
+        <a routerLink="/teacher/course-creation" class="cta-button"
+           data-wiii-id="create-course"
+           data-wiii-click-safe="true"
+           data-wiii-click-kind="navigation">
           <svg class="cta-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
           </svg>
@@ -24,6 +27,7 @@
         </div>
         <p class="flex-1 text-sm font-medium text-amber-900">bài tập cần chấm điểm</p>
         <a routerLink="/teacher/assessments/classes/assignments"
+           data-wiii-id="open-grading-queue"
            class="rounded-md bg-amber-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-amber-700 transition-colors">
           Xem ngay
         </a>
@@ -37,6 +41,7 @@
           <div class="flex flex-wrap items-center gap-2" role="tablist">
             @for (tab of tabItems; track tab.key) {
               <button type="button" role="tab"
+                [attr.data-wiii-id]="'teacher-dashboard-tab-' + tab.key"
                 [attr.aria-selected]="activeTab() === tab.key"
                 class="inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-sm font-medium transition-colors"
                 [class.bg-[#0056D2]]="activeTab() === tab.key"
@@ -52,7 +57,10 @@
             }
           </div>
           @if (hasMoreCourses()) {
-            <a routerLink="/teacher/courses/library" class="view-all-link">
+            <a routerLink="/teacher/courses/library" class="view-all-link"
+               data-wiii-id="browse-teacher-courses"
+               data-wiii-click-safe="true"
+               data-wiii-click-kind="navigation">
               Xem tất cả
             </a>
           }
@@ -99,7 +107,10 @@
             </div>
             <h3 class="empty-state-title">Chưa có khóa học</h3>
             <p class="empty-state-text">Tạo khóa học đầu tiên để bắt đầu giảng dạy</p>
-            <a routerLink="/teacher/course-creation" class="retry-link">Tạo khóa học mới &rarr;</a>
+            <a routerLink="/teacher/course-creation" class="retry-link"
+               data-wiii-id="create-first-course"
+               data-wiii-click-safe="true"
+               data-wiii-click-kind="navigation">Tạo khóa học mới &rarr;</a>
           </div>
         }
 
@@ -107,7 +118,9 @@
         @if (!teacher.isLoading() && !teacher.error() && filteredCourses().length > 0) {
           <div class="courses-list">
             @for (course of filteredCourses(); track course.id) {
-              <div class="course-card" (click)="goToCourse(course.id)">
+              <div class="course-card"
+                   [attr.data-wiii-id]="'teacher-course-card-' + course.id"
+                   (click)="goToCourse(course.id)">
                 <div class="course-card-body">
                   <!-- Thumbnail -->
                   <div class="course-thumbnail">
@@ -167,7 +180,11 @@
                     </span>
                     }
                     <span class="course-date">{{ formatDate(course.updatedAt || course.createdAt) }}</span>
-                    <button class="edit-button" (click)="goToCourse(course.id); $event.stopPropagation()">
+                    <button class="edit-button"
+                            [attr.data-wiii-id]="'open-course-editor-' + course.id"
+                            data-wiii-click-safe="true"
+                            data-wiii-click-kind="navigation"
+                            (click)="goToCourse(course.id); $event.stopPropagation()">
                       Chỉnh sửa
                     </button>
                   </div>
@@ -180,7 +197,10 @@
           @if (hasMoreCourses()) {
             <div class="courses-footer">
               <span class="footer-summary">{{ footerText() }}</span>
-              <a routerLink="/teacher/courses/library" class="footer-link">
+              <a routerLink="/teacher/courses/library" class="footer-link"
+                 data-wiii-id="browse-all-teacher-courses"
+                 data-wiii-click-safe="true"
+                 data-wiii-click-kind="navigation">
                 Xem tất cả khóa học
                 <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"/>


### PR DESCRIPTION
## Summary
- Add Wiii Pointy V1.1 `ui.click` host handling with fail-closed `data-wiii-click-safe=true` gating and bare `data-wiii-id` resolution.
- Add stable `data-wiii-id` targets across teacher dashboard, course editor shell/header/sidebar, curriculum/lesson/material upload surfaces, Wiii iframe, and learning next/previous controls.
- Keep mutate/dangerous controls visible to Pointy via IDs but without safe-click, including save/create/delete/submit/publish/start-upload/mark-complete actions.

## Evidence
- `cd fe && npx ng test --watch=false --browsers=ChromeHeadless --include=src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts --progress=false` -> `TOTAL: 25 SUCCESS`
- `cd fe && npm run build` -> success; existing Angular/Sass/CommonJS warnings only
- `git diff --check` -> clean
- `rg -n data-wiii-id=.*(submit|delete|publish|enroll|grade|payment|save|create|start|mark-|move-) fe/src/app -S` used to audit dangerous target IDs; mutate controls remain without `data-wiii-click-safe`

## Notes
- Mirrors Wiii contract work in `meiiie/wiii#282` / central issue `meiiie/wiii#283`.
- LMS-side full preview/diff UI before applying Wiii-generated lesson patch is still a follow-up gap; this PR only adds the safe target metadata and safe-click host contract.

Refs #400