### PR TITLE
[codex] Fix course image API consistency

### DIFF
--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3.java
@@ -206,7 +206,7 @@ public class StudentEnrollmentControllerV3 {
                             .description(description)
                             .teacherName(teacherName)
                             .categoryName(categoryName)
-                            .thumbnailUrl(course != null ? (course.getThumbnailUrl() != null ? course.getThumbnailUrl() : course.getIntroVideoUrl()) : null)
+                            .thumbnailUrl(course != null ? course.getThumbnailUrl() : null)
                             .status(enrollment.getStatus().name().toLowerCase())
                             .progress(enrollment.getCompletionPercent() != null ? enrollment.getCompletionPercent() : 0)
                             .totalLessons(lessonCountMap.getOrDefault(courseId, 0L).intValue())

--- a/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3Test.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3Test.java
@@ -160,6 +160,48 @@ class StudentEnrollmentControllerV3Test {
     }
 
     @Test
+    @DisplayName("enrolled course thumbnail should match the course cover image")
+    void getEnrolledCoursesUsesCourseThumbnailOnly() {
+        UUID studentId = UUID.randomUUID();
+        UUID courseId = UUID.randomUUID();
+        UserJpaEntity student = student(studentId);
+        Enrollment enrollment = enrollmentForCourse(studentId, courseId);
+        CourseJpaEntity course = CourseJpaEntity.builder()
+                .id(courseId)
+                .title("Weather routing")
+                .description("Route monitoring course")
+                .introVideoUrl("https://youtube.com/watch?v=intro")
+                .build();
+        course.setThumbnailUrl(null);
+
+        when(enrollmentRepository.findActiveAndCompletedWithClass(studentId))
+                .thenReturn(List.of(enrollment));
+        when(courseJpaRepository.findAllById(any())).thenReturn(List.of(course));
+        when(userJpaRepository.findAllById(any())).thenReturn(List.of());
+        when(chapterJpaRepository.findByCourseIdInOrderByOrderIndex(any())).thenReturn(List.of());
+        when(paymentTransactionJpaRepository.findPaidCourseIds(eq(studentId), any(), any()))
+                .thenReturn(List.of());
+
+        var response = controller.getEnrolledCourses(
+                student,
+                0,
+                20,
+                null,
+                null,
+                null,
+                "recent",
+                "desc"
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().isSuccess()).isTrue();
+        assertThat(response.getBody().getData().getContent())
+                .extracting(StudentEnrollmentControllerV3.EnrolledCourseResponse::getThumbnailUrl)
+                .containsExactly((String) null);
+    }
+
+    @Test
     @DisplayName("issue certificate should return business error when required exam is not passed")
     void issueCertificateReturnsBusinessErrorWhenIneligible() {
         UUID studentId = UUID.randomUUID();

--- a/fe/src/app/api/client/course.api.ts
+++ b/fe/src/app/api/client/course.api.ts
@@ -23,6 +23,29 @@ function mapSpringPagePagination(page: any): PaginationInfo | undefined {
   };
 }
 
+function firstNonEmptyString(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return '';
+}
+
+function normalizeCourseThumbnail<T extends Record<string, any>>(course: T): T {
+  const thumbnailUrl = firstNonEmptyString(
+    course['thumbnailUrl'],
+    course['thumbnail'],
+    course['coverImageUrl'],
+    course['imageUrl']
+  );
+
+  return {
+    ...course,
+    thumbnailUrl
+  };
+}
+
 @Injectable({ providedIn: 'root' })
 export class CourseApi {
   private api = inject(ApiClient);
@@ -33,7 +56,12 @@ export class CourseApi {
   }
 
   getCourseById(id: string) {
-    return this.api.getWithResponse<CourseDetail>(COURSE_ENDPOINTS.BY_ID(id));
+    return this.api.getWithResponse<CourseDetail>(COURSE_ENDPOINTS.BY_ID(id)).pipe(
+      map((res: ApiResponse<CourseDetail>) => ({
+        ...res,
+        data: res?.data ? normalizeCourseThumbnail(res.data as any) : res?.data
+      }) as ApiResponse<CourseDetail>)
+    );
   }
 
   updateCourse(id: string, payload: Partial<CreateCourseRequest>) {
@@ -49,18 +77,20 @@ export class CourseApi {
     // Unwrap Spring Page response to a flat array - fetch all for client-side pagination
     return this.api.getWithResponse<any>(`${COURSE_ENDPOINTS.TEACHER.MY_COURSES}?page=0&size=100`).pipe(
       map((res: ApiResponse<any>) => {
-        const content: CourseSummary[] = (res?.data?.content ?? []).map((c: any) => ({
-          ...c,
-          enrolledCount: c.enrolledCount ?? c.studentsCount ?? 0,
-          thumbnailUrl: c.thumbnail ?? c.thumbnailUrl,
-          deliveryMode: c.deliveryMode,
-          sectionCount: c.sectionCount ?? 0,
-          lessonCount: c.lessonCount ?? 0,
-          categoryName: c.categoryName,
-          updatedAt: c.updatedAt,
-          maxStudents: c.maxStudents,
-          teacherRole: c.teacherRole
-        }));
+        const content: CourseSummary[] = (res?.data?.content ?? []).map((c: any) => {
+          const course = normalizeCourseThumbnail(c);
+          return {
+            ...course,
+            enrolledCount: course.enrolledCount ?? course.studentsCount ?? 0,
+            deliveryMode: course.deliveryMode,
+            sectionCount: course.sectionCount ?? 0,
+            lessonCount: course.lessonCount ?? 0,
+            categoryName: course.categoryName,
+            updatedAt: course.updatedAt,
+            maxStudents: course.maxStudents,
+            teacherRole: course.teacherRole
+          };
+        });
         return {
           data: content,
           pagination: res?.pagination,
@@ -74,7 +104,9 @@ export class CourseApi {
     return this.api.getWithResponse<any>(COURSE_ENDPOINTS.BASE, { params }).pipe(
       map((res: ApiResponse<any>) => {
         const page = res?.data;
-        const content: CourseSummary[] = page?.content ?? [];
+        const content: CourseSummary[] = (page?.content ?? []).map((course: any) =>
+          normalizeCourseThumbnail(course)
+        );
         return {
           data: content,
           pagination: mapSpringPagePagination(page) ?? res?.pagination,
@@ -88,7 +120,9 @@ export class CourseApi {
     return this.api.getWithResponse<any>(COURSE_ENDPOINTS.STUDENT.ENROLLED, { params }).pipe(
       map((res: ApiResponse<any>) => {
         const page = res?.data;
-        const content: CourseSummary[] = page?.content ?? [];
+        const content: CourseSummary[] = (page?.content ?? []).map((course: any) =>
+          normalizeCourseThumbnail(course)
+        );
         return {
           data: content,
           pagination: mapSpringPagePagination(page) ?? res?.pagination,

--- a/fe/src/app/api/types/course.types.ts
+++ b/fe/src/app/api/types/course.types.ts
@@ -39,6 +39,7 @@ export interface CourseSummary {
   code: string;
   title: string;
   description: string;
+  thumbnailUrl?: string;
   status: string;
   teacherName: string;
   enrolledCount: number;
@@ -58,7 +59,6 @@ export interface CourseSummary {
   maxStudents?: number;
   averageRating?: number;
   // Enrollment fields (from StudentEnrollmentControllerV3)
-  thumbnailUrl?: string;
   progress?: number;
   totalLessons?: number;
   completedLessons?: number;
@@ -84,6 +84,7 @@ export interface CourseDetail {
   code: string;
   title: string;
   description: string;
+  thumbnailUrl?: string;
   status: string;
   reviewState?: string;
   draftChangeStatus?: string | null;

--- a/fe/src/app/features/student/services/enrollment.service.ts
+++ b/fe/src/app/features/student/services/enrollment.service.ts
@@ -232,7 +232,7 @@ export class StudentEnrollmentService {
       duration: totalLessons > 0 ? `${Math.ceil(totalLessons * 0.5)} giờ` : '',
       deadline: undefined,
       status,
-      thumbnail: courseAny.thumbnailUrl || '',
+      thumbnail: courseAny.thumbnailUrl || courseAny.thumbnail || '',
       category: courseAny.categoryName || undefined,
       deliveryMode: course.deliveryMode || 'SELF_PACED',
       allowOfflineDownload: courseAny.allowOfflineDownload !== false,

--- a/fe/src/app/state/course.service.ts
+++ b/fe/src/app/state/course.service.ts
@@ -277,7 +277,7 @@ export class CourseService {
       title: course.title,
       description: course.description || '',
       shortDescription: course.description?.substring(0, 100) || '',
-      thumbnail: (course as CourseDetail & { thumbnailUrl?: string }).thumbnailUrl || null as any,
+      thumbnail: course.thumbnailUrl || null as any,
       instructor: {
         id: course.teacherId || '',
         name: course.teacherName || 'Giảng viên',


### PR DESCRIPTION
## Summary
- Keep enrolled-course API thumbnails aligned with the course cover image by removing the intro-video URL fallback.
- Normalize course image fields in the Angular course API client so detail, browse, dashboard, and teacher/course state consumers all receive a consistent `thumbnailUrl`.
- Add coverage for enrolled-course thumbnail behavior when a course has an intro video but no cover image.

## Validation
- `mvn -Dtest=StudentEnrollmentControllerV3Test test`
- `npx ng build --configuration development --progress=false`

Note: the Angular build still reports existing extended diagnostic/Sass warnings outside this change, but it completes successfully.