### PR TITLE
[codex] Fix student library pagination spacing

### DIFF
--- a/fe/src/app/features/student/student-my-courses.component.ts
+++ b/fe/src/app/features/student/student-my-courses.component.ts
@@ -1059,12 +1059,19 @@ interface EnhancedEnrolledCourse extends EnrolledCourse {
     .library-pagination {
       display: block;
       grid-column: 1 / -1;
-      margin-top: 24px;
+      justify-self: center;
+      width: 100%;
+      max-width: 1024px;
+      margin: 32px auto;
       background: white;
       border: 1px solid #E5E7EB;
-      border-radius: 12px;
-      box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+      border-radius: 8px;
+      box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
       overflow: hidden;
+
+      @include mobile {
+        margin: 24px auto 28px;
+      }
     }
 
     /* Fade-in for newly loaded courses */


### PR DESCRIPTION
﻿## Summary
- Align the student course library pagination container with the `/student/browse` pagination spacing pattern.
- Center the pagination card, cap it at 1024px, and restore comfortable top/bottom margins so it no longer sits tight against the viewport edge.
- Match the browse page's lighter radius and shadow while keeping the shared pagination component unchanged.

## Validation
- `git diff --check` passed.
- Local `npx ng build --progress=false` was attempted but timed out on the Windows workstation after 5 minutes without a compiler error; GitHub CI should provide the authoritative Angular build result for this CSS-only scoped change.
