### PR TITLE
feat: require LMS preview approval for Wiii apply

### DIFF
--- a/fe/src/app/app.ts
+++ b/fe/src/app/app.ts
@@ -11,6 +11,7 @@ import { WebMcpService } from './core/services/webmcp.service';
 import { OfflineStorageTelemetryIngestService } from './core/services/offline-storage-telemetry-ingest.service';
 import { AuthService } from './core/services/auth.service';
 import { MessagingService } from './core/services/messaging.service';
+import { WiiiOperatorPreviewDialogComponent } from './features/ai-chat/presentation/components';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -22,12 +23,14 @@ import { MessagingService } from './core/services/messaging.service';
     OfflineIndicatorComponent,
     SessionExpiredBannerComponent,
     AppUpdateBannerComponent,
+    WiiiOperatorPreviewDialogComponent,
   ],
   template: `
     <app-session-expired-banner />
     <app-offline-indicator />
     <app-update-banner />
     <router-outlet></router-outlet>
+    <app-wiii-operator-preview-dialog />
     <app-toast-container />
     <app-confirm-dialog />
   `,

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
@@ -99,11 +99,17 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     } as any));
     lessonApi.updateLesson.and.returnValue(of({ success: true } as any));
 
+    let panelPreview: any;
+    const previewSub = service.operatorPreview$.subscribe((previewPanel) => {
+      panelPreview = previewPanel;
+    });
     const preview = await (service as any).handleActionRequest('authoring.preview_lesson_patch', {
       lesson_id: 'lesson-1',
       title: 'Bai hoc moi',
       content: 'Noi dung da chinh sua',
+      source_references: [{ kind: 'chapter', page_start: 2, page_end: 3, excerpt: 'Nguon tai lieu' }],
     });
+    previewSub.unsubscribe();
 
     expect(preview.success).toBeTrue();
     expect(preview.data?.preview_kind).toBe('lesson_patch');
@@ -129,10 +135,21 @@ describe('WiiiContextService - operator preview/apply flows', () => {
       unchanged: 0,
       items: jasmine.any(Array),
     }));
+    expect(preview.data?.source_references).toEqual([
+      jasmine.objectContaining({ kind: 'chapter', page_start: 2, page_end: 3, excerpt: 'Nguon tai lieu' }),
+    ]);
+    expect(panelPreview).toEqual(jasmine.objectContaining({
+      token: preview.data?.preview_token,
+      kind: 'lesson_patch',
+      sourceReferences: [jasmine.objectContaining({ page_start: 2 })],
+    }));
 
