### PR TITLE
fix: fallback Wiii token secret to env

### DIFF
--- a/backend/src/main/java/com/example/lms/ai_assistant/infrastructure/wiii/WiiiTokenExchangeAdapter.java
+++ b/backend/src/main/java/com/example/lms/ai_assistant/infrastructure/wiii/WiiiTokenExchangeAdapter.java
@@ -66,7 +66,10 @@ public class WiiiTokenExchangeAdapter {
     public Optional<TokenPair> exchangeToken(String lmsUserId, String email,
                                               String fullName, String role) {
         String url = config.getTokenExchange().getUrl();
-        String secret = config.getWebhook().getSecret();
+        String secret = resolveSigningSecret(
+                config.getWebhook().getSecret(),
+                System.getenv("WIII_WEBHOOK_SECRET")
+        );
 
         if (secret == null || secret.isBlank()) {
             log.error("Wiii webhook secret not configured — cannot sign token exchange");
@@ -144,6 +147,16 @@ public class WiiiTokenExchangeAdapter {
             case "teacher", "admin", "org_admin" -> "teacher";
             default -> "student";
         };
+    }
+
+    static String resolveSigningSecret(String configuredSecret, String envSecret) {
+        if (configuredSecret != null && !configuredSecret.isBlank()) {
+            return configuredSecret;
+        }
+        if (envSecret != null && !envSecret.isBlank()) {
+            return envSecret;
+        }
+        return "";
     }
 
     private String computeHmac(byte[] payload, String secret) {

--- a/backend/src/test/java/com/example/lms/ai_assistant/infrastructure/wiii/WiiiTokenExchangeAdapterTest.java
+++ b/backend/src/test/java/com/example/lms/ai_assistant/infrastructure/wiii/WiiiTokenExchangeAdapterTest.java
@@ -1,0 +1,29 @@
+package com.example.lms.ai_assistant.infrastructure.wiii;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WiiiTokenExchangeAdapterTest {
+
+    @Test
+    void shouldPreferConfiguredSecret() {
+        assertEquals(
+                "configured-secret",
+                WiiiTokenExchangeAdapter.resolveSigningSecret("configured-secret", "env-secret")
+        );
+    }
+
+    @Test
+    void shouldFallbackToEnvironmentSecretWhenConfigBindingIsBlank() {
+        assertEquals(
+                "env-secret",
+                WiiiTokenExchangeAdapter.resolveSigningSecret("  ", "env-secret")
+        );
+    }
+
+    @Test
+    void shouldFailClosedWhenNoSecretIsAvailable() {
+        assertEquals("", WiiiTokenExchangeAdapter.resolveSigningSecret(null, " "));
+    }
+}


### PR DESCRIPTION
## Summary
- Add a fail-closed resolver for Wiii token exchange signing secret.
- Prefer bound wiii.webhook.secret, but fallback to WIII_WEBHOOK_SECRET when Spring config binding returns blank in production.
- Add unit coverage for configured, env fallback, and no-secret paths.

## Verification
- mvn -q -Dtest=WiiiTokenExchangeAdapterTest test
- mvn -q -DskipTests package
- git diff --check

## Risk / rollback
- Low-risk backend-only patch for Wiii token exchange. No secret values are logged or committed.
- Rollback: revert this PR; LMS will return to strict config-property-only secret resolution.