### PR TITLE
[codex] Fix interactive video strict seek mode

### DIFF
--- a/fe/src/app/core/utils/interactive-video-runtime.spec.ts
+++ b/fe/src/app/core/utils/interactive-video-runtime.spec.ts
@@ -3,10 +3,12 @@ import type {
   InteractiveVideoSpec,
 } from '../../api/types/interactive-video.types';
 import {
+  addInteractiveVideoWatchedRange,
   evaluateInteractiveVideoDragDrop,
   evaluateInteractiveVideoFillBlank,
   getDueInteractiveVideoInteraction,
   getVisibleInteractiveVideoInteractions,
+  isInteractiveVideoTimeWithinWatchedRanges,
   isInteractiveVideoReviewInteraction,
   resolveInteractiveVideoChoiceTarget,
   resolveInteractiveVideoReviewTarget,
@@ -199,6 +201,47 @@ describe('interactive-video-runtime', () => {
       furthestWatchedSeconds: 45,
       hasIncompleteRequiredInteractions: true,
     })).toBeFalse();
+  });
+
+  it('requires both-mode seek targets to land inside watched ranges', () => {
+    const spec: InteractiveVideoSpec = {
+      version: 2,
+      enabled: true,
+      behavior: { preventSkippingMode: 'both' },
+      timeline,
+    };
+    const watchedRanges = [
+      { startSeconds: 0, endSeconds: 30 },
+      { startSeconds: 80, endSeconds: 90 },
+    ];
+
+    expect(shouldBlockInteractiveVideoSeek({
+      spec,
+      targetTimeSeconds: 60,
+      furthestWatchedSeconds: 90,
+      hasIncompleteRequiredInteractions: true,
+      watchedRanges,
+    })).toBeTrue();
+
+    expect(shouldBlockInteractiveVideoSeek({
+      spec,
+      targetTimeSeconds: 85,
+      furthestWatchedSeconds: 90,
+      hasIncompleteRequiredInteractions: true,
+      watchedRanges,
+    })).toBeFalse();
+  });
+
+  it('merges watched playback ranges and applies seek grace at range edges', () => {
+    const watchedRanges = addInteractiveVideoWatchedRange(
+      addInteractiveVideoWatchedRange([], 0, 12),
+      12.25,
+      24,
+    );
+
+    expect(watchedRanges).toEqual([{ startSeconds: 0, endSeconds: 24 }]);
+    expect(isInteractiveVideoTimeWithinWatchedRanges(25, watchedRanges, 1)).toBeTrue();
+    expect(isInteractiveVideoTimeWithinWatchedRanges(30, watchedRanges, 1)).toBeFalse();
   });
 
   it('evaluates fill-blank answers with alternatives and case-insensitive matching by default', () => {

--- a/fe/src/app/core/utils/interactive-video-runtime.ts
+++ b/fe/src/app/core/utils/interactive-video-runtime.ts
@@ -9,6 +9,7 @@ import type {
 
 const OPTIONAL_INTERACTION_WINDOW_SECONDS = 5;
 const SEEK_GRACE_SECONDS = 3;
+const WATCHED_RANGE_MERGE_GAP_SECONDS = 0.75;
 
 export interface InteractiveVideoTimelineLookup {
   timeline: InteractiveVideoInteraction[];
@@ -22,7 +23,13 @@ export interface InteractiveVideoSeekPolicyInput {
   targetTimeSeconds: number;
   furthestWatchedSeconds: number;
   hasIncompleteRequiredInteractions: boolean;
+  watchedRanges?: readonly InteractiveVideoWatchedRange[];
   graceSeconds?: number;
+}
+
+export interface InteractiveVideoWatchedRange {
+  startSeconds: number;
+  endSeconds: number;
 }
 
 export interface InteractiveVideoChoiceTargetOptions {
@@ -296,13 +303,65 @@ export function shouldBlockInteractiveVideoSeek(input: InteractiveVideoSeekPolic
   const furthestWatched = toNonNegativeSeconds(input.furthestWatchedSeconds);
   const grace = Math.max(0, input.graceSeconds ?? SEEK_GRACE_SECONDS);
 
-  // 'forward' and 'both' currently share the same forward gate. The design
-  // doc reserves 'both' for "navigation constrained to visited/completed
-  // ranges" (strict review mode), which would also block backward jumps to
-  // unvisited regions. Implementing that requires tracking the set of
-  // visited stretches, not just the furthest mark, and is intentionally
-  // deferred until visited-range bookkeeping lands.
-  return target > furthestWatched + grace;
+  if (target > furthestWatched + grace) {
+    return true;
+  }
+
+  if (mode !== 'both' || !input.watchedRanges?.length) {
+    return false;
+  }
+
+  return !isInteractiveVideoTimeWithinWatchedRanges(target, input.watchedRanges, grace);
+}
+
+export function addInteractiveVideoWatchedRange(
+  ranges: readonly InteractiveVideoWatchedRange[],
+  startSeconds: number,
+  endSeconds: number,
+): InteractiveVideoWatchedRange[] {
+  if (!Number.isFinite(startSeconds) || !Number.isFinite(endSeconds)) {
+    return [...ranges];
+  }
+
+  const nextRange = {
+    startSeconds: Math.max(0, Math.min(startSeconds, endSeconds)),
+    endSeconds: Math.max(0, Math.max(startSeconds, endSeconds)),
+  };
+  const sorted = [...ranges, nextRange]
+    .map(range => ({
+      startSeconds: toNonNegativeSeconds(range.startSeconds),
+      endSeconds: toNonNegativeSeconds(range.endSeconds),
+    }))
+    .filter(range => range.endSeconds >= range.startSeconds)
+    .sort((a, b) => a.startSeconds - b.startSeconds);
+
+  return sorted.reduce<InteractiveVideoWatchedRange[]>((merged, range) => {
+    const previous = merged[merged.length - 1];
+    if (!previous || range.startSeconds > previous.endSeconds + WATCHED_RANGE_MERGE_GAP_SECONDS) {
+      merged.push({ ...range });
+      return merged;
+    }
+
+    previous.endSeconds = Math.max(previous.endSeconds, range.endSeconds);
+    return merged;
+  }, []);
+}
+
+export function isInteractiveVideoTimeWithinWatchedRanges(
+  timeSeconds: number,
+  ranges: readonly InteractiveVideoWatchedRange[],
+  graceSeconds = 0,
+): boolean {
+  if (!Number.isFinite(timeSeconds)) {
+    return false;
+  }
+
+  const time = Math.max(0, timeSeconds);
+  const grace = Math.max(0, graceSeconds);
+  return ranges.some(range =>
+    time >= toNonNegativeSeconds(range.startSeconds) - grace
+    && time <= toNonNegativeSeconds(range.endSeconds) + grace,
+  );
 }
 
 function getInteractionEndSeconds(interaction: InteractiveVideoInteraction): number {

--- a/fe/src/app/shared/blocks/video-block/quiz-video-player.component.spec.ts
+++ b/fe/src/app/shared/blocks/video-block/quiz-video-player.component.spec.ts
@@ -149,6 +149,66 @@ describe('QuizVideoPlayerComponent interactive video seek behavior', () => {
     expect(getPrivate<number>(fixture.componentInstance, 'furthestWatchedSeconds')).toBe(25);
   });
 
+  it('blocks strict both-mode seeks into unwatched gaps', () => {
+    const video = prepareVideoElement(90, 120);
+    const required: InteractiveVideoInteraction = {
+      id: 'required-quiz',
+      type: 'single_choice',
+      atSeconds: 100,
+      required: true,
+      choices: [{ id: 'ack', label: 'Acknowledge', isCorrect: true }],
+    };
+    fixture.componentRef.setInput('interactiveVideoSpec', {
+      version: 2,
+      enabled: true,
+      behavior: { preventSkippingMode: 'both' },
+      timeline: [required],
+    });
+    fixture.componentInstance.currentTimeSeconds.set(90);
+    fixture.detectChanges();
+    setPrivate(fixture.componentInstance, 'furthestWatchedSeconds', 90);
+    setPrivate(fixture.componentInstance, 'watchedRanges', [
+      { startSeconds: 0, endSeconds: 30 },
+      { startSeconds: 80, endSeconds: 90 },
+    ]);
+
+    video.currentTime = 60;
+    fixture.componentInstance.onSeeking();
+
+    expect(video.currentTime).toBe(90);
+    expect(fixture.componentInstance.currentTimeSeconds()).toBe(90);
+  });
+
+  it('allows strict both-mode seeks inside watched ranges', () => {
+    const video = prepareVideoElement(90, 120);
+    const required: InteractiveVideoInteraction = {
+      id: 'required-quiz',
+      type: 'single_choice',
+      atSeconds: 100,
+      required: true,
+      choices: [{ id: 'ack', label: 'Acknowledge', isCorrect: true }],
+    };
+    fixture.componentRef.setInput('interactiveVideoSpec', {
+      version: 2,
+      enabled: true,
+      behavior: { preventSkippingMode: 'both' },
+      timeline: [required],
+    });
+    fixture.componentInstance.currentTimeSeconds.set(90);
+    fixture.detectChanges();
+    setPrivate(fixture.componentInstance, 'furthestWatchedSeconds', 90);
+    setPrivate(fixture.componentInstance, 'watchedRanges', [
+      { startSeconds: 0, endSeconds: 30 },
+      { startSeconds: 80, endSeconds: 90 },
+    ]);
+
+    video.currentTime = 85;
+    fixture.componentInstance.onSeeking();
+
+    expect(video.currentTime).toBe(85);
+    expect(fixture.componentInstance.currentTimeSeconds()).toBe(90);
+  });
+
   function prepareVideoElement(currentTime: number, duration: number): HTMLVideoElement {
     const video = fixture.nativeElement.querySelector('video') as HTMLVideoElement;
     let time = currentTime;

--- a/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
+++ b/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
@@ -14,12 +14,14 @@ import { InteractiveVideoLayerComponent } from './interactive-video-layer.compon
 import { InteractiveVideoOverlayComponent } from './interactive-video-overlay.component';
 import { InteractiveVideoMarkersComponent } from './interactive-video-markers.component';
 import {
+  addInteractiveVideoWatchedRange,
   getDueInteractiveVideoInteraction,
   isInteractiveVideoReviewInteraction,
   resolveInteractiveVideoChoiceTarget,
   resolveInteractiveVideoReviewTarget,
   shouldBlockInteractiveVideoSeek,
 } from '../../../core/utils/interactive-video-runtime';
+import type { InteractiveVideoWatchedRange } from '../../../core/utils/interactive-video-runtime';
 import {
   canUseNativeHlsForManifest,
   shouldPreferNativeHlsForManifest,
@@ -188,6 +190,7 @@ export class QuizVideoPlayerComponent {
   private loadToken = 0;
   private readonly shownInteractionIds = new Set<string>();
   private readonly completedInteractionIds = new Set<string>();
+  private watchedRanges: InteractiveVideoWatchedRange[] = [];
   private furthestWatchedSeconds = 0;
   private isSeeking = false;
   /**
@@ -256,7 +259,7 @@ export class QuizVideoPlayerComponent {
     // timeupdates would otherwise let a single forward jump bypass the
     // anti-skip gate. Backward playback is not possible without seeking.
     if (!this.isSeeking) {
-      this.markInteractiveVideoWatched(video.currentTime);
+      this.markInteractiveVideoWatched(video.currentTime, previousTimeSeconds);
     }
     this.evaluateInteractiveTimeline(video, previousTimeSeconds);
   }
@@ -672,6 +675,7 @@ export class QuizVideoPlayerComponent {
     this.shownInteractionIds.clear();
     this.completedInteractionIds.clear();
     this.completedInteractionIdsSnapshot.set(new Set<string>());
+    this.watchedRanges = [];
     this.furthestWatchedSeconds = 0;
   }
 
@@ -698,9 +702,19 @@ export class QuizVideoPlayerComponent {
       targetTimeSeconds,
       furthestWatchedSeconds: this.furthestWatchedSeconds,
       hasIncompleteRequiredInteractions: this.hasIncompleteRequiredInteractions(),
+      watchedRanges: this.watchedRanges,
     })
-      ? this.furthestWatchedSeconds
+      ? this.resolveBlockedInteractiveSeekTarget(targetTimeSeconds)
       : targetTimeSeconds;
+  }
+
+  private resolveBlockedInteractiveSeekTarget(targetTimeSeconds: number): number {
+    const mode = this.interactiveVideoSpec()?.behavior?.preventSkippingMode ?? 'none';
+    if (mode === 'both' && targetTimeSeconds <= this.furthestWatchedSeconds) {
+      return this.currentTimeSeconds();
+    }
+
+    return this.furthestWatchedSeconds;
   }
 
   private hasIncompleteRequiredInteractions(): boolean {
@@ -714,9 +728,12 @@ export class QuizVideoPlayerComponent {
     );
   }
 
-  private markInteractiveVideoWatched(seconds: number): void {
+  private markInteractiveVideoWatched(seconds: number, previousSeconds = seconds): void {
     if (Number.isFinite(seconds)) {
-      this.furthestWatchedSeconds = Math.max(this.furthestWatchedSeconds, Math.max(0, seconds));
+      const current = Math.max(0, seconds);
+      const previous = Number.isFinite(previousSeconds) ? Math.max(0, previousSeconds) : current;
+      this.furthestWatchedSeconds = Math.max(this.furthestWatchedSeconds, current);
+      this.watchedRanges = addInteractiveVideoWatchedRange(this.watchedRanges, previous, current);
     }
   }
 


### PR DESCRIPTION
## Summary
- Add watched-range tracking for interactive video natural playback.
- Make `preventSkippingMode: 'both'` block seeks into unwatched gaps while keeping `forward` mode behavior unchanged.
- Add runtime and player regression coverage for strict seek policy, watched range merging, and allowed in-range seeks.

## Root cause
The follow-up from the interactive video/H5P PR chain noted that `both` still behaved like `forward` because the player only tracked a furthest-watched mark. That was enough to block forward skips, but not enough to prevent navigation into unvisited gaps after branch/review jumps.

## Validation
- `git diff --check`
- `npx tsc -p tsconfig.spec.json --noEmit`
- `npx ng build --configuration development --progress=false`

## Local test note
Attempted focused Karma: `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include src/app/core/utils/interactive-video-runtime.spec.ts --include src/app/shared/blocks/video-block/quiz-video-player.component.spec.ts`; local Windows runner timed out without output, matching prior interactive-video PR runner behavior. Stale node/chrome processes were cleaned up.