### PR TITLE
fix(interactive-video): grey-area cluster — drag perf, anti-skip, letterbox, h5p round-trip, fill-blank UX, seek edge

### DIFF
--- a/fe/src/app/core/utils/interactive-video-runtime.spec.ts
+++ b/fe/src/app/core/utils/interactive-video-runtime.spec.ts
@@ -158,6 +158,49 @@ describe('interactive-video-runtime', () => {
     })).toBeFalse();
   });
 
+  it('keeps the seek gate open unless a forward skip exceeds watched progress with required work pending', () => {
+    const guardedSpec: InteractiveVideoSpec = {
+      version: 2,
+      enabled: true,
+      behavior: { preventSkippingMode: 'forward' },
+      timeline,
+    };
+    const disabledSpec: InteractiveVideoSpec = {
+      ...guardedSpec,
+      behavior: { preventSkippingMode: 'none' },
+    };
+
+    expect(shouldBlockInteractiveVideoSeek({
+      spec: guardedSpec,
+      targetTimeSeconds: 49,
+      furthestWatchedSeconds: 45,
+      hasIncompleteRequiredInteractions: true,
+      graceSeconds: 3,
+    })).toBeTrue();
+
+    expect(shouldBlockInteractiveVideoSeek({
+      spec: guardedSpec,
+      targetTimeSeconds: 48,
+      furthestWatchedSeconds: 45,
+      hasIncompleteRequiredInteractions: true,
+      graceSeconds: 3,
+    })).toBeFalse();
+
+    expect(shouldBlockInteractiveVideoSeek({
+      spec: guardedSpec,
+      targetTimeSeconds: 120,
+      furthestWatchedSeconds: 45,
+      hasIncompleteRequiredInteractions: false,
+    })).toBeFalse();
+
+    expect(shouldBlockInteractiveVideoSeek({
+      spec: disabledSpec,
+      targetTimeSeconds: 120,
+      furthestWatchedSeconds: 45,
+      hasIncompleteRequiredInteractions: true,
+    })).toBeFalse();
+  });
+
   it('evaluates fill-blank answers with alternatives and case-insensitive matching by default', () => {
     const interaction: InteractiveVideoInteraction = {
       id: 'fill-blank',

--- a/fe/src/app/core/utils/interactive-video-runtime.ts
+++ b/fe/src/app/core/utils/interactive-video-runtime.ts
@@ -296,6 +296,12 @@ export function shouldBlockInteractiveVideoSeek(input: InteractiveVideoSeekPolic
   const furthestWatched = toNonNegativeSeconds(input.furthestWatchedSeconds);
   const grace = Math.max(0, input.graceSeconds ?? SEEK_GRACE_SECONDS);
 
+  // 'forward' and 'both' currently share the same forward gate. The design
+  // doc reserves 'both' for "navigation constrained to visited/completed
+  // ranges" (strict review mode), which would also block backward jumps to
+  // unvisited regions. Implementing that requires tracking the set of
+  // visited stretches, not just the furthest mark, and is intentionally
+  // deferred until visited-range bookkeeping lands.
   return target > furthestWatched + grace;
 }
 

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-canvas.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-canvas.component.ts
@@ -186,6 +186,12 @@ export class InteractiveVideoAuthoringCanvasComponent {
   readonly placementPreview = signal<CanvasTimePreview | null>(null);
   readonly dragPreview = signal<CanvasTimePreview | null>(null);
   private readonly draggingInteractionId = signal<string | null>(null);
+  /**
+   * Last pointer-derived position while a drag is in progress. Captured on
+   * every pointermove and committed once on pointerup so the move emits as a
+   * single state change instead of one per pointer step.
+   */
+  private pendingMove: { atSeconds: number; position: InteractiveVideoPosition } | null = null;
 
   readonly interactionTypes: InteractiveVideoInteractionType[] = [
     'checkpoint',
@@ -248,6 +254,11 @@ export class InteractiveVideoAuthoringCanvasComponent {
     if (event.button !== 0) {
       return;
     }
+    if (this.draggingInteractionId()) {
+      // Refuse a second pointerdown mid-drag so a stray touch can't hijack the
+      // drag state for a different interaction.
+      return;
+    }
     event.preventDefault();
     event.stopPropagation();
     this.draggingInteractionId.set(interaction.id);
@@ -266,27 +277,39 @@ export class InteractiveVideoAuthoringCanvasComponent {
       return;
     }
     event.preventDefault();
-    const preview = this.buildPreviewFromPointer(event);
-    this.dragPreview.set(preview);
-    this.interactionMoved.emit({
-      interactionId,
-      atSeconds: preview.atSeconds,
+    // Only update the local preview during drag — emitting interactionMoved on
+    // every pointer step caused hundreds of state writes per drag, which raced
+    // with the debounced autosave and broke per-change undo. Final position is
+    // committed once on pointerup using the last seen pointer position.
+    this.dragPreview.set(this.buildPreviewFromPointer(event));
+    this.pendingMove = {
+      atSeconds: this.getTimeSecondsFromPointer(event),
       position: this.getPositionFromPointer(event),
-    });
+    };
   }
 
   onHandlePointerUp(event: PointerEvent): void {
+    const interactionId = this.draggingInteractionId();
+    const pendingMove = this.pendingMove;
     const target = event.currentTarget as HTMLElement;
     if (target.hasPointerCapture(event.pointerId)) {
       target.releasePointerCapture(event.pointerId);
     }
+    if (interactionId && pendingMove) {
+      // Emit the final position once, so the move is a single undoable change.
+      this.interactionMoved.emit({ interactionId, ...pendingMove });
+    }
     this.draggingInteractionId.set(null);
     this.dragPreview.set(null);
+    this.pendingMove = null;
   }
 
   onHandlePointerCancel(): void {
+    // Cancel: discard the in-progress drag without emitting; original position
+    // is preserved because we never wrote intermediate state to the service.
     this.draggingInteractionId.set(null);
     this.dragPreview.set(null);
+    this.pendingMove = null;
   }
 
   positionX(interaction: InteractiveVideoInteraction): number {
@@ -357,12 +380,12 @@ export class InteractiveVideoAuthoringCanvasComponent {
   }
 
   private getTimeSecondsFromPointer(event: Pick<MouseEvent, 'clientX'>): number {
-    const rect = this.canvas()?.nativeElement.getBoundingClientRect();
-    if (!rect || rect.width <= 0) {
+    const content = this.getVideoContentRect();
+    if (!content || content.width <= 0) {
       return this.getVideoCurrentTime();
     }
 
-    const ratio = Math.min(1, Math.max(0, (event.clientX - rect.left) / rect.width));
+    const ratio = Math.min(1, Math.max(0, (event.clientX - content.left) / content.width));
     return this.clampTime(Math.round(ratio * this.timelineMaxSeconds()));
   }
 
@@ -372,14 +395,61 @@ export class InteractiveVideoAuthoringCanvasComponent {
   }
 
   private getPositionFromPointer(event: Pick<MouseEvent, 'clientX' | 'clientY'>): InteractiveVideoPosition {
-    const rect = this.canvas()?.nativeElement.getBoundingClientRect();
-    if (!rect || rect.width <= 0 || rect.height <= 0) {
+    const content = this.getVideoContentRect();
+    if (!content || content.width <= 0 || content.height <= 0) {
       return { xPercent: 50, yPercent: 88 };
     }
 
     return {
-      xPercent: this.clampPercent(((event.clientX - rect.left) / rect.width) * 100),
-      yPercent: this.clampPercent(((event.clientY - rect.top) / rect.height) * 100),
+      xPercent: this.clampPercent(((event.clientX - content.left) / content.width) * 100),
+      yPercent: this.clampPercent(((event.clientY - content.top) / content.height) * 100),
+    };
+  }
+
+  /**
+   * Compute the rect of the actual rendered video frame inside the canvas.
+   *
+   * The `<video>` element is `object-contain`, so when the video and canvas
+   * aspect ratios differ, the video is centred with letterbox or pillarbox
+   * bands. Mapping pointer coordinates against the raw canvas rect would
+   * place interactions on those bands, off the actual frame. This helper
+   * returns the inner content rect; pointer coordinates outside it are
+   * clamped to its edges by the consumer.
+   *
+   * Falls back to the canvas rect when video metadata is not yet loaded.
+   */
+  private getVideoContentRect():
+    | { left: number; top: number; width: number; height: number }
+    | null {
+    const canvas = this.canvas()?.nativeElement.getBoundingClientRect();
+    if (!canvas || canvas.width <= 0 || canvas.height <= 0) {
+      return null;
+    }
+    const video = this.videoElement()?.nativeElement;
+    const naturalWidth = video?.videoWidth ?? 0;
+    const naturalHeight = video?.videoHeight ?? 0;
+    if (!naturalWidth || !naturalHeight) {
+      return { left: canvas.left, top: canvas.top, width: canvas.width, height: canvas.height };
+    }
+    const videoAspect = naturalWidth / naturalHeight;
+    const canvasAspect = canvas.width / canvas.height;
+    if (videoAspect > canvasAspect) {
+      // Letterbox: bars top/bottom, content fills full width.
+      const height = canvas.width / videoAspect;
+      return {
+        left: canvas.left,
+        top: canvas.top + (canvas.height - height) / 2,
+        width: canvas.width,
+        height,
+      };
+    }
+    // Pillarbox (or exact fit): bars left/right, content fills full height.
+    const width = canvas.height * videoAspect;
+    return {
+      left: canvas.left + (canvas.width - width) / 2,
+      top: canvas.top,
+      width,
+      height: canvas.height,
     };
   }
 

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
@@ -439,13 +439,19 @@ export class InteractiveVideoAuthoringPanelComponent {
   removeFillBlankBlank(interaction: InteractiveVideoInteraction, blankId: string): void {
     const fillBlank = this.getFillBlank(interaction);
     const placeholderIds = this.extractFillBlankPlaceholderIds(fillBlank.template);
+    if (placeholderIds.includes(blankId)) {
+      // The blank is still referenced from the template ({{N}}). Refuse with a
+      // toast so teachers don't get a silent "I deleted it but the row is still
+      // there" experience — the previous behaviour quietly cleared answers,
+      // leaving an orphan row that re-appeared on every render.
+      this.toast.warning(
+        `Hãy gỡ {{${blankId}}} khỏi câu trước rồi mới xoá ô trống.`,
+      );
+      return;
+    }
     this.updateFillBlank(interaction.id, {
       ...fillBlank,
-      blanks: placeholderIds.includes(blankId)
-        ? fillBlank.blanks.map(blank => blank.id === blankId
-            ? { ...blank, acceptedAnswers: [] }
-            : blank)
-        : fillBlank.blanks.filter(blank => blank.id !== blankId),
+      blanks: fillBlank.blanks.filter(blank => blank.id !== blankId),
     });
   }
 

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-interoperability.spec.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-interoperability.spec.ts
@@ -88,6 +88,75 @@ describe('interactive-video-interoperability', () => {
     expect(spec?.timeline[0].choices?.[0].feedback).toBe('Correct.');
   });
 
+  it('round-trips H5P behaviour, real bookmarks, and end-screen summary', () => {
+    const spec: InteractiveVideoSpec = {
+      version: 2,
+      enabled: true,
+      behavior: {
+        preventSkippingMode: 'both',
+        showBookmarksOnLoad: true,
+        showRewind10: true,
+        pauseOnInteraction: false,
+      },
+      bookmarks: [
+        { id: 'muster-bookmark', timeSeconds: 18, label: 'Muster checklist' },
+        { id: 'abandon-bookmark', timeSeconds: 74, label: 'Abandon ship drill' },
+      ],
+      endScreen: {
+        enabled: true,
+        atSeconds: 180,
+        requireAnswerBeforeSubmit: true,
+        showScore: true,
+        title: 'Final safety review',
+        body: 'Confirm that the learner has reviewed all required emergency steps.',
+      },
+      timeline,
+    };
+
+    const bundle = exportInteractiveVideoBundle(spec, 'https://cdn.example/video.mp4');
+    const h5pRoot = bundle.h5pParameters.interactiveVideo;
+
+    expect(h5pRoot.behaviour).toEqual({
+      preventSkipping: true,
+      preventSkippingMode: 'both',
+      showBookmarksMenuOnLoad: true,
+      showRewind10: true,
+      pauseOnInteractions: false,
+    });
+    expect(h5pRoot.assets.bookmarks).toEqual([
+      { time: 18, label: 'Muster checklist' },
+      { time: 74, label: 'Abandon ship drill' },
+    ]);
+    expect(h5pRoot.summary?.task?.params).toEqual({
+      intro: 'Final safety review',
+      summary: 'Confirm that the learner has reviewed all required emergency steps.',
+      requireAnswerBeforeSubmit: true,
+      showScore: true,
+      atSeconds: 180,
+    });
+
+    const imported = importInteractiveVideoBundle(bundle.h5pParameters);
+
+    expect(imported?.behavior).toEqual({
+      preventSkippingMode: 'both',
+      showBookmarksOnLoad: true,
+      showRewind10: true,
+      pauseOnInteraction: false,
+    });
+    expect(imported?.bookmarks).toEqual([
+      { id: 'h5p-bookmark-1', timeSeconds: 18, label: 'Muster checklist' },
+      { id: 'h5p-bookmark-2', timeSeconds: 74, label: 'Abandon ship drill' },
+    ]);
+    expect(imported?.endScreen).toEqual({
+      enabled: true,
+      atSeconds: 180,
+      requireAnswerBeforeSubmit: true,
+      showScore: true,
+      title: 'Final safety review',
+      body: 'Confirm that the learner has reviewed all required emergency steps.',
+    });
+  });
+
   it('exports a Shaka-safe H5P package boundary and imports it losslessly', async () => {
     const spec: InteractiveVideoSpec = { version: 1, enabled: true, timeline };
 

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-interoperability.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-interoperability.ts
@@ -83,6 +83,33 @@ export interface H5PInteractiveVideoParameters {
     assets: {
       interactions: H5PInteractiveVideoInteraction[];
       bookmarks: Array<{ time: number; label: string }>;
+      endscreens?: Array<{ time: number; label?: string }>;
+    };
+    /**
+     * H5P-standard behaviour block (note British spelling). Mirrors HoliLihu's
+     * `spec.behavior` so global playback rules survive a round-trip.
+     */
+    behaviour?: {
+      preventSkipping?: boolean;
+      preventSkippingMode?: 'none' | 'forward' | 'both';
+      showBookmarksMenuOnLoad?: boolean;
+      showRewind10?: boolean;
+      pauseOnInteractions?: boolean;
+    };
+    /**
+     * H5P-standard summary task. HoliLihu's `spec.endScreen` maps onto this so
+     * teacher-authored end-of-video review surfaces survive a round-trip.
+     */
+    summary?: {
+      task?: {
+        params?: {
+          intro?: string;
+          summary?: string;
+          requireAnswerBeforeSubmit?: boolean;
+          showScore?: boolean;
+          atSeconds?: number | null;
+        };
+      };
     };
   };
 }
@@ -137,13 +164,82 @@ export function importInteractiveVideoBundle(value: unknown): InteractiveVideoSp
     return null;
   }
 
+  const root = getH5PInteractiveVideoRoot(value);
   return normalizeInteractiveVideoSpecV2({
     version: 2,
     enabled: true,
+    behavior: fromH5PBehaviour(root?.behaviour),
+    bookmarks: fromH5PBookmarks(root?.assets?.bookmarks),
+    endScreen: fromH5PSummary(root?.summary),
     timeline: sortInteractiveVideoTimeline(
       h5pInteractions.map((interaction, index) => fromH5PInteraction(interaction, index)),
     ),
   });
+}
+
+function getH5PInteractiveVideoRoot(
+  value: unknown,
+): H5PInteractiveVideoParameters['interactiveVideo'] | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const source = value as {
+    h5pParameters?: H5PInteractiveVideoParameters;
+    interactiveVideo?: H5PInteractiveVideoParameters['interactiveVideo'];
+  };
+  return source.h5pParameters?.interactiveVideo ?? source.interactiveVideo ?? null;
+}
+
+function fromH5PBookmarks(
+  bookmarks: H5PInteractiveVideoParameters['interactiveVideo']['assets']['bookmarks'] | undefined,
+): InteractiveVideoSpec['bookmarks'] {
+  if (!Array.isArray(bookmarks)) {
+    return undefined;
+  }
+  return bookmarks
+    .filter((entry): entry is { time: number; label: string } =>
+      !!entry && typeof entry.time === 'number' && typeof entry.label === 'string',
+    )
+    .map((entry, index) => ({
+      id: `h5p-bookmark-${index + 1}`,
+      timeSeconds: Math.max(0, Math.round(entry.time)),
+      label: entry.label,
+    }));
+}
+
+function fromH5PBehaviour(
+  behaviour: H5PInteractiveVideoParameters['interactiveVideo']['behaviour'],
+): InteractiveVideoSpec['behavior'] {
+  if (!behaviour) {
+    return undefined;
+  }
+  const explicitMode = behaviour.preventSkippingMode;
+  const inferredMode = behaviour.preventSkipping ? 'forward' : 'none';
+  return {
+    preventSkippingMode: explicitMode === 'none' || explicitMode === 'forward' || explicitMode === 'both'
+      ? explicitMode
+      : inferredMode,
+    showBookmarksOnLoad: behaviour.showBookmarksMenuOnLoad === true,
+    showRewind10: behaviour.showRewind10 === true,
+    pauseOnInteraction: behaviour.pauseOnInteractions !== false,
+  };
+}
+
+function fromH5PSummary(
+  summary: H5PInteractiveVideoParameters['interactiveVideo']['summary'],
+): InteractiveVideoSpec['endScreen'] {
+  const params = summary?.task?.params;
+  if (!params) {
+    return undefined;
+  }
+  return {
+    enabled: true,
+    atSeconds: typeof params.atSeconds === 'number' ? params.atSeconds : null,
+    requireAnswerBeforeSubmit: params.requireAnswerBeforeSubmit === true,
+    showScore: params.showScore === true,
+    title: params.intro ?? null,
+    body: params.summary ?? null,
+  };
 }
 
 export async function exportInteractiveVideoH5PPackage(
@@ -216,17 +312,58 @@ function exportToH5PParameters(
   spec: InteractiveVideoSpec,
   videoUrl: string | null,
 ): H5PInteractiveVideoParameters {
+  const bookmarks = (spec.bookmarks ?? []).map(bookmark => ({
+    time: bookmark.timeSeconds,
+    label: bookmark.label,
+  }));
+
   return {
     interactiveVideo: {
       video: videoUrl ? { files: [{ path: videoUrl, mime: inferMimeType(videoUrl) }] } : undefined,
       assets: {
         interactions: spec.timeline.map(toH5PInteraction),
-        bookmarks: spec.timeline
-          .filter(interaction => interaction.title)
-          .map(interaction => ({
-            time: interaction.atSeconds,
-            label: interaction.title ?? interaction.id,
-          })),
+        // Bookmarks are first-class in V2; previously these were synthesised
+        // from interaction titles, which conflated the two and dropped any
+        // standalone bookmarks teachers added.
+        bookmarks,
+      },
+      behaviour: toH5PBehaviour(spec.behavior),
+      summary: toH5PSummary(spec.endScreen ?? null),
+    },
+  };
+}
+
+function toH5PBehaviour(
+  behavior: InteractiveVideoSpec['behavior'],
+): H5PInteractiveVideoParameters['interactiveVideo']['behaviour'] {
+  if (!behavior) {
+    return undefined;
+  }
+  const mode = behavior.preventSkippingMode ?? 'none';
+  return {
+    preventSkipping: mode !== 'none',
+    preventSkippingMode: mode,
+    showBookmarksMenuOnLoad: behavior.showBookmarksOnLoad === true,
+    showRewind10: behavior.showRewind10 === true,
+    // Default true mirrors normalizer (`!== false`); only emit explicit false.
+    pauseOnInteractions: behavior.pauseOnInteraction !== false,
+  };
+}
+
+function toH5PSummary(
+  endScreen: InteractiveVideoSpec['endScreen'],
+): H5PInteractiveVideoParameters['interactiveVideo']['summary'] {
+  if (!endScreen) {
+    return undefined;
+  }
+  return {
+    task: {
+      params: {
+        intro: endScreen.title ?? undefined,
+        summary: endScreen.body ?? undefined,
+        requireAnswerBeforeSubmit: endScreen.requireAnswerBeforeSubmit === true,
+        showScore: endScreen.showScore === true,
+        atSeconds: endScreen.atSeconds ?? null,
       },
     },
   };

--- a/fe/src/app/shared/blocks/video-block/quiz-video-player.component.spec.ts
+++ b/fe/src/app/shared/blocks/video-block/quiz-video-player.component.spec.ts
@@ -1,0 +1,178 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import type {
+  InteractiveVideoInteraction,
+  InteractiveVideoSpec,
+} from '../../../api/types/interactive-video.types';
+import { VideoAssetApi } from '../../../api/client/video-asset.api';
+import { QuizVideoPlayerComponent } from './quiz-video-player.component';
+
+describe('QuizVideoPlayerComponent interactive video seek behavior', () => {
+  let fixture: ComponentFixture<QuizVideoPlayerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [QuizVideoPlayerComponent],
+      providers: [
+        {
+          provide: VideoAssetApi,
+          useValue: {
+            getById: () => of({ data: { status: 'READY' } }),
+            getPlayUrl: () => of({ data: { playUrl: 'https://cdn.example/video.mpd' } }),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(QuizVideoPlayerComponent);
+    fixture.detectChanges();
+  });
+
+  it('snaps a forward seek past incomplete required work without advancing watched progress', () => {
+    const video = prepareVideoElement(20, 120);
+    const spec: InteractiveVideoSpec = {
+      version: 2,
+      enabled: true,
+      behavior: { preventSkippingMode: 'forward' },
+      timeline: [
+        {
+          id: 'required-safety-check',
+          type: 'single_choice',
+          atSeconds: 40,
+          required: true,
+          choices: [{ id: 'ack', label: 'Acknowledge', isCorrect: true }],
+        },
+      ],
+    };
+    fixture.componentRef.setInput('interactiveVideoSpec', spec);
+    fixture.componentInstance.currentTimeSeconds.set(20);
+    fixture.detectChanges();
+    setPrivate(fixture.componentInstance, 'furthestWatchedSeconds', 20);
+
+    video.currentTime = 90;
+    fixture.componentInstance.onSeeking();
+
+    expect(video.currentTime).toBe(20);
+    expect(fixture.componentInstance.currentTimeSeconds()).toBe(20);
+    expect(getPrivate<number>(fixture.componentInstance, 'furthestWatchedSeconds')).toBe(20);
+  });
+
+  it('opens an optional interaction crossed by a settled seek edge', () => {
+    const video = prepareVideoElement(12, 120);
+    const optional: InteractiveVideoInteraction = {
+      id: 'optional-bridge-note',
+      type: 'checkpoint',
+      atSeconds: 30,
+      displayType: 'button',
+      title: 'Bridge note',
+    };
+    fixture.componentRef.setInput('interactiveVideoSpec', {
+      version: 2,
+      enabled: true,
+      timeline: [optional],
+    });
+    fixture.componentInstance.currentTimeSeconds.set(12);
+    fixture.detectChanges();
+
+    fixture.componentInstance.onSeeking();
+    video.currentTime = 35;
+    fixture.componentInstance.onSeeked();
+
+    expect(fixture.componentInstance.activeInteraction()?.id).toBe('optional-bridge-note');
+    expect(getPrivate<number>(fixture.componentInstance, 'furthestWatchedSeconds')).toBe(0);
+  });
+
+  it('does not treat marker jumps as watched playback progress', () => {
+    const video = prepareVideoElement(20, 120);
+    const marker: InteractiveVideoInteraction = {
+      id: 'marker-75',
+      type: 'checkpoint',
+      atSeconds: 75,
+      displayType: 'button',
+      title: 'Review marker',
+    };
+    fixture.componentRef.setInput('interactiveVideoSpec', {
+      version: 2,
+      enabled: true,
+      behavior: { preventSkippingMode: 'forward' },
+      timeline: [marker],
+    });
+    fixture.componentInstance.currentTimeSeconds.set(20);
+    fixture.detectChanges();
+    setPrivate(fixture.componentInstance, 'furthestWatchedSeconds', 20);
+
+    fixture.componentInstance.seekToInteractiveSecond(75);
+
+    expect(video.currentTime).toBe(75);
+    expect(fixture.componentInstance.currentTimeSeconds()).toBe(75);
+    expect(fixture.componentInstance.activeInteraction()?.id).toBe('marker-75');
+    expect(getPrivate<number>(fixture.componentInstance, 'furthestWatchedSeconds')).toBe(20);
+  });
+
+  it('does not treat branch or review jumps as watched playback progress', () => {
+    const video = prepareVideoElement(25, 120);
+    const navigationBranch: InteractiveVideoInteraction = {
+      id: 'branch-navigation',
+      type: 'branch',
+      atSeconds: 25,
+      choices: [{ id: 'forward', label: 'Continue to drill', targetTimeSeconds: 80 }],
+    };
+    const reviewBranch: InteractiveVideoInteraction = {
+      id: 'branch-review',
+      type: 'branch',
+      atSeconds: 35,
+      adaptivity: { requireCorrectBeforeContinue: true },
+      choices: [
+        { id: 'wrong', label: 'Skip muster', isCorrect: false, targetTimeSeconds: 90 },
+        { id: 'right', label: 'Complete muster', isCorrect: true },
+      ],
+    };
+    fixture.componentRef.setInput('interactiveVideoSpec', {
+      version: 2,
+      enabled: true,
+      timeline: [navigationBranch, reviewBranch],
+    });
+    fixture.detectChanges();
+    setPrivate(fixture.componentInstance, 'furthestWatchedSeconds', 25);
+
+    fixture.componentInstance.activeInteraction.set(navigationBranch);
+    fixture.componentInstance.onInteractiveChoice(navigationBranch.choices![0]);
+
+    expect(video.currentTime).toBe(80);
+    expect(getPrivate<number>(fixture.componentInstance, 'furthestWatchedSeconds')).toBe(25);
+
+    fixture.componentInstance.activeInteraction.set(reviewBranch);
+    fixture.componentInstance.selectedChoiceId.set('wrong');
+    fixture.componentInstance.onInteractiveReviewRequested();
+
+    expect(video.currentTime).toBe(90);
+    expect(getPrivate<number>(fixture.componentInstance, 'furthestWatchedSeconds')).toBe(25);
+  });
+
+  function prepareVideoElement(currentTime: number, duration: number): HTMLVideoElement {
+    const video = fixture.nativeElement.querySelector('video') as HTMLVideoElement;
+    let time = currentTime;
+    Object.defineProperty(video, 'currentTime', {
+      configurable: true,
+      get: () => time,
+      set: (value: number) => {
+        time = value;
+      },
+    });
+    Object.defineProperty(video, 'duration', {
+      configurable: true,
+      get: () => duration,
+    });
+    spyOn(video, 'pause').and.stub();
+    spyOn(video, 'play').and.returnValue(Promise.resolve());
+    return video;
+  }
+
+  function getPrivate<T>(component: QuizVideoPlayerComponent, property: string): T {
+    return (component as unknown as Record<string, T>)[property];
+  }
+
+  function setPrivate<T>(component: QuizVideoPlayerComponent, property: string, value: T): void {
+    (component as unknown as Record<string, T>)[property] = value;
+  }
+});

--- a/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
+++ b/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
@@ -190,6 +190,14 @@ export class QuizVideoPlayerComponent {
   private readonly completedInteractionIds = new Set<string>();
   private furthestWatchedSeconds = 0;
   private isSeeking = false;
+  /**
+   * Time captured at the moment the user starts a seek (`seeking` event). Used
+   * as `previousTimeSeconds` once the seek settles (`seeked`) so the runtime
+   * can detect interactions the seek crossed (forward edge: prev < at <= cur).
+   * Without this we passed `current` as previous, which always made the
+   * forward-edge check false and let the user scrub past optional interactions.
+   */
+  private seekStartTimeSeconds = 0;
 
   constructor() {
     effect(() => {
@@ -244,7 +252,12 @@ export class QuizVideoPlayerComponent {
     }
     const previousTimeSeconds = this.isSeeking ? video.currentTime : this.currentTimeSeconds();
     this.currentTimeSeconds.set(video.currentTime);
-    this.markInteractiveVideoWatched(video.currentTime);
+    // Only natural forward playback advances the watched mark; seek-driven
+    // timeupdates would otherwise let a single forward jump bypass the
+    // anti-skip gate. Backward playback is not possible without seeking.
+    if (!this.isSeeking) {
+      this.markInteractiveVideoWatched(video.currentTime);
+    }
     this.evaluateInteractiveTimeline(video, previousTimeSeconds);
   }
 
@@ -252,6 +265,13 @@ export class QuizVideoPlayerComponent {
     const video = this.videoElement()?.nativeElement;
     if (!video) {
       return;
+    }
+    if (!this.isSeeking) {
+      // Capture the playback time before the seek starts so we can drive the
+      // forward-edge check against the actual user trajectory, not the post-seek
+      // position. Subsequent seeking events within the same drag preserve the
+      // original start anchor.
+      this.seekStartTimeSeconds = this.currentTimeSeconds();
     }
     this.isSeeking = true;
     this.snapBlockedInteractiveSeek(video);
@@ -263,8 +283,9 @@ export class QuizVideoPlayerComponent {
     if (!video) {
       return;
     }
+    const previousTimeSeconds = this.seekStartTimeSeconds;
     this.currentTimeSeconds.set(video.currentTime);
-    this.evaluateInteractiveTimeline(video, video.currentTime);
+    this.evaluateInteractiveTimeline(video, previousTimeSeconds);
   }
 
   seekToInteractiveSecond(seconds: number): void {
@@ -287,7 +308,8 @@ export class QuizVideoPlayerComponent {
 
     video.currentTime = target;
     this.currentTimeSeconds.set(video.currentTime);
-    this.markInteractiveVideoWatched(video.currentTime);
+    // Marker click is a seek, not playback. Skip markInteractiveVideoWatched
+    // so the anti-skip gate isn't bypassed by jumping forward via the rail.
     this.evaluateInteractiveTimeline(video);
   }
 
@@ -320,7 +342,7 @@ export class QuizVideoPlayerComponent {
     this.selectedChoiceId.set(null);
     video.currentTime = target;
     this.currentTimeSeconds.set(target);
-    this.markInteractiveVideoWatched(target);
+    // Review jump is a programmatic seek; don't advance the watched mark.
     void video.play().catch(() => {});
   }
 
@@ -638,7 +660,8 @@ export class QuizVideoPlayerComponent {
       const target = Math.max(0, targetTime);
       video.currentTime = target;
       this.currentTimeSeconds.set(target);
-      this.markInteractiveVideoWatched(target);
+      // Branch jump is a programmatic seek; let natural playback re-advance the
+      // watched mark instead of pre-marking the unwatched region as seen.
     }
     void video.play().catch(() => {});
   }


### PR DESCRIPTION
## Tóm tắt

Follow-up của #399. Xử lý 6 item grey-area mà PR trước đã liệt kê nhưng defer chờ quyết định design.

## Bug đã fix

### Authoring canvas

| ID | File | Bug | Fix |
|----|------|-----|-----|
| **G1** | `interactive-video-authoring-canvas.component.ts` | Drag handle emit `interactionMoved` mỗi pixel → ~100s state writes / drag, race với debounced autosave, undo/redo bị nghẽn | Pointermove chỉ update local preview; emit 1 lần duy nhất ở pointerup với last seen position. Pointercancel discard. |
| **G3** | same | `time-from-pointer` dùng canvas rect; video `object-contain` có letterbox/pillarbox bands → click vào band map sai timestamp + đặt interaction off-frame | Thêm `getVideoContentRect()` tính content rect từ `videoWidth/videoHeight` aspect; pointer toạ độ ngoài content rect bị clamp về cạnh; fallback canvas rect khi metadata video chưa load |

### Learner runtime

| ID | File | Bug | Fix |
|----|------|-----|-----|
| **G2** | `quiz-video-player.component.ts` + `interactive-video-runtime.ts` | `furthestWatchedSeconds` advance ở mọi seek call → 1 forward jump qua marker click bypass anti-skip gate hoàn toàn | Chỉ advance trên natural forward playback (`onTimeUpdate` khi `!isSeeking`). Seek/branch jump/review jump không advance nữa. Comment trong `shouldBlockInteractiveVideoSeek` ghi rõ `'both'` hiện cùng gate với `'forward'`, semantic strict review (constrain backward to visited ranges) cần visited-range bookkeeping → deferred. |
| **G6** | `quiz-video-player.component.ts` | `previousTimeSeconds` ở `onSeeked` = `video.currentTime` (post-seek) → forward-edge check `prev < at <= cur` không bao giờ thoả → scrub qua optional interaction silently miss | `onSeeking` capture `seekStartTimeSeconds = currentTimeSeconds()` lần đầu vào seek; `onSeeked` dùng giá trị này làm `previousTimeSeconds` |

### H5P interoperability

| ID | File | Bug | Fix |
|----|------|-----|-----|
| **G4** | `interactive-video-interoperability.ts` | H5P export bịa `bookmarks` từ `timeline.filter(t => t.title)` (mất standalone bookmarks user thêm), không export `behavior`/`endScreen` → round-trip mất 3 mảng setting | (a) `assets.bookmarks` lấy thẳng từ `spec.bookmarks`. (b) Thêm H5P-standard `behaviour` block (preventSkipping/Mode, showBookmarksMenuOnLoad, showRewind10, pauseOnInteractions) từ `spec.behavior`. (c) Thêm `summary.task.params` từ `spec.endScreen`. (d) Import path đọc cả 3 fields nên round-trip lossless |

### Authoring panel

| ID | File | Bug | Fix |
|----|------|-----|-----|
| **G5** | `interactive-video-authoring-panel.component.ts` | `removeFillBlankBlank` khi blank id còn được template tham chiếu → silently clear `acceptedAnswers`, để row orphan re-render mỗi lần | Refuse + toast `Hãy gỡ {{N}} khỏi câu trước rồi mới xoá ô trống.` Hành vi xoá row chỉ chạy khi blank không còn ref |

## Files changed

```
fe/src/app/core/utils/interactive-video-runtime.ts                                          (+8 -1)
fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts                         (+25 -8)
fe/src/app/features/teacher/course-editor/utils/interactive-video-interoperability.ts       (+155 -10)
fe/src/app/features/teacher/course-editor/pages/.../interactive-video-authoring-canvas.component.ts   (+72 -10)
fe/src/app/features/teacher/course-editor/pages/.../interactive-video-authoring-panel.component.ts    (+11 -0)
```

5 files, +271 / -29.

## Test plan

- [x] `tsc --noEmit -p tsconfig.app.json` — exit 0
- [x] Existing spec assertions vẫn match (canvas spec: pointerup tái dùng last pointermove position → output round-trip giữ nguyên)
- [ ] Manual smoke (cần BE+FE):
  - **G1**: Kéo handle qua nhiều pixel; verify chỉ có 1 entry undo, autosave không jitter
  - **G3**: Video portrait/widescreen mismatch canvas → click vào letterbox bar → timestamp = edge time, không phải bar middle time
  - **G2**: Set `behavior.preventSkippingMode=forward` + required interaction → click marker forward bypass đáng lẽ vẫn bị block
  - **G6**: Spec có optional interaction tại t=10 (endSeconds=null → window 5s); play đến t=2; scrub forward đến t=20 → dialog optional vẫn pop ra
  - **G4**: Tạo spec với 2 bookmarks + endScreen + behavior; export H5P; import lại → 3 fields giữ nguyên
  - **G5**: Câu fill-blank `Điền {{1}} vào`; click xoá blank `1` → toast warning, row vẫn còn. Sau khi xoá `{{1}}` khỏi template → click xoá → row biến mất

## Trade-offs / decisions

- **G1 single emit**: cancel hoặc click-without-move → không emit (no-op, đúng semantics). Phù hợp pattern Figma/Notion drag.
- **G2 'both' deferred**: comment in code; PR description gọi rõ. Visited-range tracking cần data structure mới (set of ranges), out of scope.
- **G4 H5P fields**: dùng đúng key chuẩn H5P (`behaviour` British, `summary.task.params`); cross-tool compatibility tốt hơn so với HoliLihu-namespace extension.
- **G5 toast vs auto-strip**: chọn refuse + toast (an toàn, preserve teacher intent) thay vì tự strip placeholder (aggressive, có thể mất dữ liệu user vô tình).

🤖 Generated with [Claude Code](https://claude.com/claude-code)