### PR TITLE
[codex] Use published thumbnails in course lists

### DIFF
--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/repository/CoursePublicationJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/persistence/repository/CoursePublicationJpaRepository.java
@@ -2,8 +2,11 @@ package com.example.lms.course_authoring.infrastructure.persistence.repository;
 
 import com.example.lms.course_authoring.infrastructure.persistence.entity.CoursePublicationJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -16,4 +19,16 @@ public interface CoursePublicationJpaRepository extends JpaRepository<CoursePubl
     long countByCourseId(UUID courseId);
 
     List<CoursePublicationJpaEntity> findByCourseIdOrderByPublicationNumberDesc(UUID courseId);
+
+    @Query("""
+            SELECT publication
+            FROM CoursePublicationJpaEntity publication
+            WHERE publication.courseId IN :courseIds
+              AND publication.publicationNumber = (
+                  SELECT MAX(latest.publicationNumber)
+                  FROM CoursePublicationJpaEntity latest
+                  WHERE latest.courseId = publication.courseId
+              )
+            """)
+    List<CoursePublicationJpaEntity> findLatestByCourseIdIn(@Param("courseIds") Collection<UUID> courseIds);
 }

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/service/CoursePublicationService.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/service/CoursePublicationService.java
@@ -151,6 +151,33 @@ public class CoursePublicationService {
                 .orElse(null);
     }
 
+    @Transactional(readOnly = true)
+    public Map<UUID, Map<String, Object>> getPublishedDetails(Collection<UUID> courseIds, UUID studentId) {
+        if (courseIds == null || courseIds.isEmpty()) {
+            return Map.of();
+        }
+
+        if (studentId != null) {
+            Map<UUID, Map<String, Object>> detailsByCourseId = new LinkedHashMap<>();
+            for (UUID courseId : courseIds) {
+                Map<String, Object> detail = getPublishedDetail(courseId, studentId);
+                if (detail != null) {
+                    detailsByCourseId.put(courseId, detail);
+                }
+            }
+            return detailsByCourseId;
+        }
+
+        Map<UUID, Map<String, Object>> detailsByCourseId = new LinkedHashMap<>();
+        for (CoursePublicationJpaEntity publication : publicationRepository.findLatestByCourseIdIn(courseIds)) {
+            Map<String, Object> detail = publishedDetailSnapshot(publication);
+            if (detail != null) {
+                detailsByCourseId.put(publication.getCourseId(), detail);
+            }
+        }
+        return detailsByCourseId;
+    }
+
     @SuppressWarnings("unchecked")
     @Transactional(readOnly = true)
     public List<Map<String, Object>> getPublishedContent(UUID courseId, UUID studentId) {
@@ -203,6 +230,20 @@ public class CoursePublicationService {
         Map<String, Object> detail = new LinkedHashMap<>(detailSnapshot);
         applyIntroVideoAssetView(detail, parseVideoAssetId(detail.get("introVideoAssetId")));
         return detail;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> publishedDetailSnapshot(CoursePublicationJpaEntity publication) {
+        if (publication == null || publication.getSnapshot() == null) {
+            return null;
+        }
+
+        Object detail = publication.getSnapshot().get("detail");
+        if (!(detail instanceof Map<?, ?>)) {
+            return null;
+        }
+
+        return new LinkedHashMap<>((Map<String, Object>) detail);
     }
 
     private List<Map<String, Object>> buildCourseContent(UUID courseId) {

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
@@ -128,8 +128,13 @@ public class CourseQueryControllerV3 {
                                 row -> (Long) row[1]
                         ));
 
+        Map<UUID, Map<String, Object>> publishedDetails = Optional
+                .ofNullable(coursePublicationService.getPublishedDetails(courseIds, null))
+                .orElse(Map.of());
+
         Page<CourseSummaryResponse> response = courses.map(course ->
-                toSummaryBatch(course, teacherNameMap, categoryNameMap, enrollmentCountMap, chapterCountMap));
+                toSummaryBatch(course, teacherNameMap, categoryNameMap, enrollmentCountMap, chapterCountMap,
+                        publishedDetails.get(course.getId())));
         return ResponseEntity.ok(ApiResponse.success(response, "Danh sách khóa học"));
     }
 
