### PR TITLE
fix(fe): mount Wiii widget in course editor

### DIFF
--- a/fe/src/app/features/ai-chat/presentation/components/chat-widget/chat-widget.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/chat-widget/chat-widget.component.ts
@@ -27,6 +27,7 @@ import { WiiiContextService, type WiiiSidebarOpenDetail } from '../../../infrast
       <!-- Chat Panel (iframe embed) -->
       @if (isPanelOpen()) {
         <app-chat-panel
+          mode="widget"
           (closePanel)="closePanel()"
         />
       }

--- a/fe/src/app/features/teacher/course-editor/layouts/course-editor-layout/course-editor-layout.component.ts
+++ b/fe/src/app/features/teacher/course-editor/layouts/course-editor-layout/course-editor-layout.component.ts
@@ -8,13 +8,14 @@ import { CourseRejectionBannerComponent } from '../../components/rejection-banne
 import { CourseEditorStore } from '../../store/course-editor.store';
 import { CurriculumSelectionService } from '../../services/curriculum-selection.service';
 import { AuthService } from '../../../../../core/services/auth.service';
+import { ChatWidgetComponent } from '../../../../ai-chat/presentation/components/chat-widget/chat-widget.component';
 import { distinctUntilChanged, filter, take, map } from 'rxjs/operators';
 
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-course-editor-layout',
-  imports: [RouterOutlet, RouterModule, CourseEditorSidebarComponent, CourseEditorHeaderComponent, CourseRejectionBannerComponent],
+  imports: [RouterOutlet, RouterModule, CourseEditorSidebarComponent, CourseEditorHeaderComponent, CourseRejectionBannerComponent, ChatWidgetComponent],
   styleUrl: './course-editor-layout.component.scss',
   template: `
     <div class="relative flex h-screen w-full flex-col overflow-hidden font-sans bg-white text-slate-900"
@@ -168,6 +169,8 @@ import { distinctUntilChanged, filter, take, map } from 'rxjs/operators';
             </div>
         </div>
       </main>
+
+      <app-chat-widget />
     </div>
   `
 })

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.ts
@@ -1719,7 +1719,7 @@ export class CourseCurriculumComponent implements OnDestroy {
       if (courseId) {
         this.store.loadCourse(courseId, true);
       }
-      this.toast.success('Da ap dung noi dung Wiii sau khi duyet preview.');
+      this.toast.success('Đã áp dụng nội dung Wiii sau khi duyệt bản xem trước.');
     });
 
   /** Open Wiii AI sidebar for course generation from document */


### PR DESCRIPTION
## Summary
- Mount the Wiii chat widget inside the course editor layout so the existing \wiii:open-sidebar\ flow can actually open Wiii from \Tạo bằng AI\.
- Render the widget panel in popup/widget mode so it does not disturb the course editor grid.
- Polish the Wiii apply-success toast copy with Vietnamese diacritics.

## Verification
- \
pm run build\ -> passed (existing Angular/Sass/CommonJS warnings only).
- \
px ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts\ -> TOTAL: 25 SUCCESS.
- \git diff --check\ -> passed.

## Risk / rollback
- Low, scoped to course editor Wiii entrypoint and chat widget display mode.
- Rollback: revert this PR; preview/apply contract remains unchanged.

Part of linhlinhlin/LMS_hohulili#400.