### PR TITLE
[codex] Fix student results pagination

### DIFF
--- a/fe/src/app/features/student/grades/student-grades.component.html
+++ b/fe/src/app/features/student/grades/student-grades.component.html
@@ -178,12 +178,12 @@
       <!-- Pagination -->
       @if (totalPages() > 1) {
         <app-pagination
-          class="results-pagination"
-          [currentPage]="safeCurrentPage()"
+          class="results-pagination mx-auto mt-8 mb-8 block w-full max-w-5xl overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm"
+          [currentPage]="safeCurrentPage() + 1"
           [totalPages]="totalPages()"
           [totalItems]="filteredGrades().length"
           [itemsPerPage]="PAGE_SIZE"
-          (pageChange)="goToPage($event)" />
+          (pageChange)="goToPage($event - 1)" />
       }
     }
   }

--- a/fe/src/app/features/student/grades/student-grades.component.html
+++ b/fe/src/app/features/student/grades/student-grades.component.html
@@ -175,18 +175,15 @@
         }
       </div>
 
-      <!-- Load More -->
-      @if (hasMoreGrades()) {
-        <div class="load-more-section">
-          <button type="button" class="load-more-btn" (click)="loadMoreGrades()">
-            Xem thêm {{ remainingGrades() }} kết quả
-          </button>
-          <p class="load-more-count">Đang hiện {{ visibleGrades().length }} / {{ filteredGrades().length }}</p>
-        </div>
-      } @else if (filteredGrades().length > 5) {
-        <p class="load-more-count" style="text-align:center;padding-top:16px">
-          Tất cả {{ filteredGrades().length }} kết quả
-        </p>
+      <!-- Pagination -->
+      @if (totalPages() > 1) {
+        <app-pagination
+          class="results-pagination"
+          [currentPage]="safeCurrentPage()"
+          [totalPages]="totalPages()"
+          [totalItems]="filteredGrades().length"
+          [itemsPerPage]="PAGE_SIZE"
+          (pageChange)="goToPage($event)" />
       }
     }
   }

--- a/fe/src/app/features/student/grades/student-grades.component.scss
+++ b/fe/src/app/features/student/grades/student-grades.component.scss
@@ -315,19 +315,6 @@
   color: $gray-400;
 }
 
-/* ===== PAGINATION ===== */
-.results-pagination {
-  display: block;
-  width: 100%;
-  max-width: 1024px;
-  margin: $spacing-8 auto $spacing-6;
-  background: white;
-  border: 1px solid $gray-200;
-  border-radius: $radius-md;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
-  overflow: hidden;
-}
-
 /* ===== EMPTY STATE ===== */
 .empty-state {
   @extend .card;

--- a/fe/src/app/features/student/grades/student-grades.component.scss
+++ b/fe/src/app/features/student/grades/student-grades.component.scss
@@ -315,32 +315,17 @@
   color: $gray-400;
 }
 
