### PR TITLE
fix(fe): expose Wiii lesson preview tools from editor URL

### DIFF
--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
@@ -302,6 +302,52 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     expect(capabilities.host_organization_id).toBe('org-1');
   });
 
+  it('exposes lesson preview tools from the editor URL when selection state has not hydrated', () => {
+    (TestBed.inject(Router) as any).url =
+      '/teacher/courses/course-1/editor/curriculum?chapterId=chapter-1&lessonId=lesson-from-url';
+
+    const capabilities = (service as any).buildCapabilities({
+      page_type: 'course_editor',
+      course_id: 'course-1',
+    });
+    const toolNames = capabilities.tools.map((tool: any) => tool.name);
+
+    expect(toolNames).toContain('authoring.preview_lesson_patch');
+    expect(toolNames).toContain('authoring.apply_lesson_patch');
+    expect(toolNames).toContain('assessment.preview_quiz_commit');
+  });
+
+  it('previews a lesson patch using the lessonId from the current editor URL', async () => {
+    (TestBed.inject(Router) as any).url =
+      '/teacher/courses/course-1/editor/curriculum?chapterId=chapter-1&lessonId=lesson-from-url';
+    lessonApi.getLessonById.and.returnValue(of({
+      data: {
+        id: 'lesson-from-url',
+        title: 'Lesson from URL',
+        description: 'Existing description',
+        content: 'Existing content',
+        courseId: 'course-1',
+        sectionId: 'chapter-1',
+        lessonType: 'LECTURE',
+        durationMinutes: 15,
+        orderIndex: 2,
+        isRequired: true,
+      },
+    } as any));
+
+    const preview = await (service as any).handleActionRequest('authoring.preview_lesson_patch', {
+      content: 'Generated content from uploaded source',
+      source_references: [{ kind: 'page', page_start: 1, excerpt: 'Uploaded source excerpt' }],
+    });
+
+    expect(preview.success).toBeTrue();
+    expect(lessonApi.getLessonById).toHaveBeenCalledWith('lesson-from-url');
+    expect(preview.data?.lesson_id).toBe('lesson-from-url');
+    expect(preview.data?.source_references).toEqual([
+      jasmine.objectContaining({ page_start: 1, excerpt: 'Uploaded source excerpt' }),
+    ]);
+  });
+
   it('recognizes student task work routes as assignment pages', () => {
     const context = (service as any).extractPageContext('/student/tasks/assignment-1/work');
 

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -528,7 +528,7 @@ export class WiiiContextService implements OnDestroy {
   private buildCapabilities(ctx: WiiiPageContext): WiiiHostCapabilities {
     const role = this.resolveCurrentUserRole();
     const courseId = String(ctx.course_id || '');
-    const selectedLessonId = String(this.selectionService.selectedLessonId() || ctx.lesson_id || '');
+    const selectedLessonId = this.resolveCurrentLessonId({ lesson_id: ctx.lesson_id });
     const hostIdentity = this.buildHostIdentityOverlay();
     const tools: WiiiHostCapabilityTool[] = [
       {
@@ -1055,9 +1055,33 @@ export class WiiiContextService implements OnDestroy {
       params['lesson_id']
       || params['lessonId']
       || this.selectionService.selectedLessonId()
+      || this.selectionService.selectedLesson()?.id
       || this.lastContext?.lesson_id
+      || this.extractLessonIdFromCurrentUrl()
       || '',
     ).trim();
+  }
+
+  private extractLessonIdFromCurrentUrl(): string {
+    if (!this.isBrowser) {
+      return '';
+    }
+    const url = String(this.router.url || '');
+    if (!url) {
+      return '';
+    }
+
+    const queryText = url.includes('?') ? url.split('?')[1].split('#')[0] : '';
+    if (queryText) {
+      const query = new URLSearchParams(queryText);
+      const fromQuery = query.get('lessonId') || query.get('lesson_id');
+      if (fromQuery) {
+        return fromQuery.trim();
+      }
+    }
+
+    const pathMatch = url.match(/\/lesson\/([^/?#]+)/i);
+    return pathMatch?.[1] ? decodeURIComponent(pathMatch[1]).trim() : '';
   }
 
   private normalizeString(value: unknown): string | undefined {


### PR DESCRIPTION
## Summary
- Let Wiii host capabilities resolve the current lesson from the course editor URL when selection state is not hydrated yet.
- Keep preview/apply lesson/quiz tools available for the selected lesson on product routes with `lessonId` query params.
- Add regression coverage for URL-based capability exposure and preview generation without explicit `lesson_id`.

## Verification
- `npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox --include src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts` -> `TOTAL: 28 SUCCESS`
- `npm run build` -> success; existing Angular/Sass/CommonJS warnings only
- `git diff --check` -> pass

## Risk / rollback
- Narrow frontend host-bridge change only. Roll back this PR if Wiii iframe exposes preview/apply tools on an incorrect editor URL.
- Mutating LMS writes are still gated by preview + `approval_token`; this only restores capability discovery for the selected lesson.