-    const applied = await (service as any).handleActionRequest('authoring.apply_lesson_patch', {
+    await expectAsync((service as any).handleActionRequest('authoring.apply_lesson_patch', {
       preview_token: preview.data?.preview_token,
-    });
+    })).toBeRejectedWithError(/host_preview_approval_required/);
+    expect(lessonApi.updateLesson).not.toHaveBeenCalled();
+
+    const applied = await service.approveOperatorPreview(String(preview.data?.preview_token));
 
     expect(applied.success).toBeTrue();
     expect(lessonApi.updateLesson).toHaveBeenCalledWith('lesson-1', jasmine.objectContaining({
@@ -171,9 +188,7 @@ describe('WiiiContextService - operator preview/apply flows', () => {
       max_attempts: 2,
     }));
 
-    const applied = await (service as any).handleActionRequest('assessment.apply_quiz_commit', {
-      preview_token: preview.data?.preview_token,
-    });
+    const applied = await service.approveOperatorPreview(String(preview.data?.preview_token));
 
     expect(applied.success).toBeTrue();
     expect(quizApi.createLessonQuizV3).toHaveBeenCalledWith('lesson-1', jasmine.objectContaining({
@@ -182,7 +197,7 @@ describe('WiiiContextService - operator preview/apply flows', () => {
       questionIds: ['q1', 'q2', 'q3'],
       publishImmediately: false,
     }));
-    expect(applied.data?.quiz_id).toBe('quiz-1');
+    expect(applied.data?.['quiz_id']).toBe('quiz-1');
   });
 
   it('previews and publishes an existing quiz through the host action flow', async () => {
@@ -208,13 +223,11 @@ describe('WiiiContextService - operator preview/apply flows', () => {
       title: 'Quiz cuoi chuong',
     }));
 
-    const published = await (service as any).handleActionRequest('publish.apply_quiz', {
-      preview_token: preview.data?.preview_token,
-    });
+    const published = await service.approveOperatorPreview(String(preview.data?.preview_token));
 
     expect(published.success).toBeTrue();
     expect(quizApi.publishQuiz).toHaveBeenCalledWith('quiz-9');
-    expect(published.data?.published).toBeTrue();
+    expect(published.data?.['published']).toBeTrue();
   });
 
   it('adds connector and workspace overlays to host context contracts', () => {

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -109,14 +109,49 @@ interface WiiiHostCapabilities {
 
 const LMS_CONNECTOR_ID = 'maritime-lms';
 
-type OperatorPreviewKind = 'lesson_patch' | 'quiz_commit' | 'quiz_publish';
+export type OperatorPreviewKind = 'lesson_patch' | 'quiz_commit' | 'quiz_publish';
 
 interface PendingOperatorPreview {
   kind: OperatorPreviewKind;
   token: string;
   createdAt: number;
+  approvedAt?: number;
+  approvalToken?: string;
   summary: string;
   payload: Record<string, unknown>;
+}
+
+export interface WiiiSourceReference {
+  kind?: string;
+  title?: string;
+  label?: string;
+  excerpt?: string;
+  page?: number;
+  page_start?: number;
+  page_end?: number;
+  chapter_index?: number;
+  lesson_index?: number;
+  block_id?: string;
+}
+
+export interface WiiiOperatorPreviewPanel {
+  token: string;
+  kind: OperatorPreviewKind;
+  createdAt: number;
+  summary: string;
+  applyAction: string;
+  targetLabel: string;
+  changedFields: string[];
+  sourceReferences: WiiiSourceReference[];
+  data: Record<string, unknown>;
+}
+
+export interface WiiiOperatorApplyResult {
+  token: string;
+  kind: OperatorPreviewKind;
+  success: boolean;
+  data?: Record<string, unknown>;
+  error?: string;
 }
 
 interface LessonPreviewBlock {
@@ -153,6 +188,8 @@ export class WiiiContextService implements OnDestroy {
 
   /** Observable for AI course generation progress events */
   readonly courseProgress$ = new Subject<CourseProgressEvent>();
+  readonly operatorPreview$ = new Subject<WiiiOperatorPreviewPanel>();
+  readonly operatorApplyResult$ = new Subject<WiiiOperatorApplyResult>();
 
   // Stored listener references for cleanup (Expert Fix 10)
   private screenshotListener: ((event: MessageEvent) => void) | null = null;
@@ -718,6 +755,7 @@ export class WiiiContextService implements OnDestroy {
                 title: { type: 'string' },
                 description: { type: 'string' },
                 content: { type: 'string' },
+                source_references: { type: 'array', items: { type: 'object' } },
               },
             },
             requires_confirmation: false,
@@ -734,7 +772,9 @@ export class WiiiContextService implements OnDestroy {
               type: 'object',
               properties: {
                 preview_token: { type: 'string' },
+                approval_token: { type: 'string' },
               },
+              required: ['preview_token', 'approval_token'],
             },
             requires_confirmation: true,
             mutates_state: true,
@@ -772,7 +812,9 @@ export class WiiiContextService implements OnDestroy {
               type: 'object',
               properties: {
                 preview_token: { type: 'string' },
+                approval_token: { type: 'string' },
               },
+              required: ['preview_token', 'approval_token'],
             },
             requires_confirmation: true,
             mutates_state: true,
@@ -805,7 +847,9 @@ export class WiiiContextService implements OnDestroy {
               type: 'object',
               properties: {
                 preview_token: { type: 'string' },
+                approval_token: { type: 'string' },
               },
+              required: ['preview_token', 'approval_token'],
             },
             requires_confirmation: true,
             mutates_state: true,
@@ -879,6 +923,10 @@ export class WiiiContextService implements OnDestroy {
     return `${kind}-${Math.random().toString(36).slice(2, 10)}`;
   }
 
+  private createApprovalToken(kind: OperatorPreviewKind): string {
+    return `approved-${kind}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+
   private prunePendingPreviews(): void {
     const now = Date.now();
     for (const [token, preview] of this.pendingOperatorPreviews.entries()) {
@@ -914,6 +962,83 @@ export class WiiiContextService implements OnDestroy {
     return preview;
   }
 
+  private requireAnyPreview(token: string): PendingOperatorPreview {
+    this.prunePendingPreviews();
+    const preview = this.pendingOperatorPreviews.get(token);
+    if (!preview) {
+      throw new Error('Missing operator preview');
+    }
+    return preview;
+  }
+
+  private requireHostApproval(
+    preview: PendingOperatorPreview,
+    approvalToken: string | undefined,
+  ): void {
+    if (!approvalToken || preview.approvalToken !== approvalToken) {
+      throw new Error('host_preview_approval_required');
+    }
+  }
+
+  async approveOperatorPreview(previewToken: string): Promise<WiiiOperatorApplyResult> {
+    const preview = this.requireAnyPreview(String(previewToken || '').trim());
+    preview.approvalToken = this.createApprovalToken(preview.kind);
+    preview.approvedAt = Date.now();
+
+    try {
+      const result = await this.handleActionRequest(this.applyActionForPreviewKind(preview.kind), {
+        preview_token: preview.token,
+        approval_token: preview.approvalToken,
+      });
+      const event: WiiiOperatorApplyResult = {
+        token: preview.token,
+        kind: preview.kind,
+        success: result.success,
+        data: result.data,
+        error: result.error,
+      };
+      this.operatorApplyResult$.next(event);
+      return event;
+    } catch (error) {
+      const event: WiiiOperatorApplyResult = {
+        token: preview.token,
+        kind: preview.kind,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+      this.operatorApplyResult$.next(event);
+      return event;
+    }
+  }
+
+  private applyActionForPreviewKind(kind: OperatorPreviewKind): string {
+    switch (kind) {
+      case 'lesson_patch':
+        return 'authoring.apply_lesson_patch';
+      case 'quiz_commit':
+        return 'assessment.apply_quiz_commit';
+      case 'quiz_publish':
+        return 'publish.apply_quiz';
+    }
+  }
+
+  private announceOperatorPreview(
+    preview: PendingOperatorPreview,
+    data: Record<string, unknown>,
+  ): void {
+    this.operatorPreview$.next({
+      token: preview.token,
+      kind: preview.kind,
+      createdAt: preview.createdAt,
+      summary: String(data['summary'] || preview.summary || '').trim(),
+      applyAction: String(data['apply_action'] || this.applyActionForPreviewKind(preview.kind)).trim(),
+      targetLabel: String(data['target_label'] || data['lesson_title'] || data['quiz_title'] || preview.kind).trim(),
+      changedFields: this.normalizeStringArray(data['changed_fields']),
+      sourceReferences: this.normalizeSourceReferences(data['source_references']),
+      data,
+    });
+  }
+
   private resolveCurrentCourseId(params: Record<string, unknown>): string {
     return String(
       params['course_id']
@@ -945,6 +1070,35 @@ export class WiiiContextService implements OnDestroy {
     return value
       .map((item) => String(item || '').trim())
       .filter((item) => item.length > 0);
+  }
+
+  private normalizeSourceReferences(value: unknown): WiiiSourceReference[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value
+      .filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item))
+      .slice(0, 12)
+      .map((item) => ({
+        kind: this.normalizeString(item['kind']),
+        title: this.normalizeString(item['title']),
+        label: this.normalizeString(item['label']),
+        excerpt: this.normalizeString(item['excerpt'] ?? item['text'] ?? item['snippet']),
+        page: this.normalizeOptionalNumber(item['page'] ?? item['page_number']),
+        page_start: this.normalizeOptionalNumber(item['page_start'] ?? item['pageStart'] ?? item['source_page_start']),
+        page_end: this.normalizeOptionalNumber(item['page_end'] ?? item['pageEnd'] ?? item['source_page_end']),
+        chapter_index: this.normalizeOptionalNumber(item['chapter_index'] ?? item['chapterIndex']),
+        lesson_index: this.normalizeOptionalNumber(item['lesson_index'] ?? item['lessonIndex']),
+        block_id: this.normalizeString(item['block_id'] ?? item['blockId']),
+      }));
+  }
+
+  private normalizeOptionalNumber(value: unknown): number | undefined {
+    if (value === null || value === undefined || value === '') {
+      return undefined;
+    }
+    const number = Number(value);
+    return Number.isFinite(number) ? number : undefined;
   }
 
   private buildPreviewExcerpt(value: unknown, maxLength = 240): string {
@@ -1160,6 +1314,9 @@ export class WiiiContextService implements OnDestroy {
     const title = this.normalizeString(params['title']);
     const description = this.normalizeString(params['description']);
     const content = this.normalizeString(params['content']);
+    const sourceReferences = this.normalizeSourceReferences(
+      params['source_references'] || params['sourceReferences'],
+    );
     const changedFields = [
       ...(title ? ['title'] : []),
       ...(description ? ['description'] : []),
@@ -1189,34 +1346,39 @@ export class WiiiContextService implements OnDestroy {
       duration_minutes: Number(lesson?.durationMinutes || 0),
       order_index: Number(lesson?.orderIndex || 0),
       is_required: Boolean((lesson as any)?.isRequired ?? false),
+      source_references: sourceReferences,
     });
+
+    const data = {
+      preview_token: preview.token,
+      preview_kind: preview.kind,
+      lesson_id: lessonId,
+      lesson_title: String(lesson?.title || lessonId).trim(),
+      course_id: String(lesson?.courseId || this.resolveCurrentCourseId(params) || '').trim() || undefined,
+      apply_action: 'authoring.apply_lesson_patch',
+      summary: `${summary} Review the LMS preview panel before applying it.`,
+      changed_fields: changedFields,
+      target_label: String(lesson?.title || lessonId).trim(),
+      source_references: sourceReferences,
+      lesson_before: {
+        title: String(lesson?.title || '').trim(),
+        description: String(lesson?.description || '').trim(),
+        content_excerpt: this.buildPreviewExcerpt(lesson?.content),
+        blocks: beforeBlocks,
+      },
+      lesson_after: {
+        title: title ?? String(lesson?.title || '').trim(),
+        description: description ?? String(lesson?.description || '').trim(),
+        content_excerpt: this.buildPreviewExcerpt(content ?? lesson?.content),
+        blocks: afterBlocks,
+      },
+      block_diff: blockDiff,
+    };
+    this.announceOperatorPreview(preview, data);
 
     return {
       success: true,
-      data: {
-        preview_token: preview.token,
-        preview_kind: preview.kind,
-        lesson_id: lessonId,
-        lesson_title: String(lesson?.title || lessonId).trim(),
-        course_id: String(lesson?.courseId || this.resolveCurrentCourseId(params) || '').trim() || undefined,
-        apply_action: 'authoring.apply_lesson_patch',
-        summary: `${summary} Confirm explicitly when you want me to apply it.`,
-        changed_fields: changedFields,
-        target_label: String(lesson?.title || lessonId).trim(),
-        lesson_before: {
-          title: String(lesson?.title || '').trim(),
-          description: String(lesson?.description || '').trim(),
-          content_excerpt: this.buildPreviewExcerpt(lesson?.content),
-          blocks: beforeBlocks,
-        },
-        lesson_after: {
-          title: title ?? String(lesson?.title || '').trim(),
-          description: description ?? String(lesson?.description || '').trim(),
-          content_excerpt: this.buildPreviewExcerpt(content ?? lesson?.content),
-          blocks: afterBlocks,
-        },
-        block_diff: blockDiff,
-      },
+      data,
     };
   }
 
@@ -1229,6 +1391,7 @@ export class WiiiContextService implements OnDestroy {
     }
 
     const preview = this.requirePreview(previewToken, 'lesson_patch');
+    this.requireHostApproval(preview, this.normalizeString(params['approval_token'] || params['approvalToken']));
     const payload = preview.payload;
     const lessonId = String(payload['lesson_id'] || '').trim();
     const courseId = String(payload['course_id'] || '').trim();
@@ -1302,28 +1465,31 @@ export class WiiiContextService implements OnDestroy {
       show_correct_answers: params['show_correct_answers'] ?? params['showCorrectAnswers'] ?? true,
     });
 
+    const data = {
+      preview_token: preview.token,
+      preview_kind: preview.kind,
+      quiz_id: existingQuizId || undefined,
+      lesson_id: lessonId,
+      quiz_title: title,
+      apply_action: 'assessment.apply_quiz_commit',
+      question_count: questionIds.length,
+      summary: `${summary} Review the LMS preview panel before committing it.`,
+      target_label: title,
+      quiz_plan: {
+        mode: existingQuizId ? 'update' : 'create',
+        title,
+        description: this.normalizeString(params['description']) || '',
+        question_count: questionIds.length,
+        time_limit_minutes: Number(params['time_limit_minutes'] || params['timeLimitMinutes'] || 30),
+        max_attempts: Number(params['max_attempts'] || params['maxAttempts'] || 1),
+        passing_score: Number(params['passing_score'] || params['passingScore'] || 60),
+      },
+    };
+    this.announceOperatorPreview(preview, data);
+
     return {
       success: true,
-      data: {
-        preview_token: preview.token,
-        preview_kind: preview.kind,
-        quiz_id: existingQuizId || undefined,
-        lesson_id: lessonId,
-        quiz_title: title,
-        apply_action: 'assessment.apply_quiz_commit',
-        question_count: questionIds.length,
-        summary: `${summary} Confirm explicitly when you want me to commit it.`,
-        target_label: title,
-        quiz_plan: {
-          mode: existingQuizId ? 'update' : 'create',
-          title,
-          description: this.normalizeString(params['description']) || '',
-          question_count: questionIds.length,
-          time_limit_minutes: Number(params['time_limit_minutes'] || params['timeLimitMinutes'] || 30),
-          max_attempts: Number(params['max_attempts'] || params['maxAttempts'] || 1),
-          passing_score: Number(params['passing_score'] || params['passingScore'] || 60),
-        },
-      },
+      data,
     };
   }
 
@@ -1336,6 +1502,7 @@ export class WiiiContextService implements OnDestroy {
     }
 
     const preview = this.requirePreview(previewToken, 'quiz_commit');
+    this.requireHostApproval(preview, this.normalizeString(params['approval_token'] || params['approvalToken']));
     const payload = preview.payload;
     const lessonId = String(payload['lesson_id'] || '').trim();
     if (!lessonId) {
@@ -1409,24 +1576,27 @@ export class WiiiContextService implements OnDestroy {
       title,
     });
 
-    return {
-      success: true,
-      data: {
-        preview_token: preview.token,
-        preview_kind: preview.kind,
+    const data = {
+      preview_token: preview.token,
+      preview_kind: preview.kind,
+      quiz_id: quizId,
+      lesson_id: lessonId,
+      quiz_title: title,
+      apply_action: 'publish.apply_quiz',
+      summary,
+      target_label: title,
+      publish_plan: {
         quiz_id: quizId,
         lesson_id: lessonId,
-        quiz_title: title,
-        apply_action: 'publish.apply_quiz',
-        summary,
-        target_label: title,
-        publish_plan: {
-          quiz_id: quizId,
-          lesson_id: lessonId,
-          title,
-          status: String((quiz as any)?.status || '').trim() || undefined,
-        },
+        title,
+        status: String((quiz as any)?.status || '').trim() || undefined,
       },
+    };
+    this.announceOperatorPreview(preview, data);
+
+    return {
+      success: true,
+      data,
     };
   }
 
@@ -1439,6 +1609,7 @@ export class WiiiContextService implements OnDestroy {
     }
 
     const preview = this.requirePreview(previewToken, 'quiz_publish');
+    this.requireHostApproval(preview, this.normalizeString(params['approval_token'] || params['approvalToken']));
     const quizId = String(preview.payload['quiz_id'] || '').trim();
     if (!quizId) {
       throw new Error('Quiz publish preview is missing quiz_id');

--- a/fe/src/app/features/ai-chat/presentation/components/index.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/index.ts
@@ -9,3 +9,4 @@ export { ChatMessageInputComponent } from './chat-message-input/chat-message-inp
 export { FloatingChatBubbleComponent } from './floating-chat-bubble/floating-chat-bubble.component';
 export { ChatPanelComponent } from './chat-panel/chat-panel.component';
 export { ChatWidgetComponent } from './chat-widget/chat-widget.component';
+export { WiiiOperatorPreviewDialogComponent } from './operator-preview-dialog/operator-preview-dialog.component';

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.html
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.html
@@ -1,0 +1,152 @@
+@if (activePreview(); as preview) {
+  <div class="wiii-preview-backdrop" role="presentation">
+    <section
+      class="wiii-preview-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="wiii-preview-title"
+      data-wiii-id="wiii-preview-diff-panel"
+    >
+      <header class="wiii-preview-header">
+        <div>
+          <p class="wiii-preview-kicker">{{ kindLabel(preview.kind) }}</p>
+          <h2 id="wiii-preview-title">{{ preview.targetLabel }}</h2>
+          <p class="wiii-preview-summary">{{ preview.summary }}</p>
+        </div>
+        <button
+          type="button"
+          class="wiii-preview-icon-button"
+          data-wiii-id="close-wiii-preview"
+          [disabled]="status() === 'applying'"
+          (click)="close()"
+          aria-label="Đóng bản xem trước"
+        >
+          &times;
+        </button>
+      </header>
+
+      <div class="wiii-preview-body">
+        <div
+          class="wiii-preview-status"
+          [class.wiii-preview-status--done]="status() === 'applied'"
+          [class.wiii-preview-status--error]="status() === 'error'"
+        >
+          <span class="wiii-preview-dot"></span>
+          <span>{{ statusLabel() }}</span>
+        </div>
+
+        @if (changedFields(preview).length > 0) {
+          <div class="wiii-preview-section">
+            <h3>Trường sẽ thay đổi</h3>
+            <div class="wiii-preview-pills">
+              @for (field of changedFields(preview); track field) {
+                <span>{{ fieldLabel(field) }}</span>
+              }
+            </div>
+          </div>
+        }
+
+        @if (preview.kind === 'lesson_patch') {
+          <div class="wiii-preview-section">
+            <h3>So sánh bài học</h3>
+            <div class="wiii-preview-diff-grid">
+              <article>
+                <span>Hiện tại</span>
+                <strong>{{ lessonBefore(preview, 'title') || 'Chưa có tiêu đề' }}</strong>
+                <p>{{ lessonBefore(preview, 'description') || 'Không có mô tả' }}</p>
+                <p>{{ lessonBefore(preview, 'content_excerpt') || 'Không có nội dung' }}</p>
+              </article>
+              <article>
+                <span>Wiii đề xuất</span>
+                <strong>{{ lessonAfter(preview, 'title') || 'Chưa có tiêu đề' }}</strong>
+                <p>{{ lessonAfter(preview, 'description') || 'Không có mô tả' }}</p>
+                <p>{{ lessonAfter(preview, 'content_excerpt') || 'Không có nội dung' }}</p>
+              </article>
+            </div>
+          </div>
+
+          @if (blockDiffItems(preview).length > 0) {
+            <div class="wiii-preview-section">
+              <h3>Thay đổi khối nội dung</h3>
+              <div class="wiii-preview-block-list">
+                @for (item of blockDiffItems(preview); track blockTrack(item)) {
+                  <article class="wiii-preview-block">
+                    <span [class]="blockStatusClass(item['status'])">{{ blockStatusLabel(item['status']) }}</span>
+                    <div>
+                      <p>{{ blockText(item['before']) || 'Trống' }}</p>
+                      <p>{{ blockText(item['after']) || 'Trống' }}</p>
+                    </div>
+                  </article>
+                }
+              </div>
+            </div>
+          }
+        }
+
+        @if (preview.kind === 'quiz_commit') {
+          <div class="wiii-preview-section">
+            <h3>Kế hoạch bài kiểm tra</h3>
+            <dl class="wiii-preview-kv">
+              <div><dt>Chế độ</dt><dd>{{ planValue(preview, 'quiz_plan', 'mode') || 'create' }}</dd></div>
+              <div><dt>Số câu hỏi</dt><dd>{{ planValue(preview, 'quiz_plan', 'question_count') || '0' }}</dd></div>
+              <div><dt>Thời gian</dt><dd>{{ planValue(preview, 'quiz_plan', 'time_limit_minutes') || '30' }} phút</dd></div>
+              <div><dt>Điểm đạt</dt><dd>{{ planValue(preview, 'quiz_plan', 'passing_score') || '60' }}%</dd></div>
+            </dl>
+          </div>
+        }
+
+        @if (preview.kind === 'quiz_publish') {
+          <div class="wiii-preview-section">
+            <h3>Kế hoạch phát hành</h3>
+            <p class="wiii-preview-warning">Bài kiểm tra chỉ được phát hành sau khi giáo viên bấm Áp dụng trong LMS.</p>
+            <dl class="wiii-preview-kv">
+              <div><dt>Bài kiểm tra</dt><dd>{{ planValue(preview, 'publish_plan', 'title') || preview.targetLabel }}</dd></div>
+              <div><dt>Trạng thái</dt><dd>{{ planValue(preview, 'publish_plan', 'status') || 'DRAFT' }}</dd></div>
+            </dl>
+          </div>
+        }
+
+        @if (sourceReferences(preview).length > 0) {
+          <div class="wiii-preview-section">
+            <h3>Nguồn từ tài liệu</h3>
+            <div class="wiii-preview-source-list">
+              @for (ref of sourceReferences(preview); track sourceTrack(ref, $index)) {
+                <article>
+                  <strong>{{ sourceLabel(ref, $index) }}</strong>
+                  @if (ref.excerpt) {
+                    <p>{{ ref.excerpt }}</p>
+                  }
+                </article>
+              }
+            </div>
+          </div>
+        }
+
+        @if (message()) {
+          <p class="wiii-preview-message">{{ message() }}</p>
+        }
+      </div>
+
+      <footer class="wiii-preview-footer">
+        <button
+          type="button"
+          class="wiii-preview-secondary"
+          data-wiii-id="cancel-wiii-preview"
+          [disabled]="status() === 'applying'"
+          (click)="close()"
+        >
+          Hủy
+        </button>
+        <button
+          type="button"
+          class="wiii-preview-primary"
+          data-wiii-id="apply-wiii-preview"
+          [disabled]="status() === 'applying' || status() === 'applied'"
+          (click)="approve()"
+        >
+          {{ primaryActionLabel() }}
+        </button>
+      </footer>
+    </section>
+  </div>
+}

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.scss
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.scss
@@ -1,0 +1,302 @@
+.wiii-preview-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.wiii-preview-dialog {
+  width: min(960px, 100%);
+  max-height: min(820px, calc(100vh - 48px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid #dbe3ef;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 24px 72px rgba(15, 23, 42, 0.22);
+}
+
+.wiii-preview-header,
+.wiii-preview-footer {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px;
+  border-bottom: 1px solid #e5eaf2;
+}
+
+.wiii-preview-footer {
+  align-items: center;
+  justify-content: flex-end;
+  border-top: 1px solid #e5eaf2;
+  border-bottom: 0;
+  background: #f8fafc;
+}
+
+.wiii-preview-kicker {
+  margin: 0 0 6px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #0056d2;
+  text-transform: uppercase;
+}
+
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+h2 {
+  font-size: 20px;
+  line-height: 1.25;
+  color: #0f172a;
+}
+
+h3 {
+  margin-bottom: 10px;
+  font-size: 14px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.wiii-preview-summary {
+  margin-top: 8px;
+  color: #475569;
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.wiii-preview-body {
+  overflow: auto;
+  padding: 18px 20px 20px;
+  background: #ffffff;
+}
+
+.wiii-preview-section {
+  margin-top: 18px;
+}
+
+.wiii-preview-status,
+.wiii-preview-message {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid #c7d7ee;
+  border-radius: 8px;
+  background: #f1f7ff;
+  color: #17406f;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.wiii-preview-status--done {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+  color: #166534;
+}
+
+.wiii-preview-status--error {
+  border-color: #fecaca;
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.wiii-preview-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.wiii-preview-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.wiii-preview-pills span {
+  padding: 5px 8px;
+  border: 1px solid #c7d7ee;
+  border-radius: 999px;
+  background: #f8fbff;
+  color: #17406f;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.wiii-preview-diff-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.wiii-preview-diff-grid article,
+.wiii-preview-block,
+.wiii-preview-source-list article {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 12px;
+  background: #fbfdff;
+}
+
+.wiii-preview-diff-grid span,
+.wiii-preview-kv dt {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #64748b;
+  text-transform: uppercase;
+}
+
+.wiii-preview-diff-grid strong,
+.wiii-preview-source-list strong {
+  display: block;
+  margin-bottom: 8px;
+  color: #0f172a;
+  font-size: 14px;
+}
+
+.wiii-preview-diff-grid p,
+.wiii-preview-block p,
+.wiii-preview-source-list p,
+.wiii-preview-warning {
+  color: #475569;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.wiii-preview-block-list,
+.wiii-preview-source-list {
+  display: grid;
+  gap: 10px;
+}
+
+.wiii-preview-block {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr);
+  gap: 12px;
+}
+
+.wiii-preview-block span {
+  align-self: start;
+  justify-self: start;
+  padding: 4px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.wiii-preview-block__added {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.wiii-preview-block__removed {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.wiii-preview-block__changed {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.wiii-preview-block__unchanged {
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.wiii-preview-kv {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.wiii-preview-kv div {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 10px;
+  background: #fbfdff;
+}
+
+.wiii-preview-kv dd {
+  margin: 0;
+  color: #0f172a;
+  font-weight: 700;
+}
+
+.wiii-preview-icon-button,
+.wiii-preview-secondary,
+.wiii-preview-primary {
+  border: 0;
+  cursor: pointer;
+  font-weight: 700;
+  transition:
+    background 160ms ease,
+    color 160ms ease,
+    opacity 160ms ease;
+}
+
+.wiii-preview-icon-button {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: #f1f5f9;
+  color: #334155;
+  font-size: 22px;
+  line-height: 1;
+}
+
+.wiii-preview-secondary,
+.wiii-preview-primary {
+  min-height: 38px;
+  padding: 0 14px;
+  border-radius: 8px;
+  font-size: 13px;
+}
+
+.wiii-preview-secondary {
+  background: #ffffff;
+  color: #334155;
+  border: 1px solid #cbd5e1;
+}
+
+.wiii-preview-primary {
+  background: #0056d2;
+  color: #ffffff;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+@media (max-width: 720px) {
+  .wiii-preview-backdrop {
+    align-items: stretch;
+    padding: 12px;
+  }
+
+  .wiii-preview-dialog {
+    max-height: calc(100vh - 24px);
+  }
+
+  .wiii-preview-diff-grid,
+  .wiii-preview-kv {
+    grid-template-columns: 1fr;
+  }
+
+  .wiii-preview-block {
+    grid-template-columns: 1fr;
+  }
+}

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
@@ -12,440 +12,8 @@ type PreviewStatus = 'idle' | 'applying' | 'applied' | 'error';
 @Component({
   selector: 'app-wiii-operator-preview-dialog',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: `
-    @if (activePreview(); as preview) {
-      <div class="wiii-preview-backdrop" role="presentation">
-        <section
-          class="wiii-preview-dialog"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="wiii-preview-title"
-          data-wiii-id="wiii-preview-diff-panel"
-        >
-          <header class="wiii-preview-header">
-            <div>
-              <p class="wiii-preview-kicker">{{ kindLabel(preview.kind) }}</p>
-              <h2 id="wiii-preview-title">{{ preview.targetLabel }}</h2>
-              <p class="wiii-preview-summary">{{ preview.summary }}</p>
-            </div>
-            <button
-              type="button"
-              class="wiii-preview-icon-button"
-              data-wiii-id="close-wiii-preview"
-              [disabled]="status() === 'applying'"
-              (click)="close()"
-              aria-label="Dong preview"
-            >
-              &times;
-            </button>
-          </header>
-
-          <div class="wiii-preview-body">
-            <div class="wiii-preview-status" [class.wiii-preview-status--done]="status() === 'applied'" [class.wiii-preview-status--error]="status() === 'error'">
-              <span class="wiii-preview-dot"></span>
-              <span>{{ statusLabel() }}</span>
-            </div>
-
-            @if (changedFields(preview).length > 0) {
-              <div class="wiii-preview-section">
-                <h3>Truong se thay doi</h3>
-                <div class="wiii-preview-pills">
-                  @for (field of changedFields(preview); track field) {
-                    <span>{{ fieldLabel(field) }}</span>
-                  }
-                </div>
-              </div>
-            }
-
-            @if (preview.kind === 'lesson_patch') {
-              <div class="wiii-preview-section">
-                <h3>Diff bai hoc</h3>
-                <div class="wiii-preview-diff-grid">
-                  <article>
-                    <span>Hien tai</span>
-                    <strong>{{ lessonBefore(preview, 'title') || 'Chua co tieu de' }}</strong>
-                    <p>{{ lessonBefore(preview, 'description') || 'Khong co mo ta' }}</p>
-                    <p>{{ lessonBefore(preview, 'content_excerpt') || 'Khong co noi dung' }}</p>
-                  </article>
-                  <article>
-                    <span>Wiii de xuat</span>
-                    <strong>{{ lessonAfter(preview, 'title') || 'Chua co tieu de' }}</strong>
-                    <p>{{ lessonAfter(preview, 'description') || 'Khong co mo ta' }}</p>
-                    <p>{{ lessonAfter(preview, 'content_excerpt') || 'Khong co noi dung' }}</p>
-                  </article>
-                </div>
-              </div>
-
-              @if (blockDiffItems(preview).length > 0) {
-                <div class="wiii-preview-section">
-                  <h3>Block diff</h3>
-                  <div class="wiii-preview-block-list">
-                    @for (item of blockDiffItems(preview); track blockTrack(item)) {
-                      <article class="wiii-preview-block">
-                        <span [class]="blockStatusClass(item['status'])">{{ blockStatusLabel(item['status']) }}</span>
-                        <div>
-                          <p>{{ blockText(item['before']) || 'Trong' }}</p>
-                          <p>{{ blockText(item['after']) || 'Trong' }}</p>
-                        </div>
-                      </article>
-                    }
-                  </div>
-                </div>
-              }
-            }
-
-            @if (preview.kind === 'quiz_commit') {
-              <div class="wiii-preview-section">
-                <h3>Quiz plan</h3>
-                <dl class="wiii-preview-kv">
-                  <div><dt>Che do</dt><dd>{{ planValue(preview, 'quiz_plan', 'mode') || 'create' }}</dd></div>
-                  <div><dt>So cau hoi</dt><dd>{{ planValue(preview, 'quiz_plan', 'question_count') || '0' }}</dd></div>
-                  <div><dt>Thoi gian</dt><dd>{{ planValue(preview, 'quiz_plan', 'time_limit_minutes') || '30' }} phut</dd></div>
-                  <div><dt>Diem dat</dt><dd>{{ planValue(preview, 'quiz_plan', 'passing_score') || '60' }}%</dd></div>
-                </dl>
-              </div>
-            }
-
-            @if (preview.kind === 'quiz_publish') {
-              <div class="wiii-preview-section">
-                <h3>Publish plan</h3>
-                <p class="wiii-preview-warning">Quiz se chi duoc publish sau khi giao vien bam ap dung trong LMS.</p>
-                <dl class="wiii-preview-kv">
-                  <div><dt>Quiz</dt><dd>{{ planValue(preview, 'publish_plan', 'title') || preview.targetLabel }}</dd></div>
-                  <div><dt>Trang thai</dt><dd>{{ planValue(preview, 'publish_plan', 'status') || 'DRAFT' }}</dd></div>
-                </dl>
-              </div>
-            }
-
-            @if (sourceReferences(preview).length > 0) {
-              <div class="wiii-preview-section">
-                <h3>Nguon tu tai lieu</h3>
-                <div class="wiii-preview-source-list">
-                  @for (ref of sourceReferences(preview); track sourceTrack(ref, $index)) {
-                    <article>
-                      <strong>{{ sourceLabel(ref, $index) }}</strong>
-                      @if (ref.excerpt) {
-                        <p>{{ ref.excerpt }}</p>
-                      }
-                    </article>
-                  }
-                </div>
-              </div>
-            }
-
-            @if (message()) {
-              <p class="wiii-preview-message">{{ message() }}</p>
-            }
-          </div>
-
-          <footer class="wiii-preview-footer">
-            <button
-              type="button"
-              class="wiii-preview-secondary"
-              data-wiii-id="cancel-wiii-preview"
-              [disabled]="status() === 'applying'"
-              (click)="close()"
-            >
-              Huy
-            </button>
-            <button
-              type="button"
-              class="wiii-preview-primary"
-              data-wiii-id="apply-wiii-preview"
-              [disabled]="status() === 'applying' || status() === 'applied'"
-              (click)="approve()"
-            >
-              {{ status() === 'applying' ? 'Dang ap dung...' : status() === 'applied' ? 'Da ap dung' : 'Ap dung vao LMS' }}
-            </button>
-          </footer>
-        </section>
-      </div>
-    }
-  `,
-  styles: [`
-    .wiii-preview-backdrop {
-      position: fixed;
-      inset: 0;
-      z-index: 1200;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 24px;
-      background: rgba(15, 23, 42, 0.45);
-    }
-
-    .wiii-preview-dialog {
-      width: min(960px, 100%);
-      max-height: min(820px, calc(100vh - 48px));
-      display: flex;
-      flex-direction: column;
-      overflow: hidden;
-      border: 1px solid #dbe3ef;
-      border-radius: 8px;
-      background: #ffffff;
-      box-shadow: 0 24px 72px rgba(15, 23, 42, 0.22);
-    }
-
-    .wiii-preview-header,
-    .wiii-preview-footer {
-      display: flex;
-      align-items: flex-start;
-      justify-content: space-between;
-      gap: 16px;
-      padding: 18px 20px;
-      border-bottom: 1px solid #e5eaf2;
-    }
-
-    .wiii-preview-footer {
-      align-items: center;
-      justify-content: flex-end;
-      border-top: 1px solid #e5eaf2;
-      border-bottom: 0;
-      background: #f8fafc;
-    }
-
-    .wiii-preview-kicker {
-      margin: 0 0 6px;
-      font-size: 12px;
-      font-weight: 700;
-      color: #0056D2;
-      text-transform: uppercase;
-    }
-
-    h2, h3, p {
-      margin: 0;
-    }
-
-    h2 {
-      font-size: 20px;
-      line-height: 1.25;
-      color: #0f172a;
-    }
-
-    h3 {
-      margin-bottom: 10px;
-      font-size: 14px;
-      font-weight: 700;
-      color: #0f172a;
-    }
-
-    .wiii-preview-summary {
-      margin-top: 8px;
-      color: #475569;
-      font-size: 14px;
-      line-height: 1.55;
-    }
-
-    .wiii-preview-body {
-      overflow: auto;
-      padding: 18px 20px 20px;
-      background: #ffffff;
-    }
-
-    .wiii-preview-section {
-      margin-top: 18px;
-    }
-
-    .wiii-preview-status,
-    .wiii-preview-message {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 10px 12px;
-      border: 1px solid #c7d7ee;
-      border-radius: 8px;
-      background: #f1f7ff;
-      color: #17406f;
-      font-size: 13px;
-      font-weight: 600;
-    }
-
-    .wiii-preview-status--done {
-      border-color: #bbf7d0;
-      background: #f0fdf4;
-      color: #166534;
-    }
-
-    .wiii-preview-status--error {
-      border-color: #fecaca;
-      background: #fef2f2;
-      color: #991b1b;
-    }
-
-    .wiii-preview-dot {
-      width: 8px;
-      height: 8px;
-      border-radius: 999px;
-      background: currentColor;
-    }
-
-    .wiii-preview-pills {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-    }
-
-    .wiii-preview-pills span {
-      padding: 5px 8px;
-      border: 1px solid #c7d7ee;
-      border-radius: 999px;
-      background: #f8fbff;
-      color: #17406f;
-      font-size: 12px;
-      font-weight: 700;
-    }
-
-    .wiii-preview-diff-grid {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 12px;
-    }
-
-    .wiii-preview-diff-grid article,
-    .wiii-preview-block,
-    .wiii-preview-source-list article {
-      border: 1px solid #e2e8f0;
-      border-radius: 8px;
-      padding: 12px;
-      background: #fbfdff;
-    }
-
-    .wiii-preview-diff-grid span,
-    .wiii-preview-kv dt {
-      display: block;
-      margin-bottom: 6px;
-      font-size: 12px;
-      font-weight: 700;
-      color: #64748b;
-      text-transform: uppercase;
-    }
-
-    .wiii-preview-diff-grid strong,
-    .wiii-preview-source-list strong {
-      display: block;
-      margin-bottom: 8px;
-      color: #0f172a;
-      font-size: 14px;
-    }
-
-    .wiii-preview-diff-grid p,
-    .wiii-preview-block p,
-    .wiii-preview-source-list p,
-    .wiii-preview-warning {
-      color: #475569;
-      font-size: 13px;
-      line-height: 1.55;
-    }
-
-    .wiii-preview-block-list,
-    .wiii-preview-source-list {
-      display: grid;
-      gap: 10px;
-    }
-
-    .wiii-preview-block {
-      display: grid;
-      grid-template-columns: 96px minmax(0, 1fr);
-      gap: 12px;
-    }
-
-    .wiii-preview-block span {
-      align-self: start;
-      justify-self: start;
-      padding: 4px 7px;
-      border-radius: 999px;
-      font-size: 11px;
-      font-weight: 800;
-    }
-
-    .wiii-preview-block__added { background: #dcfce7; color: #166534; }
-    .wiii-preview-block__removed { background: #fee2e2; color: #991b1b; }
-    .wiii-preview-block__changed { background: #dbeafe; color: #1d4ed8; }
-    .wiii-preview-block__unchanged { background: #f1f5f9; color: #475569; }
-
-    .wiii-preview-kv {
-      display: grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
-      gap: 10px;
-      margin: 0;
-    }
-
-    .wiii-preview-kv div {
-      border: 1px solid #e2e8f0;
-      border-radius: 8px;
-      padding: 10px;
-      background: #fbfdff;
-    }
-
-    .wiii-preview-kv dd {
-      margin: 0;
-      color: #0f172a;
-      font-weight: 700;
-    }
-
-    .wiii-preview-icon-button,
-    .wiii-preview-secondary,
-    .wiii-preview-primary {
-      border: 0;
-      cursor: pointer;
-      font-weight: 700;
-      transition: background 160ms ease, color 160ms ease, opacity 160ms ease;
-    }
-
-    .wiii-preview-icon-button {
-      width: 32px;
-      height: 32px;
-      border-radius: 8px;
-      background: #f1f5f9;
-      color: #334155;
-      font-size: 22px;
-      line-height: 1;
-    }
-
-    .wiii-preview-secondary,
-    .wiii-preview-primary {
-      min-height: 38px;
-      padding: 0 14px;
-      border-radius: 8px;
-      font-size: 13px;
-    }
-
-    .wiii-preview-secondary {
-      background: #ffffff;
-      color: #334155;
-      border: 1px solid #cbd5e1;
-    }
-
-    .wiii-preview-primary {
-      background: #0056D2;
-      color: #ffffff;
-    }
-
-    button:disabled {
-      cursor: not-allowed;
-      opacity: 0.6;
-    }
-
-    @media (max-width: 720px) {
-      .wiii-preview-backdrop {
-        align-items: stretch;
-        padding: 12px;
-      }
-
-      .wiii-preview-dialog {
-        max-height: calc(100vh - 24px);
-      }
-
-      .wiii-preview-diff-grid,
-      .wiii-preview-kv {
-        grid-template-columns: 1fr;
-      }
-
-      .wiii-preview-block {
-        grid-template-columns: 1fr;
-      }
-    }
-  `],
+  templateUrl: './operator-preview-dialog.component.html',
+  styleUrl: './operator-preview-dialog.component.scss',
 })
 export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
   private readonly contextService = inject(WiiiContextService);
@@ -486,36 +54,47 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
     const result = await this.contextService.approveOperatorPreview(preview.token);
     if (result.success) {
       this.status.set('applied');
-      this.message.set('Da ap dung thanh cong. LMS dang tai lai noi dung lien quan.');
+      this.message.set('Đã áp dụng thành công. LMS đang tải lại nội dung liên quan.');
       return;
     }
     this.status.set('error');
-    this.message.set(result.error || 'Khong the ap dung preview nay.');
+    this.message.set(result.error || 'Không thể áp dụng bản xem trước này.');
   }
 
   protected kindLabel(kind: string): string {
     switch (kind) {
       case 'lesson_patch':
-        return 'Wiii lesson preview';
+        return 'Wiii - xem trước bài học';
       case 'quiz_commit':
-        return 'Wiii quiz preview';
+        return 'Wiii - xem trước bài kiểm tra';
       case 'quiz_publish':
-        return 'Wiii publish preview';
+        return 'Wiii - xem trước phát hành';
       default:
-        return 'Wiii preview';
+        return 'Wiii - bản xem trước';
     }
   }
 
   protected statusLabel(): string {
     switch (this.status()) {
       case 'applying':
-        return 'Dang ap dung preview da duyet vao LMS';
+        return 'Đang áp dụng bản xem trước đã duyệt vào LMS';
       case 'applied':
-        return 'Da ap dung preview trong LMS';
+        return 'Đã áp dụng bản xem trước trong LMS';
       case 'error':
-        return 'Apply bi chan hoac that bai';
+        return 'Áp dụng bị chặn hoặc thất bại';
       default:
-        return 'Dang cho giao vien duyet tren LMS';
+        return 'Đang chờ giáo viên duyệt trên LMS';
+    }
+  }
+
+  protected primaryActionLabel(): string {
+    switch (this.status()) {
+      case 'applying':
+        return 'Đang áp dụng...';
+      case 'applied':
+        return 'Đã áp dụng';
+      default:
+        return 'Áp dụng vào LMS';
     }
   }
 
@@ -557,13 +136,13 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
   protected blockStatusLabel(status: unknown): string {
     switch (String(status || 'unchanged')) {
       case 'added':
-        return 'Them';
+        return 'Thêm';
       case 'removed':
-        return 'Xoa';
+        return 'Xóa';
       case 'changed':
-        return 'Sua';
+        return 'Sửa';
       default:
-        return 'Giu nguyen';
+        return 'Giữ nguyên';
     }
   }
 
@@ -586,7 +165,7 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
   }
 
   protected sourceLabel(ref: WiiiSourceReference, index: number): string {
-    const label = ref.label || ref.title || `${ref.kind || 'Nguon'} ${index + 1}`;
+    const label = ref.label || ref.title || `${ref.kind || 'Nguồn'} ${index + 1}`;
     const pageStart = ref.page_start ?? ref.page;
     const pageText = pageStart
       ? ref.page_end && ref.page_end !== pageStart
@@ -599,11 +178,11 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
   protected fieldLabel(field: string): string {
     switch (field) {
       case 'title':
-        return 'Tieu de';
+        return 'Tiêu đề';
       case 'description':
-        return 'Mo ta';
+        return 'Mô tả';
       case 'content':
-        return 'Noi dung';
+        return 'Nội dung';
       default:
         return field;
     }

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
@@ -1,0 +1,618 @@
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { Subscription } from 'rxjs';
+
+import {
+  WiiiContextService,
+  type WiiiOperatorPreviewPanel,
+  type WiiiSourceReference,
+} from '../../../infrastructure/api/wiii-context.service';
+
+type PreviewStatus = 'idle' | 'applying' | 'applied' | 'error';
+
+@Component({
+  selector: 'app-wiii-operator-preview-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (activePreview(); as preview) {
+      <div class="wiii-preview-backdrop" role="presentation">
+        <section
+          class="wiii-preview-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="wiii-preview-title"
+          data-wiii-id="wiii-preview-diff-panel"
+        >
+          <header class="wiii-preview-header">
+            <div>
+              <p class="wiii-preview-kicker">{{ kindLabel(preview.kind) }}</p>
+              <h2 id="wiii-preview-title">{{ preview.targetLabel }}</h2>
+              <p class="wiii-preview-summary">{{ preview.summary }}</p>
+            </div>
+            <button
+              type="button"
+              class="wiii-preview-icon-button"
+              data-wiii-id="close-wiii-preview"
+              [disabled]="status() === 'applying'"
+              (click)="close()"
+              aria-label="Dong preview"
+            >
+              &times;
+            </button>
+          </header>
+
+          <div class="wiii-preview-body">
+            <div class="wiii-preview-status" [class.wiii-preview-status--done]="status() === 'applied'" [class.wiii-preview-status--error]="status() === 'error'">
+              <span class="wiii-preview-dot"></span>
+              <span>{{ statusLabel() }}</span>
+            </div>
+
+            @if (changedFields(preview).length > 0) {
+              <div class="wiii-preview-section">
+                <h3>Truong se thay doi</h3>
+                <div class="wiii-preview-pills">
+                  @for (field of changedFields(preview); track field) {
+                    <span>{{ fieldLabel(field) }}</span>
+                  }
+                </div>
+              </div>
+            }
+
+            @if (preview.kind === 'lesson_patch') {
+              <div class="wiii-preview-section">
+                <h3>Diff bai hoc</h3>
+                <div class="wiii-preview-diff-grid">
+                  <article>
+                    <span>Hien tai</span>
+                    <strong>{{ lessonBefore(preview, 'title') || 'Chua co tieu de' }}</strong>
+                    <p>{{ lessonBefore(preview, 'description') || 'Khong co mo ta' }}</p>
+                    <p>{{ lessonBefore(preview, 'content_excerpt') || 'Khong co noi dung' }}</p>
+                  </article>
+                  <article>
+                    <span>Wiii de xuat</span>
+                    <strong>{{ lessonAfter(preview, 'title') || 'Chua co tieu de' }}</strong>
+                    <p>{{ lessonAfter(preview, 'description') || 'Khong co mo ta' }}</p>
+                    <p>{{ lessonAfter(preview, 'content_excerpt') || 'Khong co noi dung' }}</p>
+                  </article>
+                </div>
+              </div>
+
+              @if (blockDiffItems(preview).length > 0) {
+                <div class="wiii-preview-section">
+                  <h3>Block diff</h3>
+                  <div class="wiii-preview-block-list">
+                    @for (item of blockDiffItems(preview); track blockTrack(item)) {
+                      <article class="wiii-preview-block">
+                        <span [class]="blockStatusClass(item['status'])">{{ blockStatusLabel(item['status']) }}</span>
+                        <div>
+                          <p>{{ blockText(item['before']) || 'Trong' }}</p>
+                          <p>{{ blockText(item['after']) || 'Trong' }}</p>
+                        </div>
+                      </article>
+                    }
+                  </div>
+                </div>
+              }
+            }
+
+            @if (preview.kind === 'quiz_commit') {
+              <div class="wiii-preview-section">
+                <h3>Quiz plan</h3>
+                <dl class="wiii-preview-kv">
+                  <div><dt>Che do</dt><dd>{{ planValue(preview, 'quiz_plan', 'mode') || 'create' }}</dd></div>
+                  <div><dt>So cau hoi</dt><dd>{{ planValue(preview, 'quiz_plan', 'question_count') || '0' }}</dd></div>
+                  <div><dt>Thoi gian</dt><dd>{{ planValue(preview, 'quiz_plan', 'time_limit_minutes') || '30' }} phut</dd></div>
+                  <div><dt>Diem dat</dt><dd>{{ planValue(preview, 'quiz_plan', 'passing_score') || '60' }}%</dd></div>
+                </dl>
+              </div>
+            }
+
+            @if (preview.kind === 'quiz_publish') {
+              <div class="wiii-preview-section">
+                <h3>Publish plan</h3>
+                <p class="wiii-preview-warning">Quiz se chi duoc publish sau khi giao vien bam ap dung trong LMS.</p>
+                <dl class="wiii-preview-kv">
+                  <div><dt>Quiz</dt><dd>{{ planValue(preview, 'publish_plan', 'title') || preview.targetLabel }}</dd></div>
+                  <div><dt>Trang thai</dt><dd>{{ planValue(preview, 'publish_plan', 'status') || 'DRAFT' }}</dd></div>
+                </dl>
+              </div>
+            }
+
+            @if (sourceReferences(preview).length > 0) {
+              <div class="wiii-preview-section">
+                <h3>Nguon tu tai lieu</h3>
+                <div class="wiii-preview-source-list">
+                  @for (ref of sourceReferences(preview); track sourceTrack(ref, $index)) {
+                    <article>
+                      <strong>{{ sourceLabel(ref, $index) }}</strong>
+                      @if (ref.excerpt) {
+                        <p>{{ ref.excerpt }}</p>
+                      }
+                    </article>
+                  }
+                </div>
+              </div>
+            }
+
+            @if (message()) {
+              <p class="wiii-preview-message">{{ message() }}</p>
+            }
+          </div>
+
+          <footer class="wiii-preview-footer">
+            <button
+              type="button"
+              class="wiii-preview-secondary"
+              data-wiii-id="cancel-wiii-preview"
+              [disabled]="status() === 'applying'"
+              (click)="close()"
+            >
+              Huy
+            </button>
+            <button
+              type="button"
+              class="wiii-preview-primary"
+              data-wiii-id="apply-wiii-preview"
+              [disabled]="status() === 'applying' || status() === 'applied'"
+              (click)="approve()"
+            >
+              {{ status() === 'applying' ? 'Dang ap dung...' : status() === 'applied' ? 'Da ap dung' : 'Ap dung vao LMS' }}
+            </button>
+          </footer>
+        </section>
+      </div>
+    }
+  `,
+  styles: [`
+    .wiii-preview-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 1200;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      background: rgba(15, 23, 42, 0.45);
+    }
+
+    .wiii-preview-dialog {
+      width: min(960px, 100%);
+      max-height: min(820px, calc(100vh - 48px));
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      border: 1px solid #dbe3ef;
+      border-radius: 8px;
+      background: #ffffff;
+      box-shadow: 0 24px 72px rgba(15, 23, 42, 0.22);
+    }
+
+    .wiii-preview-header,
+    .wiii-preview-footer {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 18px 20px;
+      border-bottom: 1px solid #e5eaf2;
+    }
+
+    .wiii-preview-footer {
+      align-items: center;
+      justify-content: flex-end;
+      border-top: 1px solid #e5eaf2;
+      border-bottom: 0;
+      background: #f8fafc;
+    }
+
+    .wiii-preview-kicker {
+      margin: 0 0 6px;
+      font-size: 12px;
+      font-weight: 700;
+      color: #0056D2;
+      text-transform: uppercase;
+    }
+
+    h2, h3, p {
+      margin: 0;
+    }
+
+    h2 {
+      font-size: 20px;
+      line-height: 1.25;
+      color: #0f172a;
+    }
+
+    h3 {
+      margin-bottom: 10px;
+      font-size: 14px;
+      font-weight: 700;
+      color: #0f172a;
+    }
+
+    .wiii-preview-summary {
+      margin-top: 8px;
+      color: #475569;
+      font-size: 14px;
+      line-height: 1.55;
+    }
+
+    .wiii-preview-body {
+      overflow: auto;
+      padding: 18px 20px 20px;
+      background: #ffffff;
+    }
+
+    .wiii-preview-section {
+      margin-top: 18px;
+    }
+
+    .wiii-preview-status,
+    .wiii-preview-message {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 12px;
+      border: 1px solid #c7d7ee;
+      border-radius: 8px;
+      background: #f1f7ff;
+      color: #17406f;
+      font-size: 13px;
+      font-weight: 600;
+    }
+
+    .wiii-preview-status--done {
+      border-color: #bbf7d0;
+      background: #f0fdf4;
+      color: #166534;
+    }
+
+    .wiii-preview-status--error {
+      border-color: #fecaca;
+      background: #fef2f2;
+      color: #991b1b;
+    }
+
+    .wiii-preview-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 999px;
+      background: currentColor;
+    }
+
+    .wiii-preview-pills {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .wiii-preview-pills span {
+      padding: 5px 8px;
+      border: 1px solid #c7d7ee;
+      border-radius: 999px;
+      background: #f8fbff;
+      color: #17406f;
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    .wiii-preview-diff-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .wiii-preview-diff-grid article,
+    .wiii-preview-block,
+    .wiii-preview-source-list article {
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 12px;
+      background: #fbfdff;
+    }
+
+    .wiii-preview-diff-grid span,
+    .wiii-preview-kv dt {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 12px;
+      font-weight: 700;
+      color: #64748b;
+      text-transform: uppercase;
+    }
+
+    .wiii-preview-diff-grid strong,
+    .wiii-preview-source-list strong {
+      display: block;
+      margin-bottom: 8px;
+      color: #0f172a;
+      font-size: 14px;
+    }
+
+    .wiii-preview-diff-grid p,
+    .wiii-preview-block p,
+    .wiii-preview-source-list p,
+    .wiii-preview-warning {
+      color: #475569;
+      font-size: 13px;
+      line-height: 1.55;
+    }
+
+    .wiii-preview-block-list,
+    .wiii-preview-source-list {
+      display: grid;
+      gap: 10px;
+    }
+
+    .wiii-preview-block {
+      display: grid;
+      grid-template-columns: 96px minmax(0, 1fr);
+      gap: 12px;
+    }
+
+    .wiii-preview-block span {
+      align-self: start;
+      justify-self: start;
+      padding: 4px 7px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 800;
+    }
+
+    .wiii-preview-block__added { background: #dcfce7; color: #166534; }
+    .wiii-preview-block__removed { background: #fee2e2; color: #991b1b; }
+    .wiii-preview-block__changed { background: #dbeafe; color: #1d4ed8; }
+    .wiii-preview-block__unchanged { background: #f1f5f9; color: #475569; }
+
+    .wiii-preview-kv {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+      margin: 0;
+    }
+
+    .wiii-preview-kv div {
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 10px;
+      background: #fbfdff;
+    }
+
+    .wiii-preview-kv dd {
+      margin: 0;
+      color: #0f172a;
+      font-weight: 700;
+    }
+
+    .wiii-preview-icon-button,
+    .wiii-preview-secondary,
+    .wiii-preview-primary {
+      border: 0;
+      cursor: pointer;
+      font-weight: 700;
+      transition: background 160ms ease, color 160ms ease, opacity 160ms ease;
+    }
+
+    .wiii-preview-icon-button {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+      background: #f1f5f9;
+      color: #334155;
+      font-size: 22px;
+      line-height: 1;
+    }
+
+    .wiii-preview-secondary,
+    .wiii-preview-primary {
+      min-height: 38px;
+      padding: 0 14px;
+      border-radius: 8px;
+      font-size: 13px;
+    }
+
+    .wiii-preview-secondary {
+      background: #ffffff;
+      color: #334155;
+      border: 1px solid #cbd5e1;
+    }
+
+    .wiii-preview-primary {
+      background: #0056D2;
+      color: #ffffff;
+    }
+
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+
+    @media (max-width: 720px) {
+      .wiii-preview-backdrop {
+        align-items: stretch;
+        padding: 12px;
+      }
+
+      .wiii-preview-dialog {
+        max-height: calc(100vh - 24px);
+      }
+
+      .wiii-preview-diff-grid,
+      .wiii-preview-kv {
+        grid-template-columns: 1fr;
+      }
+
+      .wiii-preview-block {
+        grid-template-columns: 1fr;
+      }
+    }
+  `],
+})
+export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
+  private readonly contextService = inject(WiiiContextService);
+  private sub?: Subscription;
+
+  protected readonly activePreview = signal<WiiiOperatorPreviewPanel | null>(null);
+  protected readonly status = signal<PreviewStatus>('idle');
+  protected readonly message = signal('');
+
+  ngOnInit(): void {
+    this.sub = this.contextService.operatorPreview$.subscribe((preview) => {
+      this.activePreview.set(preview);
+      this.status.set('idle');
+      this.message.set('');
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+
+  protected close(): void {
+    if (this.status() === 'applying') {
+      return;
+    }
+    this.activePreview.set(null);
+    this.status.set('idle');
+    this.message.set('');
+  }
+
+  protected async approve(): Promise<void> {
+    const preview = this.activePreview();
+    if (!preview || this.status() === 'applying') {
+      return;
+    }
+    this.status.set('applying');
+    this.message.set('');
+    const result = await this.contextService.approveOperatorPreview(preview.token);
+    if (result.success) {
+      this.status.set('applied');
+      this.message.set('Da ap dung thanh cong. LMS dang tai lai noi dung lien quan.');
+      return;
+    }
+    this.status.set('error');
+    this.message.set(result.error || 'Khong the ap dung preview nay.');
+  }
+
+  protected kindLabel(kind: string): string {
+    switch (kind) {
+      case 'lesson_patch':
+        return 'Wiii lesson preview';
+      case 'quiz_commit':
+        return 'Wiii quiz preview';
+      case 'quiz_publish':
+        return 'Wiii publish preview';
+      default:
+        return 'Wiii preview';
+    }
+  }
+
+  protected statusLabel(): string {
+    switch (this.status()) {
+      case 'applying':
+        return 'Dang ap dung preview da duyet vao LMS';
+      case 'applied':
+        return 'Da ap dung preview trong LMS';
+      case 'error':
+        return 'Apply bi chan hoac that bai';
+      default:
+        return 'Dang cho giao vien duyet tren LMS';
+    }
+  }
+
+  protected changedFields(preview: WiiiOperatorPreviewPanel): string[] {
+    return preview.changedFields;
+  }
+
+  protected sourceReferences(preview: WiiiOperatorPreviewPanel): WiiiSourceReference[] {
+    return preview.sourceReferences;
+  }
+
+  protected lessonBefore(preview: WiiiOperatorPreviewPanel, field: string): string {
+    return this.objectValue(preview.data['lesson_before'], field);
+  }
+
+  protected lessonAfter(preview: WiiiOperatorPreviewPanel, field: string): string {
+    return this.objectValue(preview.data['lesson_after'], field);
+  }
+
+  protected blockDiffItems(preview: WiiiOperatorPreviewPanel): Array<Record<string, unknown>> {
+    const diff = preview.data['block_diff'];
+    if (!diff || typeof diff !== 'object' || Array.isArray(diff)) {
+      return [];
+    }
+    const items = (diff as Record<string, unknown>)['items'];
+    return Array.isArray(items)
+      ? items.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item))
+      : [];
+  }
+
+  protected blockTrack(item: Record<string, unknown>): string {
+    return `${item['index'] || 0}-${item['status'] || 'unknown'}`;
+  }
+
+  protected blockStatusClass(status: unknown): string {
+    return `wiii-preview-block__${String(status || 'unchanged')}`;
+  }
+
+  protected blockStatusLabel(status: unknown): string {
+    switch (String(status || 'unchanged')) {
+      case 'added':
+        return 'Them';
+      case 'removed':
+        return 'Xoa';
+      case 'changed':
+        return 'Sua';
+      default:
+        return 'Giu nguyen';
+    }
+  }
+
+  protected blockText(value: unknown): string {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return '';
+    }
+    const item = value as Record<string, unknown>;
+    const label = String(item['label'] || item['type'] || '').trim();
+    const excerpt = String(item['excerpt'] || '').trim();
+    return [label, excerpt].filter(Boolean).join(': ');
+  }
+
+  protected planValue(preview: WiiiOperatorPreviewPanel, planKey: string, field: string): string {
+    return this.objectValue(preview.data[planKey], field);
+  }
+
+  protected sourceTrack(ref: WiiiSourceReference, index: number): string {
+    return `${ref.kind || 'source'}-${ref.page || ref.page_start || index}`;
+  }
+
+  protected sourceLabel(ref: WiiiSourceReference, index: number): string {
+    const label = ref.label || ref.title || `${ref.kind || 'Nguon'} ${index + 1}`;
+    const pageStart = ref.page_start ?? ref.page;
+    const pageText = pageStart
+      ? ref.page_end && ref.page_end !== pageStart
+        ? `, trang ${pageStart}-${ref.page_end}`
+        : `, trang ${pageStart}`
+      : '';
+    return `${label}${pageText}`;
+  }
+
+  protected fieldLabel(field: string): string {
+    switch (field) {
+      case 'title':
+        return 'Tieu de';
+      case 'description':
+        return 'Mo ta';
+      case 'content':
+        return 'Noi dung';
+      default:
+        return field;
+    }
+  }
+
+  private objectValue(source: unknown, field: string): string {
+    if (!source || typeof source !== 'object' || Array.isArray(source)) {
+      return '';
+    }
+    return String((source as Record<string, unknown>)[field] || '').trim();
+  }
+}

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.ts
@@ -1711,6 +1711,16 @@ export class CourseCurriculumComponent implements OnDestroy {
         this.toast.success('Tạo khóa học bằng AI hoàn tất!');
       }
     });
+  private operatorApplySub = this.wiiiContextService.operatorApplyResult$
+    .pipe(takeUntilDestroyed(this.destroyRef))
+    .subscribe(result => {
+      if (!result.success) return;
+      const courseId = this.store.courseTree()?.id;
+      if (courseId) {
+        this.store.loadCourse(courseId, true);
+      }
+      this.toast.success('Da ap dung noi dung Wiii sau khi duyet preview.');
+    });
 
   /** Open Wiii AI sidebar for course generation from document */
   openAiCourseGeneration(): void {


### PR DESCRIPTION
﻿## Summary
- Adds a host-level Wiii operator preview dialog with lesson/quiz/publish diff details and source references.
- Requires a teacher-approved LMS preview token before Wiii apply actions can mutate lesson, quiz, or publish state.
- Refreshes the teacher curriculum after a successful host-approved Wiii apply.

## Safety
- Direct `authoring.apply_lesson_patch`, `assessment.apply_quiz_commit`, and `publish.apply_quiz` calls now require `preview_token` plus host-only `approval_token`.
- Dialog Apply/Cancel controls expose stable `data-wiii-id` values but are intentionally not marked `data-wiii-click-safe`.

## Validation
- `git diff --check`
- `npm run build` (passes; existing Angular/Sass/CommonJS warnings remain)
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts --progress=false` via redirected Start-Process log: `TOTAL: 25 SUCCESS`