-/* ===== LOAD MORE ===== */
-.load-more-section {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: $spacing-2;
-  padding-top: $spacing-4;
-}
-
-.load-more-btn {
-  padding: 10px 24px;
+/* ===== PAGINATION ===== */
+.results-pagination {
+  display: block;
+  width: 100%;
+  max-width: 1024px;
+  margin: $spacing-8 auto $spacing-6;
+  background: white;
   border: 1px solid $gray-200;
   border-radius: $radius-md;
-  background: white;
-  font-size: $text-sm;
-  font-weight: $font-medium;
-  color: $gray-700;
-  cursor: pointer;
-  transition: all $transition-normal;
-
-  &:hover { border-color: $blue-primary; color: $blue-primary; background: rgba($blue-primary, 0.04); }
-}
-
-.load-more-count {
-  font-size: $text-xs;
-  color: $gray-400;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+  overflow: hidden;
 }
 
 /* ===== EMPTY STATE ===== */
@@ -421,7 +406,7 @@
   .grades-header { margin-bottom: 10px; }
   .grades-title { font-size: 18px; }
 
-  .main-tabs, .filter-bar, .load-more-section { display: none !important; }
+  .main-tabs, .filter-bar, .results-pagination { display: none !important; }
 
   .card, .grade-card, .empty-state, .cert-card {
     box-shadow: none !important;

--- a/fe/src/app/features/student/grades/student-grades.component.ts
+++ b/fe/src/app/features/student/grades/student-grades.component.ts
@@ -123,15 +123,15 @@ export class StudentGradesComponent implements OnInit {
 
   // === Pagination ===
   readonly PAGE_SIZE = 12;
-  currentPage = signal(1);
+  currentPage = signal(0);
   totalPages = computed(() =>
     Math.max(1, Math.ceil(this.filteredGrades().length / this.PAGE_SIZE))
   );
   safeCurrentPage = computed(() =>
-    Math.min(Math.max(1, this.currentPage()), this.totalPages())
+    Math.min(Math.max(0, this.currentPage()), this.totalPages() - 1)
   );
   visibleGrades = computed(() => {
-    const start = (this.safeCurrentPage() - 1) * this.PAGE_SIZE;
+    const start = this.safeCurrentPage() * this.PAGE_SIZE;
     return this.filteredGrades().slice(start, start + this.PAGE_SIZE);
   });
 
@@ -186,8 +186,8 @@ export class StudentGradesComponent implements OnInit {
   }
 
   goToPage(page: number): void {
-    const nextPage = Math.min(Math.max(1, page), this.totalPages());
-    this.currentPage.set(nextPage);
+    if (page < 0 || page >= this.totalPages()) return;
+    this.currentPage.set(page);
     if (typeof window !== 'undefined') {
       window.scrollTo({ top: 0, behavior: 'smooth' });
     }
@@ -236,6 +236,6 @@ export class StudentGradesComponent implements OnInit {
   }
 
   private resetPagination(): void {
-    this.currentPage.set(1);
+    this.currentPage.set(0);
   }
 }

--- a/fe/src/app/features/student/grades/student-grades.component.ts
+++ b/fe/src/app/features/student/grades/student-grades.component.ts
@@ -4,6 +4,7 @@ import { RouterModule, Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 import { ApiClient } from '../../../api/client/api-client';
 import { CertificateApi, CertificateDTO } from '../../../api/endpoints/certificate.api';
+import { PaginationComponent } from '../../../shared/components/pagination/pagination.component';
 
 type DeliveryMode = 'SELF_PACED' | 'INSTRUCTOR_LED';
 type EnrollmentStatus = 'ACTIVE' | 'COMPLETED';
@@ -54,7 +55,7 @@ interface StatusTab {
 
 @Component({
   selector: 'app-student-grades',
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, PaginationComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './student-grades.component.html',
   styleUrl: './student-grades.component.scss',
@@ -120,12 +121,19 @@ export class StudentGradesComponent implements OnInit {
 
   certBadgeCount = computed(() => this.grades().filter(g => g.hasCertificate).length);
 
-  // === Load More ===
-  private readonly LOAD_MORE_COUNT = 5;
-  visibleCount = signal(5);
-  visibleGrades = computed(() => this.filteredGrades().slice(0, this.visibleCount()));
-  hasMoreGrades = computed(() => this.visibleCount() < this.filteredGrades().length);
-  remainingGrades = computed(() => Math.max(0, this.filteredGrades().length - this.visibleCount()));
+  // === Pagination ===
+  readonly PAGE_SIZE = 12;
+  currentPage = signal(1);
+  totalPages = computed(() =>
+    Math.max(1, Math.ceil(this.filteredGrades().length / this.PAGE_SIZE))
+  );
+  safeCurrentPage = computed(() =>
+    Math.min(Math.max(1, this.currentPage()), this.totalPages())
+  );
+  visibleGrades = computed(() => {
+    const start = (this.safeCurrentPage() - 1) * this.PAGE_SIZE;
+    return this.filteredGrades().slice(start, start + this.PAGE_SIZE);
+  });
 
   // === Expand/Collapse per enrollment ===
   expandedEnrollments = signal<Set<string>>(new Set());
@@ -169,16 +177,20 @@ export class StudentGradesComponent implements OnInit {
 
   setStatusFilter(key: StatusFilterKey): void {
     this.activeStatusFilter.set(key);
-    this.visibleCount.set(5);
+    this.resetPagination();
   }
 
   setSemesterFilter(semester: string | null): void {
     this.selectedSemester.set(semester);
-    this.visibleCount.set(5);
+    this.resetPagination();
   }
 
-  loadMoreGrades(): void {
-    this.visibleCount.update(c => c + this.LOAD_MORE_COUNT);
+  goToPage(page: number): void {
+    const nextPage = Math.min(Math.max(1, page), this.totalPages());
+    this.currentPage.set(nextPage);
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
   }
 
   async loadCertificates(): Promise<void> {
@@ -221,5 +233,9 @@ export class StudentGradesComponent implements OnInit {
       case 'OVERDUE': return 'Quá hạn';
       default: return 'Chưa nộp';
     }
+  }
+
+  private resetPagination(): void {
+    this.currentPage.set(1);
   }
 }


### PR DESCRIPTION
## Description

Replace the student results page load-more flow with the shared numbered pagination component used on `/student/browse`.

## Motivation

`/student/results` still used a local 5-item incremental load pattern while `/student/browse` already used shared pagination. This made result browsing inconsistent and left the footer/count copy different from the rest of the student experience.

## Changes Made

- Use `app-pagination` in `student-grades.component.html` instead of the old `Xem thêm` button.
- Paginate results at 12 items per page, matching the browse page page size.
- Align results page state with browse: 0-based page state internally, 1-based binding into the shared pagination component.
- Reuse the same pagination wrapper classes from `/student/browse` for visual consistency.
- Reset page state when status or semester filters change.
- Scroll back to the top when the user changes page.
- Remove obsolete load-more styling.

## Scope Note

This PR does not change result data fetching, grade calculations, filters, semester logic, or card content. It only changes local pagination presentation and page state.

## Testing Guide

1. Open `/student/results` with more than 12 results.
2. Change pages with the numbered pagination controls and confirm the visible range updates correctly.
3. Change status or semester filters and confirm pagination resets to page 1.
4. Compare the pagination behavior and styling with `/student/browse`.

## Local Checks

- `npm run build` - pass

Notes: build still reports existing Angular template optional/nullish, Sass `@import`, and CommonJS dependency warnings outside this change.

## GitHub CI

- Backend Tests - pass
- Frontend Build - pass
- Compose Validation - pass
- Docker Smoke Test - pass

## Checklist

- [x] Focused fix with no unrelated refactor
- [x] Risk-appropriate validation completed
- [x] Frontend build passed locally
- [x] Latest GitHub CI completed after final push
- [x] PR remains draft for review