### PR TITLE
[codex] fix interactive video review targets

### DIFF
--- a/fe/src/app/core/utils/interactive-video-runtime.spec.ts
+++ b/fe/src/app/core/utils/interactive-video-runtime.spec.ts
@@ -8,6 +8,7 @@ import {
   evaluateInteractiveVideoFillBlank,
   getDueInteractiveVideoInteraction,
   getVisibleInteractiveVideoInteractions,
+  hasInteractiveVideoReviewTarget,
   isInteractiveVideoProgressGateInteraction,
   isInteractiveVideoTimeWithinWatchedRanges,
   isInteractiveVideoReviewInteraction,
@@ -136,6 +137,30 @@ describe('interactive-video-runtime', () => {
       interaction.choices![0],
       timeline,
     )).toBe(5);
+  });
+
+  it('does not invent a review target when no seek destination is configured', () => {
+    const interaction: InteractiveVideoInteraction = {
+      id: 'review-without-target',
+      type: 'branch',
+      atSeconds: 47,
+      adaptivity: {
+        requireCorrectBeforeContinue: true,
+        onWrong: { type: 'continue', message: 'Try again.' },
+      },
+      choices: [
+        { id: 'wrong', label: 'Wrong', isCorrect: false },
+        { id: 'right', label: 'Right', isCorrect: true },
+      ],
+    };
+    const wrongChoice = interaction.choices![0];
+
+    expect(resolveInteractiveVideoReviewTarget(
+      interaction,
+      wrongChoice,
+      timeline,
+    )).toBeNull();
+    expect(hasInteractiveVideoReviewTarget(interaction, wrongChoice, timeline)).toBeFalse();
   });
 
   it('identifies every interaction type that blocks learner progress', () => {

--- a/fe/src/app/core/utils/interactive-video-runtime.ts
+++ b/fe/src/app/core/utils/interactive-video-runtime.ts
@@ -188,11 +188,19 @@ export function isInteractiveVideoProgressGateInteraction(
     || interaction.dragDrop?.requireAllCorrectBeforeContinue === true;
 }
 
+export function hasInteractiveVideoReviewTarget(
+  interaction: InteractiveVideoInteraction,
+  choice: InteractiveVideoChoice,
+  timeline: InteractiveVideoInteraction[],
+): boolean {
+  return resolveInteractiveVideoReviewTarget(interaction, choice, timeline) != null;
+}
+
 export function resolveInteractiveVideoReviewTarget(
   interaction: InteractiveVideoInteraction,
   choice: InteractiveVideoChoice,
   timeline: InteractiveVideoInteraction[],
-): number {
+): number | null {
   const adaptivityAction = choice.isCorrect === true
     ? interaction.adaptivity?.onCorrect
     : interaction.adaptivity?.onWrong;
@@ -213,8 +221,9 @@ export function resolveInteractiveVideoReviewTarget(
     timeline,
     { sourceTimeSeconds: interaction.atSeconds, allowBackwardSeek: true },
   );
+  const target = adaptivityTarget ?? choiceTarget;
 
-  return Math.max(0, adaptivityTarget ?? choiceTarget ?? 0);
+  return target == null ? null : Math.max(0, target);
 }
 
 function resolveRawInteractiveVideoChoiceTarget(

--- a/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
+++ b/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
@@ -207,6 +207,7 @@ export function shouldShowMediaNetworkHint(state: MediaNetworkHintState): boolea
         <app-interactive-video-overlay
           [interaction]="interaction"
           [selectedChoiceId]="selectedChoiceId()"
+          [timeline]="interactiveVideoSpec()?.enabled === false ? [] : (interactiveVideoSpec()?.timeline ?? [])"
           (choiceSelected)="onInteractiveChoice($event)"
           (reviewRequested)="onInteractiveReviewRequested()"
           (continueRequested)="onInteractiveContinue()" />
@@ -862,6 +863,10 @@ export class AdaptiveVideoPlayerComponent {
       choice,
       this.interactiveVideoSpec()?.timeline ?? [],
     );
+    if (target == null) {
+      return;
+    }
+
     this.activeInteraction.set(null);
     this.selectedChoiceId.set(null);
     video.currentTime = target;

--- a/fe/src/app/features/learning/components/youtube-player/youtube-player.component.ts
+++ b/fe/src/app/features/learning/components/youtube-player/youtube-player.component.ts
@@ -104,6 +104,7 @@ function extractVideoId(url: string): string | null {
         <app-interactive-video-overlay
           [interaction]="interaction"
           [selectedChoiceId]="selectedChoiceId()"
+          [timeline]="interactiveVideoSpec()?.enabled === false ? [] : (interactiveVideoSpec()?.timeline ?? [])"
           [density]="overlayDensity()"
           (choiceSelected)="onInteractiveChoice($event)"
           (reviewRequested)="onInteractiveReviewRequested()"
@@ -396,6 +397,10 @@ export class YouTubePlayerComponent implements OnDestroy {
       choice,
       this.interactiveVideoSpec()?.timeline ?? [],
     );
+    if (target == null) {
+      return;
+    }
+
     this.activeInteraction.set(null);
     this.selectedChoiceId.set(null);
     this.player?.seekTo?.(target, true);

--- a/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.spec.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.spec.ts
@@ -131,6 +131,40 @@ describe('InteractiveVideoOverlayComponent', () => {
     expect(reviewButton.textContent).toContain('Xem lại video');
   });
 
+  it('lets learners retry a wrong branch answer when no review target exists', () => {
+    fixture.componentRef.setInput('interaction', {
+      id: 'branch-no-review-target',
+      type: 'branch',
+      atSeconds: 47,
+      title: 'Pick the safer action.',
+      adaptivity: {
+        requireCorrectBeforeContinue: true,
+        onWrong: { type: 'continue', message: 'Try the safer option.' },
+      },
+      choices: [
+        { id: 'wrong', label: 'Skip the checklist', isCorrect: false },
+        { id: 'right', label: 'Complete the checklist', isCorrect: true },
+      ],
+    });
+    fixture.componentRef.setInput('selectedChoiceId', 'wrong');
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    const wrongChoice = Array.from(element.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('Skip the checklist')) as HTMLButtonElement;
+    const rightChoice = Array.from(element.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('Complete the checklist')) as HTMLButtonElement;
+    const continueButton = Array.from(element.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => !button.hasAttribute('data-answer-state')) as HTMLButtonElement;
+
+    expect(element.querySelector('[data-testid="interactive-video-review-button"]')).toBeNull();
+    expect(wrongChoice.disabled).toBeFalse();
+    expect(rightChoice.disabled).toBeFalse();
+    expect(rightChoice.getAttribute('data-answer-state')).toBe('correct-answer');
+    expect(continueButton.disabled).toBeTrue();
+    expect(element.textContent).toContain('Try the safer option.');
+  });
+
   it('keeps tab focus inside the dialog', fakeAsync(() => {
     fixture.componentRef.setInput('interaction', {
       id: 'focus1',

--- a/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
@@ -17,6 +17,7 @@ import type {
   InteractiveVideoChoice,
   InteractiveVideoInteraction,
 } from '../../../api/types/interactive-video.types';
+import { hasInteractiveVideoReviewTarget } from '../../../core/utils/interactive-video-runtime';
 import { ContentIdentityService } from '../../../core/services/content-identity.service';
 import katex from 'katex';
 import { InteractiveVideoDragDropComponent } from './interactive-video-drag-drop.component';
@@ -161,6 +162,7 @@ export class InteractiveVideoOverlayComponent implements OnDestroy {
 
   readonly interaction = input.required<InteractiveVideoInteraction>();
   readonly selectedChoiceId = input<string | null>(null);
+  readonly timeline = input<InteractiveVideoInteraction[]>([]);
   readonly density = input<'comfortable' | 'compact'>('comfortable');
   private readonly panel = viewChild<ElementRef<HTMLElement>>('panel');
 
@@ -401,13 +403,9 @@ export class InteractiveVideoOverlayComponent implements OnDestroy {
   readonly shouldOfferReview = computed(() => {
     const interaction = this.interaction();
     const selected = this.selectedChoice();
-    const hasReviewTarget = interaction.type === 'branch'
-      || interaction.adaptivity?.onWrong?.type === 'seek'
-      || selected?.targetTimeSeconds != null
-      || !!selected?.targetInteractionId;
     return this.requiresCorrectAnswer()
       && selected?.isCorrect === false
-      && hasReviewTarget;
+      && hasInteractiveVideoReviewTarget(interaction, selected, this.timeline());
   });
 
   readonly areChoicesLocked = computed(() => this.shouldOfferReview());

--- a/fe/src/app/shared/blocks/video-block/quiz-video-player.component.spec.ts
+++ b/fe/src/app/shared/blocks/video-block/quiz-video-player.component.spec.ts
@@ -181,6 +181,37 @@ describe('QuizVideoPlayerComponent interactive video seek behavior', () => {
     expect(getPrivate<number>(fixture.componentInstance, 'furthestWatchedSeconds')).toBe(25);
   });
 
+  it('does not jump to the beginning when a review action has no seek target', () => {
+    const video = prepareVideoElement(42, 120);
+    const reviewWithoutTarget: InteractiveVideoInteraction = {
+      id: 'branch-review-without-target',
+      type: 'branch',
+      atSeconds: 42,
+      adaptivity: {
+        requireCorrectBeforeContinue: true,
+        onWrong: { type: 'continue', message: 'Try again.' },
+      },
+      choices: [
+        { id: 'wrong', label: 'Wrong', isCorrect: false },
+        { id: 'right', label: 'Right', isCorrect: true },
+      ],
+    };
+    fixture.componentRef.setInput('interactiveVideoSpec', {
+      version: 2,
+      enabled: true,
+      timeline: [reviewWithoutTarget],
+    });
+    fixture.detectChanges();
+
+    fixture.componentInstance.activeInteraction.set(reviewWithoutTarget);
+    fixture.componentInstance.selectedChoiceId.set('wrong');
+    fixture.componentInstance.onInteractiveReviewRequested();
+
+    expect(video.currentTime).toBe(42);
+    expect(fixture.componentInstance.activeInteraction()?.id).toBe('branch-review-without-target');
+    expect(fixture.componentInstance.selectedChoiceId()).toBe('wrong');
+  });
+
   it('blocks strict both-mode seeks into unwatched gaps', () => {
     const video = prepareVideoElement(90, 120);
     const required: InteractiveVideoInteraction = {

--- a/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
+++ b/fe/src/app/shared/blocks/video-block/quiz-video-player.component.ts
@@ -148,6 +148,7 @@ type ResolvedSource =
         <app-interactive-video-overlay
           [interaction]="interaction"
           [selectedChoiceId]="selectedChoiceId()"
+          [timeline]="interactiveVideoSpec()?.enabled === false ? [] : (interactiveVideoSpec()?.timeline ?? [])"
           [density]="overlayDensity()"
           (choiceSelected)="onInteractiveChoice($event)"
           (reviewRequested)="onInteractiveReviewRequested()"
@@ -342,6 +343,10 @@ export class QuizVideoPlayerComponent {
       choice,
       this.interactiveVideoSpec()?.timeline ?? [],
     );
+    if (target == null) {
+      return;
+    }
+
     this.activeInteraction.set(null);
     this.selectedChoiceId.set(null);
     video.currentTime = target;


### PR DESCRIPTION
﻿## Description

This follow-up hardens the interactive-video review and seek flow after #431. The overlay now only offers "Xem lại video" when the selected wrong answer has a real seek destination, and native/adaptive/YouTube players consistently avoid treating programmatic jumps as watched playback progress.

## Motivation

A correctness-gated branch could be configured with feedback/continue behavior but no review seek target. The old flow still treated any branch wrong answer as reviewable, locked the choices, and `resolveInteractiveVideoReviewTarget()` fell back to `0`, which could unexpectedly send learners back to the beginning of the video.

A second consistency issue remained in the adaptive and YouTube players: marker/review/branch jumps could advance `furthestWatchedSeconds`, and those players still checked only `required` interactions for anti-skip gating. That made the learner flow differ from the native quiz player and could weaken skip prevention for correctness-gated interactions.

## Type of Change

- Bug fix
- UX/reliability hardening
- Test coverage

## Related Issues

Refs: #431

## Changes Made

- Added `hasInteractiveVideoReviewTarget()` and made `resolveInteractiveVideoReviewTarget()` return `null` when no seek target exists.
- Passed the interactive-video timeline into `app-interactive-video-overlay` so review availability is resolved against real timeline targets.
- Guarded native quiz, adaptive video, and YouTube review handlers against missing targets.
- Aligned adaptive and YouTube players with the shared progress-gate helper from #431.
- Prevented adaptive and YouTube marker/review/branch programmatic jumps from immediately advancing watched progress.
- Added watched-range tracking for adaptive and YouTube seek policy so `preventSkippingMode: 'both'` has the same stricter semantics as the native player.
- Allowed adaptive and YouTube branch choices to intentionally navigate backward for review paths.
- Added runtime, overlay, quiz player, and YouTube player regression tests.

## Scope Note

This PR does not change scoring, answer feedback copy, H5P rendering, or content authoring fields. It only hardens runtime behavior around review actions, seek gates, and watched-progress accounting.

## Testing Guide

1. Configure an interactive branch with `adaptivity.requireCorrectBeforeContinue: true`, a wrong answer, and `adaptivity.onWrong.type: 'continue'` with no `targetTimeSeconds` or `targetInteractionId`.
2. Select the wrong answer during playback.
3. Expected: the choices remain selectable, the correct answer can be selected, no "Xem lại video" button appears, and the player does not jump to the start.
4. Configure a wrong answer with a valid seek target.
5. Expected: the review button still appears and seeks to that target.
6. In adaptive or YouTube playback, jump with a marker/branch/review action.
7. Expected: the player moves, but watched progress is not advanced merely because of that jump.

## Local Checks

- `git diff --check`
- `npx tsc -p tsconfig.spec.json --noEmit`
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/core/utils/interactive-video-runtime.spec.ts --include=src/app/shared/blocks/video-block/quiz-video-player.component.spec.ts --include=src/app/shared/blocks/video-block/interactive-video-overlay.component.spec.ts --include=src/app/features/learning/components/youtube-player/youtube-player.component.spec.ts`
- `npx ng build --configuration development --progress=false` (passed with existing unrelated Angular/Sass warnings)

## Checklist

- [x] Focused fix with no unrelated refactor
- [x] Regression tests added
- [x] Typecheck, focused tests, and build pass
- [x] PR opened ready for teammate review
