### PR TITLE
[codex] integrate Wiii LMS webhooks

### DIFF
--- a/backend/src/main/java/com/example/lms/assessment/domain/event/AssignmentSubmittedEvent.java
+++ b/backend/src/main/java/com/example/lms/assessment/domain/event/AssignmentSubmittedEvent.java
@@ -1,0 +1,41 @@
+package com.example.lms.assessment.domain.event;
+
+import com.example.lms.shared.domain.event.AbstractDomainEvent;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Domain event raised after a student submits or resubmits an assignment.
+ */
+public class AssignmentSubmittedEvent extends AbstractDomainEvent {
+
+    private final UUID submissionId;
+    private final UUID assignmentId;
+    private final UUID studentId;
+    private final Instant submittedAt;
+
+    public AssignmentSubmittedEvent(UUID submissionId, UUID assignmentId, UUID studentId, Instant submittedAt) {
+        super(submissionId);
+        this.submissionId = submissionId;
+        this.assignmentId = assignmentId;
+        this.studentId = studentId;
+        this.submittedAt = submittedAt;
+    }
+
+    public UUID getSubmissionId() {
+        return submissionId;
+    }
+
+    public UUID getAssignmentId() {
+        return assignmentId;
+    }
+
+    public UUID getStudentId() {
+        return studentId;
+    }
+
+    public Instant getSubmittedAt() {
+        return submittedAt;
+    }
+}

--- a/backend/src/main/java/com/example/lms/assessment/infrastructure/web/AssignmentSubmissionControllerV3.java
+++ b/backend/src/main/java/com/example/lms/assessment/infrastructure/web/AssignmentSubmissionControllerV3.java
@@ -9,6 +9,7 @@ import com.example.lms.assessment.infrastructure.persistence.repository.Assignme
 import com.example.lms.course_authoring.infrastructure.persistence.JpaCourseRepository;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
+import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import com.example.lms.shared.infrastructure.web.ApiResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -54,6 +55,7 @@ public class AssignmentSubmissionControllerV3 {
     private final UserJpaRepository userJpaRepository;
     private final com.example.lms.assessment.infrastructure.persistence.repository.GradingAuditLogJpaRepository gradingAuditLogRepository;
     private final ObjectMapper objectMapper;
+    private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
 
     // =============================================
     // Teacher endpoints
@@ -271,6 +273,11 @@ public class AssignmentSubmissionControllerV3 {
                     : AssignmentSubmissionJpaEntity.SubmissionStatus.RESUBMITTED);
             submission.setSubmittedAt(Instant.now());
             submissionRepository.save(submission);
+            wiiiLmsEventPublisher.sendAssignmentSubmitted(
+                    submission.getStudentId(),
+                    submission.getAssignmentId(),
+                    submission.getSubmittedAt()
+            );
             return ResponseEntity.ok(ApiResponse.success(
                     toSubmissionDetailMapWithStudent(submission), "Da nop lai bai tap"));
         }
@@ -290,6 +297,11 @@ public class AssignmentSubmissionControllerV3 {
                 .build();
 
         submission = submissionRepository.save(submission);
+        wiiiLmsEventPublisher.sendAssignmentSubmitted(
+                submission.getStudentId(),
+                submission.getAssignmentId(),
+                submission.getSubmittedAt()
+        );
         return ResponseEntity.ok(ApiResponse.success(
                 toSubmissionDetailMapWithStudent(submission), "Da nop bai tap"));
     }

--- a/backend/src/main/java/com/example/lms/assessment/infrastructure/web/AssignmentSubmissionControllerV3.java
+++ b/backend/src/main/java/com/example/lms/assessment/infrastructure/web/AssignmentSubmissionControllerV3.java
@@ -2,6 +2,7 @@ package com.example.lms.assessment.infrastructure.web;
 
 import com.example.lms.assessment.application.port.StudentAssessmentAccessPort;
 import com.example.lms.assessment.application.usecase.GradeSubmissionUseCase;
+import com.example.lms.assessment.domain.event.AssignmentSubmittedEvent;
 import com.example.lms.assessment.infrastructure.persistence.entity.AssignmentJpaEntity;
 import com.example.lms.assessment.infrastructure.persistence.entity.AssignmentSubmissionJpaEntity;
 import com.example.lms.assessment.infrastructure.persistence.repository.AssignmentJpaRepository;
@@ -9,7 +10,7 @@ import com.example.lms.assessment.infrastructure.persistence.repository.Assignme
 import com.example.lms.course_authoring.infrastructure.persistence.JpaCourseRepository;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
-import com.example.lms.shared.integration.WiiiLmsEventPublisher;
+import com.example.lms.shared.domain.event.DomainEventPublisher;
 import com.example.lms.shared.infrastructure.web.ApiResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,7 +56,7 @@ public class AssignmentSubmissionControllerV3 {
     private final UserJpaRepository userJpaRepository;
     private final com.example.lms.assessment.infrastructure.persistence.repository.GradingAuditLogJpaRepository gradingAuditLogRepository;
     private final ObjectMapper objectMapper;
-    private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
+    private final DomainEventPublisher eventPublisher;
 
     // =============================================
     // Teacher endpoints
@@ -272,12 +273,8 @@ public class AssignmentSubmissionControllerV3 {
                     ? AssignmentSubmissionJpaEntity.SubmissionStatus.LATE
                     : AssignmentSubmissionJpaEntity.SubmissionStatus.RESUBMITTED);
             submission.setSubmittedAt(Instant.now());
-            submissionRepository.save(submission);
-            wiiiLmsEventPublisher.sendAssignmentSubmitted(
-                    submission.getStudentId(),
-                    submission.getAssignmentId(),
-                    submission.getSubmittedAt()
-            );
+            submission = submissionRepository.save(submission);
+            publishAssignmentSubmitted(submission);
             return ResponseEntity.ok(ApiResponse.success(
                     toSubmissionDetailMapWithStudent(submission), "Da nop lai bai tap"));
         }
@@ -297,13 +294,18 @@ public class AssignmentSubmissionControllerV3 {
                 .build();
 
         submission = submissionRepository.save(submission);
-        wiiiLmsEventPublisher.sendAssignmentSubmitted(
-                submission.getStudentId(),
-                submission.getAssignmentId(),
-                submission.getSubmittedAt()
-        );
+        publishAssignmentSubmitted(submission);
         return ResponseEntity.ok(ApiResponse.success(
                 toSubmissionDetailMapWithStudent(submission), "Da nop bai tap"));
+    }
+
+    private void publishAssignmentSubmitted(AssignmentSubmissionJpaEntity submission) {
+        eventPublisher.publish(new AssignmentSubmittedEvent(
+                submission.getId(),
+                submission.getAssignmentId(),
+                submission.getStudentId(),
+                submission.getSubmittedAt()
+        ));
     }
 
     @Operation(summary = "Get my submission for an assignment (Student compatibility route)")

--- a/backend/src/main/java/com/example/lms/assessment/infrastructure/web/StudentAssignmentControllerV3.java
+++ b/backend/src/main/java/com/example/lms/assessment/infrastructure/web/StudentAssignmentControllerV3.java
@@ -3,6 +3,7 @@ package com.example.lms.assessment.infrastructure.web;
 import com.example.lms.assessment.application.dto.StudentAssignmentResponse;
 import com.example.lms.assessment.application.port.StudentAssessmentAccessPort;
 import com.example.lms.assessment.application.usecase.GetStudentAssignmentsUseCase;
+import com.example.lms.assessment.domain.event.AssignmentSubmittedEvent;
 import com.example.lms.assessment.infrastructure.persistence.entity.AssignmentAttachmentJpaEntity;
 import com.example.lms.assessment.infrastructure.persistence.entity.AssignmentJpaEntity;
 import com.example.lms.assessment.infrastructure.persistence.entity.AssignmentSubmissionJpaEntity;
@@ -11,7 +12,7 @@ import com.example.lms.assessment.infrastructure.persistence.repository.Assignme
 import com.example.lms.assessment.infrastructure.persistence.repository.AssignmentSubmissionJpaRepository;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.shared.application.port.FileManagementPort;
-import com.example.lms.shared.integration.WiiiLmsEventPublisher;
+import com.example.lms.shared.domain.event.DomainEventPublisher;
 import com.example.lms.shared.infrastructure.web.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,7 +45,7 @@ public class StudentAssignmentControllerV3 {
     private final AssignmentJpaRepository assignmentRepository;
     private final AssignmentAttachmentJpaRepository attachmentRepository;
     private final FileManagementPort fileManagementPort;
-    private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
+    private final DomainEventPublisher eventPublisher;
 
     @Operation(summary = "Danh sach bai tap cua hoc vien")
     @GetMapping
@@ -171,11 +172,12 @@ public class StudentAssignmentControllerV3 {
             }
         }
 
