### PR TITLE
[codex] Reduce false slow connection warnings

### DIFF
--- a/fe/public/health
+++ b/fe/public/health
@@ -1,0 +1,1 @@
+healthy

--- a/fe/src/app/api/interceptors/offline.interceptor.ts
+++ b/fe/src/app/api/interceptors/offline.interceptor.ts
@@ -28,69 +28,84 @@ export const offlineInterceptor = (req: HttpRequest<any>, next: HttpHandlerFn): 
   const networkStatus = inject(NetworkStatusService);
   const path = extractApiPath(req.url) || req.url;
 
-  const forwardToNetwork = () => withBackgroundMutationTimeout(
-    next(req).pipe(
-      tap((event) => {
-        if (event instanceof HttpResponse) {
-          networkStatus.markOnlineFromHttpSuccess();
+  const forwardToNetwork = () => {
+    const requestStartedAt = readNetworkClock();
+
+    return withBackgroundMutationTimeout(
+      next(req).pipe(
+        tap((event) => {
+          if (event instanceof HttpResponse) {
+            networkStatus.markOnlineFromHttpSuccess(readNetworkClock() - requestStartedAt);
+          }
+        }),
+      ),
+      path,
+      req.method,
+    ).pipe(
+      catchError((error: unknown) => {
+        const isBackgroundTimeout =
+          isNetworkTimeoutError(error) && isBackgroundLearningMutation(path, req.method);
+        const isOfflineError =
+          isBackgroundTimeout ||
+          isOfflineCompatibleHttpError(error as HttpErrorResponse, req.url, {
+            navigatorOnline: typeof navigator === 'undefined' ? true : navigator.onLine,
+            appOnline: networkStatus.online(),
+            hasRecentOfflineSignal: networkStatus.hasRecentOfflineSignal(),
+          });
+        if (!isOfflineError) {
+          return throwError(() => error);
         }
+
+        // Never intercept auth or health-check endpoints
+        if (shouldBypassOfflineInterception(path)) {
+          return throwError(() => error);
+        }
+
+        if (isBackgroundTimeout) {
+          networkStatus.markBackgroundMutationTimeout();
+        } else {
+          networkStatus.markOfflineFromTransportFailure();
+        }
+
+        // For GET requests → try offline fallback
+        if (req.method === 'GET') {
+          return from(getOfflineFallback(req.url)).pipe(
+            switchMap((cached) => {
+              if (cached !== null) {
+                return of(
+                  new HttpResponse({
+                    status: 200,
+                    body: cached,
+                    headers: req.headers,
+                    url: req.url,
+                  }),
+                );
+              }
+              // No cached data available
+              return throwError(
+                () =>
+                  new HttpErrorResponse({
+                    status: 0,
+                    statusText: 'Offline',
+                    url: req.url,
+                    error: { message: 'Không có kết nối mạng và dữ liệu chưa được tải xuống' },
+                  }),
+              );
+            }),
+          );
+        }
+
+        // For mutation requests → queue for later sync
+        if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
+          return buildQueuedMutationResponse(syncService, req, path).pipe(
+            catchError(() => throwError(() => error)),
+          );
+        }
+
+        return throwError(() => error);
       }),
-    ),
-    path,
-    req.method,
-  ).pipe(
-    catchError((error: unknown) => {
-      const isBackgroundTimeout = isNetworkTimeoutError(error)
-        && isBackgroundLearningMutation(path, req.method);
-      const isOfflineError = isBackgroundTimeout
-        || isOfflineCompatibleHttpError(error as HttpErrorResponse, req.url, {
-          navigatorOnline: typeof navigator === 'undefined' ? true : navigator.onLine,
-          appOnline: networkStatus.online(),
-          hasRecentOfflineSignal: networkStatus.hasRecentOfflineSignal(),
-        });
-      if (!isOfflineError) {
-        return throwError(() => error);
-      }
-
-      // Never intercept auth or health-check endpoints
-      if (shouldBypassOfflineInterception(path)) {
-        return throwError(() => error);
-      }
-
-      networkStatus.markOfflineFromTransportFailure();
-
-      // For GET requests → try offline fallback
-      if (req.method === 'GET') {
-        return from(getOfflineFallback(req.url)).pipe(
-          switchMap(cached => {
-            if (cached !== null) {
-              return of(new HttpResponse({
-                status: 200,
-                body: cached,
-                headers: req.headers,
-                url: req.url,
-              }));
-            }
-            // No cached data available
-            return throwError(() => new HttpErrorResponse({
-              status: 0,
-              statusText: 'Offline',
-              url: req.url,
-              error: { message: 'Không có kết nối mạng và dữ liệu chưa được tải xuống' },
-            }));
-          }),
-        );
-      }
-
-      // For mutation requests → queue for later sync
-      if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
-        return buildQueuedMutationResponse(syncService, req, path)
-          .pipe(catchError(() => throwError(() => error)));
-      }
-
-      return throwError(() => error);
-    }),
-  );
+    );
+  };
 
   if (shouldQueueBeforeNetwork(path, req.method, networkStatus.shouldDeferNonCriticalSync())) {
     return buildQueuedMutationResponse(syncService, req, path)
@@ -145,6 +160,10 @@ function isNetworkTimeoutError(error: unknown): boolean {
   return !!error
     && typeof error === 'object'
     && (error as { name?: string }).name === 'TimeoutError';
+}
+
+function readNetworkClock(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now();
 }
 
 function buildQueuedMutationResponse(

--- a/fe/src/app/core/services/network-status.service.spec.ts
+++ b/fe/src/app/core/services/network-status.service.spec.ts
@@ -6,9 +6,7 @@ describe('NetworkStatusService', () => {
   let fetchSpy: jasmine.Spy<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>;
 
   beforeEach(() => {
-    fetchSpy = spyOn(window, 'fetch').and.callFake(async () =>
-      new Response('', { status: 200 }),
-    );
+    fetchSpy = spyOn(window, 'fetch').and.callFake(async () => new Response('', { status: 200 }));
     service = new NetworkStatusService();
   });
 
@@ -16,6 +14,19 @@ describe('NetworkStatusService', () => {
     service.ngOnDestroy();
     fetchSpy.calls.reset();
   });
+
+  async function confirmSlowConnection(rttMs = 1600): Promise<void> {
+    let now = 0;
+    spyOn(performance, 'now').and.callFake(() => now);
+    fetchSpy.calls.reset();
+    fetchSpy.and.callFake(async () => {
+      now += rttMs;
+      return new Response('', { status: 200 });
+    });
+
+    await service.probeNow();
+    await service.probeNow();
+  }
 
   describe('Initial state', () => {
     it('should have online signal reflecting navigator.onLine', () => {
@@ -27,7 +38,10 @@ describe('NetworkStatusService', () => {
     });
 
     it('should expose reportedDownlinkMbps as nullable browser telemetry', () => {
-      expect(service.reportedDownlinkMbps() === null || typeof service.reportedDownlinkMbps() === 'number').toBeTrue();
+      expect(
+        service.reportedDownlinkMbps() === null ||
+          typeof service.reportedDownlinkMbps() === 'number',
+      ).toBeTrue();
     });
   });
 
@@ -37,22 +51,24 @@ describe('NetworkStatusService', () => {
       expect(service.connectionTier()).toBe('none');
     });
 
-    it('should return "slow" when bandwidth < 1 Mbps', () => {
+    it('should not show slow from raw bandwidth telemetry alone', () => {
       service.online.set(true);
       service.effectiveBandwidthMbps.set(0.5);
-      expect(service.connectionTier()).toBe('slow');
+      expect(service.connectionTier()).toBe('fast');
     });
 
-    it('should return "fast" when bandwidth >= 1 Mbps', () => {
+    it('should return "fast" while online before slow connectivity is confirmed', () => {
       service.online.set(true);
       service.effectiveBandwidthMbps.set(5);
       expect(service.connectionTier()).toBe('fast');
     });
 
-    it('should return "fast" when bandwidth is exactly 1 Mbps', () => {
+    it('should return "slow" after repeated slow connectivity probes', async () => {
       service.online.set(true);
-      service.effectiveBandwidthMbps.set(1);
-      expect(service.connectionTier()).toBe('fast');
+
+      await confirmSlowConnection();
+
+      expect(service.connectionTier()).toBe('slow');
     });
   });
 
@@ -62,9 +78,11 @@ describe('NetworkStatusService', () => {
       expect(service.connectionLabel()).toBe('Ngoại tuyến');
     });
 
-    it('should return "Kết nối chậm" when slow', () => {
+    it('should return "Kết nối chậm" when slow is confirmed', async () => {
       service.online.set(true);
-      service.effectiveBandwidthMbps.set(0.3);
+
+      await confirmSlowConnection();
+
       expect(service.connectionLabel()).toBe('Kết nối chậm');
     });
 
@@ -78,7 +96,6 @@ describe('NetworkStatusService', () => {
   describe('Signal reactivity', () => {
     it('should update connectionTier when online signal changes', () => {
       service.online.set(true);
-      service.effectiveBandwidthMbps.set(10);
       expect(service.connectionTier()).toBe('fast');
 
       service.online.set(false);
@@ -88,27 +105,52 @@ describe('NetworkStatusService', () => {
       expect(service.connectionTier()).toBe('fast');
     });
 
-    it('should update connectionTier when bandwidth changes', () => {
+    it('should keep connectionTier stable when bandwidth telemetry changes', () => {
       service.online.set(true);
 
       service.effectiveBandwidthMbps.set(10);
       expect(service.connectionTier()).toBe('fast');
 
       service.effectiveBandwidthMbps.set(0.2);
-      expect(service.connectionTier()).toBe('slow');
+      expect(service.connectionTier()).toBe('fast');
     });
   });
 
-  describe('Edge cases', () => {
-    it('should handle zero bandwidth as slow', () => {
-      service.online.set(true);
-      service.effectiveBandwidthMbps.set(0);
+  describe('probe behavior', () => {
+    it('should probe the frontend edge instead of backend actuator health', async () => {
+      fetchSpy.calls.reset();
+
+      await service.probeNow();
+
+      const probeUrl = String(fetchSpy.calls.mostRecent().args[0]);
+      expect(probeUrl).toContain('/health?offlineProbe=');
+    });
+
+    it('should require two slow probe samples before showing slow', async () => {
+      let now = 0;
+      spyOn(performance, 'now').and.callFake(() => now);
+      fetchSpy.calls.reset();
+      fetchSpy.and.callFake(async () => {
+        now += 1600;
+        return new Response('', { status: 200 });
+      });
+
+      await service.probeNow();
+      expect(service.connectionTier()).toBe('fast');
+
+      await service.probeNow();
       expect(service.connectionTier()).toBe('slow');
     });
 
-    it('should handle very high bandwidth as fast', () => {
-      service.online.set(true);
-      service.effectiveBandwidthMbps.set(1000);
+    it('should clear confirmed slow state after a fast probe', async () => {
+      await confirmSlowConnection();
+      expect(service.connectionTier()).toBe('slow');
+
+      (performance.now as jasmine.Spy).and.returnValues(0, 200);
+      fetchSpy.and.callFake(async () => new Response('', { status: 200 }));
+
+      await service.probeNow();
+
       expect(service.connectionTier()).toBe('fast');
     });
   });
@@ -132,7 +174,7 @@ describe('NetworkStatusService', () => {
       expect(service.hasRecentOfflineSignal()).toBeFalse();
     }));
 
-    it('should treat one failed probe as degraded instead of immediately offline', fakeAsync(() => {
+    it('should treat one failed probe as suspected, not visible slow', fakeAsync(() => {
       service.online.set(true);
       fetchSpy.and.callFake(async () => new Response('', { status: 503 }));
 
@@ -141,7 +183,8 @@ describe('NetworkStatusService', () => {
       flushMicrotasks();
 
       expect(service.online()).toBeTrue();
-      expect(service.connectionTier()).toBe('slow');
+      expect(service.connectionTier()).toBe('fast');
+      expect(service.effectiveBandwidthMbps()).toBe(0.5);
       expect(service.hasRecentOfflineSignal()).toBeTrue();
       expect(service.isEffectivelyOffline()).toBeFalse();
     }));
@@ -158,7 +201,7 @@ describe('NetworkStatusService', () => {
       expect(service.isEffectivelyOffline()).toBeTrue();
     });
 
-    it('should let manual retry recover on a successful health probe', async () => {
+    it('should let manual retry recover on a successful frontend probe', async () => {
       service.online.set(true);
       fetchSpy.calls.reset();
       fetchSpy.and.callFake(async () => new Response('', { status: 200 }));
@@ -176,7 +219,7 @@ describe('NetworkStatusService', () => {
       fetchSpy.calls.reset();
       service.markOfflineFromTransportFailure();
 
-      service.markOnlineFromHttpSuccess();
+      service.markOnlineFromHttpSuccess(250);
       tick(250);
 
       expect(service.online()).toBeTrue();
@@ -186,6 +229,42 @@ describe('NetworkStatusService', () => {
     }));
   });
 
+  describe('background mutation timeout tracking', () => {
+    it('should defer background sync without showing the slow badge', () => {
+      service.online.set(true);
+
+      service.markBackgroundMutationTimeout();
+
+      expect(service.hasRecentBackgroundTimeout()).toBeTrue();
+      expect(service.shouldDeferNonCriticalSync()).toBeTrue();
+      expect(service.connectionTier()).toBe('fast');
+    });
+
+    it('should keep background deferral after a successful frontend probe', fakeAsync(() => {
+      service.online.set(true);
+      fetchSpy.calls.reset();
+
+      service.markBackgroundMutationTimeout();
+      tick(250);
+      flushMicrotasks();
+
+      expect(fetchSpy).toHaveBeenCalled();
+      expect(service.hasRecentBackgroundTimeout()).toBeTrue();
+      expect(service.shouldDeferNonCriticalSync()).toBeTrue();
+      expect(service.connectionTier()).toBe('fast');
+    }));
+
+    it('should clear background timeout state after a successful HTTP response', () => {
+      service.online.set(true);
+      service.markBackgroundMutationTimeout();
+
+      service.markOnlineFromHttpSuccess(250);
+
+      expect(service.hasRecentBackgroundTimeout()).toBeFalse();
+      expect(service.shouldDeferNonCriticalSync()).toBeFalse();
+    });
+  });
+
   describe('non-critical sync deferral', () => {
     it('should defer background sync while effectively offline', () => {
       service.online.set(false);
@@ -193,9 +272,10 @@ describe('NetworkStatusService', () => {
       expect(service.shouldDeferNonCriticalSync()).toBeTrue();
     });
 
-    it('should defer background sync on slow connections', () => {
+    it('should defer background sync on confirmed slow connections', async () => {
       service.online.set(true);
-      service.effectiveBandwidthMbps.set(0.5);
+
+      await confirmSlowConnection();
 
       expect(service.shouldDeferNonCriticalSync()).toBeTrue();
     });

--- a/fe/src/app/core/services/network-status.service.ts
+++ b/fe/src/app/core/services/network-status.service.ts
@@ -6,10 +6,16 @@ export type ConnectionTransport = 'wifi' | 'ethernet' | 'cellular' | 'unknown';
 const OFFLINE_GRACE_MS = 1_500;
 const RECENT_OFFLINE_WINDOW_MS = 5_000;
 const NON_CRITICAL_SYNC_DEFER_WINDOW_MS = 15_000;
+const BACKGROUND_TIMEOUT_DEFER_WINDOW_MS = 15_000;
 const PROBE_INTERVAL_MS = 120_000;
 const PROBE_TIMEOUT_MS = 4_000;
 const TRANSPORT_FAILURE_PROBE_DELAY_MS = 250;
 const OFFLINE_PROBE_FAILURE_THRESHOLD = 2;
+const FRONTEND_CONNECTIVITY_PROBE_PATH = '/health';
+const SLOW_PROBE_RTT_MS = 1_500;
+const MODERATE_PROBE_RTT_MS = 900;
+const HTTP_SUCCESS_RECOVERY_MS = 1_200;
+const SLOW_PROBE_CONFIRMATION_THRESHOLD = 2;
 const DEGRADED_PROBE_BANDWIDTH_MBPS = 0.5;
 
 @Injectable({ providedIn: 'root' })
@@ -23,7 +29,7 @@ export class NetworkStatusService implements OnDestroy {
 
   readonly connectionTier = computed<ConnectionTier>(() => {
     if (!this.online()) return 'none';
-    return this.effectiveBandwidthMbps() < 1 ? 'slow' : 'fast';
+    return this.confirmedSlowConnection() ? 'slow' : 'fast';
   });
 
   readonly isLikelyMetered = computed(() => {
@@ -32,8 +38,11 @@ export class NetworkStatusService implements OnDestroy {
     return this.connectionTransport() === 'cellular';
   });
 
-  readonly connectionDetailsAvailable = computed(() =>
-    this.connectionTransport() !== 'unknown' || this.effectiveNetworkType() != null || this.saveDataEnabled()
+  readonly connectionDetailsAvailable = computed(
+    () =>
+      this.connectionTransport() !== 'unknown' ||
+      this.effectiveNetworkType() != null ||
+      this.saveDataEnabled(),
   );
 
   readonly connectionLabel = computed(() => {
@@ -50,11 +59,14 @@ export class NetworkStatusService implements OnDestroy {
   private readonly recentOfflineSignalAt = signal<number | null>(
     this.getBrowserOnlineHint() ? null : Date.now(),
   );
+  private readonly recentBackgroundTimeoutAt = signal<number | null>(null);
+  private readonly confirmedSlowConnection = signal(false);
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private offlineGraceTimer: ReturnType<typeof setTimeout> | null = null;
   private transportFailureProbeTimer: ReturnType<typeof setTimeout> | null = null;
   private probeInterval: ReturnType<typeof setInterval> | null = null;
   private consecutiveProbeFailures = 0;
+  private consecutiveSlowProbeSamples = 0;
 
   private readonly onlineHandler = () => {
     if (this.offlineGraceTimer) {
@@ -80,7 +92,9 @@ export class NetworkStatusService implements OnDestroy {
   };
 
   private readonly connectionChangeHandler = () => this.debouncedUpdate();
-  private connectionRef: { removeEventListener?: (type: string, listener: EventListenerOrEventListenerObject) => void } | null = null;
+  private connectionRef: {
+    removeEventListener?: (type: string, listener: EventListenerOrEventListenerObject) => void;
+  } | null = null;
 
   constructor() {
     if (typeof window === 'undefined') return;
@@ -133,16 +147,23 @@ export class NetworkStatusService implements OnDestroy {
     return lastOfflineSignalAt != null && Date.now() - lastOfflineSignalAt <= windowMs;
   }
 
+  hasRecentBackgroundTimeout(windowMs = BACKGROUND_TIMEOUT_DEFER_WINDOW_MS): boolean {
+    const lastBackgroundTimeoutAt = this.recentBackgroundTimeoutAt();
+    return lastBackgroundTimeoutAt != null && Date.now() - lastBackgroundTimeoutAt <= windowMs;
+  }
+
   isEffectivelyOffline(): boolean {
-    return !this.getBrowserOnlineHint()
-      || !this.online();
+    return !this.getBrowserOnlineHint() || !this.online();
   }
 
   shouldDeferNonCriticalSync(windowMs = NON_CRITICAL_SYNC_DEFER_WINDOW_MS): boolean {
-    return this.isEffectivelyOffline()
-      || this.connectionTier() === 'slow'
-      || this.saveDataEnabled()
-      || this.hasRecentOfflineSignal(windowMs);
+    return (
+      this.isEffectivelyOffline() ||
+      this.saveDataEnabled() ||
+      this.confirmedSlowConnection() ||
+      this.hasRecentOfflineSignal(windowMs) ||
+      this.hasRecentBackgroundTimeout(windowMs)
+    );
   }
 
   markOfflineFromTransportFailure(): void {
@@ -155,7 +176,17 @@ export class NetworkStatusService implements OnDestroy {
     this.scheduleTransportFailureProbe();
   }
 
-  markOnlineFromHttpSuccess(): void {
+  markBackgroundMutationTimeout(): void {
+    if (!this.getBrowserOnlineHint()) {
+      this.markOfflineState();
+      return;
+    }
+
+    this.recentBackgroundTimeoutAt.set(Date.now());
+    this.scheduleTransportFailureProbe();
+  }
+
+  markOnlineFromHttpSuccess(responseTimeMs?: number): void {
     if (!this.getBrowserOnlineHint()) {
       return;
     }
@@ -168,7 +199,16 @@ export class NetworkStatusService implements OnDestroy {
     this.online.set(true);
     this.consecutiveProbeFailures = 0;
     this.recentOfflineSignalAt.set(null);
-    if (this.effectiveBandwidthMbps() <= 0) {
+    this.recentBackgroundTimeoutAt.set(null);
+
+    if (responseTimeMs == null || responseTimeMs <= HTTP_SUCCESS_RECOVERY_MS) {
+      this.clearSlowConnectionState();
+    }
+
+    if (
+      this.effectiveBandwidthMbps() <= 0 ||
+      (!this.confirmedSlowConnection() && this.effectiveBandwidthMbps() < 1)
+    ) {
       this.effectiveBandwidthMbps.set(2);
     }
   }
@@ -197,7 +237,9 @@ export class NetworkStatusService implements OnDestroy {
 
     this.connectionTransport.set(this.normalizeConnectionTransport(conn?.type));
     this.saveDataEnabled.set(conn?.saveData === true);
-    this.effectiveNetworkType.set(typeof conn?.effectiveType === 'string' ? conn.effectiveType : null);
+    this.effectiveNetworkType.set(
+      typeof conn?.effectiveType === 'string' ? conn.effectiveType : null,
+    );
     this.reportedDownlinkMbps.set(this.readReportedDownlinkMbps(conn));
 
     if (!browserOnline) {
@@ -213,9 +255,9 @@ export class NetworkStatusService implements OnDestroy {
     void this.runProbe();
   }
 
-  // Single-probe health check against /actuator/health. A single 504/timeout
-  // means "degraded" first, not "offline"; mobile networks and sleeping VMs can
-  // spike briefly while the browser still has usable connectivity.
+  // Keep the connectivity probe on the frontend edge. Backend health checks can
+  // include DB, storage, or video pipeline dependencies and would turn server
+  // slowness into a misleading user-network warning.
   private async runProbe(): Promise<boolean> {
     if (!this.getBrowserOnlineHint()) {
       this.markOfflineState();
@@ -227,7 +269,7 @@ export class NetworkStatusService implements OnDestroy {
     const start = performance.now();
 
     try {
-      const response = await fetch(this.buildProbeUrl('/actuator/health'), {
+      const response = await fetch(this.buildProbeUrl(FRONTEND_CONNECTIVITY_PROBE_PATH), {
         method: 'GET',
         signal: controller.signal,
         cache: 'no-store',
@@ -299,25 +341,50 @@ export class NetworkStatusService implements OnDestroy {
     this.recentOfflineSignalAt.set(null);
 
     const reportedDownlink = this.reportedDownlinkMbps();
+    const measuredBandwidth = this.estimateBandwidthFromRtt(rtt);
     if (reportedDownlink != null) {
-      this.effectiveBandwidthMbps.set(reportedDownlink);
-      return;
+      this.effectiveBandwidthMbps.set(Math.min(reportedDownlink, measuredBandwidth));
+    } else {
+      this.effectiveBandwidthMbps.set(measuredBandwidth);
     }
 
-    if (rtt > 1200) {
-      this.effectiveBandwidthMbps.set(0.5);
-    } else if (rtt > 700) {
-      this.effectiveBandwidthMbps.set(1.5);
-    } else {
-      this.effectiveBandwidthMbps.set(10);
+    if (rtt > SLOW_PROBE_RTT_MS) {
+      this.recordSlowProbeSample();
+    } else if (rtt <= MODERATE_PROBE_RTT_MS || this.confirmedSlowConnection()) {
+      this.clearSlowConnectionState();
     }
+  }
+
+  private estimateBandwidthFromRtt(rtt: number): number {
+    if (rtt > SLOW_PROBE_RTT_MS) {
+      return 0.5;
+    }
+    if (rtt > MODERATE_PROBE_RTT_MS) {
+      return 1.5;
+    }
+    return 10;
+  }
+
+  private recordSlowProbeSample(): void {
+    this.consecutiveSlowProbeSamples += 1;
+    if (this.consecutiveSlowProbeSamples >= SLOW_PROBE_CONFIRMATION_THRESHOLD) {
+      this.confirmedSlowConnection.set(true);
+    }
+  }
+
+  private clearSlowConnectionState(): void {
+    this.consecutiveSlowProbeSamples = 0;
+    this.confirmedSlowConnection.set(false);
   }
 
   private markProbeFailureState(): void {
     this.consecutiveProbeFailures += 1;
     this.recentOfflineSignalAt.set(Date.now());
 
-    if (!this.getBrowserOnlineHint() || this.consecutiveProbeFailures >= OFFLINE_PROBE_FAILURE_THRESHOLD) {
+    if (
+      !this.getBrowserOnlineHint() ||
+      this.consecutiveProbeFailures >= OFFLINE_PROBE_FAILURE_THRESHOLD
+    ) {
       this.markOfflineState();
       return;
     }
@@ -328,6 +395,7 @@ export class NetworkStatusService implements OnDestroy {
 
   private markOfflineState(): void {
     this.online.set(false);
+    this.clearSlowConnectionState();
     this.effectiveBandwidthMbps.set(0);
     this.reportedDownlinkMbps.set(null);
     this.recentOfflineSignalAt.set(Date.now());


### PR DESCRIPTION
## Summary
- Only show the slow connection badge after repeated slow frontend-edge probes instead of raw browser downlink telemetry or a single failed probe.
- Move the connectivity probe from backend `/actuator/health` to frontend `/health`, with a static `fe/public/health` file for dev/test parity.
- Treat background learning mutation timeouts as temporary sync deferral, not global offline/slow state.
- Clear slow/background timeout state from successful HTTP responses when the response is fast enough.

## Validation
- `npm run test:ci` - pass (`TOTAL: 473 SUCCESS`, 2 skipped)
- `npm run build` - pass

Notes: build still reports existing Sass deprecation, Angular template optional/nullish, and CommonJS dependency warnings.