### PR TITLE
[codex] fix interactive video progress gates

### DIFF
--- a/fe/src/app/core/utils/interactive-video-runtime.spec.ts
+++ b/fe/src/app/core/utils/interactive-video-runtime.spec.ts
@@ -8,6 +8,7 @@ import {
   evaluateInteractiveVideoFillBlank,
   getDueInteractiveVideoInteraction,
   getVisibleInteractiveVideoInteractions,
+  isInteractiveVideoProgressGateInteraction,
   isInteractiveVideoTimeWithinWatchedRanges,
   isInteractiveVideoReviewInteraction,
   resolveInteractiveVideoChoiceTarget,
@@ -135,6 +136,55 @@ describe('interactive-video-runtime', () => {
       interaction.choices![0],
       timeline,
     )).toBe(5);
+  });
+
+  it('identifies every interaction type that blocks learner progress', () => {
+    const gateInteractions: InteractiveVideoInteraction[] = [
+      {
+        id: 'required-checkpoint',
+        type: 'checkpoint',
+        atSeconds: 5,
+        required: true,
+      },
+      {
+        id: 'review-branch',
+        type: 'branch',
+        atSeconds: 10,
+        adaptivity: { requireCorrectBeforeContinue: true },
+        choices: [{ id: 'right', label: 'Right', isCorrect: true }],
+      },
+      {
+        id: 'fill-blank-gate',
+        type: 'fill_blank',
+        atSeconds: 15,
+        fillBlank: {
+          template: '{{1}}',
+          blanks: [{ id: '1', acceptedAnswers: ['correct'] }],
+          requireAllCorrectBeforeContinue: true,
+        },
+      },
+      {
+        id: 'drag-drop-gate',
+        type: 'drag_drop',
+        atSeconds: 20,
+        dragDrop: {
+          instruction: 'Place the item.',
+          backgroundImage: null,
+          dropZones: [],
+          draggables: [],
+          requireAllCorrectBeforeContinue: true,
+        },
+      },
+    ];
+
+    expect(gateInteractions.every(isInteractiveVideoProgressGateInteraction)).toBeTrue();
+    expect(isInteractiveVideoProgressGateInteraction(
+      {
+        id: 'optional-note',
+        type: 'checkpoint',
+        atSeconds: 25,
+      },
+    )).toBeFalse();
   });
 
   it('blocks forward seeks past watched time when required work remains', () => {

--- a/fe/src/app/core/utils/interactive-video-runtime.ts
+++ b/fe/src/app/core/utils/interactive-video-runtime.ts
@@ -179,6 +179,15 @@ export function isInteractiveVideoReviewInteraction(
     || (interaction.choices ?? []).some(choice => typeof choice.isCorrect === 'boolean');
 }
 
+export function isInteractiveVideoProgressGateInteraction(
+  interaction: InteractiveVideoInteraction,
+): boolean {
+  return interaction.required === true
+    || interaction.adaptivity?.requireCorrectBeforeContinue === true
+    || interaction.fillBlank?.requireAllCorrectBeforeContinue === true
+    || interaction.dragDrop?.requireAllCorrectBeforeContinue === true;
+}
+
 export function resolveInteractiveVideoReviewTarget(
   interaction: InteractiveVideoInteraction,
   choice: InteractiveVideoChoice,

--- a/fe/src/app/shared/blocks/video-block/quiz-video-player.component.spec.ts
+++ b/fe/src/app/shared/blocks/video-block/quiz-video-player.component.spec.ts
@@ -57,6 +57,38 @@ describe('QuizVideoPlayerComponent interactive video seek behavior', () => {
     expect(getPrivate<number>(fixture.componentInstance, 'furthestWatchedSeconds')).toBe(20);
   });
 
+  it('snaps a forward seek past correctness-gated work even when it is not marked required', () => {
+    const video = prepareVideoElement(20, 120);
+    const spec: InteractiveVideoSpec = {
+      version: 2,
+      enabled: true,
+      behavior: { preventSkippingMode: 'forward' },
+      timeline: [
+        {
+          id: 'branch-review',
+          type: 'branch',
+          atSeconds: 40,
+          required: false,
+          adaptivity: { requireCorrectBeforeContinue: true },
+          choices: [
+            { id: 'wrong', label: 'Wrong', isCorrect: false, targetTimeSeconds: 15 },
+            { id: 'right', label: 'Right', isCorrect: true },
+          ],
+        },
+      ],
+    };
+    fixture.componentRef.setInput('interactiveVideoSpec', spec);
+    fixture.componentInstance.currentTimeSeconds.set(20);
+    fixture.detectChanges();
+    setPrivate(fixture.componentInstance, 'furthestWatchedSeconds', 20);
+
+    video.currentTime = 90;
+    fixture.componentInstance.onSeeking();
+
+    expect(video.currentTime).toBe(20);
+    expect(fixture.componentInstance.currentTimeSeconds()).toBe(20);
+  });
+
   it('opens an optional interaction crossed by a settled seek edge', () => {
     const video = prepareVideoElement(12, 120);
     const optional: InteractiveVideoInteraction = {

--- a/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
+++ b/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
@@ -16,6 +16,7 @@ import { InteractiveVideoMarkersComponent } from './interactive-video-markers.co
 import {
   addInteractiveVideoWatchedRange,
   getDueInteractiveVideoInteraction,
+  isInteractiveVideoProgressGateInteraction,
   isInteractiveVideoReviewInteraction,
   resolveInteractiveVideoChoiceTarget,
   resolveInteractiveVideoReviewTarget,
@@ -724,7 +725,8 @@ export class QuizVideoPlayerComponent {
     }
 
     return spec.timeline.some(interaction =>
-      interaction.required === true && !this.completedInteractionIds.has(interaction.id),
+      isInteractiveVideoProgressGateInteraction(interaction)
+        && !this.completedInteractionIds.has(interaction.id),
     );
   }
 


### PR DESCRIPTION
﻿## Description

Interactive video anti-skip logic now treats all configured progress gates as blocking work, not only interactions marked `required`.

## Motivation

The player previously passed `hasIncompleteRequiredInteractions` based only on `interaction.required === true`. Authoring/runtime can also require a correct answer before continuing through `adaptivity.requireCorrectBeforeContinue`, `fillBlank.requireAllCorrectBeforeContinue`, or `dragDrop.requireAllCorrectBeforeContinue`, so learners could seek past those interactions when the teacher did not also mark them `required`.

## Type of Change

- Bug fix
- Test coverage

## Related Issues

Refs: none

## Changes Made

- Added `isInteractiveVideoProgressGateInteraction()` in the interactive video runtime util.
- Updated the quiz video player seek guard to use that shared progress-gate definition.
- Added runtime and player regression tests for non-required correctness-gated interactions.

## Scope Note

This PR does not change interaction rendering, answer scoring, or H5P content rendering. It only aligns seek blocking with the existing interactive-video gate configuration.

## Testing Guide

1. Create or open an interactive video with `preventSkippingMode: 'forward'` and a branch/single-choice interaction that has `adaptivity.requireCorrectBeforeContinue: true` but `required: false`.
2. Start before that interaction, then drag the video timeline past it.
3. Expected: the player snaps back to the furthest watched time until the gated interaction is completed.

## Local Checks

- `git diff --check`
- `npx tsc -p tsconfig.spec.json --noEmit`
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/core/utils/interactive-video-runtime.spec.ts --include=src/app/shared/blocks/video-block/quiz-video-player.component.spec.ts`
- `npx ng build --configuration development --progress=false` (passed with existing unrelated Angular/Sass warnings)

## Checklist

- [x] Focused fix with no unrelated refactor
- [x] Regression test added
- [x] Typecheck, focused tests, and build pass
- [x] PR opened ready for teammate review after CI passed

