### PR TITLE
[codex] Add PPTX document preview support

### DIFF
--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
@@ -751,6 +751,8 @@ public class CourseQueryControllerV3 {
                     section.setVideoType(null);
                     section.setStreamVideoUid(null);
                     section.setFileUrl(null);
+                    section.setPreviewPdfUrl(null);
+                    section.setPreviewStatus(null);
                     section.setQuizData(null);
                     section.setInteractiveVideoSpec(null);
                 }
@@ -1110,6 +1112,8 @@ public class CourseQueryControllerV3 {
                     .videoType(showContent ? videoType : null)
                     .streamVideoUid(showContent ? streamVideoUid : null)
                     .fileUrl(showContent ? (String) data.get("fileUrl") : null)
+                    .previewPdfUrl(showContent ? (String) data.get("previewPdfUrl") : null)
+                    .previewStatus(showContent ? (String) data.get("previewStatus") : null)
                     .duration(safeInt(data.get("duration"), 0))
                     .orderIndex(safeInt(data.get("orderIndex"), 0))
                     .isRequired(safeBool(data.get("isRequired"), false))
@@ -1637,6 +1641,8 @@ public class CourseQueryControllerV3 {
         private String videoType;
         private String streamVideoUid;
         private String fileUrl;
+        private String previewPdfUrl;
+        private String previewStatus;
         private Integer duration; // seconds
         private Integer orderIndex;
         private Boolean isRequired;

--- a/fe/src/app/api/types/course.types.ts
+++ b/fe/src/app/api/types/course.types.ts
@@ -303,6 +303,8 @@ export interface SectionDetail { // New L3 Section
   cfObjectKey?: string;
   interactiveVideoSpec?: InteractiveVideoSpec | null;
   fileUrl: string;
+  previewPdfUrl?: string;
+  previewStatus?: 'PROCESSING' | 'READY' | 'FAILED' | string | null;
   duration: number;
   orderIndex: number;
   lessonId: string;

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
@@ -240,6 +240,17 @@
                  class="max-w-full max-h-[520px] md:max-h-[680px] object-contain block"
                  loading="lazy" />
           </div>
+        } @else if (isConvertibleDocumentFile(ext) && section.previewStatus === 'PROCESSING') {
+          <!-- Office document is being converted to a normalized PDF preview. -->
+          <div class="px-4 py-5 text-center bg-slate-50/60 text-sm text-slate-600">
+            <app-icon name="info" size="sm" class="text-slate-400 align-middle mr-1"></app-icon>
+            Đang chuẩn bị bản xem trước. Bấm <strong>"Tải xuống"</strong> để xem ngay nếu cần.
+          </div>
+        } @else if (isConvertibleDocumentFile(ext) && section.previewStatus === 'FAILED') {
+          <div class="px-4 py-5 text-center bg-amber-50 text-sm text-amber-800">
+            <app-icon name="info" size="sm" class="text-amber-500 align-middle mr-1"></app-icon>
+            Không thể tạo bản xem trước cho tài liệu này. Bạn vẫn có thể tải xuống tệp gốc.
+          </div>
         } @else if (ext === 'pdf') {
           <!-- PDF requested but preview URL not ready (still converting / failed) -->
           <div class="px-4 py-5 text-center bg-slate-50/60 text-sm text-slate-600">

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
@@ -254,7 +254,9 @@ export class LessonContentComponent implements AfterViewInit {
     if (section?.type !== 'FILE') return;
 
     // Prefer previewPdfUrl (Gotenberg-converted) over original fileUrl
-    const previewPdfUrl = (section as any).previewPdfUrl || null;
+    const previewPdfUrl = (!section.previewStatus || section.previewStatus === 'READY')
+      ? section.previewPdfUrl || null
+      : null;
     const fileUrl = section.fileUrl || null;
     const urlToPreview = previewPdfUrl ?? (fileUrl && this.isPdfFileUrl(fileUrl) ? fileUrl : null);
 
@@ -351,6 +353,10 @@ export class LessonContentComponent implements AfterViewInit {
     if (ext === 'pdf') return false;
     if (this.isImageFile(ext)) return false;
     return true;
+  }
+
+  isConvertibleDocumentFile(ext: string): boolean {
+    return ['doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'rtf', 'txt', 'csv'].includes(ext);
   }
 
   private extractFileNameFromUrl(url: string | null): string {

--- a/fe/src/app/features/learning/models/learning.models.ts
+++ b/fe/src/app/features/learning/models/learning.models.ts
@@ -77,6 +77,8 @@ export interface SectionContent {
   streamVideoUid?: string;
   videoOfflineUri?: string;
   fileUrl?: string;
+  previewPdfUrl?: string;
+  previewStatus?: 'PROCESSING' | 'READY' | 'FAILED' | string | null;
   duration?: number;
   orderIndex: number;
   isRequired: boolean;

--- a/fe/src/app/features/learning/services/learning.service.spec.ts
+++ b/fe/src/app/features/learning/services/learning.service.spec.ts
@@ -313,6 +313,53 @@ describe('LearningService — videoOfflineUri preservation', () => {
   });
 
   describe('Interactive video section mapping', () => {
+    it('keeps document preview metadata for converted PPTX sections', () => {
+      const section = (service as any).mapSectionContent({
+        id: 'pptx-section',
+        title: 'Bridge resource',
+        type: 'FILE',
+        fileUrl: '/uploads/sections/bridge.pptx',
+        previewPdfUrl: '/uploads/previews/bridge_preview.pdf',
+        previewStatus: 'READY',
+        orderIndex: 0,
+        isRequired: true,
+      }) as SectionContent;
+
+      expect(section.fileUrl).toBe('/uploads/sections/bridge.pptx');
+      expect(section.previewPdfUrl).toBe('/uploads/previews/bridge_preview.pdf');
+      expect(section.previewStatus).toBe('READY');
+    });
+
+    it('merges document preview metadata from course content cache into lesson details', () => {
+      (service as any).lessonSectionsCache.set('lesson-with-pptx', [
+        buildSection({
+          id: 'pptx-section',
+          type: 'FILE',
+          fileUrl: '/uploads/sections/bridge.pptx',
+          previewPdfUrl: '/uploads/previews/bridge_preview.pdf',
+          previewStatus: 'READY',
+        }),
+      ]);
+
+      const lesson = (service as any).mapLessonResponse({
+        id: 'lesson-with-pptx',
+        title: 'PPTX lesson',
+        sections: [
+          {
+            id: 'pptx-section',
+            title: 'Bridge resource',
+            type: 'FILE',
+            fileUrl: '/uploads/sections/bridge.pptx',
+            orderIndex: 0,
+            isRequired: true,
+          },
+        ],
+      }) as LessonDetail;
+
+      expect(lesson.sections?.[0].previewPdfUrl).toBe('/uploads/previews/bridge_preview.pdf');
+      expect(lesson.sections?.[0].previewStatus).toBe('READY');
+    });
+
     it('normalizes timeline aliases and keeps interactions sorted by time', () => {
       const section = (service as any).mapSectionContent({
         id: 'iv-section',

--- a/fe/src/app/features/learning/services/learning.service.ts
+++ b/fe/src/app/features/learning/services/learning.service.ts
@@ -396,6 +396,12 @@ export class LearningService {
     const offlineFileUrl = (section.fileOfflineUri && section.fileOfflineUri !== 'undefined' && section.fileOfflineUri !== 'null')
       ? section.fileOfflineUri
       : undefined;
+    const previewPdfUrl = (section.previewPdfUrl && section.previewPdfUrl !== 'undefined' && section.previewPdfUrl !== 'null')
+      ? section.previewPdfUrl
+      : undefined;
+    const previewStatus = (section.previewStatus && section.previewStatus !== 'undefined' && section.previewStatus !== 'null')
+      ? section.previewStatus
+      : undefined;
 
     return {
       id: section.id,
@@ -418,6 +424,8 @@ export class LearningService {
         : undefined,
       videoOfflineUri: offlineVideoUrl,
       fileUrl: offlineFileUrl || ((section.fileUrl && section.fileUrl !== 'undefined' && section.fileUrl !== 'null') ? section.fileUrl : undefined),
+      previewPdfUrl,
+      previewStatus,
       duration: section.duration,
       orderIndex: section.orderIndex ?? 0,
       isRequired: section.isRequired ?? false,
@@ -825,12 +833,24 @@ export class LearningService {
    */
   private mapLessonResponse(data: any): LessonDetail {
     let mappedSections: SectionContent[] = (data.sections || []).map((s: any) => this.mapSectionContent(s));
+    const fromCourseContent = this.findSectionsFromCourseContent(data.id);
 
     if (mappedSections.length === 0) {
-      const fromCourseContent = this.findSectionsFromCourseContent(data.id);
       if (fromCourseContent && fromCourseContent.length > 0) {
         mappedSections = fromCourseContent;
       }
+    } else if (fromCourseContent && fromCourseContent.length > 0) {
+      const cachedById = new Map(fromCourseContent.map(section => [section.id, section]));
+      mappedSections = mappedSections.map(section => {
+        const cached = cachedById.get(section.id);
+        if (!cached) return section;
+        return {
+          ...section,
+          fileUrl: section.fileUrl ?? cached.fileUrl,
+          previewPdfUrl: section.previewPdfUrl ?? cached.previewPdfUrl,
+          previewStatus: section.previewStatus ?? cached.previewStatus,
+        };
+      });
     }
 
     return {

--- a/fe/src/app/features/teacher/course-editor/services/course-authoring.service.ts
+++ b/fe/src/app/features/teacher/course-editor/services/course-authoring.service.ts
@@ -224,6 +224,8 @@ interface ChapterResponse { // Was SectionWithLessons
             streamVideoUid?: string;
             interactiveVideoSpec?: InteractiveVideoSpec | null;
             fileUrl?: string; // [NEW] For FILE type sections - SOTA 2025
+            previewPdfUrl?: string;
+            previewStatus?: 'PROCESSING' | 'READY' | 'FAILED' | null;
             duration?: number;
             orderIndex: number;
             isRequired?: boolean;
@@ -254,6 +256,8 @@ interface ChapterResponse { // Was SectionWithLessons
             streamVideoUid?: string;
             interactiveVideoSpec?: InteractiveVideoSpec | null;
             fileUrl?: string;
+            previewPdfUrl?: string;
+            previewStatus?: 'PROCESSING' | 'READY' | 'FAILED' | null;
             duration?: number;
             orderIndex: number;
             isRequired?: boolean;

--- a/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
+++ b/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
@@ -407,25 +407,29 @@ export class CurriculumEditorService {
       if (isNew) {
         const res: any = await firstValueFrom(this.sectionApi.createSection(lessonId, formData));
         const created = res.data || res;
-        this.editingSectionId.set(created?.id ?? null);
-        if (created?.id) {
+        const createdData = (created?.data && typeof created.data === 'object') ? created.data : (created || {});
+        const createdId = created?.id ?? createdData['id'];
+        this.editingSectionId.set(createdId ?? null);
+        if (createdId) {
           this.store.addSectionLocal(lessonId, {
-            id: created.id,
-            title: created.title || payload['title'] || '',
-            type: created.type || type,
-            content: created.content || payload['content'],
-            videoAssetId: created.videoAssetId || payload['videoAssetId'],
-            videoProcessingStatus: created.videoProcessingStatus,
-            videoUrl: created.videoUrl || payload['videoUrl'],
-            videoType: created.videoType || payload['videoType'],
-            streamVideoUid: created.streamVideoUid || payload['streamVideoUid'],
-            interactiveVideoSpec: created.interactiveVideoSpec ?? payload['interactiveVideoSpec'],
-            fileUrl: created.fileUrl,
-            orderIndex: created.orderIndex ?? 0,
-            isRequired: created.isRequired ?? payload['isRequired'] ?? false,
-            completionThreshold: created.completionThreshold ?? payload['completionThreshold'],
-            availableOfflineProfiles: created.availableOfflineProfiles ?? [],
-            quizData: created.quizData ?? payload['quizData'],
+            id: createdId,
+            title: createdData['title'] || payload['title'] || '',
+            type: created?.type ? String(created.type).toUpperCase() : type,
+            content: createdData['content'] || payload['content'],
+            videoAssetId: createdData['videoAssetId'] || payload['videoAssetId'],
+            videoProcessingStatus: createdData['videoProcessingStatus'],
+            videoUrl: createdData['videoUrl'] || payload['videoUrl'],
+            videoType: createdData['videoType'] || payload['videoType'],
+            streamVideoUid: createdData['streamVideoUid'] || payload['streamVideoUid'],
+            interactiveVideoSpec: createdData['interactiveVideoSpec'] ?? payload['interactiveVideoSpec'],
+            fileUrl: createdData['fileUrl'],
+            previewPdfUrl: createdData['previewPdfUrl'],
+            previewStatus: createdData['previewStatus'],
+            orderIndex: createdData['orderIndex'] ?? 0,
+            isRequired: createdData['isRequired'] ?? payload['isRequired'] ?? false,
+            completionThreshold: createdData['completionThreshold'] ?? payload['completionThreshold'],
+            availableOfflineProfiles: createdData['availableOfflineProfiles'] ?? [],
+            quizData: createdData['quizData'] ?? payload['quizData'],
           });
         }
       } else {
@@ -436,7 +440,7 @@ export class CurriculumEditorService {
         // BE response làm source of truth, fallback FE payload khi BE không trả field.
         const block = res?.data ?? res;
         const beData = (block?.data && typeof block.data === 'object') ? block.data : {};
-        this.store.updateSectionLocal(lessonId, this.editingSectionId()!, {
+        const updates: Partial<SectionDraftDTO> = {
           title: (beData['title'] as string) ?? payload['title'] ?? '',
           type: (block?.type ? String(block.type).toUpperCase() : type),
           content: (beData['content'] as string) ?? payload['content'],
@@ -448,7 +452,15 @@ export class CurriculumEditorService {
           isRequired: (beData['isRequired'] as boolean) ?? payload['isRequired'] ?? false,
           completionThreshold: (beData['completionThreshold'] as number) ?? payload['completionThreshold'],
           quizData: beData['quizData'] ?? payload['quizData'],
-        } as any);
+        } as any;
+        const fileUrl = (beData['fileUrl'] as string | undefined) ?? (payload['fileUrl'] as string | undefined);
+        const previewPdfUrl = (beData['previewPdfUrl'] as string | undefined) ?? (payload['previewPdfUrl'] as string | undefined);
+        const previewStatus = (beData['previewStatus'] as SectionDraftDTO['previewStatus'] | undefined)
+          ?? (payload['previewStatus'] as SectionDraftDTO['previewStatus'] | undefined);
+        if (fileUrl !== undefined) updates.fileUrl = fileUrl;
+        if (previewPdfUrl !== undefined) updates.previewPdfUrl = previewPdfUrl;
+        if (previewStatus !== undefined) updates.previewStatus = previewStatus;
+        this.store.updateSectionLocal(lessonId, this.editingSectionId()!, updates);
       }
 
       this.selectedSectionVideoFile.set(null);


### PR DESCRIPTION
﻿## What changed

- Expose `previewPdfUrl` and `previewStatus` in the published/student course section API so converted document previews can reach the learning UI.
- Preserve document preview metadata in student learning models and mapping, including lesson-detail responses that need metadata from the course-content cache.
- Update the lesson file viewer to prefer READY converted PDF previews and show clear Vietnamese status messages while Office documents are converting or when conversion fails.
- Preserve file preview metadata in the teacher curriculum editor after creating or updating FILE sections, including nested backend response payloads.
- Add focused Angular service specs for PPTX preview metadata mapping and cache merge behavior.

## Why

The backend already has a Gotenberg/LibreOffice conversion pipeline that can convert PPT/PPTX and other Office documents to PDF, and the frontend already has a PDF viewer path. The missing pieces were metadata propagation and UI handling: `previewPdfUrl`/`previewStatus` were dropped from published/student responses and frontend models, so PPTX files could not reliably render through the existing PDF viewer.

## Approach

Large production document-viewing products generally avoid client-side PPTX rendering for private LMS content unless they run a full document server. Microsoft web embeds require externally hosted/shared files, while ONLYOFFICE and Collabora are heavier document-server options. This PR uses the existing server-side conversion path and reuses the LMS PDF viewer, keeping permissions and UI behavior consistent with current PDF handling.

## Validation

- `git diff --check origin/main...HEAD`
- `mvn -DskipTests compile` in `backend`
- `npm run build` in `fe`
- Local screenshots captured before PR:
  - `C:\hhll\LMS_hohulili\.tmp\screenshots\pptx-preview-student.png`
  - `C:\hhll\LMS_hohulili\.tmp\screenshots\pptx-preview-teacher.png`

## Known local test issue

Attempted focused Angular Karma tests, but the repo-local Karma setup failed before running specs because `@angular-devkit/build-angular/plugins/karma` could not be resolved under the current Angular setup. The frontend production build passes.