@@ -825,7 +830,8 @@ public class CourseQueryControllerV3 {
             Map<UUID, String> teacherNameMap,
             Map<UUID, String> categoryNameMap,
             Map<UUID, Long> enrollmentCountMap,
-            Map<UUID, Long> chapterCountMap
+            Map<UUID, Long> chapterCountMap,
+            Map<String, Object> publishedDetail
     ) {
         String teacherName = course.getTeacherId() != null ? teacherNameMap.getOrDefault(course.getTeacherId(), "") : "";
         String categoryName = course.getCategoryId() != null ? categoryNameMap.get(course.getCategoryId()) : null;
@@ -834,7 +840,7 @@ public class CourseQueryControllerV3 {
                 .code(course.getCode() != null ? course.getCode().getValue() : null)
                 .title(course.getTitle())
                 .description(course.getDescription())
-                .thumbnailUrl(course.getThumbnailUrl())
+                .thumbnailUrl(resolvePublishedThumbnailUrl(course, publishedDetail))
                 .status(course.getStatus().name().toLowerCase())
                 .teacherName(teacherName)
                 .createdAt(course.getCreatedAt() != null ? course.getCreatedAt().toString() : null)
@@ -847,6 +853,14 @@ public class CourseQueryControllerV3 {
                 .enrolledCount(enrollmentCountMap.getOrDefault(course.getId(), 0L).intValue())
                 .chapterCount(chapterCountMap.getOrDefault(course.getId(), 0L).intValue())
                 .build();
+    }
+
+    private String resolvePublishedThumbnailUrl(Course course, Map<String, Object> publishedDetail) {
+        if (publishedDetail != null && publishedDetail.containsKey("thumbnailUrl")) {
+            Object thumbnailUrl = publishedDetail.get("thumbnailUrl");
+            return thumbnailUrl instanceof String value ? value : null;
+        }
+        return course.getThumbnailUrl();
     }
 
     private CourseDetailResponse toDetail(Course course) {

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3.java
@@ -8,6 +8,7 @@ import com.example.lms.course_authoring.infrastructure.persistence.repository.Ch
 import com.example.lms.course_authoring.infrastructure.persistence.repository.LessonJpaRepository;
 import com.example.lms.course_authoring.infrastructure.persistence.entity.ChapterJpaEntity;
 import com.example.lms.course_authoring.infrastructure.persistence.entity.LessonJpaEntity;
+import com.example.lms.course_authoring.infrastructure.service.CoursePublicationService;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
 import com.example.lms.learning_delivery.domain.model.Enrollment;
@@ -69,6 +70,7 @@ public class StudentEnrollmentControllerV3 {
     private final QuizJpaRepositoryV3 quizJpaRepository;
     private final QuizAttemptJpaRepository quizAttemptJpaRepository;
     private final com.example.lms.shared.infrastructure.persistence.repository.PaymentTransactionJpaRepository paymentTransactionJpaRepository;
+    private final CoursePublicationService coursePublicationService;
 
     @Operation(summary = "Get student's enrolled courses")
     @GetMapping("/courses/enrolled")
@@ -174,6 +176,9 @@ public class StudentEnrollmentControllerV3 {
                         studentId, courseIds,
                         com.example.lms.shared.infrastructure.persistence.entity.PaymentTransactionJpaEntity.PaymentStatus.COMPLETED))
                 : Set.of();
+        Map<UUID, Map<String, Object>> publishedDetails = Optional
+                .ofNullable(coursePublicationService.getPublishedDetails(courseIds, studentId))
+                .orElse(Map.of());
 
         // Build response with real course data
         Map<UUID, CourseJpaEntity> finalCourseMap = courseMap;
@@ -206,7 +211,7 @@ public class StudentEnrollmentControllerV3 {
                             .description(description)
                             .teacherName(teacherName)
                             .categoryName(categoryName)
-                            .thumbnailUrl(course != null ? course.getThumbnailUrl() : null)
+                            .thumbnailUrl(resolvePublishedThumbnailUrl(course, publishedDetails.get(courseId)))
                             .status(enrollment.getStatus().name().toLowerCase())
                             .progress(enrollment.getCompletionPercent() != null ? enrollment.getCompletionPercent() : 0)
                             .totalLessons(lessonCountMap.getOrDefault(courseId, 0L).intValue())
@@ -1150,6 +1155,14 @@ private Map<String, Object> buildSectionCompletionResponse(
         }
         return normalizedSearch == null
                 || normalizeForSearch(course.getTitle()).contains(normalizedSearch);
+    }
+
+    private String resolvePublishedThumbnailUrl(CourseJpaEntity course, Map<String, Object> publishedDetail) {
+        if (publishedDetail != null && publishedDetail.containsKey("thumbnailUrl")) {
+            Object thumbnailUrl = publishedDetail.get("thumbnailUrl");
+            return thumbnailUrl instanceof String value ? value : null;
+        }
+        return course != null ? course.getThumbnailUrl() : null;
     }
 
     private void sortEnrolledCourseResponses(List<EnrolledCourseResponse> courseResponses, String sort, String order) {

--- a/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3ContractTest.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3ContractTest.java
@@ -114,6 +114,33 @@ class CourseQueryControllerV3ContractTest {
     }
 
     @Test
+    @DisplayName("public course list should use the published thumbnail snapshot")
+    void getPublicCoursesUsesPublishedThumbnailSnapshot() {
+        approvedPaidCourse.updateThumbnail("https://cdn.example.com/draft-cover.jpg");
+        Map<String, Object> publishedDetail = Map.of(
+                "thumbnailUrl", "https://cdn.example.com/published-cover.jpg"
+        );
+
+        when(courseRepository.findByStatusAndFilters(eq(Course.CourseStatus.APPROVED), any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(approvedPaidCourse)));
+        when(userJpaRepository.findAllById(any())).thenReturn(List.of());
+        when(enrollmentJpaRepository.countEnrollmentsByCourseIds(any())).thenReturn(List.of());
+        when(chapterRepository.countByCourseIds(any())).thenReturn(List.of());
+        when(coursePublicationService.getPublishedDetails(any(), eq(null)))
+                .thenReturn(Map.of(approvedPaidCourse.getId(), publishedDetail));
+
+        var response = controller.getPublicCourses(0, 20, null, null, null, null, null);
+
+        assertThat(response.getBody()).isNotNull();
+        @SuppressWarnings("unchecked")
+        var page = (org.springframework.data.domain.Page<CourseQueryControllerV3.CourseSummaryResponse>)
+                response.getBody().getData();
+
+        assertThat(page.getContent().getFirst().getThumbnailUrl())
+                .isEqualTo("https://cdn.example.com/published-cover.jpg");
+    }
+
+    @Test
     @DisplayName("course detail includes enrolled count for course detail sidebar")
     void getCourseByIdIncludesEnrolledCount() {
         UserJpaEntity teacher = mock(UserJpaEntity.class);

--- a/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3Test.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/StudentEnrollmentControllerV3Test.java
@@ -9,6 +9,7 @@ import com.example.lms.course_authoring.infrastructure.persistence.entity.Course
 import com.example.lms.course_authoring.infrastructure.persistence.entity.LessonJpaEntity;
 import com.example.lms.course_authoring.infrastructure.persistence.repository.ChapterJpaRepository;
 import com.example.lms.course_authoring.infrastructure.persistence.repository.LessonJpaRepository;
+import com.example.lms.course_authoring.infrastructure.service.CoursePublicationService;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRepository;
 import com.example.lms.learning_delivery.application.usecase.CertificateUseCase;
@@ -60,6 +61,7 @@ class StudentEnrollmentControllerV3Test {
     @Mock private QuizJpaRepositoryV3 quizJpaRepository;
     @Mock private QuizAttemptJpaRepository quizAttemptJpaRepository;
     @Mock private PaymentTransactionJpaRepository paymentTransactionJpaRepository;
+    @Mock private CoursePublicationService coursePublicationService;
 
     @InjectMocks
     private StudentEnrollmentControllerV3 controller;
@@ -157,6 +159,52 @@ class StudentEnrollmentControllerV3Test {
         assertThat(response.getBody().getData().getContent())
                 .extracting(StudentEnrollmentControllerV3.EnrolledCourseResponse::getTitle)
                 .containsExactly("Hàng hải căn bản");
+    }
+
+    @Test
+    @DisplayName("enrolled course thumbnail should use the student's published snapshot")
+    void getEnrolledCoursesUsesPublishedThumbnailSnapshot() {
+        UUID studentId = UUID.randomUUID();
+        UUID courseId = UUID.randomUUID();
+        UserJpaEntity student = student(studentId);
+        Enrollment enrollment = enrollmentForCourse(studentId, courseId);
+        CourseJpaEntity course = CourseJpaEntity.builder()
+                .id(courseId)
+                .title("Weather routing")
+                .description("Route monitoring course")
+                .build();
+        course.setThumbnailUrl("https://cdn.example.com/draft-cover.jpg");
+
+        when(enrollmentRepository.findActiveAndCompletedWithClass(studentId))
+                .thenReturn(List.of(enrollment));
+        when(courseJpaRepository.findAllById(any())).thenReturn(List.of(course));
+        when(userJpaRepository.findAllById(any())).thenReturn(List.of());
+        when(chapterJpaRepository.findByCourseIdInOrderByOrderIndex(any())).thenReturn(List.of());
+        when(paymentTransactionJpaRepository.findPaidCourseIds(eq(studentId), any(), any()))
+                .thenReturn(List.of());
+        when(coursePublicationService.getPublishedDetails(any(), eq(studentId)))
+                .thenReturn(Map.of(
+                        courseId,
+                        Map.of("thumbnailUrl", "https://cdn.example.com/published-cover.jpg")
+                ));
+
+        var response = controller.getEnrolledCourses(
+                student,
+                0,
+                20,
+                null,
+                null,
+                null,
+                "recent",
+                "desc"
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().isSuccess()).isTrue();
+        assertThat(response.getBody().getData().getContent())
+                .extracting(StudentEnrollmentControllerV3.EnrolledCourseResponse::getThumbnailUrl)
+                .containsExactly("https://cdn.example.com/published-cover.jpg");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Resolve public course-list thumbnails from the latest published course snapshot, matching the public course detail page source.
- Resolve enrolled/student-library thumbnails from the student-visible published snapshot before falling back to the course table.
- Add backend coverage for public browse and enrolled course thumbnail consistency.

## Root cause
`/api/v3/courses/{id}` prefers the published snapshot for public detail pages, but course list endpoints were still returning the mutable course-table thumbnail. That let `/student/browse` and `/courses/{id}` show different images for the same published course.

## Validation
- `git diff --check`
- `mvn '-Dtest=CourseQueryControllerV3ContractTest,StudentEnrollmentControllerV3Test' test`