### PR TITLE
[codex] Polish student pagination spacing

### DIFF
--- a/fe/src/app/features/student/browse/student-course-browser.component.ts
+++ b/fe/src/app/features/student/browse/student-course-browser.component.ts
@@ -324,7 +324,7 @@ type CourseBrowserQueryParams = {
           <!-- Pagination -->
           @if (totalPages() > 1) {
             <app-pagination
-              class="mt-8 block overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm"
+              class="mx-auto mt-8 mb-8 block w-full max-w-5xl overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm"
               [currentPage]="currentPage() + 1"
               [totalPages]="totalPages()"
               [totalItems]="totalItems()"

--- a/fe/src/app/shared/components/pagination/pagination.component.ts
+++ b/fe/src/app/shared/components/pagination/pagination.component.ts
@@ -15,53 +15,53 @@ export interface PaginationInfo {
   imports: [CommonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <nav class="flex items-center justify-between border-t border-gray-200 bg-white px-4 py-3 sm:px-6"
+    <nav class="flex items-center justify-between border-t border-gray-200 bg-white px-4 py-2.5 sm:px-5"
          role="navigation" 
          aria-label="Phân trang kết quả">
       
       <!-- Mobile view -->
-      <div class="flex flex-1 justify-between sm:hidden">
+      <div class="flex flex-1 items-center justify-between gap-3 sm:hidden">
         <button 
           (click)="onPageChange(currentPage() - 1)"
           [disabled]="!hasPrevious()"
           [attr.aria-label]="'Trang trước, trang ' + (currentPage() - 1)"
-          class="relative inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0056D2] disabled:cursor-not-allowed disabled:opacity-50">
+          class="relative inline-flex items-center rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0056D2] disabled:cursor-not-allowed disabled:opacity-50">
           Trước
         </button>
-        <span class="text-sm text-gray-700">
+        <span class="shrink-0 rounded-full bg-slate-50 px-3 py-1 text-sm font-semibold text-slate-700">
           Trang {{ currentPage() }} / {{ totalPages() }}
         </span>
         <button 
           (click)="onPageChange(currentPage() + 1)"
           [disabled]="!hasNext()"
           [attr.aria-label]="'Trang tiếp theo, trang ' + (currentPage() + 1)"
-          class="relative ml-3 inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0056D2] disabled:cursor-not-allowed disabled:opacity-50">
+          class="relative inline-flex items-center rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0056D2] disabled:cursor-not-allowed disabled:opacity-50">
           Tiếp
         </button>
       </div>
 
       <!-- Desktop view -->
-      <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between sm:gap-4">
+      <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between sm:gap-6">
         <div>
-          <p class="whitespace-nowrap text-sm text-gray-700">
+          <p class="whitespace-nowrap text-sm leading-5 text-slate-600">
             Hiển thị 
-            <span class="font-medium">{{ getStartItem() }}</span>
+            <span class="font-semibold text-slate-900">{{ getStartItem() }}</span>
             đến 
-            <span class="font-medium">{{ getEndItem() }}</span>
+            <span class="font-semibold text-slate-900">{{ getEndItem() }}</span>
             trong tổng số 
-            <span class="font-medium">{{ totalItems() }}</span>
+            <span class="font-semibold text-slate-900">{{ totalItems() }}</span>
             kết quả
           </p>
         </div>
         
         <div>
-          <nav class="isolate inline-flex -space-x-px rounded-md shadow-sm" aria-label="Phân trang">
+          <nav class="isolate inline-flex -space-x-px overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm" aria-label="Phân trang">
             <!-- Previous button -->
             <button 
               (click)="onPageChange(currentPage() - 1)"
               [disabled]="!hasPrevious()"
               [attr.aria-label]="'Trang trước, trang ' + (currentPage() - 1)"
-              class="relative inline-flex items-center rounded-l-md px-2 py-2 text-gray-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0056D2] disabled:cursor-not-allowed disabled:opacity-50">
+              class="relative inline-flex h-9 w-9 items-center justify-center text-slate-500 ring-1 ring-inset ring-slate-200 transition-colors hover:bg-slate-50 focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0056D2] disabled:cursor-not-allowed disabled:opacity-50">
               <span class="sr-only">Trang trước</span>
               <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path fill-rule="evenodd" d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z" clip-rule="evenodd" />
@@ -75,7 +75,7 @@ export interface PaginationInfo {
                   (click)="onPageChange(+page)"
                   [attr.aria-label]="'Trang ' + page"
                   [attr.aria-current]="page === currentPage() ? 'page' : null"
-                  class="relative inline-flex min-w-10 items-center justify-center px-3 py-2 text-sm font-semibold ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0056D2]"
+                  class="relative inline-flex h-9 min-w-9 items-center justify-center px-3 text-sm font-semibold ring-1 ring-inset ring-slate-200 transition-colors hover:bg-slate-50 focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0056D2]"
                   [ngClass]="{
                     'bg-[#0056D2] text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0056D2]': page === currentPage(),
                     'text-gray-900': page !== currentPage()
@@ -84,7 +84,7 @@ export interface PaginationInfo {
                 </button>
               } @else {
                 <span 
-                  class="relative inline-flex min-w-10 items-center justify-center px-3 py-2 text-sm font-semibold text-gray-700 ring-1 ring-inset ring-gray-300 focus:outline-offset-0">
+                  class="relative inline-flex h-9 min-w-9 items-center justify-center px-3 text-sm font-semibold text-slate-500 ring-1 ring-inset ring-slate-200 focus:outline-offset-0">
                   …
                 </span>
               }
@@ -95,7 +95,7 @@ export interface PaginationInfo {
               (click)="onPageChange(currentPage() + 1)"
               [disabled]="!hasNext()"
               [attr.aria-label]="'Trang tiếp theo, trang ' + (currentPage() + 1)"
-              class="relative inline-flex items-center rounded-r-md px-2 py-2 text-gray-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0056D2] disabled:cursor-not-allowed disabled:opacity-50">
+              class="relative inline-flex h-9 w-9 items-center justify-center text-slate-500 ring-1 ring-inset ring-slate-200 transition-colors hover:bg-slate-50 focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0056D2] disabled:cursor-not-allowed disabled:opacity-50">
               <span class="sr-only">Trang tiếp theo</span>
               <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />


### PR DESCRIPTION
﻿## Summary
- Tighten the shared pagination control spacing and page button sizing for a cleaner footer.
- Center and cap the student browse pagination width so it no longer stretches too wide across the page.
- Preserve existing pagination logic and accessibility focus states.

## Validation
- `git diff --check --cached -- fe/src/app/shared/components/pagination/pagination.component.ts fe/src/app/features/student/browse/student-course-browser.component.ts`
- `node ./node_modules/typescript/bin/tsc -p tsconfig.app.json --noEmit --pretty false`
- `npx ng build --configuration development --progress=false`

## Notes
- Existing Angular build warnings are unrelated to this UI-only change.
