### PR TITLE
Fix admin user data and rubric starters

### DIFF
--- a/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/repository/UserJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/persistence/repository/UserJpaRepository.java
@@ -3,6 +3,7 @@ package com.example.lms.identity.infrastructure.persistence.repository;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,7 +20,7 @@ import java.util.UUID;
  * not directly by application or domain layers.
  */
 @Repository
-public interface UserJpaRepository extends JpaRepository<UserJpaEntity, UUID> {
+public interface UserJpaRepository extends JpaRepository<UserJpaEntity, UUID>, JpaSpecificationExecutor<UserJpaEntity> {
 
     // Custom JPQL — avoids Hibernate 6.x UUID[] ClassCastException with findAllById
     @org.springframework.data.jpa.repository.Query("SELECT u FROM UserJpaEntity u WHERE u.id IN :ids")
@@ -135,4 +136,3 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, UUID> {
     @Query("SELECT COUNT(u) FROM UserJpaEntity u WHERE u.organizationId IS NOT NULL")
     long countByOrganizationIdIsNotNull();
 }
-

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/web/UserControllerV3.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/web/UserControllerV3.java
@@ -28,6 +28,7 @@ import lombok.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -38,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.Normalizer;
 import java.time.Instant;
+import jakarta.persistence.criteria.Predicate;
 import java.util.*;
 import java.util.Locale;
 import java.util.stream.Collectors;
@@ -70,52 +72,40 @@ public class UserControllerV3 {
             @RequestParam(defaultValue = "10") int limit,
             @RequestParam(required = false) String search,
             @RequestParam(required = false) String role,
+            @RequestParam(required = false) String roles,
             @RequestParam(required = false) String status,
             // Issue #229: ADMIN có thể filter user theo tổ chức cụ thể.
             // ORG_ADMIN auto-scoped tới organization của họ — param này
             // bị ignore cho ORG_ADMIN role (security: không cho cross-org).
             @RequestParam(required = false) UUID organizationId,
+            @RequestParam(defaultValue = "false") boolean systemOnly,
             @org.springframework.security.core.annotation.AuthenticationPrincipal UserJpaEntity currentUser
     ) {
         PageRequest pageable = PageRequest.of(Math.max(0, page - 1), limit);
 
-        boolean hasRole = role != null && !role.isBlank();
-        boolean hasSearch = search != null && !search.isBlank();
-        UserJpaEntity.UserRole roleEnum = null;
+        Set<UserJpaEntity.UserRole> roleFilter = parseRoleFilter(role, roles);
+        if (roleFilter == null) {
+            return badRequest("Vai trò không hợp lệ");
+        }
 
-        if (hasRole) {
-            roleEnum = parseRole(role);
-            if (roleEnum == null) {
-                return badRequest("Vai trò không hợp lệ");
-            }
+        String normalizedStatus = normalizeStatus(status);
+        if (status != null && !status.isBlank() && normalizedStatus == null) {
+            return badRequest("Trạng thái không hợp lệ");
         }
 
         if (isOrgAdminWithoutOrganization(currentUser)) {
             return forbidden("Chuyên viên quản lý phải thuộc một tổ chức để xem danh sách người dùng");
         }
 
-        Page<UserJpaEntity> users;
-
-        // ORG_ADMIN: filter to users within their organization (organizationId
-        // param từ FE bị ignore — auto-scope to own org, security boundary).
-        if (isOrgAdmin(currentUser)) {
-            UUID orgId = currentUser.getOrganizationId();
-            users = queryUsersInOrg(orgId, roleEnum, search, hasRole, hasSearch, pageable);
-        } else if (organizationId != null) {
-            // ADMIN with org filter (#229): scope to selected organization
-            users = queryUsersInOrg(organizationId, roleEnum, search, hasRole, hasSearch, pageable);
-        } else {
-            // ADMIN: sees all users across orgs (unchanged behavior)
-            if (hasRole && hasSearch) {
-                users = userRepository.searchUsersByRole(roleEnum, search, pageable);
-            } else if (hasRole) {
-                users = userRepository.findByRole(roleEnum, pageable);
-            } else if (hasSearch) {
-                users = userRepository.searchUsersByKeyword(search, pageable);
-            } else {
-                users = userRepository.findAll(pageable);
-            }
-        }
+        Page<UserJpaEntity> users = queryUsers(
+                currentUser,
+                roleFilter,
+                search,
+                normalizedStatus,
+                organizationId,
+                systemOnly,
+                pageable
+        );
 
         // Issue #229: batch lookup org names cho mọi user trong page có
         // organizationId (avoid N+1 query). System ADMIN không thuộc org
@@ -127,24 +117,65 @@ public class UserControllerV3 {
         // teacher-management KPI strip ("Đang dạy", "Khóa học") shows real
         // numbers instead of zeros. Batched to a single SQL aggregate.
         enrichTeacherCourseCounts(response.getContent());
+        enrichStudentCourseCounts(response.getContent());
         return ResponseEntity.ok(ApiResponse.success(response, "Danh sách người dùng"));
     }
 
     /**
-     * Issue #229: 4-branch query helper cho org-scoped user list. Tránh
-     * duplicate logic giữa ORG_ADMIN auto-scope và ADMIN explicit filter.
+     * Query users with role, status, search, and organization filters in one
+     * specification so every list surface gets consistent pagination totals.
      */
-    private Page<UserJpaEntity> queryUsersInOrg(UUID orgId, UserJpaEntity.UserRole roleEnum,
-                                                  String search, boolean hasRole, boolean hasSearch,
-                                                  Pageable pageable) {
-        if (hasRole && hasSearch) {
-            return userRepository.searchByOrganizationIdAndRoleAndKeyword(orgId, roleEnum, search, pageable);
-        } else if (hasRole) {
-            return userRepository.findByOrganizationIdAndRole(orgId, roleEnum, pageable);
-        } else if (hasSearch) {
-            return userRepository.searchByOrganizationIdAndKeyword(orgId, search, pageable);
-        }
-        return userRepository.findByOrganizationId(orgId, pageable);
+    private Page<UserJpaEntity> queryUsers(UserJpaEntity currentUser,
+                                           Set<UserJpaEntity.UserRole> roles,
+                                           String search,
+                                           String status,
+                                           UUID organizationId,
+                                           boolean systemOnly,
+                                           Pageable pageable) {
+        Specification<UserJpaEntity> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (isOrgAdmin(currentUser)) {
+                predicates.add(cb.equal(root.get("organizationId"), currentUser.getOrganizationId()));
+            } else if (systemOnly) {
+                predicates.add(cb.isNull(root.get("organizationId")));
+            } else if (organizationId != null) {
+                predicates.add(cb.equal(root.get("organizationId"), organizationId));
+            }
+
+            if (roles != null && !roles.isEmpty()) {
+                predicates.add(root.get("role").in(roles));
+            }
+
+            if (search != null && !search.isBlank()) {
+                String like = "%" + search.trim().toLowerCase(Locale.ROOT) + "%";
+                predicates.add(cb.or(
+                        cb.like(cb.lower(root.get("email")), like),
+                        cb.like(cb.lower(root.get("fullName")), like),
+                        cb.like(cb.lower(root.get("username")), like)
+                ));
+            }
+
+            if (status != null && !status.isBlank()) {
+                if ("ACTIVE".equals(status)) {
+                    predicates.add(cb.or(
+                            cb.equal(root.get("accountStatus"), status),
+                            cb.and(cb.isNull(root.get("accountStatus")), cb.isTrue(root.get("enabled")))
+                    ));
+                } else if ("BLOCKED".equals(status)) {
+                    predicates.add(cb.or(
+                            cb.equal(root.get("accountStatus"), status),
+                            cb.and(cb.isNull(root.get("accountStatus")), cb.isFalse(root.get("enabled")))
+                    ));
+                } else {
+                    predicates.add(cb.equal(root.get("accountStatus"), status));
+                }
+            }
+
+            return cb.and(predicates.toArray(Predicate[]::new));
+        };
+
+        return userRepository.findAll(spec, pageable);
     }
 
     /**
@@ -160,6 +191,14 @@ public class UserControllerV3 {
         if (orgIds.isEmpty()) return Map.of();
         return organizationRepository.findAllById(orgIds).stream()
                 .collect(Collectors.toMap(OrganizationJpaEntity::getId, OrganizationJpaEntity::getName));
+    }
+
+    private String resolveAccountStatus(UserJpaEntity user) {
+        String status = user.getAccountStatus();
+        if (status != null && !status.isBlank()) {
+            return status.trim().toUpperCase(Locale.ROOT);
+        }
+        return user.isEnabled() ? "ACTIVE" : "BLOCKED";
     }
 
     @Operation(summary = "Get all users (capped at 1000)")
@@ -733,7 +772,7 @@ public class UserControllerV3 {
                 .role(user.getRole() != null ? user.getRole().name().toLowerCase(Locale.ROOT) : "student")
                 .isActive(user.isEnabled())
                 .enabled(user.isEnabled())
-                .accountStatus(user.getAccountStatus())
+                .accountStatus(resolveAccountStatus(user))
                 .statusReason(user.getStatusReason())
                 .statusUpdatedAt(user.getStatusUpdatedAt() != null ? user.getStatusUpdatedAt().toString() : null)
                 .mustChangePassword(user.isMustChangePassword())
@@ -816,6 +855,39 @@ public class UserControllerV3 {
         }
     }
 
+    private void enrichStudentCourseCounts(java.util.Collection<UserResponse> rows) {
+        if (rows == null || rows.isEmpty()) return;
+
+        java.util.Set<UUID> studentIds = rows.stream()
+                .filter(r -> "student".equalsIgnoreCase(r.getRole()))
+                .map(r -> {
+                    try {
+                        return UUID.fromString(r.getId());
+                    } catch (IllegalArgumentException ex) {
+                        return null;
+                    }
+                })
+                .filter(java.util.Objects::nonNull)
+                .collect(java.util.stream.Collectors.toCollection(java.util.HashSet::new));
+        if (studentIds.isEmpty()) return;
+
+        java.util.Map<UUID, Long> counts = new java.util.HashMap<>(studentIds.size());
+        for (Object[] row : enrollmentRepository.countDistinctActiveCoursesByStudentIds(studentIds)) {
+            if (row == null || row.length < 2 || row[0] == null || row[1] == null) continue;
+            counts.put((UUID) row[0], ((Number) row[1]).longValue());
+        }
+
+        for (UserResponse r : rows) {
+            if (!"student".equalsIgnoreCase(r.getRole())) continue;
+            try {
+                UUID id = UUID.fromString(r.getId());
+                r.setCoursesEnrolled(counts.getOrDefault(id, 0L).intValue());
+            } catch (IllegalArgumentException ex) {
+                // Leave default 0 if id is malformed.
+            }
+        }
+    }
+
     // === Business Guard Helpers ===
 
     private boolean isOrgAdmin(UserJpaEntity user) {
@@ -849,6 +921,39 @@ public class UserControllerV3 {
         }
         return userRepository.findById(userId)
                 .filter(target -> canAccessUser(currentUser, target));
+    }
+
+    private Set<UserJpaEntity.UserRole> parseRoleFilter(String role, String roles) {
+        Set<UserJpaEntity.UserRole> result = new LinkedHashSet<>();
+
+        if (role != null && !role.isBlank()) {
+            UserJpaEntity.UserRole parsed = parseRole(role);
+            if (parsed == null) return null;
+            result.add(parsed);
+        }
+
+        if (roles != null && !roles.isBlank()) {
+            for (String item : roles.split(",")) {
+                if (item == null || item.isBlank()) continue;
+                UserJpaEntity.UserRole parsed = parseRole(item);
+                if (parsed == null) return null;
+                result.add(parsed);
+            }
+        }
+
+        return result;
+    }
+
+    private String normalizeStatus(String rawStatus) {
+        if (rawStatus == null || rawStatus.isBlank()) {
+            return null;
+        }
+
+        String normalized = rawStatus.trim().toUpperCase(Locale.ROOT);
+        return switch (normalized) {
+            case "ACTIVE", "BLOCKED", "RESTRICTED" -> normalized;
+            default -> null;
+        };
     }
 
     private UserJpaEntity.UserRole parseRole(String rawRole) {

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/persistence/JpaEnrollmentRepository.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/persistence/JpaEnrollmentRepository.java
@@ -193,6 +193,16 @@ public interface JpaEnrollmentRepository extends JpaRepository<EnrollmentJpaEnti
     @Query("SELECT lc.courseId, COUNT(e) FROM EnrollmentJpaEntity e JOIN e.learningClass lc WHERE lc.courseId IN :courseIds GROUP BY lc.courseId")
     List<Object[]> countEnrollmentsByCourseIds(@Param("courseIds") List<UUID> courseIds);
 
+    @Query("""
+        SELECT e.studentId, COUNT(DISTINCT lc.courseId)
+        FROM EnrollmentJpaEntity e
+        JOIN e.learningClass lc
+        WHERE e.studentId IN :studentIds
+        AND e.status = 'ACTIVE'
+        GROUP BY e.studentId
+    """)
+    List<Object[]> countDistinctActiveCoursesByStudentIds(@Param("studentIds") java.util.Collection<UUID> studentIds);
+
     @Query("SELECT COUNT(e) FROM EnrollmentJpaEntity e JOIN e.learningClass lc WHERE lc.courseId IN :courseIds")
     long countTotalByCourseIds(@Param("courseIds") List<UUID> courseIds);
 

--- a/backend/src/test/java/com/example/lms/identity/infrastructure/web/MultiTierAdminSecurityTest.java
+++ b/backend/src/test/java/com/example/lms/identity/infrastructure/web/MultiTierAdminSecurityTest.java
@@ -645,13 +645,20 @@ class MultiTierAdminSecurityTest {
             // KHÔNG phải otherOrgId. Nếu logic sai, test sẽ fail vì stub không match.
             org.springframework.data.domain.Page<UserJpaEntity> emptyPage =
                     new org.springframework.data.domain.PageImpl<>(java.util.List.of());
-            when(userRepository.findByOrganizationId(eq(organizationId), any())).thenReturn(emptyPage);
+            when(userRepository.findAll(
+                    any(org.springframework.data.jpa.domain.Specification.class),
+                    any(org.springframework.data.domain.Pageable.class)
+            )).thenReturn(emptyPage);
 
             // Act: ORG_ADMIN cố gắng filter sang org khác
-            controller.getUsers(1, 10, null, null, null, otherOrgId, orgAdmin);
+            controller.getUsers(1, 10, null, null, null, null, otherOrgId, false, orgAdmin);
 
-            // Assert: query was made with own organizationId, NOT otherOrgId
-            verify(userRepository).findByOrganizationId(eq(organizationId), any());
+            // Assert: the unified Specification query is used; legacy direct
+            // organization lookup must not be called with the foreign org.
+            verify(userRepository).findAll(
+                    any(org.springframework.data.jpa.domain.Specification.class),
+                    any(org.springframework.data.domain.Pageable.class)
+            );
             verify(userRepository, never()).findByOrganizationId(eq(otherOrgId), any());
         }
 
@@ -661,13 +668,19 @@ class MultiTierAdminSecurityTest {
             UUID targetOrgId = UUID.randomUUID();
             org.springframework.data.domain.Page<UserJpaEntity> emptyPage =
                     new org.springframework.data.domain.PageImpl<>(java.util.List.of());
-            when(userRepository.findByOrganizationId(eq(targetOrgId), any())).thenReturn(emptyPage);
+            when(userRepository.findAll(
+                    any(org.springframework.data.jpa.domain.Specification.class),
+                    any(org.springframework.data.domain.Pageable.class)
+            )).thenReturn(emptyPage);
 
             // Act: ADMIN filter to specific org
-            controller.getUsers(1, 10, null, null, null, targetOrgId, systemAdmin);
+            controller.getUsers(1, 10, null, null, null, null, targetOrgId, false, systemAdmin);
 
-            // Assert: query was made with targetOrgId
-            verify(userRepository).findByOrganizationId(eq(targetOrgId), any());
+            // Assert: query was made through the unified Specification path.
+            verify(userRepository).findAll(
+                    any(org.springframework.data.jpa.domain.Specification.class),
+                    any(org.springframework.data.domain.Pageable.class)
+            );
         }
 
         @Test
@@ -675,13 +688,19 @@ class MultiTierAdminSecurityTest {
         void systemAdminWithoutOrgFilterSeesAll() {
             org.springframework.data.domain.Page<UserJpaEntity> emptyPage =
                     new org.springframework.data.domain.PageImpl<>(java.util.List.of());
-            when(userRepository.findAll(any(org.springframework.data.domain.Pageable.class))).thenReturn(emptyPage);
+            when(userRepository.findAll(
+                    any(org.springframework.data.jpa.domain.Specification.class),
+                    any(org.springframework.data.domain.Pageable.class)
+            )).thenReturn(emptyPage);
 
             // Act
-            controller.getUsers(1, 10, null, null, null, null, systemAdmin);
+            controller.getUsers(1, 10, null, null, null, null, null, false, systemAdmin);
 
-            // Assert: cross-org findAll, không scope by orgId
-            verify(userRepository).findAll(any(org.springframework.data.domain.Pageable.class));
+            // Assert: cross-org Specification query, không scope by orgId
+            verify(userRepository).findAll(
+                    any(org.springframework.data.jpa.domain.Specification.class),
+                    any(org.springframework.data.domain.Pageable.class)
+            );
             verify(userRepository, never()).findByOrganizationId(any(), any());
         }
     }

--- a/backend/src/test/java/com/example/lms/identity/infrastructure/web/UserControllerV3TeacherKpiTest.java
+++ b/backend/src/test/java/com/example/lms/identity/infrastructure/web/UserControllerV3TeacherKpiTest.java
@@ -71,7 +71,10 @@ class UserControllerV3TeacherKpiTest {
                 userEntity(teacherBId, "teacher-b@m.edu", "Teacher B", UserJpaEntity.UserRole.TEACHER),
                 userEntity(studentId, "student@m.edu", "Student",      UserJpaEntity.UserRole.STUDENT)
         );
-        when(userRepository.findAll(any(PageRequest.class)))
+        when(userRepository.findAll(
+                any(org.springframework.data.jpa.domain.Specification.class),
+                any(PageRequest.class)
+        ))
                 .thenReturn(new PageImpl<>(users));
 
         // Teacher A has 5 courses, Teacher B has 0 (absent from the result set
@@ -81,7 +84,7 @@ class UserControllerV3TeacherKpiTest {
                 .thenReturn(teacherACountRow);
 
         ResponseEntity<ApiResponse<Page<UserControllerV3.UserResponse>>> response =
-                controller.getUsers(1, 10, null, null, null, null, admin);
+                controller.getUsers(1, 10, null, null, null, null, null, false, admin);
 
         @SuppressWarnings("ConstantConditions")
         List<UserControllerV3.UserResponse> rows = response.getBody().getData().getContent();
@@ -103,11 +106,14 @@ class UserControllerV3TeacherKpiTest {
                 userEntity(studentId, "student@m.edu", "Student",      UserJpaEntity.UserRole.STUDENT),
                 userEntity(admin.getId(), "admin@m.edu", "Admin",      UserJpaEntity.UserRole.ADMIN)
         );
-        when(userRepository.findAll(any(PageRequest.class)))
+        when(userRepository.findAll(
+                any(org.springframework.data.jpa.domain.Specification.class),
+                any(PageRequest.class)
+        ))
                 .thenReturn(new PageImpl<>(users));
         when(courseRepository.countCoursesByTeacherIds(any())).thenReturn(List.of());
 
-        controller.getUsers(1, 10, null, null, null, null, admin);
+        controller.getUsers(1, 10, null, null, null, null, null, false, admin);
 
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Collection<UUID>> captor = ArgumentCaptor.forClass(Collection.class);
@@ -121,10 +127,13 @@ class UserControllerV3TeacherKpiTest {
         List<UserJpaEntity> users = List.of(
                 userEntity(studentId, "student@m.edu", "Student", UserJpaEntity.UserRole.STUDENT)
         );
-        when(userRepository.findAll(any(PageRequest.class)))
+        when(userRepository.findAll(
+                any(org.springframework.data.jpa.domain.Specification.class),
+                any(PageRequest.class)
+        ))
                 .thenReturn(new PageImpl<>(users));
 
-        controller.getUsers(1, 10, null, null, null, null, admin);
+        controller.getUsers(1, 10, null, null, null, null, null, false, admin);
 
         verify(courseRepository, never()).countCoursesByTeacherIds(any());
     }

--- a/fe/src/app/features/admin/infrastructure/services/admin.service.ts
+++ b/fe/src/app/features/admin/infrastructure/services/admin.service.ts
@@ -119,7 +119,7 @@ export interface AdminUser {
   id: string;
   email: string;
   name: string;
-  role: string; // Backend returns 'TEACHER', 'STUDENT', 'ADMIN' (uppercase)
+  role: string;
   avatar?: string;
   department?: string;
   studentId?: string;
@@ -147,7 +147,7 @@ export interface BackendUser {
   username: string;
   email: string;
   fullName: string;
-  role: 'ADMIN' | 'ORG_ADMIN' | 'TEACHER' | 'STUDENT';
+  role: 'ADMIN' | 'ORG_ADMIN' | 'TEACHER' | 'STUDENT' | 'admin' | 'org_admin' | 'teacher' | 'student';
   enabled: boolean;
   accountStatus?: string;  // ACTIVE, BLOCKED, RESTRICTED
   statusReason?: string;
@@ -614,26 +614,56 @@ export class AdminService {
       finalize(() => this._isLoading.next(false)),
       map(response => {
 
-        // Extract the actual user array from content
         const responseData = response.data as any;
         const backendUsers: BackendUser[] = Array.isArray(response.data)
           ? response.data
           : (responseData?.content || responseData?.data || []);
 
-
-        // Convert BackendUser to AdminUser
         const users: AdminUser[] = backendUsers.map((u: BackendUser) => this.mapBackendUserToAdminUser(u));
         this._users.set(users);
 
+        const pageData = !Array.isArray(response.data) ? responseData : null;
+        const rawPagination = (response.pagination || {}) as any;
+        const page = rawPagination.page ?? pageData?.page ?? (pageData?.number != null ? pageData.number + 1 : (params.page ?? 1));
+        const limit = rawPagination.limit ?? pageData?.size ?? params.limit ?? backendUsers.length;
+        const totalItems = rawPagination.totalItems ?? pageData?.totalElements ?? backendUsers.length;
+        const totalPages = rawPagination.totalPages ?? pageData?.totalPages ?? 1;
+
         return {
           data: users,
-          pagination: response.pagination || {}
+          pagination: {
+            page,
+            limit,
+            totalItems,
+            totalPages: Math.max(1, totalPages),
+            first: rawPagination.first ?? pageData?.first ?? page <= 1,
+            last: rawPagination.last ?? pageData?.last ?? page >= Math.max(1, totalPages)
+          }
         };
       }),
       catchError(error => {
 
         return throwError(() => error);
       })
+    );
+  }
+
+  getUserCount(params: any = {}): Observable<number> {
+    const queryParams = { ...params, page: 1, limit: 1 };
+
+    return this.apiClient.getWithResponse<BackendUser[]>(ADMIN_ENDPOINTS.USERS, { params: queryParams }).pipe(
+      map(response => {
+        const responseData = response.data as any;
+        const rawPagination = (response.pagination || {}) as any;
+        const backendUsers: BackendUser[] = Array.isArray(response.data)
+          ? response.data
+          : (responseData?.content || responseData?.data || []);
+
+        return rawPagination.totalItems
+          ?? responseData?.totalElements
+          ?? backendUsers.length;
+      }),
+      catchError(error => throwError(() => error))
     );
   }
 
@@ -882,7 +912,7 @@ export class AdminService {
     return {
       id: backendUser.id,
       email: backendUser.email,
-      name: backendUser.fullName,
+      name: backendUser.fullName || (backendUser as any).name || backendUser.username,
       role: this.mapBackendRoleToUserRole(backendUser.role),
       createdAt: new Date(backendUser.createdAt),
       updatedAt: backendUser.updatedAt ? new Date(backendUser.updatedAt) : new Date(),

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.html
@@ -22,9 +22,9 @@
         [sub]="activeAdmins() + ' đang hoạt động'" />
 
       <app-kpi-card
-        [value]="superAdmins()"
-        label="Super Admin"
-        sub="Quyền cao nhất" />
+        [value]="orgAdmins()"
+        label="Org Admin"
+        sub="Quyền org_admin" />
 
       <app-kpi-card
         [value]="blockedAdmins()"
@@ -33,9 +33,9 @@
         variant="error" />
 
       <app-kpi-card
-        [value]="recentlyActive()"
-        label="Hoạt động gần đây"
-        sub="Trong 7 ngày qua" />
+        [value]="restrictedAdmins()"
+        label="Hạn chế"
+        sub="Tài khoản bị hạn chế" />
     </div>
 
     <!-- Search & Filter -->
@@ -70,7 +70,7 @@
       <div class="filter-summary">
         <p class="filter-summary-text">
           Hiển thị <span class="filter-count">{{ filteredAdmins().length }}</span>
-          trong tổng số <span class="filter-count">{{ totalAdmins() }}</span> quản trị viên
+          trong tổng số <span class="filter-count">{{ totalItems() }}</span> quản trị viên
         </p>
       </div>
     </div>
@@ -107,8 +107,7 @@
                 <!-- Issue #229: column "Tổ chức" multi-org admin scoping. -->
                 <th>Tổ chức</th>
                 <th>Trạng thái</th>
-                <th>Hoạt động cuối</th>
-                <th>Đăng nhập</th>
+                <th>Ngày tạo</th>
                 <th class="text-center">Thao tác</th>
               </tr>
             </thead>
@@ -141,6 +140,7 @@
                       <option value="STUDENT">Học viên</option>
                       <option value="TEACHER">Giảng viên</option>
                       <option value="ADMIN">Quản trị viên</option>
+                      <option value="ORG_ADMIN">Quyền org_admin</option>
                     </select>
                   </td>
                   <!-- Issue #229: Tổ chức column — 3 trạng thái:
@@ -166,22 +166,8 @@
                       {{ getStatusLabel(admin.accountStatus) }}
                     </span>
                   </td>
-                  <!-- Last Login — relative time (Linear/GitHub/Stripe pattern,
-                       đồng bộ users/all PR #224). cursor-help + title chỉ khi
-                       có lastLogin (tránh hand cursor + tooltip rỗng). -->
-                  <td class="date-text"
-                      [class.cursor-help]="admin.lastLogin"
-                      [attr.title]="admin.lastLogin || null">
-                    {{ admin.lastLogin ? formatRelativeTime(admin.lastLogin) : 'Chưa đăng nhập' }}
-                  </td>
-                  <!-- Login Count -->
-                  <td>
-                    <div class="login-count">
-                      <svg fill="currentColor" viewBox="0 0 20 20">
-                        <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5z"></path>
-                      </svg>
-                      {{ admin.loginCount || 0 }} lần
-                    </div>
+                  <td class="date-text">
+                    {{ formatDateValue(admin.createdAt) }}
                   </td>
                   <!-- Actions — CC-10: replaced inline status select + revoke
                        icon button with shared kebab menu. Status pill
@@ -199,6 +185,36 @@
             </tbody>
           </table>
         </div>
+        @if (totalPages() > 1) {
+          <div class="pagination-bar">
+            <div class="pagination-info">
+              Hiển thị <strong>{{ pageStart() }}</strong> - <strong>{{ pageEnd() }}</strong>
+              trong tổng số <strong>{{ totalItems() }}</strong> quản trị viên
+            </div>
+            <div class="pagination-controls" aria-label="Phân trang quản trị viên">
+              <button (click)="goToPage(currentPage() - 1)" [disabled]="currentPage() === 1"
+                      class="pagination-btn pagination-arrow" aria-label="Trang trước">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+              </button>
+              @for (page of paginationPages(); track $index) {
+                @if (page === -1) {
+                  <span class="pagination-ellipsis">...</span>
+                } @else {
+                  <button (click)="goToPage(page)"
+                          class="pagination-btn"
+                          [class.active]="currentPage() === page"
+                          [attr.aria-current]="currentPage() === page ? 'page' : null">
+                    {{ page }}
+                  </button>
+                }
+              }
+              <button (click)="goToPage(currentPage() + 1)" [disabled]="currentPage() === totalPages()"
+                      class="pagination-btn pagination-arrow" aria-label="Trang tiếp theo">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+              </button>
+            </div>
+          </div>
+        }
       }
     </div>
   </div>

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.scss
@@ -407,6 +407,80 @@ $orange-700: #9A3412;
   gap: $spacing-1;
 }
 
+.pagination-bar {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-3;
+  align-items: center;
+  justify-content: space-between;
+  padding: $spacing-4 $spacing-6;
+  border-top: 1px solid $border-default;
+  background: $bg-surface;
+
+  @media (min-width: $breakpoint-sm) {
+    flex-direction: row;
+  }
+}
+
+.pagination-info {
+  font-size: $text-sm;
+  color: $text-secondary;
+}
+
+.pagination-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.pagination-btn {
+  min-width: 36px;
+  height: 36px;
+  padding: 0 $spacing-2;
+  border: 1px solid $border-default;
+  border-radius: $radius-sm;
+  background: $bg-surface;
+  color: $gray-700;
+  font-size: $text-sm;
+  font-weight: $font-medium;
+  cursor: pointer;
+  transition: background $transition-fast, border-color $transition-fast, color $transition-fast;
+
+  &:hover:not(:disabled):not(.active) {
+    background: $gray-50;
+    border-color: $gray-300;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  &.active {
+    background: $blue-primary;
+    border-color: $blue-primary;
+    color: $text-inverse;
+  }
+}
+
+.pagination-arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.pagination-ellipsis {
+  padding: 0 $spacing-1;
+  color: $text-muted;
+  font-size: $text-sm;
+}
+
 .action-select {
   font-size: $text-xs;
   padding: $spacing-1 $spacing-2;

--- a/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/admin-user-management.component.ts
@@ -13,8 +13,15 @@ import { ConfirmStatusChangeService } from '../../services/confirm-status-change
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
 import { KebabMenuComponent, KebabAction } from '../../../../shared/components/admin/kebab-menu/kebab-menu.component';
-import { formatRelativeTimeVN } from '../../../../shared/utils/relative-time.util';
 import { initialsAvatar } from '../../../../shared/utils/avatar.util';
+
+interface AdminStats {
+  total: number;
+  active: number;
+  blocked: number;
+  restricted: number;
+  orgAdmins: number;
+}
 /**
  * Admin User Management Component
  * SOTA Design: Coursera-inspired with role change, status actions
@@ -33,6 +40,8 @@ export class AdminUserManagementComponent implements OnInit {
   private confirmDialog = inject(ConfirmDialogService);
   private authService = inject(AuthService);
   private confirmStatus = inject(ConfirmStatusChangeService);
+  private loadRequestId = 0;
+  private statsRequestId = 0;
 
   // State
   allUsers = signal<AdminUser[]>([]);
@@ -40,6 +49,17 @@ export class AdminUserManagementComponent implements OnInit {
   isLoading = signal(false);
   searchQuery = signal('');
   statusFilter = signal('');
+  currentPage = signal(1);
+  totalPages = signal(1);
+  totalItems = signal(0);
+  readonly pageSize = 12;
+  adminStats = signal<AdminStats>({
+    total: 0,
+    active: 0,
+    blocked: 0,
+    restricted: 0,
+    orgAdmins: 0
+  });
   // Issue #229: '' = tất cả, 'system' = ADMIN không thuộc org, UUID = org cụ thể
   orgFilter = signal('');
   showCreateModal = signal(false);
@@ -83,7 +103,7 @@ export class AdminUserManagementComponent implements OnInit {
 
   filteredAdmins = computed(() => {
     let admins = this.adminUsers();
-    const query = this.searchQuery().toLowerCase();
+    const query = this.searchQuery().trim().toLowerCase();
     const status = this.statusFilter();
     const org = this.orgFilter();
 
@@ -112,29 +132,79 @@ export class AdminUserManagementComponent implements OnInit {
   });
 
   // Stats
-  totalAdmins = computed(() => this.adminUsers().length);
-  activeAdmins = computed(() => this.adminUsers().filter(a => a.accountStatus === 'ACTIVE').length);
-  blockedAdmins = computed(() => this.adminUsers().filter(a => a.accountStatus === 'BLOCKED').length);
-  superAdmins = computed(() => 1); // Placeholder - needs backend support
-  recentlyActive = computed(() => {
-    const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    return this.adminUsers().filter(a => a.lastLogin && new Date(a.lastLogin) > weekAgo).length;
-  });
+  totalAdmins = computed(() => this.adminStats().total);
+  activeAdmins = computed(() => this.adminStats().active);
+  blockedAdmins = computed(() => this.adminStats().blocked);
+  restrictedAdmins = computed(() => this.adminStats().restricted);
+  orgAdmins = computed(() => this.adminStats().orgAdmins);
 
   ngOnInit() {
-    this.loadUsers();
+    this.loadUsers(1);
     this.loadOrganizations();
   }
 
-  loadUsers() {
+  loadUsers(page = this.currentPage()) {
     this.isLoading.set(true);
-    this.adminService.getUsers({ page: 1, limit: 1000 }).subscribe({
+    const requestId = ++this.loadRequestId;
+    const params: any = { ...this.buildAdminFilterParams(), page, limit: this.pageSize, roles: 'ADMIN,ORG_ADMIN' };
+    if (this.statusFilter()) params.status = this.statusFilter();
+    this.loadStats();
+
+    this.adminService.getUsers(params).subscribe({
       next: (response) => {
+        if (requestId !== this.loadRequestId) return;
         this.allUsers.set(response.data || []);
+        this.currentPage.set(response.pagination?.page ?? page);
+        this.totalPages.set(Math.max(1, response.pagination?.totalPages ?? 1));
+        this.totalItems.set(response.pagination?.totalItems ?? response.data?.length ?? 0);
         this.clearSelection();
         this.isLoading.set(false);
       },
-      error: () => this.isLoading.set(false)
+      error: () => {
+        if (requestId !== this.loadRequestId) return;
+        this.isLoading.set(false);
+      }
+    });
+  }
+
+  private buildAdminFilterParams(): any {
+    const params: any = {};
+    const search = this.searchQuery().trim();
+    if (search) params.search = search;
+    if (this.orgFilter() === 'system') {
+      params.systemOnly = true;
+    } else if (this.orgFilter()) {
+      params.organizationId = this.orgFilter();
+    }
+    return params;
+  }
+
+  private loadStats(): void {
+    const requestId = ++this.statsRequestId;
+    const baseParams = this.buildAdminFilterParams();
+    const adminRoles = 'ADMIN,ORG_ADMIN';
+
+    forkJoin({
+      total: this.adminService.getUserCount({ ...baseParams, roles: adminRoles }),
+      active: this.adminService.getUserCount({ ...baseParams, roles: adminRoles, status: 'ACTIVE' }),
+      blocked: this.adminService.getUserCount({ ...baseParams, roles: adminRoles, status: 'BLOCKED' }),
+      restricted: this.adminService.getUserCount({ ...baseParams, roles: adminRoles, status: 'RESTRICTED' }),
+      orgAdmins: this.adminService.getUserCount({ ...baseParams, role: 'ORG_ADMIN' })
+    }).subscribe({
+      next: (stats) => {
+        if (requestId !== this.statsRequestId) return;
+        this.adminStats.set(stats);
+      },
+      error: () => {
+        if (requestId !== this.statsRequestId) return;
+        this.adminStats.set({
+          total: this.totalItems(),
+          active: 0,
+          blocked: 0,
+          restricted: 0,
+          orgAdmins: 0
+        });
+      }
     });
   }
 
@@ -188,6 +258,36 @@ export class AdminUserManagementComponent implements OnInit {
 
   clearSelection(): void {
     this.selectedUserIds.set(new Set());
+  }
+
+  paginationPages = computed(() => {
+    const total = this.totalPages();
+    const current = this.currentPage();
+    if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+
+    const pages: number[] = [1];
+    const start = Math.max(2, current - 1);
+    const end = Math.min(total - 1, current + 1);
+    if (start > 2) pages.push(-1);
+    for (let page = start; page <= end; page++) pages.push(page);
+    if (end < total - 1) pages.push(-1);
+    pages.push(total);
+    return pages;
+  });
+
+  goToPage(page: number): void {
+    if (page < 1 || page > this.totalPages() || page === this.currentPage()) return;
+    this.loadUsers(page);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  pageStart(): number {
+    if (this.totalItems() === 0) return 0;
+    return (this.currentPage() - 1) * this.pageSize + 1;
+  }
+
+  pageEnd(): number {
+    return Math.min(this.currentPage() * this.pageSize, this.totalItems());
   }
 
   // --- Per-row kebab menu (CC-10) ---
@@ -317,16 +417,19 @@ export class AdminUserManagementComponent implements OnInit {
 
   onSearchInput(value: string) {
     this.searchQuery.set(value);
+    this.loadUsers(1);
   }
 
   onStatusFilterChange(value: string) {
     this.statusFilter.set(value);
+    this.loadUsers(1);
   }
 
   // Issue #229: org filter handler — '' = tất cả, 'system' = ADMIN không
   // thuộc org, UUID = scope tới org cụ thể.
   onOrgFilterChange(value: string) {
     this.orgFilter.set(value);
+    this.loadUsers(1);
   }
 
   openCreateModal() {
@@ -378,7 +481,7 @@ export class AdminUserManagementComponent implements OnInit {
       return;
     }
 
-    this.adminService.updateUser(userId, { role: newRole as 'ADMIN' | 'TEACHER' | 'STUDENT' }).subscribe({
+    this.adminService.updateUser(userId, { role: newRole as 'ADMIN' | 'ORG_ADMIN' | 'TEACHER' | 'STUDENT' }).subscribe({
       next: () => this.loadUsers(),
       error: (err) => this.toast.error('Không thể thay đổi vai trò: ' + (err.error?.message || 'Vui lòng thử lại'))
     });
@@ -441,6 +544,7 @@ export class AdminUserManagementComponent implements OnInit {
   getRoleLabel(role: string): string {
     switch (role.toUpperCase()) {
       case 'ADMIN': return 'Quản trị viên';
+      case 'ORG_ADMIN': return 'Chuyên viên quản lý';
       case 'TEACHER': return 'Giảng viên';
       case 'STUDENT': return 'Học viên';
       default: return role;
@@ -452,12 +556,6 @@ export class AdminUserManagementComponent implements OnInit {
     return d.toLocaleDateString('vi-VN', {
       day: '2-digit', month: '2-digit', year: 'numeric'
     });
-  }
-
-  // Cột "Hoạt động cuối" — relative time (Linear/GitHub/Stripe pattern,
-  // đồng bộ users/all PR #224). Tooltip [title] giữ ISO timestamp gốc.
-  formatRelativeTime(input: Date | string | null | undefined): string {
-    return formatRelativeTimeVN(input);
   }
 
   getDefaultAvatar(email: string): string {
@@ -491,4 +589,3 @@ export class AdminUserManagementComponent implements OnInit {
     }
   }
 }
-

--- a/fe/src/app/features/admin/presentation/components/student-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.html
@@ -154,10 +154,9 @@
                        đồng bộ users/all PR #224). cursor-help + title chỉ khi
                        có lastLogin (tránh hand cursor + tooltip rỗng). -->
                   <td>
-                    <span class="date-text"
-                          [class.cursor-help]="student.lastLogin"
-                          [attr.title]="student.lastLogin || null">
-                      {{ student.lastLogin ? formatRelativeTime(student.lastLogin) : 'Chưa đăng nhập' }}
+                    <span class="badge" [class]="getStatusBadgeClass(student.accountStatus)">
+                      <span class="status-dot" [class]="getStatusDotClass(student.accountStatus)"></span>
+                      {{ getActivityLabel(student) }}
                     </span>
                   </td>
                   <!-- Actions — CC-10: shared kebab replaces inline status
@@ -175,6 +174,36 @@
             </tbody>
           </table>
         </div>
+        @if (totalPages() > 1) {
+          <div class="pagination-bar">
+            <div class="pagination-info">
+              Hiển thị <strong>{{ pageStart() }}</strong> - <strong>{{ pageEnd() }}</strong>
+              trong tổng số <strong>{{ totalItems() }}</strong> học viên
+            </div>
+            <div class="pagination-controls" aria-label="Phân trang học viên">
+              <button (click)="goToPage(currentPage() - 1)" [disabled]="currentPage() === 1"
+                      class="pagination-btn pagination-arrow" aria-label="Trang trước">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+              </button>
+              @for (page of paginationPages(); track $index) {
+                @if (page === -1) {
+                  <span class="pagination-ellipsis">...</span>
+                } @else {
+                  <button (click)="goToPage(page)"
+                          class="pagination-btn"
+                          [class.active]="currentPage() === page"
+                          [attr.aria-current]="currentPage() === page ? 'page' : null">
+                    {{ page }}
+                  </button>
+                }
+              }
+              <button (click)="goToPage(currentPage() + 1)" [disabled]="currentPage() === totalPages()"
+                      class="pagination-btn pagination-arrow" aria-label="Trang tiếp theo">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+              </button>
+            </div>
+          </div>
+        }
       }
     </div>
   </div>

--- a/fe/src/app/features/admin/presentation/components/student-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.scss
@@ -390,6 +390,80 @@
   gap: $spacing-1;
 }
 
+.pagination-bar {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-3;
+  align-items: center;
+  justify-content: space-between;
+  padding: $spacing-4 $spacing-6;
+  border-top: 1px solid $border-default;
+  background: $bg-surface;
+
+  @media (min-width: $breakpoint-sm) {
+    flex-direction: row;
+  }
+}
+
+.pagination-info {
+  font-size: $text-sm;
+  color: $text-secondary;
+}
+
+.pagination-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.pagination-btn {
+  min-width: 36px;
+  height: 36px;
+  padding: 0 $spacing-2;
+  border: 1px solid $border-default;
+  border-radius: $radius-sm;
+  background: $bg-surface;
+  color: $gray-700;
+  font-size: $text-sm;
+  font-weight: $font-medium;
+  cursor: pointer;
+  transition: background $transition-fast, border-color $transition-fast, color $transition-fast;
+
+  &:hover:not(:disabled):not(.active) {
+    background: $gray-50;
+    border-color: $gray-300;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  &.active {
+    background: $blue-primary;
+    border-color: $blue-primary;
+    color: $text-inverse;
+  }
+}
+
+.pagination-arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.pagination-ellipsis {
+  padding: 0 $spacing-1;
+  color: $text-muted;
+  font-size: $text-sm;
+}
+
 .action-select {
   font-size: $text-xs;
   padding: $spacing-1 $spacing-2;

--- a/fe/src/app/features/admin/presentation/components/student-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.ts
@@ -12,7 +12,6 @@ import { forkJoin } from 'rxjs';
 import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/kpi-card.component';
 import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
 import { KebabMenuComponent, KebabAction } from '../../../../shared/components/admin/kebab-menu/kebab-menu.component';
-import { formatRelativeTimeVN } from '../../../../shared/utils/relative-time.util';
 import { initialsAvatar } from '../../../../shared/utils/avatar.util';
 
 /**
@@ -44,6 +43,7 @@ export class StudentManagementComponent implements OnInit {
   private confirmDialog = inject(ConfirmDialogService);
   private confirmStatus = inject(ConfirmStatusChangeService);
   private authService = inject(AuthService);
+  private loadRequestId = 0;
 
   isSystemAdmin = computed(() => this.authService.userRole() === 'admin');
   courseSearchRoute = computed(() => `${getAdminPortalBase(this.authService.userRole())}/courses`);
@@ -59,6 +59,10 @@ export class StudentManagementComponent implements OnInit {
   isLoading = signal(false);
   searchQuery = signal('');
   statusFilter = signal('');
+  currentPage = signal(1);
+  totalPages = signal(1);
+  totalItems = signal(0);
+  readonly pageSize = 12;
   showCreateModal = signal(false);
   newStudentName = signal('');
   newStudentEmail = signal('');
@@ -94,7 +98,7 @@ export class StudentManagementComponent implements OnInit {
 
   filteredStudents = computed(() => {
     let students = this.studentUsers();
-    const query = this.searchQuery().toLowerCase();
+    const query = this.searchQuery().trim().toLowerCase();
     const status = this.statusFilter();
 
     if (query) {
@@ -112,7 +116,7 @@ export class StudentManagementComponent implements OnInit {
   });
 
   // Stats
-  totalStudents = computed(() => this.studentUsers().length);
+  totalStudents = computed(() => this.totalItems());
   activeStudents = computed(() => this.studentUsers().filter(s => s.accountStatus === 'ACTIVE').length);
   blockedStudents = computed(() => this.studentUsers().filter(s => s.accountStatus === 'BLOCKED').length);
   totalEnrollments = computed(() => this.studentUsers().reduce((sum, s) => sum + (s.coursesEnrolled || 0), 0));
@@ -122,18 +126,31 @@ export class StudentManagementComponent implements OnInit {
   });
 
   ngOnInit() {
-    this.loadUsers();
+    this.loadUsers(1);
   }
 
-  loadUsers() {
+  loadUsers(page = this.currentPage()) {
     this.isLoading.set(true);
-    this.adminService.getUsers({ page: 1, limit: 200, role: 'STUDENT' }).subscribe({
+    const requestId = ++this.loadRequestId;
+    const params: any = { page, limit: this.pageSize, role: 'STUDENT' };
+    const search = this.searchQuery().trim();
+    if (search) params.search = search;
+    if (this.statusFilter()) params.status = this.statusFilter();
+
+    this.adminService.getUsers(params).subscribe({
       next: (response) => {
+        if (requestId !== this.loadRequestId) return;
         this.allUsers.set(response.data || []);
+        this.currentPage.set(response.pagination?.page ?? page);
+        this.totalPages.set(Math.max(1, response.pagination?.totalPages ?? 1));
+        this.totalItems.set(response.pagination?.totalItems ?? response.data?.length ?? 0);
         this.clearSelection();
         this.isLoading.set(false);
       },
-      error: () => this.isLoading.set(false)
+      error: () => {
+        if (requestId !== this.loadRequestId) return;
+        this.isLoading.set(false);
+      }
     });
   }
 
@@ -171,6 +188,36 @@ export class StudentManagementComponent implements OnInit {
 
   clearSelection(): void {
     this.selectedUserIds.set(new Set());
+  }
+
+  paginationPages = computed(() => {
+    const total = this.totalPages();
+    const current = this.currentPage();
+    if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+
+    const pages: number[] = [1];
+    const start = Math.max(2, current - 1);
+    const end = Math.min(total - 1, current + 1);
+    if (start > 2) pages.push(-1);
+    for (let page = start; page <= end; page++) pages.push(page);
+    if (end < total - 1) pages.push(-1);
+    pages.push(total);
+    return pages;
+  });
+
+  goToPage(page: number): void {
+    if (page < 1 || page > this.totalPages() || page === this.currentPage()) return;
+    this.loadUsers(page);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  pageStart(): number {
+    if (this.totalItems() === 0) return 0;
+    return (this.currentPage() - 1) * this.pageSize + 1;
+  }
+
+  pageEnd(): number {
+    return Math.min(this.currentPage() * this.pageSize, this.totalItems());
   }
 
   // --- Per-row kebab menu (CC-10) ---
@@ -271,10 +318,12 @@ export class StudentManagementComponent implements OnInit {
 
   onSearchInput(value: string) {
     this.searchQuery.set(value);
+    this.loadUsers(1);
   }
 
   onStatusFilterChange(value: string) {
     this.statusFilter.set(value);
+    this.loadUsers(1);
   }
 
   openCreateModal() {
@@ -439,12 +488,6 @@ export class StudentManagementComponent implements OnInit {
     });
   }
 
-  // Cột "Hoạt động cuối" — relative time (Linear/GitHub/Stripe pattern,
-  // đồng bộ users/all PR #224). Tooltip [title] giữ ISO timestamp gốc.
-  formatRelativeTime(input: Date | string | null | undefined): string {
-    return formatRelativeTimeVN(input);
-  }
-
   getDefaultAvatar(email: string): string {
     return initialsAvatar(email, '#4f46e5', '#ffffff');
   }
@@ -474,5 +517,12 @@ export class StudentManagementComponent implements OnInit {
       case 'RESTRICTED': return 'Hạn chế';
       default: return 'Chờ xác thực';
     }
+  }
+
+  getActivityLabel(student: AdminUser): string {
+    if (student.accountStatus === 'ACTIVE' && student.isActive) {
+      return 'Hoạt động';
+    }
+    return this.getStatusLabel(student.accountStatus);
   }
 }

--- a/fe/src/app/features/admin/presentation/components/teacher-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.component.scss
@@ -425,6 +425,80 @@ $purple-bg: #FAF5FF;
   gap: $spacing-1;
 }
 
+.pagination-bar {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-3;
+  align-items: center;
+  justify-content: space-between;
+  padding: $spacing-4 $spacing-6;
+  border-top: 1px solid $border-default;
+  background: white;
+
+  @media (min-width: $breakpoint-sm) {
+    flex-direction: row;
+  }
+}
+
+.pagination-info {
+  font-size: $text-sm;
+  color: $text-secondary;
+}
+
+.pagination-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.pagination-btn {
+  min-width: 36px;
+  height: 36px;
+  padding: 0 $spacing-2;
+  border: 1px solid $border-default;
+  border-radius: $radius-sm;
+  background: white;
+  color: $gray-700;
+  font-size: $text-sm;
+  font-weight: $font-medium;
+  cursor: pointer;
+  transition: background $transition-fast, border-color $transition-fast, color $transition-fast;
+
+  &:hover:not(:disabled):not(.active) {
+    background: $gray-50;
+    border-color: $gray-300;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  &.active {
+    background: $blue-primary;
+    border-color: $blue-primary;
+    color: white;
+  }
+}
+
+.pagination-arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.pagination-ellipsis {
+  padding: 0 $spacing-1;
+  color: $text-muted;
+  font-size: $text-sm;
+}
+
 .status-select {
   font-size: $text-xs;
   padding: $spacing-1 $spacing-2;

--- a/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.component.ts
@@ -32,6 +32,7 @@ export class TeacherManagementComponent implements OnInit {
   private confirmDialog = inject(ConfirmDialogService);
   private confirmStatus = inject(ConfirmStatusChangeService);
   private authService = inject(AuthService);
+  private loadRequestId = 0;
 
   isSystemAdmin = computed(() => this.authService.userRole() === 'admin');
   courseSearchRoute = computed(() => `${getAdminPortalBase(this.authService.userRole())}/courses`);
@@ -47,6 +48,10 @@ export class TeacherManagementComponent implements OnInit {
   isLoading = signal(false);
   searchQuery = signal('');
   statusFilter = signal('');
+  currentPage = signal(1);
+  totalPages = signal(1);
+  totalItems = signal(0);
+  readonly pageSize = 12;
   showCreateModal = signal(false);
   newTeacherName = signal('');
   newTeacherEmail = signal('');
@@ -90,7 +95,7 @@ export class TeacherManagementComponent implements OnInit {
 
   filteredTeachers = computed(() => {
     let teachers = this.teacherUsers();
-    const query = this.searchQuery().toLowerCase();
+    const query = this.searchQuery().trim().toLowerCase();
     const status = this.statusFilter();
 
     if (query) {
@@ -108,7 +113,7 @@ export class TeacherManagementComponent implements OnInit {
   });
 
   // Stats
-  totalTeachers = computed(() => this.teacherUsers().length);
+  totalTeachers = computed(() => this.totalItems());
   activeTeachers = computed(() => this.teacherUsers().filter(t => t.accountStatus === 'ACTIVE').length);
   blockedTeachers = computed(() => this.teacherUsers().filter(t => t.accountStatus === 'BLOCKED').length);
   totalCourses = computed(() => this.teacherUsers().reduce((sum, t) => sum + (t.coursesCreated || 0), 0));
@@ -118,18 +123,31 @@ export class TeacherManagementComponent implements OnInit {
   });
 
   ngOnInit() {
-    this.loadUsers();
+    this.loadUsers(1);
   }
 
-  loadUsers() {
+  loadUsers(page = this.currentPage()) {
     this.isLoading.set(true);
-    this.adminService.getUsers({ page: 1, limit: 200, role: 'TEACHER' }).subscribe({
+    const requestId = ++this.loadRequestId;
+    const params: any = { page, limit: this.pageSize, role: 'TEACHER' };
+    const search = this.searchQuery().trim();
+    if (search) params.search = search;
+    if (this.statusFilter()) params.status = this.statusFilter();
+
+    this.adminService.getUsers(params).subscribe({
       next: (response) => {
+        if (requestId !== this.loadRequestId) return;
         this.allUsers.set(response.data || []);
+        this.currentPage.set(response.pagination?.page ?? page);
+        this.totalPages.set(Math.max(1, response.pagination?.totalPages ?? 1));
+        this.totalItems.set(response.pagination?.totalItems ?? response.data?.length ?? 0);
         this.clearSelection();
         this.isLoading.set(false);
       },
-      error: () => this.isLoading.set(false)
+      error: () => {
+        if (requestId !== this.loadRequestId) return;
+        this.isLoading.set(false);
+      }
     });
   }
 
@@ -167,6 +185,36 @@ export class TeacherManagementComponent implements OnInit {
 
   clearSelection(): void {
     this.selectedUserIds.set(new Set());
+  }
+
+  paginationPages = computed(() => {
+    const total = this.totalPages();
+    const current = this.currentPage();
+    if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+
+    const pages: number[] = [1];
+    const start = Math.max(2, current - 1);
+    const end = Math.min(total - 1, current + 1);
+    if (start > 2) pages.push(-1);
+    for (let page = start; page <= end; page++) pages.push(page);
+    if (end < total - 1) pages.push(-1);
+    pages.push(total);
+    return pages;
+  });
+
+  goToPage(page: number): void {
+    if (page < 1 || page > this.totalPages() || page === this.currentPage()) return;
+    this.loadUsers(page);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  pageStart(): number {
+    if (this.totalItems() === 0) return 0;
+    return (this.currentPage() - 1) * this.pageSize + 1;
+  }
+
+  pageEnd(): number {
+    return Math.min(this.currentPage() * this.pageSize, this.totalItems());
   }
 
   // --- Per-row kebab menu (CC-10) ---
@@ -271,10 +319,12 @@ export class TeacherManagementComponent implements OnInit {
 
   onSearchInput(value: string) {
     this.searchQuery.set(value);
+    this.loadUsers(1);
   }
 
   onStatusFilterChange(value: string) {
     this.statusFilter.set(value);
+    this.loadUsers(1);
   }
 
   openCreateModal() {

--- a/fe/src/app/features/admin/presentation/components/teacher-management.html
+++ b/fe/src/app/features/admin/presentation/components/teacher-management.html
@@ -183,6 +183,36 @@
                 </tbody>
               </table>
             </div>
+            @if (totalPages() > 1) {
+              <div class="pagination-bar">
+                <div class="pagination-info">
+                  Hiển thị <strong>{{ pageStart() }}</strong> - <strong>{{ pageEnd() }}</strong>
+                  trong tổng số <strong>{{ totalItems() }}</strong> giảng viên
+                </div>
+                <div class="pagination-controls" aria-label="Phân trang giảng viên">
+                  <button (click)="goToPage(currentPage() - 1)" [disabled]="currentPage() === 1"
+                          class="pagination-btn pagination-arrow" aria-label="Trang trước">
+                    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+                  </button>
+                  @for (page of paginationPages(); track $index) {
+                    @if (page === -1) {
+                      <span class="pagination-ellipsis">...</span>
+                    } @else {
+                      <button (click)="goToPage(page)"
+                              class="pagination-btn"
+                              [class.active]="currentPage() === page"
+                              [attr.aria-current]="currentPage() === page ? 'page' : null">
+                        {{ page }}
+                      </button>
+                    }
+                  }
+                  <button (click)="goToPage(currentPage() + 1)" [disabled]="currentPage() === totalPages()"
+                          class="pagination-btn pagination-arrow" aria-label="Trang tiếp theo">
+                    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                  </button>
+                </div>
+              </div>
+            }
           }
         </div>
       </div>

--- a/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.html
+++ b/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.html
@@ -128,7 +128,7 @@
               <!-- Thống kê -->
               <td class="no-wrap cell-muted">
                 <div class="stats-cell">
-                  @if (user.role === 'TEACHER') {
+                  @if (isTeacherRole(user.role)) {
                     <div class="stat-row">
                       <svg class="stat-icon" fill="currentColor" viewBox="0 0 20 20">
                         <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"></path>
@@ -137,7 +137,7 @@
                       <span>{{ user.coursesCreated || 0 }} khóa học</span>
                     </div>
                   }
-                  @if (user.role === 'STUDENT') {
+                  @if (isStudentRole(user.role)) {
                     <div class="stat-row">
                       <svg class="stat-icon" fill="currentColor" viewBox="0 0 20 20">
                         <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"></path>
@@ -146,7 +146,7 @@
                       <span>{{ user.coursesEnrolled || 0 }} đã đăng ký</span>
                     </div>
                   }
-                  @if (user.role !== 'TEACHER' && user.role !== 'STUDENT') {
+                  @if (!isTeacherRole(user.role) && !isStudentRole(user.role)) {
                     <span class="cell-muted">Không áp dụng</span>
                   }
                 </div>

--- a/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.html
+++ b/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.html
@@ -146,12 +146,9 @@
                       <span>{{ user.coursesEnrolled || 0 }} đã đăng ký</span>
                     </div>
                   }
-                  <div class="stat-row">
-                    <svg class="stat-icon" fill="currentColor" viewBox="0 0 20 20">
-                      <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z"></path>
-                    </svg>
-                    <span>{{ user.loginCount || 0 }} lần</span>
-                  </div>
+                  @if (user.role !== 'TEACHER' && user.role !== 'STUDENT') {
+                    <span class="cell-muted">Không áp dụng</span>
+                  }
                 </div>
               </td>
             </tr>

--- a/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.ts
+++ b/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.ts
@@ -178,7 +178,7 @@ import { formatRelativeTimeVN } from '../../../../../../../shared/utils/relative
                   <!-- Thống kê -->
                   <td class="px-6 py-4 whitespace-nowrap text-xs text-gray-600">
                     <div class="space-y-1">
-                      @if (user.role === 'TEACHER') {
+                      @if (isTeacherRole(user.role)) {
                         <div class="flex items-center">
                           <svg class="w-3 h-3 mr-1.5 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
                             <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"></path>
@@ -187,7 +187,7 @@ import { formatRelativeTimeVN } from '../../../../../../../shared/utils/relative
                           <span>{{ user.coursesCreated || 0 }} khóa học</span>
                         </div>
                       }
-                      @if (user.role === 'STUDENT') {
+                      @if (isStudentRole(user.role)) {
                         <div class="flex items-center">
                           <svg class="w-3 h-3 mr-1.5 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
                             <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"></path>
@@ -196,7 +196,7 @@ import { formatRelativeTimeVN } from '../../../../../../../shared/utils/relative
                           <span>{{ user.coursesEnrolled || 0 }} đã đăng ký</span>
                         </div>
                       }
-                      @if (user.role !== 'TEACHER' && user.role !== 'STUDENT') {
+                      @if (!isTeacherRole(user.role) && !isStudentRole(user.role)) {
                         <span class="text-gray-400">Không áp dụng</span>
                       }
                     </div>
@@ -269,6 +269,14 @@ export class UsersTableComponent {
   // util accept union nên truyền thẳng Date.
   formatRelativeTime(input: Date | string | null | undefined): string {
     return formatRelativeTimeVN(input);
+  }
+
+  isTeacherRole(role: string | null | undefined): boolean {
+    return role?.toLowerCase() === 'teacher';
+  }
+
+  isStudentRole(role: string | null | undefined): boolean {
+    return role?.toLowerCase() === 'student';
   }
 
   onStatusAction(user: AdminUser, status: string): void {

--- a/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.ts
+++ b/fe/src/app/features/admin/presentation/components/user-management/components/users-table/users-table.component.ts
@@ -196,12 +196,9 @@ import { formatRelativeTimeVN } from '../../../../../../../shared/utils/relative
                           <span>{{ user.coursesEnrolled || 0 }} đã đăng ký</span>
                         </div>
                       }
-                      <div class="flex items-center">
-                        <svg class="w-3 h-3 mr-1.5 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
-                          <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z"></path>
-                        </svg>
-                        <span>{{ user.loginCount || 0 }} lần</span>
-                      </div>
+                      @if (user.role !== 'TEACHER' && user.role !== 'STUDENT') {
+                        <span class="text-gray-400">Không áp dụng</span>
+                      }
                     </div>
                   </td>
                 </tr>

--- a/fe/src/app/features/teacher/grading/rubric-creator.component.ts
+++ b/fe/src/app/features/teacher/grading/rubric-creator.component.ts
@@ -16,7 +16,8 @@ const SEGMENT_COLORS = ['#0056D2', '#10b981', '#f59e0b', '#8b5cf6', '#ef4444', '
 
 const RUBRIC_TEMPLATES = [
   {
-    id: 'practical', name: 'Kỹ năng thực hành', icon: '🔧',
+    id: 'practical', name: 'Kỹ năng thực hành', icon: 'settings',
+    description: 'Phù hợp cho bài thực hành, thao tác kỹ thuật, kiểm tra quy trình và tiêu chuẩn an toàn.',
     criteria: [
       { name: 'Kỹ thuật thực hiện', weight: 40 },
       { name: 'Độ chính xác', weight: 30 },
@@ -25,7 +26,8 @@ const RUBRIC_TEMPLATES = [
     ]
   },
   {
-    id: 'report', name: 'Báo cáo bài viết', icon: '📝',
+    id: 'report', name: 'Báo cáo bài viết', icon: 'file-text',
+    description: 'Dùng cho báo cáo, bài luận hoặc hồ sơ nộp bài cần đánh giá nội dung, cấu trúc và nguồn tham khảo.',
     criteria: [
       { name: 'Nội dung chuyên môn', weight: 50 },
       { name: 'Cấu trúc & Trình bày', weight: 30 },
@@ -33,7 +35,8 @@ const RUBRIC_TEMPLATES = [
     ]
   },
   {
-    id: 'presentation', name: 'Thuyết trình', icon: '🎤',
+    id: 'presentation', name: 'Thuyết trình', icon: 'presentation',
+    description: 'Dành cho phần trình bày trước lớp, bảo vệ dự án hoặc hoạt động cần đánh giá giao tiếp và phản hồi.',
     criteria: [
       { name: 'Nội dung', weight: 40 },
       { name: 'Kỹ năng trình bày', weight: 30 },
@@ -42,7 +45,8 @@ const RUBRIC_TEMPLATES = [
     ]
   },
   {
-    id: 'simulation', name: 'Mô phỏng', icon: '🥽',
+    id: 'simulation', name: 'Mô phỏng', icon: 'activity',
+    description: 'Phù hợp với tình huống mô phỏng, bài tập xử lý sự cố hoặc hoạt động phối hợp nhóm theo kịch bản.',
     criteria: [
       { name: 'Thực hiện quy trình', weight: 40 },
       { name: 'Xử lý tình huống', weight: 30 },
@@ -476,20 +480,23 @@ const RUBRIC_TEMPLATES = [
       <!-- Template Dialog -->
       @if (showTemplateDialog()) {
         <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6">
-          <div class="bg-white rounded-2xl shadow-xl w-full max-w-lg overflow-hidden">
+          <div class="bg-white rounded-2xl shadow-xl w-full max-w-2xl overflow-hidden">
             <div class="px-6 py-5 border-b border-slate-100">
               <h2 class="text-lg font-bold text-slate-900">Bắt đầu với</h2>
               <p class="text-sm text-slate-500 mt-1">Chọn mẫu có sẵn hoặc tạo từ đầu</p>
             </div>
             <div class="p-6">
-              <div class="grid grid-cols-2 gap-3 mb-4">
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4">
                 @for (t of templates; track t.id) {
                   <button type="button" (click)="loadTemplate(t)"
-                          class="flex items-start gap-3 p-4 rounded-xl border-2 border-slate-200 hover:border-[#0056D2] hover:bg-[#0056D2]/5 transition-all text-left group">
-                    <span class="text-2xl">{{ t.icon }}</span>
-                    <div>
+                          class="flex items-start gap-3 p-4 min-h-[132px] rounded-xl border-2 border-slate-200 hover:border-[#0056D2] hover:bg-[#0056D2]/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0056D2]/30 transition-all text-left group">
+                    <span class="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-600 group-hover:bg-[#0056D2] group-hover:text-white transition-colors">
+                      <lucide-icon [name]="t.icon" [size]="22"></lucide-icon>
+                    </span>
+                    <div class="min-w-0">
                       <p class="text-sm font-semibold text-slate-800 group-hover:text-[#0056D2]">{{ t.name }}</p>
-                      <p class="text-xs text-slate-400 mt-0.5">{{ t.criteria.length }} tiêu chí</p>
+                      <p class="text-xs text-slate-500 mt-1 leading-relaxed">{{ t.description }}</p>
+                      <p class="text-xs font-medium text-slate-400 mt-2">{{ t.criteria.length }} tiêu chí</p>
                     </div>
                   </button>
                 }

--- a/fe/src/app/shared/components/navigation/sidebar.config.ts
+++ b/fe/src/app/shared/components/navigation/sidebar.config.ts
@@ -242,12 +242,6 @@ const allAdminMenuItems: SidebarMenuItem[] = [
     group: 'Hệ thống'
   },
   {
-    label: 'Nhật ký kiểm toán',
-    route: '/admin/logs',
-    icon: 'file-text',
-    group: 'Hệ thống'
-  },
-  {
     label: 'Bộ nhớ ngoại tuyến',
     route: '/admin/offline-storage',
     icon: 'download',


### PR DESCRIPTION
﻿## Summary
- Add real backend filtering/pagination for admin user lists, including multi-role admin queries, status/org/system filters, and real student course counts.
- Update admin, teacher, and student user pages to use server pagination and real count/status data; show `org_admin`, hide the audit-log sidebar item, and remove fake login statistics from the all-users stats column.
- Replace rubric starter template emojis with SVG lucide icons and add descriptions for each template choice.

## Verification
- `mvn -DskipTests compile`
- `mvn -DskipTests test-compile`
- `mvn "-Dtest=UserControllerV3TeacherKpiTest,MultiTierAdminSecurityTest" test` (36 tests)
- `npx ng build --configuration development --progress=false`

Angular build still reports existing unrelated diagnostics/warnings in other modules, but completed successfully.
