### PR TITLE
[codex] align interactive video seek progress

### DIFF
--- a/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
+++ b/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
@@ -29,12 +29,15 @@ import { InteractiveVideoOverlayComponent } from '../../../../shared/blocks/vide
 import { InteractiveVideoMarkersComponent } from '../../../../shared/blocks/video-block/interactive-video-markers.component';
 import { buildInteractiveVideoAnalyticsProjection } from '../../../../core/utils/interactive-video-analytics';
 import {
+  addInteractiveVideoWatchedRange,
   getDueInteractiveVideoInteraction,
+  isInteractiveVideoProgressGateInteraction,
   isInteractiveVideoReviewInteraction,
   resolveInteractiveVideoChoiceTarget,
   resolveInteractiveVideoReviewTarget,
   shouldBlockInteractiveVideoSeek,
 } from '../../../../core/utils/interactive-video-runtime';
+import type { InteractiveVideoWatchedRange } from '../../../../core/utils/interactive-video-runtime';
 import {
   canUseNativeHlsForManifest,
   shouldPreferNativeHlsForManifest,
@@ -114,6 +117,7 @@ export function shouldShowMediaNetworkHint(state: MediaNetworkHintState): boolea
         (loadedmetadata)="onLoadedMetadata($event)"
         (timeupdate)="onTimeUpdate($event)"
         (seeking)="onSeeking($event)"
+        (seeked)="onSeeked($event)"
         (play)="onPlay()"
         (pause)="onPause()"
         (ended)="onEnded()"
@@ -276,7 +280,11 @@ export class AdaptiveVideoPlayerComponent {
   private readonly offlineBlobFallbackLimitBytes = 220 * 1024 * 1024;
   private readonly shownInteractionIds = new Set<string>();
   private readonly completedInteractionIds = new Set<string>();
+  private watchedRanges: InteractiveVideoWatchedRange[] = [];
   private furthestWatchedSeconds = 0;
+  private isSeeking = false;
+  private seekStartTimeSeconds = 0;
+  private skipNextWatchedMark = false;
 
   constructor() {
     effect(() => {
@@ -332,13 +340,21 @@ export class AdaptiveVideoPlayerComponent {
     if (!video) {
       return;
     }
-    if (this.snapBlockedInteractiveSeek(video)) {
+    if (this.isSeeking && this.snapBlockedInteractiveSeek(video)) {
       return;
     }
+    const previousTimeSeconds = this.isSeeking ? video.currentTime : this.currentTimeSeconds();
     this.currentTimeSeconds.set(video.currentTime);
-    this.markInteractiveVideoWatched(video.currentTime);
-    this.tracker.recordSecond(video.currentTime);
-    this.evaluateInteractiveTimeline(video);
+    const shouldTrackPlaybackProgress = !this.isSeeking && !this.skipNextWatchedMark;
+    if (shouldTrackPlaybackProgress) {
+      this.markInteractiveVideoWatched(video.currentTime, previousTimeSeconds);
+    }
+    if (shouldTrackPlaybackProgress) {
+      this.tracker.recordSecond(video.currentTime);
+    } else if (!this.isSeeking && this.skipNextWatchedMark) {
+      this.skipNextWatchedMark = false;
+    }
+    this.evaluateInteractiveTimeline(video, previousTimeSeconds);
   }
 
   onSeeking(event: Event): void {
@@ -346,7 +362,22 @@ export class AdaptiveVideoPlayerComponent {
     if (!video) {
       return;
     }
+    if (!this.isSeeking) {
+      this.seekStartTimeSeconds = this.currentTimeSeconds();
+    }
+    this.isSeeking = true;
     this.snapBlockedInteractiveSeek(video);
+  }
+
+  onSeeked(event: Event): void {
+    const video = event.target as HTMLVideoElement | null;
+    this.isSeeking = false;
+    if (!video) {
+      return;
+    }
+    const previousTimeSeconds = this.seekStartTimeSeconds;
+    this.currentTimeSeconds.set(video.currentTime);
+    this.evaluateInteractiveTimeline(video, previousTimeSeconds);
   }
 
   seekToInteractiveSecond(seconds: number): void {
@@ -357,9 +388,9 @@ export class AdaptiveVideoPlayerComponent {
 
     const duration = Number.isFinite(video.duration) && video.duration > 0 ? video.duration : seconds;
     const target = this.resolveAllowedInteractiveSeekTarget(Math.max(0, Math.min(seconds, duration)));
-    video.currentTime = target;
+    this.reopenInteractiveMarkerAtTarget(target);
+    this.seekVideoProgrammatically(video, target);
     this.currentTimeSeconds.set(video.currentTime);
-    this.markInteractiveVideoWatched(video.currentTime);
     this.evaluateInteractiveTimeline(video);
   }
 
@@ -869,9 +900,8 @@ export class AdaptiveVideoPlayerComponent {
 
     this.activeInteraction.set(null);
     this.selectedChoiceId.set(null);
-    video.currentTime = target;
+    this.seekVideoProgrammatically(video, target);
     this.currentTimeSeconds.set(target);
-    this.markInteractiveVideoWatched(target);
     void video.play().catch(() => {});
   }
 
@@ -905,7 +935,10 @@ export class AdaptiveVideoPlayerComponent {
     this.activateInteractiveInteraction(interaction, video);
   }
 
-  private evaluateInteractiveTimeline(video: HTMLVideoElement): void {
+  private evaluateInteractiveTimeline(
+    video: HTMLVideoElement,
+    previousTimeSeconds = this.currentTimeSeconds(),
+  ): void {
     if (this.activeInteraction()) {
       return;
     }
@@ -918,6 +951,7 @@ export class AdaptiveVideoPlayerComponent {
     const dueInteraction = getDueInteractiveVideoInteraction({
       timeline: spec.timeline,
       currentTimeSeconds: video.currentTime,
+      previousTimeSeconds,
       completedInteractionIds: this.completedInteractionIds,
     });
 
@@ -957,16 +991,19 @@ export class AdaptiveVideoPlayerComponent {
     this.activeInteraction.set(null);
     this.selectedChoiceId.set(null);
 
+    const isBranch = active?.type === 'branch';
     const targetTime = resolveInteractiveVideoChoiceTarget(
       choice,
       this.interactiveVideoSpec()?.timeline ?? [],
-      { sourceTimeSeconds: active?.type === 'branch' ? active.atSeconds : null },
+      {
+        sourceTimeSeconds: isBranch ? active.atSeconds : null,
+        allowBackwardSeek: isBranch,
+      },
     );
     if (typeof targetTime === 'number' && Number.isFinite(targetTime)) {
       const target = Math.max(0, targetTime);
-      video.currentTime = target;
+      this.seekVideoProgrammatically(video, target);
       this.currentTimeSeconds.set(target);
-      this.markInteractiveVideoWatched(target);
     }
     void video.play().catch(() => {});
   }
@@ -977,7 +1014,34 @@ export class AdaptiveVideoPlayerComponent {
     this.shownInteractionIds.clear();
     this.completedInteractionIds.clear();
     this.completedInteractionIdsSnapshot.set(new Set<string>());
+    this.watchedRanges = [];
     this.furthestWatchedSeconds = 0;
+    this.isSeeking = false;
+    this.seekStartTimeSeconds = 0;
+    this.skipNextWatchedMark = false;
+  }
+
+  private reopenInteractiveMarkerAtTarget(targetTimeSeconds: number): void {
+    const targetInteraction = this.interactiveVideoSpec()?.timeline
+      ?.find(interaction => Math.abs(interaction.atSeconds - targetTimeSeconds) <= 1);
+    if (!targetInteraction) {
+      return;
+    }
+
+    this.completedInteractionIds.delete(targetInteraction.id);
+    this.shownInteractionIds.delete(targetInteraction.id);
+    this.completedInteractionIdsSnapshot.set(new Set(this.completedInteractionIds));
+    this.activeInteraction.set(null);
+    this.selectedChoiceId.set(null);
+  }
+
+  private seekVideoProgrammatically(video: HTMLVideoElement, targetTimeSeconds: number): void {
+    if (!this.isSeeking) {
+      this.seekStartTimeSeconds = this.currentTimeSeconds();
+    }
+    this.isSeeking = true;
+    this.skipNextWatchedMark = true;
+    video.currentTime = targetTimeSeconds;
   }
 
   private markInteractiveInteractionCompleted(interactionId: string): void {
@@ -1003,9 +1067,19 @@ export class AdaptiveVideoPlayerComponent {
       targetTimeSeconds,
       furthestWatchedSeconds: this.furthestWatchedSeconds,
       hasIncompleteRequiredInteractions: this.hasIncompleteRequiredInteractions(),
+      watchedRanges: this.watchedRanges,
     })
-      ? this.furthestWatchedSeconds
+      ? this.resolveBlockedInteractiveSeekTarget(targetTimeSeconds)
       : targetTimeSeconds;
+  }
+
+  private resolveBlockedInteractiveSeekTarget(targetTimeSeconds: number): number {
+    const mode = this.interactiveVideoSpec()?.behavior?.preventSkippingMode ?? 'none';
+    if (mode === 'both' && targetTimeSeconds <= this.furthestWatchedSeconds) {
+      return this.currentTimeSeconds();
+    }
+
+    return this.furthestWatchedSeconds;
   }
 
   private hasIncompleteRequiredInteractions(): boolean {
@@ -1015,13 +1089,17 @@ export class AdaptiveVideoPlayerComponent {
     }
 
     return spec.timeline.some(interaction =>
-      interaction.required === true && !this.completedInteractionIds.has(interaction.id),
+      isInteractiveVideoProgressGateInteraction(interaction)
+        && !this.completedInteractionIds.has(interaction.id),
     );
   }
 
-  private markInteractiveVideoWatched(seconds: number): void {
+  private markInteractiveVideoWatched(seconds: number, previousSeconds = seconds): void {
     if (Number.isFinite(seconds)) {
-      this.furthestWatchedSeconds = Math.max(this.furthestWatchedSeconds, Math.max(0, seconds));
+      const current = Math.max(0, seconds);
+      const previous = Number.isFinite(previousSeconds) ? Math.max(0, previousSeconds) : current;
+      this.furthestWatchedSeconds = Math.max(this.furthestWatchedSeconds, current);
+      this.watchedRanges = addInteractiveVideoWatchedRange(this.watchedRanges, previous, current);
     }
   }
 

--- a/fe/src/app/features/learning/components/youtube-player/youtube-player.component.spec.ts
+++ b/fe/src/app/features/learning/components/youtube-player/youtube-player.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, flushMicrotasks, tick } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { YouTubePlayerComponent } from './youtube-player.component';
 import { WatchedSegmentsTracker } from '../../services/watched-segments-tracker.service';
@@ -144,4 +144,147 @@ describe('YouTubePlayerComponent', () => {
     expect(player.seekTo).toHaveBeenCalledWith(0, true);
     expect(fixture.componentInstance.currentTimeSeconds()).toBe(0);
   });
+
+  it('blocks marker seeks past non-required correctness-gated work', async () => {
+    fixture.componentRef.setInput('interactiveVideoSpec', {
+      version: 2,
+      enabled: true,
+      behavior: { preventSkippingMode: 'forward' },
+      timeline: [
+        {
+          id: 'branch-review',
+          type: 'branch',
+          atSeconds: 40,
+          required: false,
+          adaptivity: { requireCorrectBeforeContinue: true },
+          choices: [
+            { id: 'wrong', label: 'Wrong', isCorrect: false, targetTimeSeconds: 10 },
+            { id: 'right', label: 'Right', isCorrect: true },
+          ],
+        },
+      ],
+    });
+    fixture.detectChanges();
+    (window as any).onYouTubeIframeAPIReady?.();
+    await fixture.whenStable();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const player = players[0].player;
+    player.getDuration = () => 120;
+    setPrivate(fixture.componentInstance, 'furthestWatchedSeconds', 20);
+
+    fixture.componentInstance.seekToInteractiveSecond(90);
+
+    expect(player.seekTo).toHaveBeenCalledWith(20, true);
+    expect(fixture.componentInstance.currentTimeSeconds()).toBe(20);
+  });
+
+  it('does not treat marker jumps as watched playback progress', async () => {
+    fixture.componentRef.setInput('interactiveVideoSpec', {
+      version: 2,
+      enabled: true,
+      timeline: [
+        {
+          id: 'marker-75',
+          type: 'checkpoint',
+          atSeconds: 75,
+          displayType: 'button',
+          title: 'Review marker',
+        },
+      ],
+    });
+    fixture.detectChanges();
+    (window as any).onYouTubeIframeAPIReady?.();
+    await fixture.whenStable();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const player = players[0].player;
+    player.getDuration = () => 120;
+    setPrivate(fixture.componentInstance, 'furthestWatchedSeconds', 20);
+    getPrivate<Set<string>>(fixture.componentInstance, 'completedInteractionIds').add('marker-75');
+    getPrivate<Set<string>>(fixture.componentInstance, 'shownInteractionIds').add('marker-75');
+    fixture.componentInstance.completedInteractionIdsSnapshot.set(new Set(['marker-75']));
+
+    fixture.componentInstance.seekToInteractiveSecond(75);
+
+    expect(player.seekTo).toHaveBeenCalledWith(75, true);
+    expect(fixture.componentInstance.currentTimeSeconds()).toBe(75);
+    expect(fixture.componentInstance.activeInteraction()?.id).toBe('marker-75');
+    expect(getPrivate<number>(fixture.componentInstance, 'furthestWatchedSeconds')).toBe(20);
+    expect(getPrivate<Set<string>>(fixture.componentInstance, 'completedInteractionIds').has('marker-75')).toBeFalse();
+    expect(getPrivate<Set<string>>(fixture.componentInstance, 'shownInteractionIds').has('marker-75')).toBeTrue();
+  });
+
+  it('does not send tracker progress for the first poll after a programmatic marker seek', fakeAsync(() => {
+    fixture.componentRef.setInput('trackingEnabled', true);
+    fixture.componentRef.setInput('interactiveVideoSpec', {
+      version: 2,
+      enabled: true,
+      timeline: [
+        {
+          id: 'marker-75',
+          type: 'checkpoint',
+          atSeconds: 75,
+          displayType: 'button',
+          title: 'Review marker',
+        },
+      ],
+    });
+    fixture.detectChanges();
+    (window as any).onYouTubeIframeAPIReady?.();
+    flushMicrotasks();
+    tick(0);
+
+    const player = players[0].player;
+    const tracker = TestBed.inject(WatchedSegmentsTracker) as jasmine.SpyObj<WatchedSegmentsTracker>;
+    player.getDuration = () => 120;
+    player.getCurrentTime = () => 75;
+
+    fixture.componentInstance.seekToInteractiveSecond(75);
+    players[0].config.events.onStateChange({ target: player, data: (window as any).YT.PlayerState.PLAYING });
+    tick(1000);
+
+    expect(tracker.recordSecond).not.toHaveBeenCalledWith(75);
+
+    player.getCurrentTime = () => 76;
+    tick(1000);
+
+    expect(tracker.recordSecond).toHaveBeenCalledWith(76);
+  }));
+
+  it('allows branch choices to review earlier video without advancing watched progress', async () => {
+    fixture.componentRef.setInput('interactiveVideoSpec', {
+      version: 2,
+      enabled: true,
+      timeline: [],
+    });
+    fixture.detectChanges();
+    (window as any).onYouTubeIframeAPIReady?.();
+    await fixture.whenStable();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const player = players[0].player;
+    const branch = {
+      id: 'branch-navigation',
+      type: 'branch' as const,
+      atSeconds: 50,
+      choices: [{ id: 'review', label: 'Review', targetTimeSeconds: 10 }],
+    };
+    setPrivate(fixture.componentInstance, 'furthestWatchedSeconds', 50);
+    fixture.componentInstance.activeInteraction.set(branch);
+
+    fixture.componentInstance.onInteractiveChoice(branch.choices[0]);
+
+    expect(player.seekTo).toHaveBeenCalledWith(10, true);
+    expect(fixture.componentInstance.currentTimeSeconds()).toBe(10);
+    expect(getPrivate<number>(fixture.componentInstance, 'furthestWatchedSeconds')).toBe(50);
+  });
+
+  function getPrivate<T>(component: YouTubePlayerComponent, property: string): T {
+    return (component as unknown as Record<string, T>)[property];
+  }
+
+  function setPrivate<T>(component: YouTubePlayerComponent, property: string, value: T): void {
+    (component as unknown as Record<string, T>)[property] = value;
+  }
 });

--- a/fe/src/app/features/learning/components/youtube-player/youtube-player.component.ts
+++ b/fe/src/app/features/learning/components/youtube-player/youtube-player.component.ts
@@ -23,12 +23,15 @@ import { InteractiveVideoOverlayComponent } from '../../../../shared/blocks/vide
 import { InteractiveVideoMarkersComponent } from '../../../../shared/blocks/video-block/interactive-video-markers.component';
 import { buildInteractiveVideoAnalyticsProjection } from '../../../../core/utils/interactive-video-analytics';
 import {
+  addInteractiveVideoWatchedRange,
   getDueInteractiveVideoInteraction,
+  isInteractiveVideoProgressGateInteraction,
   isInteractiveVideoReviewInteraction,
   resolveInteractiveVideoChoiceTarget,
   resolveInteractiveVideoReviewTarget,
   shouldBlockInteractiveVideoSeek,
 } from '../../../../core/utils/interactive-video-runtime';
+import type { InteractiveVideoWatchedRange } from '../../../../core/utils/interactive-video-runtime';
 import type {
   InteractiveVideoChoice,
   InteractiveVideoInteraction,
@@ -166,7 +169,9 @@ export class YouTubePlayerComponent implements OnDestroy {
   readonly completedInteractionIdsSnapshot = signal<ReadonlySet<string>>(new Set<string>());
   private readonly shownInteractionIds = new Set<string>();
   private readonly completedInteractionIds = new Set<string>();
+  private watchedRanges: InteractiveVideoWatchedRange[] = [];
   private furthestWatchedSeconds = 0;
+  private skipNextWatchedMark = false;
 
   readonly playerId = 'yt-player-' + Math.random().toString(36).substring(2, 9);
   private readonly playerSourceKey = computed(() => {
@@ -338,21 +343,27 @@ export class YouTubePlayerComponent implements OnDestroy {
       if (this.player?.getCurrentTime) {
         let currentTime = this.player.getCurrentTime();
         this.zone.run(() => {
+          const previousTimeSeconds = this.currentTimeSeconds();
           const allowedTime = this.resolveAllowedInteractiveSeekTarget(currentTime);
           if (allowedTime !== currentTime) {
-            this.player?.seekTo?.(allowedTime, true);
+            this.seekPlayerProgrammatically(allowedTime);
             currentTime = allowedTime;
           }
-          if (this.trackingEnabled()) {
+          const shouldTrackPlaybackProgress = !this.skipNextWatchedMark;
+          if (this.trackingEnabled() && shouldTrackPlaybackProgress) {
             this.tracker.recordSecond(currentTime);
           }
           this.currentTimeSeconds.set(currentTime);
-          this.markInteractiveVideoWatched(currentTime);
+          if (shouldTrackPlaybackProgress) {
+            this.markInteractiveVideoWatched(currentTime, previousTimeSeconds);
+          } else {
+            this.skipNextWatchedMark = false;
+          }
           const duration = this.player?.getDuration?.() || 0;
           if (duration > 0 && this.videoDurationSeconds() == null) {
             this.videoDurationSeconds.set(duration);
           }
-          this.evaluateInteractiveTimeline(currentTime);
+          this.evaluateInteractiveTimeline(currentTime, previousTimeSeconds);
         });
       }
     }, 1000);
@@ -403,9 +414,8 @@ export class YouTubePlayerComponent implements OnDestroy {
 
     this.activeInteraction.set(null);
     this.selectedChoiceId.set(null);
-    this.player?.seekTo?.(target, true);
+    this.seekPlayerProgrammatically(target);
     this.currentTimeSeconds.set(target);
-    this.markInteractiveVideoWatched(target);
     this.player?.playVideo?.();
   }
 
@@ -440,13 +450,16 @@ export class YouTubePlayerComponent implements OnDestroy {
     const target = this.resolveAllowedInteractiveSeekTarget(
       Math.max(0, Math.min(seconds, Number.isFinite(duration) && duration > 0 ? duration : seconds)),
     );
-    this.player.seekTo(target, true);
+    this.reopenInteractiveMarkerAtTarget(target);
+    this.seekPlayerProgrammatically(target);
     this.currentTimeSeconds.set(target);
-    this.markInteractiveVideoWatched(target);
     this.evaluateInteractiveTimeline(target);
   }
 
-  private evaluateInteractiveTimeline(currentTime: number): void {
+  private evaluateInteractiveTimeline(
+    currentTime: number,
+    previousTimeSeconds = this.currentTimeSeconds(),
+  ): void {
     if (this.activeInteraction()) {
       return;
     }
@@ -459,6 +472,7 @@ export class YouTubePlayerComponent implements OnDestroy {
     const dueInteraction = getDueInteractiveVideoInteraction({
       timeline: spec.timeline,
       currentTimeSeconds: currentTime,
+      previousTimeSeconds,
       completedInteractionIds: this.completedInteractionIds,
     });
 
@@ -490,16 +504,19 @@ export class YouTubePlayerComponent implements OnDestroy {
     this.activeInteraction.set(null);
     this.selectedChoiceId.set(null);
 
+    const isBranch = active?.type === 'branch';
     const targetTime = resolveInteractiveVideoChoiceTarget(
       choice,
       this.interactiveVideoSpec()?.timeline ?? [],
-      { sourceTimeSeconds: active?.type === 'branch' ? active.atSeconds : null },
+      {
+        sourceTimeSeconds: isBranch ? active.atSeconds : null,
+        allowBackwardSeek: isBranch,
+      },
     );
     if (typeof targetTime === 'number' && Number.isFinite(targetTime)) {
       const target = Math.max(0, targetTime);
-      this.player?.seekTo?.(target, true);
+      this.seekPlayerProgrammatically(target);
       this.currentTimeSeconds.set(target);
-      this.markInteractiveVideoWatched(target);
     }
     this.player?.playVideo?.();
   }
@@ -510,7 +527,23 @@ export class YouTubePlayerComponent implements OnDestroy {
     this.shownInteractionIds.clear();
     this.completedInteractionIds.clear();
     this.completedInteractionIdsSnapshot.set(new Set<string>());
+    this.watchedRanges = [];
     this.furthestWatchedSeconds = 0;
+    this.skipNextWatchedMark = false;
+  }
+
+  private reopenInteractiveMarkerAtTarget(targetTimeSeconds: number): void {
+    const targetInteraction = this.interactiveVideoSpec()?.timeline
+      ?.find(interaction => Math.abs(interaction.atSeconds - targetTimeSeconds) <= 1);
+    if (!targetInteraction) {
+      return;
+    }
+
+    this.completedInteractionIds.delete(targetInteraction.id);
+    this.shownInteractionIds.delete(targetInteraction.id);
+    this.completedInteractionIdsSnapshot.set(new Set(this.completedInteractionIds));
+    this.activeInteraction.set(null);
+    this.selectedChoiceId.set(null);
   }
 
   private markInteractiveInteractionCompleted(interactionId: string): void {
@@ -524,9 +557,19 @@ export class YouTubePlayerComponent implements OnDestroy {
       targetTimeSeconds,
       furthestWatchedSeconds: this.furthestWatchedSeconds,
       hasIncompleteRequiredInteractions: this.hasIncompleteRequiredInteractions(),
+      watchedRanges: this.watchedRanges,
     })
-      ? this.furthestWatchedSeconds
+      ? this.resolveBlockedInteractiveSeekTarget(targetTimeSeconds)
       : targetTimeSeconds;
+  }
+
+  private resolveBlockedInteractiveSeekTarget(targetTimeSeconds: number): number {
+    const mode = this.interactiveVideoSpec()?.behavior?.preventSkippingMode ?? 'none';
+    if (mode === 'both' && targetTimeSeconds <= this.furthestWatchedSeconds) {
+      return this.currentTimeSeconds();
+    }
+
+    return this.furthestWatchedSeconds;
   }
 
   private hasIncompleteRequiredInteractions(): boolean {
@@ -536,14 +579,23 @@ export class YouTubePlayerComponent implements OnDestroy {
     }
 
     return spec.timeline.some(interaction =>
-      interaction.required === true && !this.completedInteractionIds.has(interaction.id),
+      isInteractiveVideoProgressGateInteraction(interaction)
+        && !this.completedInteractionIds.has(interaction.id),
     );
   }
 
-  private markInteractiveVideoWatched(seconds: number): void {
+  private markInteractiveVideoWatched(seconds: number, previousSeconds = seconds): void {
     if (Number.isFinite(seconds)) {
-      this.furthestWatchedSeconds = Math.max(this.furthestWatchedSeconds, Math.max(0, seconds));
+      const current = Math.max(0, seconds);
+      const previous = Number.isFinite(previousSeconds) ? Math.max(0, previousSeconds) : current;
+      this.furthestWatchedSeconds = Math.max(this.furthestWatchedSeconds, current);
+      this.watchedRanges = addInteractiveVideoWatchedRange(this.watchedRanges, previous, current);
     }
+  }
+
+  private seekPlayerProgrammatically(targetTimeSeconds: number): void {
+    this.player?.seekTo?.(targetTimeSeconds, true);
+    this.skipNextWatchedMark = true;
   }
 
   private async recordInteractiveEvent(


### PR DESCRIPTION
﻿## Description
Follow-up to PR #432 that hardens interactive-video seeking behavior across adaptive video and YouTube players.

## Motivation
PR #432 fixed missing review-target handling, but a deeper pass found the non-native players still diverged from the shared quiz video player: marker/review/branch jumps could be treated as watched progress, marker clicks could stay blocked after an interaction was already completed, and progress gates were not consistently applied for non-required correctness-gated work.

## Type of Change
- Bug fix
- Test coverage
- Interactive video flow hardening

## Related Issues
Refs #432

## Changes Made
- Track watched ranges in adaptive and YouTube players so `preventSkippingMode: 'both'` behaves like the shared quiz player.
- Treat correctness-gated interactions as progress gates even when `required` is false.
- Prevent marker, review, and branch programmatic seeks from advancing interactive watched progress.
- Prevent the first polling tick after a YouTube programmatic seek from being sent to the watched-segment tracker.
- Reopen the target marker interaction when a learner clicks a marker, matching the shared quiz player behavior.
- Allow branch choices to seek backward for review without inflating progress.
- Add YouTube component tests for gated marker seek, marker progress, tracker progress, and backward branch review.

## Scope Note
This does not change H5P rendering/scoring, authoring schemas, backend progress APIs, or course content data.

## Testing Guide
1. In an interactive video with `preventSkippingMode: forward`, try jumping past an unanswered correctness-gated checkpoint; the player should snap back to the watched boundary.
2. Click a marker ahead in an ungated video; the marker overlay should open, but watched progress should not immediately advance just because of the jump.
3. Use a branch answer that sends the learner back to an earlier explanation; the jump should work and progress should continue only from actual playback.
4. With `preventSkippingMode: both`, try jumping into an unwatched gap behind the furthest watched time; the player should stay at the current safe position.

## Local Checks
- `git diff --check`
- `npx tsc -p tsconfig.spec.json --noEmit`
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/core/utils/interactive-video-runtime.spec.ts --include=src/app/shared/blocks/video-block/quiz-video-player.component.spec.ts --include=src/app/shared/blocks/video-block/interactive-video-overlay.component.spec.ts --include=src/app/features/learning/components/youtube-player/youtube-player.component.spec.ts` (39 SUCCESS)
- `npx ng build --configuration development --progress=false` (passed with existing unrelated Angular/Sass warnings)
- GitHub CI passed: Backend Tests, Frontend Build, Compose Validation, Docker Smoke Test

## Checklist
- [x] Focused fix scoped to interactive video seeking/progress
- [x] Focused tests added/updated
- [x] Typecheck passed
- [x] Development build passed
- [x] GitHub CI passed