-        wiiiLmsEventPublisher.sendAssignmentSubmitted(
-                submission.getStudentId(),
+        eventPublisher.publish(new AssignmentSubmittedEvent(
+                submission.getId(),
                 submission.getAssignmentId(),
+                submission.getStudentId(),
                 submission.getSubmittedAt()
-        );
+        ));
 
         return ResponseEntity.ok(ApiResponse.success(
                 Map.of("submissionId", submission.getId().toString(), "status", submission.getStatus().name()),

--- a/backend/src/main/java/com/example/lms/assessment/infrastructure/web/StudentAssignmentControllerV3.java
+++ b/backend/src/main/java/com/example/lms/assessment/infrastructure/web/StudentAssignmentControllerV3.java
@@ -11,6 +11,7 @@ import com.example.lms.assessment.infrastructure.persistence.repository.Assignme
 import com.example.lms.assessment.infrastructure.persistence.repository.AssignmentSubmissionJpaRepository;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.shared.application.port.FileManagementPort;
+import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import com.example.lms.shared.infrastructure.web.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,6 +44,7 @@ public class StudentAssignmentControllerV3 {
     private final AssignmentJpaRepository assignmentRepository;
     private final AssignmentAttachmentJpaRepository attachmentRepository;
     private final FileManagementPort fileManagementPort;
+    private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
 
     @Operation(summary = "Danh sach bai tap cua hoc vien")
     @GetMapping
@@ -168,6 +170,12 @@ public class StudentAssignmentControllerV3 {
                 submissionRepository.save(submission);
             }
         }
+
+        wiiiLmsEventPublisher.sendAssignmentSubmitted(
+                submission.getStudentId(),
+                submission.getAssignmentId(),
+                submission.getSubmittedAt()
+        );
 
         return ResponseEntity.ok(ApiResponse.success(
                 Map.of("submissionId", submission.getId().toString(), "status", submission.getStatus().name()),

--- a/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/BatchEnrollPaidStudentsUseCase.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/BatchEnrollPaidStudentsUseCase.java
@@ -1,11 +1,12 @@
 package com.example.lms.learning_delivery.application.usecase;
 
 import com.example.lms.learning_delivery.application.dto.BatchEnrollPaidResult;
+import com.example.lms.learning_delivery.domain.event.CourseEnrolledEvent;
 import com.example.lms.learning_delivery.domain.model.Enrollment;
 import com.example.lms.learning_delivery.domain.model.LearningClass;
 import com.example.lms.learning_delivery.domain.repository.EnrollmentRepository;
 import com.example.lms.learning_delivery.domain.repository.LearningClassRepository;
-import com.example.lms.shared.integration.WiiiLmsEventPublisher;
+import com.example.lms.shared.domain.event.DomainEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -31,7 +32,7 @@ public class BatchEnrollPaidStudentsUseCase {
 
     private final EnrollmentRepository enrollmentRepository;
     private final LearningClassRepository classRepository;
-    private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
+    private final DomainEventPublisher eventPublisher;
 
     /**
      * Batch enroll paid students into a class.
@@ -76,8 +77,15 @@ public class BatchEnrollPaidStudentsUseCase {
                         .lastAccessedAt(java.time.Instant.now())
                         .status(Enrollment.EnrollmentStatus.ACTIVE)
                         .build();
-                enrollmentRepository.save(enrollment);
-                wiiiLmsEventPublisher.sendCourseEnrolled(studentId, learningClass, null);
+                Enrollment saved = enrollmentRepository.save(enrollment);
+                eventPublisher.publish(new CourseEnrolledEvent(
+                        saved.getId(),
+                        studentId,
+                        learningClass.getId(),
+                        learningClass.getCourseId(),
+                        null,
+                        learningClass.getSemester()
+                ));
                 enrolledCount++;
                 log.debug("Enrolled student {} into class {}", studentId, classId);
             } catch (Exception e) {

--- a/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/BatchEnrollPaidStudentsUseCase.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/BatchEnrollPaidStudentsUseCase.java
@@ -5,6 +5,7 @@ import com.example.lms.learning_delivery.domain.model.Enrollment;
 import com.example.lms.learning_delivery.domain.model.LearningClass;
 import com.example.lms.learning_delivery.domain.repository.EnrollmentRepository;
 import com.example.lms.learning_delivery.domain.repository.LearningClassRepository;
+import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -30,6 +31,7 @@ public class BatchEnrollPaidStudentsUseCase {
 
     private final EnrollmentRepository enrollmentRepository;
     private final LearningClassRepository classRepository;
+    private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
 
     /**
      * Batch enroll paid students into a class.
@@ -75,6 +77,7 @@ public class BatchEnrollPaidStudentsUseCase {
                         .status(Enrollment.EnrollmentStatus.ACTIVE)
                         .build();
                 enrollmentRepository.save(enrollment);
+                wiiiLmsEventPublisher.sendCourseEnrolled(studentId, learningClass, null);
                 enrolledCount++;
                 log.debug("Enrolled student {} into class {}", studentId, classId);
             } catch (Exception e) {

--- a/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/EnrollStudentByEmailUseCase.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/EnrollStudentByEmailUseCase.java
@@ -4,13 +4,14 @@ import com.example.lms.course_authoring.domain.model.Course;
 import com.example.lms.course_authoring.domain.repository.CourseRepository;
 import com.example.lms.identity.domain.model.User;
 import com.example.lms.identity.domain.repository.UserRepository;
+import com.example.lms.learning_delivery.domain.event.CourseEnrolledEvent;
 import com.example.lms.learning_delivery.domain.model.Enrollment;
 import com.example.lms.learning_delivery.domain.model.LearningClass;
 import com.example.lms.learning_delivery.domain.repository.EnrollmentRepository;
 import com.example.lms.learning_delivery.domain.repository.LearningClassRepository;
+import com.example.lms.shared.domain.event.DomainEventPublisher;
 import com.example.lms.shared.exception.BusinessRuleException;
 import com.example.lms.shared.exception.EntityNotFoundException;
-import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -32,7 +33,7 @@ public class EnrollStudentByEmailUseCase {
     private final EnrollmentRepository enrollmentRepository;
     private final LearningClassRepository learningClassRepository;
     private final CourseRepository courseRepository;
-    private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
+    private final DomainEventPublisher eventPublisher;
 
     @Transactional
     public UUID enroll(String email, UUID classId) {
@@ -72,7 +73,14 @@ public class EnrollStudentByEmailUseCase {
                 .build();
 
         Enrollment saved = enrollmentRepository.save(enrollment);
-        wiiiLmsEventPublisher.sendCourseEnrolled(student.getId().value(), learningClass, course.getTitle());
+        eventPublisher.publish(new CourseEnrolledEvent(
+                saved.getId(),
+                student.getId().value(),
+                learningClass.getId(),
+                learningClass.getCourseId(),
+                course.getTitle(),
+                learningClass.getSemester()
+        ));
 
         log.info("Student {} enrolled successfully in class {} with enrollment ID {}",
                 email, classId, saved.getId());

--- a/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/EnrollStudentByEmailUseCase.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/EnrollStudentByEmailUseCase.java
@@ -10,6 +10,7 @@ import com.example.lms.learning_delivery.domain.repository.EnrollmentRepository;
 import com.example.lms.learning_delivery.domain.repository.LearningClassRepository;
 import com.example.lms.shared.exception.BusinessRuleException;
 import com.example.lms.shared.exception.EntityNotFoundException;
+import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -31,6 +32,7 @@ public class EnrollStudentByEmailUseCase {
     private final EnrollmentRepository enrollmentRepository;
     private final LearningClassRepository learningClassRepository;
     private final CourseRepository courseRepository;
+    private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
 
     @Transactional
     public UUID enroll(String email, UUID classId) {
@@ -70,6 +72,7 @@ public class EnrollStudentByEmailUseCase {
                 .build();
 
         Enrollment saved = enrollmentRepository.save(enrollment);
+        wiiiLmsEventPublisher.sendCourseEnrolled(student.getId().value(), learningClass, course.getTitle());
 
         log.info("Student {} enrolled successfully in class {} with enrollment ID {}",
                 email, classId, saved.getId());

--- a/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/EnrollStudentUseCaseV3.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/EnrollStudentUseCaseV3.java
@@ -10,6 +10,7 @@ import com.example.lms.learning_delivery.domain.repository.EnrollmentRepositoryP
 import com.example.lms.learning_delivery.domain.repository.LearningClassRepositoryPort;
 import com.example.lms.shared.domain.valueobject.UserId;
 import com.example.lms.shared.exception.BusinessRuleException;
+import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -32,6 +33,7 @@ public class EnrollStudentUseCaseV3 {
     private final EnrollmentRepositoryPort enrollmentRepository;
     private final LearningClassRepositoryPort learningClassRepository;
     private final CourseRepository courseRepository;
+    private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
 
     @Transactional
     public UUID enroll(UUID studentId, UUID classId) {
@@ -70,6 +72,7 @@ public class EnrollStudentUseCaseV3 {
                 .build();
 
         Enrollment saved = enrollmentRepository.save(enrollment);
+        wiiiLmsEventPublisher.sendCourseEnrolled(studentId, learningClass, course.getTitle());
 
         log.info("Student {} enrolled successfully in class {} with enrollment ID {}",
                 studentId, classId, saved.getId());

--- a/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/EnrollStudentUseCaseV3.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/EnrollStudentUseCaseV3.java
@@ -4,13 +4,14 @@ import com.example.lms.course_authoring.domain.model.Course;
 import com.example.lms.course_authoring.domain.repository.CourseRepository;
 import com.example.lms.identity.domain.model.User;
 import com.example.lms.identity.domain.repository.UserRepository;
+import com.example.lms.learning_delivery.domain.event.CourseEnrolledEvent;
 import com.example.lms.learning_delivery.domain.model.Enrollment;
 import com.example.lms.learning_delivery.domain.model.LearningClass;
 import com.example.lms.learning_delivery.domain.repository.EnrollmentRepositoryPort;
 import com.example.lms.learning_delivery.domain.repository.LearningClassRepositoryPort;
+import com.example.lms.shared.domain.event.DomainEventPublisher;
 import com.example.lms.shared.domain.valueobject.UserId;
 import com.example.lms.shared.exception.BusinessRuleException;
-import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -33,7 +34,7 @@ public class EnrollStudentUseCaseV3 {
     private final EnrollmentRepositoryPort enrollmentRepository;
     private final LearningClassRepositoryPort learningClassRepository;
     private final CourseRepository courseRepository;
-    private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
+    private final DomainEventPublisher eventPublisher;
 
     @Transactional
     public UUID enroll(UUID studentId, UUID classId) {
@@ -72,7 +73,14 @@ public class EnrollStudentUseCaseV3 {
                 .build();
 
         Enrollment saved = enrollmentRepository.save(enrollment);
-        wiiiLmsEventPublisher.sendCourseEnrolled(studentId, learningClass, course.getTitle());
+        eventPublisher.publish(new CourseEnrolledEvent(
+                saved.getId(),
+                studentId,
+                learningClass.getId(),
+                learningClass.getCourseId(),
+                course.getTitle(),
+                learningClass.getSemester()
+        ));
 
         log.info("Student {} enrolled successfully in class {} with enrollment ID {}",
                 studentId, classId, saved.getId());

--- a/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/SelfEnrollUseCase.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/SelfEnrollUseCase.java
@@ -10,6 +10,7 @@ import com.example.lms.learning_delivery.domain.model.LearningClass;
 import com.example.lms.learning_delivery.domain.repository.EnrollmentRepositoryPort;
 import com.example.lms.learning_delivery.domain.repository.LearningClassRepositoryPort;
 import com.example.lms.shared.exception.BusinessRuleException;
+import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -40,6 +41,7 @@ public class SelfEnrollUseCase {
     private final EnrollmentRepositoryPort enrollmentRepository;
     private final PaymentVerificationPort paymentVerification;
     private final CoursePublicationPort coursePublicationPort;
+    private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
 
     @Transactional
     public UUID execute(SelfEnrollCommand command) {
@@ -84,6 +86,7 @@ public class SelfEnrollUseCase {
                     || enrollment.getStatus() == Enrollment.EnrollmentStatus.SUSPENDED) {
                 enrollment.reactivate();
                 Enrollment reactivated = enrollmentRepository.save(enrollment);
+                wiiiLmsEventPublisher.sendCourseEnrolled(studentId, enrollment.getLearningClass(), course.getTitle());
                 log.info("Reactivated enrollment {} for student {} course {}",
                         reactivated.getId(), studentId, courseId);
                 return reactivated.getId();
@@ -101,6 +104,7 @@ public class SelfEnrollUseCase {
                 .build();
 
         Enrollment saved = enrollmentRepository.save(enrollment);
+        wiiiLmsEventPublisher.sendCourseEnrolled(studentId, defaultClass, course.getTitle());
         log.info("Self-enrollment successful: student {} → course {} (enrollment {})",
                 studentId, courseId, saved.getId());
 

--- a/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/SelfEnrollUseCase.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/application/usecase/SelfEnrollUseCase.java
@@ -5,12 +5,13 @@ import com.example.lms.course_authoring.domain.repository.CourseRepository;
 import com.example.lms.course_authoring.application.port.CoursePublicationPort;
 import com.example.lms.learning_delivery.application.dto.SelfEnrollCommand;
 import com.example.lms.learning_delivery.application.port.PaymentVerificationPort;
+import com.example.lms.learning_delivery.domain.event.CourseEnrolledEvent;
 import com.example.lms.learning_delivery.domain.model.Enrollment;
 import com.example.lms.learning_delivery.domain.model.LearningClass;
 import com.example.lms.learning_delivery.domain.repository.EnrollmentRepositoryPort;
 import com.example.lms.learning_delivery.domain.repository.LearningClassRepositoryPort;
+import com.example.lms.shared.domain.event.DomainEventPublisher;
 import com.example.lms.shared.exception.BusinessRuleException;
-import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -41,7 +42,7 @@ public class SelfEnrollUseCase {
     private final EnrollmentRepositoryPort enrollmentRepository;
     private final PaymentVerificationPort paymentVerification;
     private final CoursePublicationPort coursePublicationPort;
-    private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
+    private final DomainEventPublisher eventPublisher;
 
     @Transactional
     public UUID execute(SelfEnrollCommand command) {
@@ -86,7 +87,7 @@ public class SelfEnrollUseCase {
                     || enrollment.getStatus() == Enrollment.EnrollmentStatus.SUSPENDED) {
                 enrollment.reactivate();
                 Enrollment reactivated = enrollmentRepository.save(enrollment);
-                wiiiLmsEventPublisher.sendCourseEnrolled(studentId, enrollment.getLearningClass(), course.getTitle());
+                publishCourseEnrolled(reactivated, course.getTitle());
                 log.info("Reactivated enrollment {} for student {} course {}",
                         reactivated.getId(), studentId, courseId);
                 return reactivated.getId();
@@ -104,11 +105,23 @@ public class SelfEnrollUseCase {
                 .build();
 
         Enrollment saved = enrollmentRepository.save(enrollment);
-        wiiiLmsEventPublisher.sendCourseEnrolled(studentId, defaultClass, course.getTitle());
+        publishCourseEnrolled(saved, course.getTitle());
         log.info("Self-enrollment successful: student {} → course {} (enrollment {})",
                 studentId, courseId, saved.getId());
 
         return saved.getId();
+    }
+
+    private void publishCourseEnrolled(Enrollment enrollment, String courseTitle) {
+        LearningClass learningClass = enrollment.getLearningClass();
+        eventPublisher.publish(new CourseEnrolledEvent(
+                enrollment.getId(),
+                enrollment.getStudentId(),
+                learningClass.getId(),
+                learningClass.getCourseId(),
+                courseTitle,
+                learningClass.getSemester()
+        ));
     }
 
     private LearningClass findOrCreateDefaultClass(UUID courseId, Course course) {

--- a/backend/src/main/java/com/example/lms/learning_delivery/domain/event/CourseEnrolledEvent.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/domain/event/CourseEnrolledEvent.java
@@ -1,0 +1,57 @@
+package com.example.lms.learning_delivery.domain.event;
+
+import com.example.lms.shared.domain.event.AbstractDomainEvent;
+
+import java.util.UUID;
+
+/**
+ * Domain event raised after a student is enrolled in a course/class.
+ */
+public class CourseEnrolledEvent extends AbstractDomainEvent {
+
+    private final UUID enrollmentId;
+    private final UUID studentId;
+    private final UUID classId;
+    private final UUID courseId;
+    private final String courseName;
+    private final String semester;
+
+    public CourseEnrolledEvent(UUID enrollmentId,
+                               UUID studentId,
+                               UUID classId,
+                               UUID courseId,
+                               String courseName,
+                               String semester) {
+        super(enrollmentId);
+        this.enrollmentId = enrollmentId;
+        this.studentId = studentId;
+        this.classId = classId;
+        this.courseId = courseId;
+        this.courseName = courseName;
+        this.semester = semester;
+    }
+
+    public UUID getEnrollmentId() {
+        return enrollmentId;
+    }
+
+    public UUID getStudentId() {
+        return studentId;
+    }
+
+    public UUID getClassId() {
+        return classId;
+    }
+
+    public UUID getCourseId() {
+        return courseId;
+    }
+
+    public String getCourseName() {
+        return courseName;
+    }
+
+    public String getSemester() {
+        return semester;
+    }
+}

--- a/backend/src/main/java/com/example/lms/shared/integration/WiiiDataControllerV3.java
+++ b/backend/src/main/java/com/example/lms/shared/integration/WiiiDataControllerV3.java
@@ -264,7 +264,9 @@ public class WiiiDataControllerV3 {
         Double avgGrade = jdbc.queryForObject(
                 "SELECT COALESCE(AVG(qa.score), 0) FROM quiz_attempts qa " +
                 "JOIN quizzes q ON qa.quiz_id = q.id " +
-                "WHERE q.course_id = ? AND qa.status IN ('SUBMITTED', 'GRADED')",
+                "JOIN lessons l ON q.lesson_id = l.id " +
+                "JOIN chapters ch ON l.chapter_id = ch.id " +
+                "WHERE ch.course_id = ? AND qa.status IN ('SUBMITTED', 'GRADED')",
                 Double.class, courseId
         );
 

--- a/backend/src/main/java/com/example/lms/shared/integration/WiiiEventBridge.java
+++ b/backend/src/main/java/com/example/lms/shared/integration/WiiiEventBridge.java
@@ -1,47 +1,29 @@
 package com.example.lms.shared.integration;
 
+import com.example.lms.assessment.domain.event.QuizSubmittedEvent;
+import com.example.lms.assessment.domain.event.SubmissionGradedEvent;
 import com.example.lms.shared.domain.event.DomainEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
- * Anti-corruption bridge: LMS domain events → Wiii AI webhooks.
- *
- * <p>Listens for Spring ApplicationEvents (published by SpringEventPublisher)
- * and forwards them to Wiii as webhook events. Each domain event type is
- * mapped to a Wiii webhook event type:
- *
- * <ul>
- *   <li>QuizSubmittedEvent → quiz_completed + grade_saved
- *   <li>StudentEnrolledEvent → course_enrolled
- *   <li>AssignmentSubmittedEvent → assignment_submitted
- * </ul>
- *
- * <p>Wiii event format matches LMSWebhookEventType enum in
- * {@code app/integrations/lms/models.py}.
+ * Anti-corruption bridge: LMS domain events to Wiii AI webhooks.
  */
 @Component
 public class WiiiEventBridge {
 
     private static final Logger log = LoggerFactory.getLogger(WiiiEventBridge.class);
 
-    private final WiiiWebhookEmitter webhookEmitter;
+    private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
     private final WiiiIntegrationConfig config;
 
-    public WiiiEventBridge(WiiiWebhookEmitter webhookEmitter, WiiiIntegrationConfig config) {
-        this.webhookEmitter = webhookEmitter;
+    public WiiiEventBridge(WiiiLmsEventPublisher wiiiLmsEventPublisher, WiiiIntegrationConfig config) {
+        this.wiiiLmsEventPublisher = wiiiLmsEventPublisher;
         this.config = config;
     }
 
-    /**
-     * Catch-all listener for DomainEvent.
-     * Routes to specific handlers based on event type.
-     */
     @EventListener
     public void onDomainEvent(DomainEvent event) {
         if (!config.getWebhook().isEnabled()) {
@@ -52,88 +34,9 @@ public class WiiiEventBridge {
         log.debug("Domain event received for Wiii forwarding: {}", eventType);
 
         switch (eventType) {
-            case "QuizSubmittedEvent" -> handleQuizSubmitted(event);
-            case "StudentEnrolledEvent" -> handleStudentEnrolled(event);
-            case "AssignmentSubmittedEvent" -> handleAssignmentSubmitted(event);
+            case "QuizSubmittedEvent" -> wiiiLmsEventPublisher.sendQuizCompleted((QuizSubmittedEvent) event);
+            case "SubmissionGradedEvent" -> wiiiLmsEventPublisher.sendSubmissionGraded((SubmissionGradedEvent) event);
             default -> log.trace("Ignoring event type for Wiii: {}", eventType);
-        }
-    }
-
-    /**
-     * QuizSubmittedEvent → quiz_completed webhook.
-     *
-     * <p>Expected event properties (accessed via reflection or casting):
-     * quizId, studentId, lessonId, score, passed
-     */
-    private void handleQuizSubmitted(DomainEvent event) {
-        try {
-            // QuizSubmittedEvent fields (from assessment domain)
-            var quizEvent = (com.example.lms.assessment.domain.event.QuizSubmittedEvent) event;
-
-            Map<String, Object> payload = new HashMap<>();
-            String studentId = quizEvent.getStudentId().value().toString();
-            String lessonId = quizEvent.getLessonId() != null
-                    ? quizEvent.getLessonId().toString() : "";
-
-            payload.put("student_id", studentId);
-            payload.put("quiz_id", quizEvent.getQuizId().toString());
-            payload.put("lesson_id", lessonId);
-            payload.put("score", quizEvent.getScore());
-            payload.put("max_score", 100.0);  // QuizAttempt normalizes to 0-100
-            payload.put("quiz_name", "");  // Not in event, enriched by Wiii
-
-            webhookEmitter.sendEvent("quiz_completed", payload);
-
-            // Also send as grade_saved (quiz score is a grade)
-            Map<String, Object> gradePayload = new HashMap<>();
-            gradePayload.put("student_id", studentId);
-            gradePayload.put("lesson_id", lessonId);
-            gradePayload.put("grade", quizEvent.getScore());
-            gradePayload.put("max_grade", 100.0);
-            gradePayload.put("assignment_name", "Quiz");
-
-            webhookEmitter.sendEvent("grade_saved", gradePayload);
-
-            log.info("Forwarded QuizSubmittedEvent to Wiii: student={}", quizEvent.getStudentId());
-        } catch (Exception e) {
-            log.warn("Failed to forward QuizSubmittedEvent: {}", e.getMessage());
-        }
-    }
-
-    /**
-     * StudentEnrolledEvent → course_enrolled webhook.
-     *
-     * <p>Since we don't have a specific StudentEnrolledEvent domain event class yet,
-     * this handler is prepared for when it's added. Meanwhile, enrollment webhooks
-     * can be triggered directly from EnrollStudentUseCaseV3.
-     */
-    private void handleStudentEnrolled(DomainEvent event) {
-        try {
-            Map<String, Object> payload = new HashMap<>();
-            payload.put("student_id", event.getAggregateId().toString());
-            // Additional fields will be populated when StudentEnrolledEvent is created
-
-            webhookEmitter.sendEvent("course_enrolled", payload);
-            log.info("Forwarded StudentEnrolledEvent to Wiii: aggregate={}", event.getAggregateId());
-        } catch (Exception e) {
-            log.warn("Failed to forward StudentEnrolledEvent: {}", e.getMessage());
-        }
-    }
-
-    /**
-     * AssignmentSubmittedEvent → assignment_submitted webhook.
-     */
-    private void handleAssignmentSubmitted(DomainEvent event) {
-        try {
-            Map<String, Object> payload = new HashMap<>();
-            payload.put("student_id", event.getAggregateId().toString());
-            payload.put("assignment_id", event.getAggregateId().toString());
-            payload.put("submitted_at", event.getOccurredAt().toString());
-
-            webhookEmitter.sendEvent("assignment_submitted", payload);
-            log.info("Forwarded AssignmentSubmittedEvent to Wiii: aggregate={}", event.getAggregateId());
-        } catch (Exception e) {
-            log.warn("Failed to forward AssignmentSubmittedEvent: {}", e.getMessage());
         }
     }
 }

--- a/backend/src/main/java/com/example/lms/shared/integration/WiiiEventBridge.java
+++ b/backend/src/main/java/com/example/lms/shared/integration/WiiiEventBridge.java
@@ -1,8 +1,9 @@
 package com.example.lms.shared.integration;
 
+import com.example.lms.assessment.domain.event.AssignmentSubmittedEvent;
 import com.example.lms.assessment.domain.event.QuizSubmittedEvent;
 import com.example.lms.assessment.domain.event.SubmissionGradedEvent;
-import com.example.lms.shared.domain.event.DomainEvent;
+import com.example.lms.learning_delivery.domain.event.CourseEnrolledEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
@@ -17,26 +18,32 @@ public class WiiiEventBridge {
     private static final Logger log = LoggerFactory.getLogger(WiiiEventBridge.class);
 
     private final WiiiLmsEventPublisher wiiiLmsEventPublisher;
-    private final WiiiIntegrationConfig config;
 
-    public WiiiEventBridge(WiiiLmsEventPublisher wiiiLmsEventPublisher, WiiiIntegrationConfig config) {
+    public WiiiEventBridge(WiiiLmsEventPublisher wiiiLmsEventPublisher) {
         this.wiiiLmsEventPublisher = wiiiLmsEventPublisher;
-        this.config = config;
     }
 
     @EventListener
-    public void onDomainEvent(DomainEvent event) {
-        if (!config.getWebhook().isEnabled()) {
-            return;
-        }
+    public void onCourseEnrolled(CourseEnrolledEvent event) {
+        log.debug("Course enrolled event received for Wiii forwarding: {}", event.getEventId());
+        wiiiLmsEventPublisher.sendCourseEnrolled(event);
+    }
 
-        String eventType = event.getEventType();
-        log.debug("Domain event received for Wiii forwarding: {}", eventType);
+    @EventListener
+    public void onAssignmentSubmitted(AssignmentSubmittedEvent event) {
+        log.debug("Assignment submitted event received for Wiii forwarding: {}", event.getEventId());
+        wiiiLmsEventPublisher.sendAssignmentSubmitted(event);
+    }
 
-        switch (eventType) {
-            case "QuizSubmittedEvent" -> wiiiLmsEventPublisher.sendQuizCompleted((QuizSubmittedEvent) event);
-            case "SubmissionGradedEvent" -> wiiiLmsEventPublisher.sendSubmissionGraded((SubmissionGradedEvent) event);
-            default -> log.trace("Ignoring event type for Wiii: {}", eventType);
-        }
+    @EventListener
+    public void onQuizSubmitted(QuizSubmittedEvent event) {
+        log.debug("Quiz submitted event received for Wiii forwarding: {}", event.getEventId());
+        wiiiLmsEventPublisher.sendQuizCompleted(event);
+    }
+
+    @EventListener
+    public void onSubmissionGraded(SubmissionGradedEvent event) {
+        log.debug("Submission graded event received for Wiii forwarding: {}", event.getEventId());
+        wiiiLmsEventPublisher.sendSubmissionGraded(event);
     }
 }

--- a/backend/src/main/java/com/example/lms/shared/integration/WiiiLmsEventPublisher.java
+++ b/backend/src/main/java/com/example/lms/shared/integration/WiiiLmsEventPublisher.java
@@ -1,8 +1,9 @@
 package com.example.lms.shared.integration;
 
+import com.example.lms.assessment.domain.event.AssignmentSubmittedEvent;
 import com.example.lms.assessment.domain.event.QuizSubmittedEvent;
 import com.example.lms.assessment.domain.event.SubmissionGradedEvent;
-import com.example.lms.learning_delivery.domain.model.LearningClass;
+import com.example.lms.learning_delivery.domain.event.CourseEnrolledEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -34,61 +35,52 @@ public class WiiiLmsEventPublisher {
         this.jdbc = jdbc;
     }
 
-    public void sendCourseEnrolled(UUID studentId, LearningClass learningClass, String courseName) {
+    public void sendCourseEnrolled(CourseEnrolledEvent event) {
         if (!isWebhookEnabled()) {
             return;
         }
-        if (studentId == null || learningClass == null || learningClass.getCourseId() == null) {
-            log.debug("Skipping Wiii course_enrolled webhook because enrollment context is incomplete");
-            return;
-        }
-        sendCourseEnrolled(studentId, learningClass.getCourseId(), courseName, learningClass.getSemester());
-    }
-
-    public void sendCourseEnrolled(UUID studentId, UUID courseId, String courseName, String semester) {
-        if (!isWebhookEnabled()) {
-            return;
-        }
-        if (studentId == null || courseId == null) {
+        if (event == null || event.getStudentId() == null || event.getCourseId() == null) {
             log.debug("Skipping Wiii course_enrolled webhook because student_id or course_id is missing");
             return;
         }
-
-        String resolvedCourseName = firstNonBlank(courseName, resolveCourseName(courseId).orElse(""));
+        String resolvedCourseName = firstNonBlank(
+                event.getCourseName(),
+                resolveCourseName(event.getCourseId()).orElse(""));
 
         Map<String, Object> payload = new HashMap<>();
-        payload.put("student_id", studentId.toString());
-        payload.put("course_id", courseId.toString());
+        payload.put("student_id", event.getStudentId().toString());
+        payload.put("course_id", event.getCourseId().toString());
         payload.put("course_name", resolvedCourseName);
-        if (semester != null && !semester.isBlank()) {
-            payload.put("semester", semester);
+        if (event.getSemester() != null && !event.getSemester().isBlank()) {
+            payload.put("semester", event.getSemester());
         }
 
         webhookEmitter.sendEvent("course_enrolled", payload);
     }
 
-    public void sendAssignmentSubmitted(UUID studentId, UUID assignmentId, Instant submittedAt) {
+    public void sendAssignmentSubmitted(AssignmentSubmittedEvent event) {
         if (!isWebhookEnabled()) {
             return;
         }
-        if (studentId == null || assignmentId == null) {
+        if (event == null || event.getStudentId() == null || event.getAssignmentId() == null) {
             log.debug("Skipping Wiii assignment_submitted webhook because student_id or assignment_id is missing");
             return;
         }
 
-        AssignmentContext context = resolveAssignmentContext(assignmentId).orElse(null);
+        AssignmentContext context = resolveAssignmentContext(event.getAssignmentId()).orElse(null);
         if (context == null || context.courseId() == null) {
-            log.warn("Skipping Wiii assignment_submitted webhook because assignment {} has no course context", assignmentId);
+            log.warn("Skipping Wiii assignment_submitted webhook because assignment {} has no course context",
+                    event.getAssignmentId());
             return;
         }
 
         Map<String, Object> payload = new HashMap<>();
-        payload.put("student_id", studentId.toString());
-        payload.put("assignment_id", assignmentId.toString());
+        payload.put("student_id", event.getStudentId().toString());
+        payload.put("assignment_id", event.getAssignmentId().toString());
         payload.put("assignment_name", context.assignmentName());
         payload.put("course_id", context.courseId().toString());
         payload.put("course_name", context.courseName());
-        payload.put("submitted_at", (submittedAt != null ? submittedAt : Instant.now()).toString());
+        payload.put("submitted_at", (event.getSubmittedAt() != null ? event.getSubmittedAt() : Instant.now()).toString());
 
         webhookEmitter.sendEvent("assignment_submitted", payload);
     }

--- a/backend/src/main/java/com/example/lms/shared/integration/WiiiLmsEventPublisher.java
+++ b/backend/src/main/java/com/example/lms/shared/integration/WiiiLmsEventPublisher.java
@@ -1,0 +1,260 @@
+package com.example.lms.shared.integration;
+
+import com.example.lms.assessment.domain.event.QuizSubmittedEvent;
+import com.example.lms.assessment.domain.event.SubmissionGradedEvent;
+import com.example.lms.learning_delivery.domain.model.LearningClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Builds Wiii LMS webhook payloads from LMS domain/application events.
+ */
+@Service
+public class WiiiLmsEventPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(WiiiLmsEventPublisher.class);
+
+    private final WiiiWebhookEmitter webhookEmitter;
+    private final WiiiIntegrationConfig config;
+    private final JdbcTemplate jdbc;
+
+    public WiiiLmsEventPublisher(WiiiWebhookEmitter webhookEmitter,
+                                 WiiiIntegrationConfig config,
+                                 JdbcTemplate jdbc) {
+        this.webhookEmitter = webhookEmitter;
+        this.config = config;
+        this.jdbc = jdbc;
+    }
+
+    public void sendCourseEnrolled(UUID studentId, LearningClass learningClass, String courseName) {
+        if (!isWebhookEnabled()) {
+            return;
+        }
+        if (studentId == null || learningClass == null || learningClass.getCourseId() == null) {
+            log.debug("Skipping Wiii course_enrolled webhook because enrollment context is incomplete");
+            return;
+        }
+        sendCourseEnrolled(studentId, learningClass.getCourseId(), courseName, learningClass.getSemester());
+    }
+
+    public void sendCourseEnrolled(UUID studentId, UUID courseId, String courseName, String semester) {
+        if (!isWebhookEnabled()) {
+            return;
+        }
+        if (studentId == null || courseId == null) {
+            log.debug("Skipping Wiii course_enrolled webhook because student_id or course_id is missing");
+            return;
+        }
+
+        String resolvedCourseName = firstNonBlank(courseName, resolveCourseName(courseId).orElse(""));
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("student_id", studentId.toString());
+        payload.put("course_id", courseId.toString());
+        payload.put("course_name", resolvedCourseName);
+        if (semester != null && !semester.isBlank()) {
+            payload.put("semester", semester);
+        }
+
+        webhookEmitter.sendEvent("course_enrolled", payload);
+    }
+
+    public void sendAssignmentSubmitted(UUID studentId, UUID assignmentId, Instant submittedAt) {
+        if (!isWebhookEnabled()) {
+            return;
+        }
+        if (studentId == null || assignmentId == null) {
+            log.debug("Skipping Wiii assignment_submitted webhook because student_id or assignment_id is missing");
+            return;
+        }
+
+        AssignmentContext context = resolveAssignmentContext(assignmentId).orElse(null);
+        if (context == null || context.courseId() == null) {
+            log.warn("Skipping Wiii assignment_submitted webhook because assignment {} has no course context", assignmentId);
+            return;
+        }
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("student_id", studentId.toString());
+        payload.put("assignment_id", assignmentId.toString());
+        payload.put("assignment_name", context.assignmentName());
+        payload.put("course_id", context.courseId().toString());
+        payload.put("course_name", context.courseName());
+        payload.put("submitted_at", (submittedAt != null ? submittedAt : Instant.now()).toString());
+
+        webhookEmitter.sendEvent("assignment_submitted", payload);
+    }
+
+    public void sendSubmissionGraded(SubmissionGradedEvent event) {
+        if (!isWebhookEnabled()) {
+            return;
+        }
+        if (event == null || event.getNewGrade() == null) {
+            return;
+        }
+
+        AssignmentContext context = resolveAssignmentContext(event.getAssignmentId()).orElse(null);
+        if (context == null || context.courseId() == null) {
+            log.warn("Skipping Wiii grade_saved webhook because assignment {} has no course context",
+                    event.getAssignmentId());
+            return;
+        }
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("student_id", event.getStudentId().toString());
+        payload.put("course_id", context.courseId().toString());
+        payload.put("course_name", context.courseName());
+        payload.put("grade", event.getNewGrade());
+        payload.put("max_grade", context.maxGrade() != null ? context.maxGrade() : 100.0);
+        payload.put("assignment_name", context.assignmentName());
+
+        webhookEmitter.sendEvent("grade_saved", payload);
+    }
+
+    public void sendQuizCompleted(QuizSubmittedEvent event) {
+        if (!isWebhookEnabled()) {
+            return;
+        }
+        if (event == null || event.getStudentId() == null || event.getQuizId() == null) {
+            return;
+        }
+
+        QuizContext context = resolveQuizContext(event.getQuizId()).orElse(null);
+        if (context == null || context.courseId() == null) {
+            log.warn("Skipping Wiii quiz_completed webhook because quiz {} has no course context",
+                    event.getQuizId());
+            return;
+        }
+
+        String studentId = event.getStudentId().value().toString();
+
+        Map<String, Object> quizPayload = new HashMap<>();
+        quizPayload.put("student_id", studentId);
+        quizPayload.put("quiz_id", event.getQuizId().toString());
+        quizPayload.put("quiz_name", context.quizName());
+        quizPayload.put("course_id", context.courseId().toString());
+        quizPayload.put("course_name", context.courseName());
+        quizPayload.put("score", event.getScore());
+        quizPayload.put("max_score", 100.0);
+        webhookEmitter.sendEvent("quiz_completed", quizPayload);
+
+        Map<String, Object> gradePayload = new HashMap<>();
+        gradePayload.put("student_id", studentId);
+        gradePayload.put("course_id", context.courseId().toString());
+        gradePayload.put("course_name", context.courseName());
+        gradePayload.put("grade", event.getScore());
+        gradePayload.put("max_grade", 100.0);
+        gradePayload.put("assignment_name", context.quizName().isBlank() ? "Quiz" : context.quizName());
+        webhookEmitter.sendEvent("grade_saved", gradePayload);
+    }
+
+    private boolean isWebhookEnabled() {
+        return config.getWebhook() != null && config.getWebhook().isEnabled();
+    }
+
+    private Optional<String> resolveCourseName(UUID courseId) {
+        return queryForString("SELECT c.title FROM courses c WHERE c.id = ?", courseId);
+    }
+
+    private Optional<AssignmentContext> resolveAssignmentContext(UUID assignmentId) {
+        try {
+            Map<String, Object> row = jdbc.queryForMap(
+                    "SELECT " +
+                    "  a.title AS assignment_name, " +
+                    "  COALESCE(a.course_id, ch.course_id)::text AS course_id, " +
+                    "  c.title AS course_name, " +
+                    "  a.max_score::double precision AS max_grade " +
+                    "FROM assignments a " +
+                    "LEFT JOIN lessons l ON a.lesson_id = l.id " +
+                    "LEFT JOIN chapters ch ON l.chapter_id = ch.id " +
+                    "LEFT JOIN courses c ON c.id = COALESCE(a.course_id, ch.course_id) " +
+                    "WHERE a.id = ?",
+                    assignmentId
+            );
+            return Optional.of(new AssignmentContext(
+                    stringValue(row.get("assignment_name")),
+                    uuidValue(row.get("course_id")),
+                    stringValue(row.get("course_name")),
+                    doubleValue(row.get("max_grade"))
+            ));
+        } catch (Exception e) {
+            log.debug("Could not resolve assignment context for Wiii event: assignment={}, error={}",
+                    assignmentId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private Optional<QuizContext> resolveQuizContext(UUID quizId) {
+        try {
+            Map<String, Object> row = jdbc.queryForMap(
+                    "SELECT " +
+                    "  q.title AS quiz_name, " +
+                    "  c.id::text AS course_id, " +
+                    "  c.title AS course_name " +
+                    "FROM quizzes q " +
+                    "JOIN lessons l ON q.lesson_id = l.id " +
+                    "JOIN chapters ch ON l.chapter_id = ch.id " +
+                    "JOIN courses c ON ch.course_id = c.id " +
+                    "WHERE q.id = ?",
+                    quizId
+            );
+            return Optional.of(new QuizContext(
+                    stringValue(row.get("quiz_name")),
+                    uuidValue(row.get("course_id")),
+                    stringValue(row.get("course_name"))
+            ));
+        } catch (Exception e) {
+            log.debug("Could not resolve quiz context for Wiii event: quiz={}, error={}",
+                    quizId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private Optional<String> queryForString(String sql, Object... args) {
+        try {
+            String value = jdbc.queryForObject(sql, String.class, args);
+            return Optional.ofNullable(value).filter(s -> !s.isBlank());
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    private String firstNonBlank(String first, String second) {
+        if (first != null && !first.isBlank()) {
+            return first;
+        }
+        return second != null ? second : "";
+    }
+
+    private String stringValue(Object value) {
+        return value != null ? value.toString() : "";
+    }
+
+    private UUID uuidValue(Object value) {
+        if (value == null || value.toString().isBlank()) {
+            return null;
+        }
+        return UUID.fromString(value.toString());
+    }
+
+    private Double doubleValue(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        if (value != null && !value.toString().isBlank()) {
+            return Double.parseDouble(value.toString());
+        }
+        return null;
+    }
+
+    private record AssignmentContext(String assignmentName, UUID courseId, String courseName, Double maxGrade) {}
+    private record QuizContext(String quizName, UUID courseId, String courseName) {}
+}

--- a/backend/src/test/java/com/example/lms/architecture/CleanArchitectureTest.java
+++ b/backend/src/test/java/com/example/lms/architecture/CleanArchitectureTest.java
@@ -130,6 +130,17 @@ class CleanArchitectureTest {
         }
 
         @Test
+        @DisplayName("Use cases should not depend on integration adapters")
+        void useCasesShouldNotDependOnIntegrationAdapters() {
+            noClasses()
+                    .that(COMMAND_USE_CASES_OUTSIDE_APPROVED_LEGACY_DEBT)
+                    .should().dependOnClassesThat()
+                    .resideInAPackage("..integration..")
+                    .because("Command use cases must publish domain events or depend on ports, not concrete integration adapters")
+                    .check(importedClasses);
+        }
+
+        @Test
         @DisplayName("Application DTOs should not depend on infrastructure")
         void dtosShouldNotDependOnInfrastructure() {
             noClasses()

--- a/backend/src/test/java/com/example/lms/assessment/infrastructure/web/AssignmentSecurityTest.java
+++ b/backend/src/test/java/com/example/lms/assessment/infrastructure/web/AssignmentSecurityTest.java
@@ -11,6 +11,7 @@ import com.example.lms.course_authoring.infrastructure.persistence.JpaCourseRepo
 import com.example.lms.course_authoring.infrastructure.persistence.entity.CourseJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
+import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -44,6 +45,7 @@ class AssignmentSecurityTest {
     @Mock private GradeSubmissionUseCase gradeSubmissionUseCase;
     @Mock private UserJpaRepository userJpaRepository;
     @Mock private GradingAuditLogJpaRepository gradingAuditLogRepository;
+    @Mock private WiiiLmsEventPublisher wiiiLmsEventPublisher;
 
     @InjectMocks
     private AssignmentSubmissionControllerV3 controller;

--- a/backend/src/test/java/com/example/lms/assessment/infrastructure/web/AssignmentSecurityTest.java
+++ b/backend/src/test/java/com/example/lms/assessment/infrastructure/web/AssignmentSecurityTest.java
@@ -11,7 +11,7 @@ import com.example.lms.course_authoring.infrastructure.persistence.JpaCourseRepo
 import com.example.lms.course_authoring.infrastructure.persistence.entity.CourseJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
-import com.example.lms.shared.integration.WiiiLmsEventPublisher;
+import com.example.lms.shared.domain.event.DomainEventPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -45,7 +45,7 @@ class AssignmentSecurityTest {
     @Mock private GradeSubmissionUseCase gradeSubmissionUseCase;
     @Mock private UserJpaRepository userJpaRepository;
     @Mock private GradingAuditLogJpaRepository gradingAuditLogRepository;
-    @Mock private WiiiLmsEventPublisher wiiiLmsEventPublisher;
+    @Mock private DomainEventPublisher eventPublisher;
 
     @InjectMocks
     private AssignmentSubmissionControllerV3 controller;

--- a/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/EnrollStudentUseCaseV3Test.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/EnrollStudentUseCaseV3Test.java
@@ -10,6 +10,7 @@ import com.example.lms.learning_delivery.domain.repository.LearningClassReposito
 import com.example.lms.shared.domain.valueobject.Email;
 import com.example.lms.shared.domain.valueobject.UserId;
 import com.example.lms.shared.exception.BusinessRuleException;
+import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -44,6 +45,9 @@ class EnrollStudentUseCaseV3Test {
 
     @Mock
     private CourseRepository courseRepository;
+
+    @Mock
+    private WiiiLmsEventPublisher wiiiLmsEventPublisher;
 
     @InjectMocks
     private EnrollStudentUseCaseV3 useCase;

--- a/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/EnrollStudentUseCaseV3Test.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/EnrollStudentUseCaseV3Test.java
@@ -8,9 +8,9 @@ import com.example.lms.identity.domain.repository.UserRepository;
 import com.example.lms.learning_delivery.domain.repository.EnrollmentRepositoryPort;
 import com.example.lms.learning_delivery.domain.repository.LearningClassRepositoryPort;
 import com.example.lms.shared.domain.valueobject.Email;
+import com.example.lms.shared.domain.event.DomainEventPublisher;
 import com.example.lms.shared.domain.valueobject.UserId;
 import com.example.lms.shared.exception.BusinessRuleException;
-import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -47,7 +47,7 @@ class EnrollStudentUseCaseV3Test {
     private CourseRepository courseRepository;
 
     @Mock
-    private WiiiLmsEventPublisher wiiiLmsEventPublisher;
+    private DomainEventPublisher eventPublisher;
 
     @InjectMocks
     private EnrollStudentUseCaseV3 useCase;

--- a/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/SelfEnrollUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/SelfEnrollUseCaseTest.java
@@ -11,6 +11,7 @@ import com.example.lms.learning_delivery.domain.repository.EnrollmentRepositoryP
 import com.example.lms.learning_delivery.domain.repository.LearningClassRepositoryPort;
 import com.example.lms.shared.domain.valueobject.CourseCode;
 import com.example.lms.shared.exception.BusinessRuleException;
+import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,9 @@ class SelfEnrollUseCaseTest {
 
     @Mock
     private CoursePublicationPort coursePublicationPort;
+
+    @Mock
+    private WiiiLmsEventPublisher wiiiLmsEventPublisher;
 
     @InjectMocks
     private SelfEnrollUseCase useCase;

--- a/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/SelfEnrollUseCaseTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/application/usecase/SelfEnrollUseCaseTest.java
@@ -9,9 +9,9 @@ import com.example.lms.learning_delivery.domain.model.Enrollment;
 import com.example.lms.learning_delivery.domain.model.LearningClass;
 import com.example.lms.learning_delivery.domain.repository.EnrollmentRepositoryPort;
 import com.example.lms.learning_delivery.domain.repository.LearningClassRepositoryPort;
+import com.example.lms.shared.domain.event.DomainEventPublisher;
 import com.example.lms.shared.domain.valueobject.CourseCode;
 import com.example.lms.shared.exception.BusinessRuleException;
-import com.example.lms.shared.integration.WiiiLmsEventPublisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,7 +49,7 @@ class SelfEnrollUseCaseTest {
     private CoursePublicationPort coursePublicationPort;
 
     @Mock
-    private WiiiLmsEventPublisher wiiiLmsEventPublisher;
+    private DomainEventPublisher eventPublisher;
 
     @InjectMocks
     private SelfEnrollUseCase useCase;

--- a/backend/src/test/java/com/example/lms/shared/integration/WiiiDataControllerV3Test.java
+++ b/backend/src/test/java/com/example/lms/shared/integration/WiiiDataControllerV3Test.java
@@ -1,0 +1,69 @@
+package com.example.lms.shared.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WiiiDataControllerV3Test {
+
+    @Mock private JdbcTemplate jdbc;
+
+    private WiiiDataControllerV3 controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new WiiiDataControllerV3(jdbc);
+    }
+
+    @Test
+    void getCourseStatsCalculatesQuizAverageThroughLessonChapterCoursePath() {
+        UUID courseId = UUID.randomUUID();
+
+        when(jdbc.queryForObject(anyString(), eq(Integer.class), eq(courseId)))
+                .thenReturn(12, 8, 3);
+        when(jdbc.queryForObject(
+                argThat(sql -> sql != null
+                        && sql.contains("AVG(qa.score)")
+                        && sql.contains("JOIN lessons l ON q.lesson_id = l.id")),
+                eq(Double.class),
+                eq(courseId)
+        )).thenReturn(84.44);
+        when(jdbc.queryForObject(
+                argThat(sql -> sql != null && sql.contains("AVG(e.completion_percent)")),
+                eq(Double.class),
+                eq(courseId)
+        )).thenReturn(62.22);
+
+        var response = controller.getCourseStats(courseId);
+
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getData())
+                .containsEntry("students_count", 12)
+                .containsEntry("avg_grade", 84.4)
+                .containsEntry("completion_rate", 62.2)
+                .containsEntry("active_last_7d", 8)
+                .containsEntry("at_risk_count", 3);
+
+        verify(jdbc).queryForObject(
+                argThat(sql -> sql != null
+                        && sql.contains("JOIN lessons l ON q.lesson_id = l.id")
+                        && sql.contains("JOIN chapters ch ON l.chapter_id = ch.id")
+                        && sql.contains("WHERE ch.course_id = ?")),
+                eq(Double.class),
+                eq(courseId)
+        );
+    }
+}

--- a/backend/src/test/java/com/example/lms/shared/integration/WiiiLmsEventPublisherTest.java
+++ b/backend/src/test/java/com/example/lms/shared/integration/WiiiLmsEventPublisherTest.java
@@ -1,0 +1,142 @@
+package com.example.lms.shared.integration;
+
+import com.example.lms.assessment.domain.event.QuizSubmittedEvent;
+import com.example.lms.assessment.domain.event.SubmissionGradedEvent;
+import com.example.lms.shared.domain.valueobject.StudentId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WiiiLmsEventPublisherTest {
+
+    @Mock private WiiiWebhookEmitter webhookEmitter;
+    @Mock private JdbcTemplate jdbc;
+
+    private WiiiLmsEventPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        WiiiIntegrationConfig config = new WiiiIntegrationConfig();
+        config.getWebhook().setEnabled(true);
+        publisher = new WiiiLmsEventPublisher(webhookEmitter, config, jdbc);
+    }
+
+    @Test
+    void sendQuizCompletedIncludesCourseContextForBothWebhookEvents() {
+        UUID attemptId = UUID.randomUUID();
+        UUID quizId = UUID.randomUUID();
+        UUID studentId = UUID.randomUUID();
+        UUID lessonId = UUID.randomUUID();
+        UUID courseId = UUID.randomUUID();
+
+        when(jdbc.queryForMap(anyString(), eq(quizId))).thenReturn(Map.of(
+                "quiz_name", "COLREGs check",
+                "course_id", courseId.toString(),
+                "course_name", "COLREGs"
+        ));
+
+        publisher.sendQuizCompleted(new QuizSubmittedEvent(
+                attemptId, quizId, StudentId.of(studentId), lessonId, 87.5, true));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> quizPayload =
+                ArgumentCaptor.forClass((Class) Map.class);
+        verify(webhookEmitter).sendEvent(eq("quiz_completed"), quizPayload.capture());
+
+        assertThat(quizPayload.getValue())
+                .containsEntry("student_id", studentId.toString())
+                .containsEntry("quiz_id", quizId.toString())
+                .containsEntry("quiz_name", "COLREGs check")
+                .containsEntry("course_id", courseId.toString())
+                .containsEntry("course_name", "COLREGs")
+                .containsEntry("score", 87.5)
+                .containsEntry("max_score", 100.0);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> gradePayload =
+                ArgumentCaptor.forClass((Class) Map.class);
+        verify(webhookEmitter).sendEvent(eq("grade_saved"), gradePayload.capture());
+
+        assertThat(gradePayload.getValue())
+                .containsEntry("student_id", studentId.toString())
+                .containsEntry("course_id", courseId.toString())
+                .containsEntry("grade", 87.5)
+                .containsEntry("max_grade", 100.0)
+                .containsEntry("assignment_name", "COLREGs check");
+    }
+
+    @Test
+    void sendAssignmentSubmittedSkipsInvalidPayloadWhenCourseContextIsMissing() {
+        UUID studentId = UUID.randomUUID();
+        UUID assignmentId = UUID.randomUUID();
+
+        when(jdbc.queryForMap(anyString(), eq(assignmentId))).thenReturn(Map.of(
+                "assignment_name", "Essay",
+                "course_id", "",
+                "course_name", "",
+                "max_grade", 100.0
+        ));
+
+        publisher.sendAssignmentSubmitted(studentId, assignmentId, Instant.parse("2026-05-10T10:15:30Z"));
+
+        verify(webhookEmitter, never()).sendEvent(eq("assignment_submitted"), org.mockito.ArgumentMatchers.anyMap());
+    }
+
+    @Test
+    void sendSubmissionGradedMapsGradeSavedContract() {
+        UUID submissionId = UUID.randomUUID();
+        UUID assignmentId = UUID.randomUUID();
+        UUID studentId = UUID.randomUUID();
+        UUID graderId = UUID.randomUUID();
+        UUID courseId = UUID.randomUUID();
+
+        when(jdbc.queryForMap(anyString(), eq(assignmentId))).thenReturn(Map.of(
+                "assignment_name", "Navigation exercise",
+                "course_id", courseId.toString(),
+                "course_name", "Navigation",
+                "max_grade", 50.0
+        ));
+
+        publisher.sendSubmissionGraded(new SubmissionGradedEvent(
+                submissionId,
+                assignmentId,
+                studentId,
+                graderId,
+                "Teacher",
+                "GRADE_CREATED",
+                null,
+                42.0,
+                null,
+                "Good"
+        ));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> payload =
+                ArgumentCaptor.forClass((Class) Map.class);
+        verify(webhookEmitter).sendEvent(eq("grade_saved"), payload.capture());
+
+        assertThat(payload.getValue())
+                .containsEntry("student_id", studentId.toString())
+                .containsEntry("course_id", courseId.toString())
+                .containsEntry("course_name", "Navigation")
+                .containsEntry("grade", 42.0)
+                .containsEntry("max_grade", 50.0)
+                .containsEntry("assignment_name", "Navigation exercise");
+    }
+}

--- a/backend/src/test/java/com/example/lms/shared/integration/WiiiLmsEventPublisherTest.java
+++ b/backend/src/test/java/com/example/lms/shared/integration/WiiiLmsEventPublisherTest.java
@@ -1,7 +1,9 @@
 package com.example.lms.shared.integration;
 
+import com.example.lms.assessment.domain.event.AssignmentSubmittedEvent;
 import com.example.lms.assessment.domain.event.QuizSubmittedEvent;
 import com.example.lms.assessment.domain.event.SubmissionGradedEvent;
+import com.example.lms.learning_delivery.domain.event.CourseEnrolledEvent;
 import com.example.lms.shared.domain.valueobject.StudentId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,28 @@ class WiiiLmsEventPublisherTest {
         WiiiIntegrationConfig config = new WiiiIntegrationConfig();
         config.getWebhook().setEnabled(true);
         publisher = new WiiiLmsEventPublisher(webhookEmitter, config, jdbc);
+    }
+
+    @Test
+    void sendCourseEnrolledMapsNeutralDomainEventToWebhookContract() {
+        UUID enrollmentId = UUID.randomUUID();
+        UUID studentId = UUID.randomUUID();
+        UUID classId = UUID.randomUUID();
+        UUID courseId = UUID.randomUUID();
+
+        publisher.sendCourseEnrolled(new CourseEnrolledEvent(
+                enrollmentId, studentId, classId, courseId, "Maritime Safety", "2026A"));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Object>> payload =
+                ArgumentCaptor.forClass((Class) Map.class);
+        verify(webhookEmitter).sendEvent(eq("course_enrolled"), payload.capture());
+
+        assertThat(payload.getValue())
+                .containsEntry("student_id", studentId.toString())
+                .containsEntry("course_id", courseId.toString())
+                .containsEntry("course_name", "Maritime Safety")
+                .containsEntry("semester", "2026A");
     }
 
     @Test
@@ -93,7 +117,8 @@ class WiiiLmsEventPublisherTest {
                 "max_grade", 100.0
         ));
 
-        publisher.sendAssignmentSubmitted(studentId, assignmentId, Instant.parse("2026-05-10T10:15:30Z"));
+        publisher.sendAssignmentSubmitted(new AssignmentSubmittedEvent(
+                UUID.randomUUID(), assignmentId, studentId, Instant.parse("2026-05-10T10:15:30Z")));
 
         verify(webhookEmitter, never()).sendEvent(eq("assignment_submitted"), org.mockito.ArgumentMatchers.anyMap());
     }


### PR DESCRIPTION
## Summary
- Keep Wiii as an external AI service and harden the LMS-side Spring integration contract.
- Add a centralized `WiiiLmsEventPublisher` to build valid Wiii webhook payloads with required LMS/course context.
- Emit `course_enrolled` from manual, email, batch-paid, self-enrollment, and payment-backed enrollment flows.
- Emit `assignment_submitted` from both student assignment submission routes.
- Map quiz and grading domain events to Wiii `quiz_completed` and `grade_saved` payloads.
- Fix Wiii course stats data-pull SQL so quiz averages resolve course context through lessons/chapters.

## Validation
- `mvn test -Dtest=WiiiLmsEventPublisherTest,WiiiDataControllerV3Test,EnrollStudentUseCaseV3Test,SelfEnrollUseCaseTest,AssignmentSecurityTest`
- `mvn test`
- `git diff --cached --check`

## Pre-PR screenshot
- Captured frontend render before opening this PR: `C:\hhll\LMS_hohulili_wiii\.tmp\screenshots\wiii-integration-pre-pr.png`

Notes: frontend screenshot was taken with the Angular dev server on `127.0.0.1:4301`; backend API proxy errors were expected because the backend server was not started for that screenshot run.