### PR TITLE
Add Wiii document course plan preview and apply

### DIFF
--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
@@ -6,16 +6,20 @@ import { of, Subject, throwError } from 'rxjs';
 import { WiiiContextService } from './wiii-context.service';
 import { PageDataExtractorService } from './page-data-extractor.service';
 import { AuthService } from '../../../../core/services/auth.service';
+import { ChapterApi } from '../../../../api/client/chapter.api';
 import { LessonApi } from '../../../../api/client/lesson.api';
 import { SectionApi } from '../../../../api/client/section.api';
 import { QuizApi } from '../../../../api/endpoints/quiz.api';
+import { CourseEditorStore } from '../../../teacher/course-editor/store/course-editor.store';
 import { CurriculumSelectionService } from '../../../teacher/course-editor/services/curriculum-selection.service';
 
 describe('WiiiContextService - operator preview/apply flows', () => {
   let service: WiiiContextService;
+  let chapterApi: jasmine.SpyObj<ChapterApi>;
   let lessonApi: jasmine.SpyObj<LessonApi>;
   let sectionApi: jasmine.SpyObj<SectionApi>;
   let quizApi: jasmine.SpyObj<QuizApi>;
+  let courseEditorStore: jasmine.SpyObj<CourseEditorStore>;
   let pageDataExtractor: jasmine.SpyObj<PageDataExtractorService>;
   let router: { url: string; events: Subject<unknown>; navigate: jasmine.Spy; navigateByUrl: jasmine.Spy };
   let routerEvents$: Subject<unknown>;
@@ -30,6 +34,14 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     };
     pageDataExtractor = jasmine.createSpyObj<PageDataExtractorService>('PageDataExtractorService', ['extract']);
     pageDataExtractor.extract.and.returnValue(null);
+    courseEditorStore = jasmine.createSpyObj<CourseEditorStore>('CourseEditorStore', [
+      'courseTree',
+      'addChapterLocal',
+      'addLessonLocal',
+      'invalidateCache',
+      'loadCourse',
+    ]);
+    courseEditorStore.courseTree.and.returnValue({ id: 'course-1', chapters: [] } as any);
 
     TestBed.configureTestingModule({
       providers: [
@@ -56,8 +68,12 @@ describe('WiiiContextService - operator preview/apply flows', () => {
           },
         },
         {
+          provide: ChapterApi,
+          useValue: jasmine.createSpyObj<ChapterApi>('ChapterApi', ['createChapter']),
+        },
+        {
           provide: LessonApi,
-          useValue: jasmine.createSpyObj<LessonApi>('LessonApi', ['getLessonById', 'updateLesson']),
+          useValue: jasmine.createSpyObj<LessonApi>('LessonApi', ['getLessonById', 'updateLesson', 'createLesson']),
         },
         {
           provide: SectionApi,
@@ -78,10 +94,15 @@ describe('WiiiContextService - operator preview/apply flows', () => {
           provide: PLATFORM_ID,
           useValue: 'browser',
         },
+        {
+          provide: CourseEditorStore,
+          useValue: courseEditorStore,
+        },
       ],
     });
 
     service = TestBed.inject(WiiiContextService);
+    chapterApi = TestBed.inject(ChapterApi) as jasmine.SpyObj<ChapterApi>;
     lessonApi = TestBed.inject(LessonApi) as jasmine.SpyObj<LessonApi>;
     sectionApi = TestBed.inject(SectionApi) as jasmine.SpyObj<SectionApi>;
     quizApi = TestBed.inject(QuizApi) as jasmine.SpyObj<QuizApi>;
@@ -214,6 +235,98 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     expect(applied.success).toBeTrue();
     expect(sectionApi.updateSection).toHaveBeenCalledWith('lesson-1', 'section-1', jasmine.any(FormData));
     expect(lessonApi.updateLesson).not.toHaveBeenCalled();
+  });
+
+  it('previews and applies a document course plan through teacher approval', async () => {
+    chapterApi.createChapter.and.returnValues(
+      of({ data: { id: 'chapter-1', title: 'Chương 1', orderIndex: 0 } } as any),
+      of({ data: { id: 'chapter-2', title: 'Chương 2', orderIndex: 1 } } as any),
+    );
+    lessonApi.createLesson.and.returnValues(
+      of({ data: { id: 'lesson-1', title: 'Bài 1', lessonType: 'LECTURE', orderIndex: 0 } } as any),
+      of({ data: { id: 'lesson-2', title: 'Bài 2', lessonType: 'LECTURE', orderIndex: 0 } } as any),
+    );
+
+    let panelPreview: any;
+    const previewSub = service.operatorPreview$.subscribe((previewPanel) => {
+      panelPreview = previewPanel;
+    });
+    const preview = await (service as any).handleActionRequest('authoring.generate_course_from_document', {
+      course_id: 'course-1',
+      course_plan: {
+        title: 'Khai thác HoLiLiHu LMS',
+        description: 'Khóa học từ tài liệu hướng dẫn',
+        chapters: [
+          {
+            title: 'Chương 1',
+            summary: 'Tổng quan',
+            learning_objectives: ['Hiểu vai trò'],
+            lessons: [
+              {
+                title: 'Bài 1',
+                summary: 'Bản đồ hệ thống',
+                activity: 'Đối chiếu vai trò',
+                quick_check: 'Vai trò nào được tạo khóa?',
+                source_references: [{ kind: 'document', title: 'Manual', page_start: 1 }],
+              },
+            ],
+            source_references: [{ kind: 'document', title: 'Manual', page_start: 1 }],
+          },
+          {
+            title: 'Chương 2',
+            summary: 'Giảng viên',
+            learning_objectives: ['Tạo khóa'],
+            lessons: [
+              {
+                title: 'Bài 2',
+                summary: 'Tạo khóa học mới',
+                source_references: [{ kind: 'document', title: 'Manual', page_start: 23 }],
+              },
+            ],
+          },
+        ],
+        implementation_checklist: ['Không publish tự động'],
+      },
+      source_references: [{ kind: 'document', title: 'Manual', page_start: 1 }],
+    });
+    previewSub.unsubscribe();
+
+    expect(preview.success).toBeTrue();
+    expect(preview.data?.preview_kind).toBe('course_plan');
+    expect(preview.data?.apply_action).toBe('authoring.apply_course_plan');
+    expect(preview.data?.course_plan).toEqual(jasmine.objectContaining({
+      title: 'Khai thác HoLiLiHu LMS',
+      chapters: jasmine.any(Array),
+    }));
+    expect(panelPreview).toEqual(jasmine.objectContaining({
+      token: preview.data?.preview_token,
+      kind: 'course_plan',
+      targetLabel: 'Khai thác HoLiLiHu LMS',
+      sourceReferences: jasmine.arrayContaining([
+        jasmine.objectContaining({ page_start: 1 }),
+        jasmine.objectContaining({ page_start: 23 }),
+      ]),
+    }));
+
+    await expectAsync((service as any).handleActionRequest('authoring.apply_course_plan', {
+      preview_token: preview.data?.preview_token,
+    })).toBeRejectedWithError(/host_preview_approval_required/);
+    expect(chapterApi.createChapter).not.toHaveBeenCalled();
+
+    const applied = await service.approveOperatorPreview(String(preview.data?.preview_token));
+
+    expect(applied.success).toBeTrue();
+    expect(chapterApi.createChapter).toHaveBeenCalledTimes(2);
+    expect(lessonApi.createLesson).toHaveBeenCalledTimes(2);
+    expect(lessonApi.createLesson).toHaveBeenCalledWith('chapter-1', jasmine.objectContaining({
+      title: 'Bài 1',
+      type: 'LECTURE',
+      content: jasmine.stringContaining('## Nguồn đối chiếu'),
+    }));
+    expect(courseEditorStore.invalidateCache).toHaveBeenCalledWith('course-1');
+    expect(courseEditorStore.loadCourse).toHaveBeenCalledWith('course-1', true);
+    expect(applied.data?.['chapters_created']).toBe(2);
+    expect(applied.data?.['lessons_created']).toBe(2);
   });
 
   it('previews and commits a new quiz through the host action flow', async () => {

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -20,9 +20,11 @@ import { Subject, Subscription, filter, firstValueFrom } from 'rxjs';
 import { environment } from '../../../../../environments/environment';
 import { PageDataExtractorService, type PageStructuredData } from './page-data-extractor.service';
 import { AuthService } from '../../../../core/services/auth.service';
+import { ChapterApi } from '../../../../api/client/chapter.api';
 import { LessonApi } from '../../../../api/client/lesson.api';
 import { SectionApi } from '../../../../api/client/section.api';
 import { QuizApi } from '../../../../api/endpoints/quiz.api';
+import { CourseEditorStore } from '../../../teacher/course-editor/store/course-editor.store';
 import { CurriculumSelectionService } from '../../../teacher/course-editor/services/curriculum-selection.service';
 import {
   POINTY_ACTION_CLICK,
@@ -110,7 +112,7 @@ interface WiiiHostCapabilities {
 
 const LMS_CONNECTOR_ID = 'maritime-lms';
 
-export type OperatorPreviewKind = 'lesson_patch' | 'quiz_commit' | 'quiz_publish';
+export type OperatorPreviewKind = 'lesson_patch' | 'course_plan' | 'quiz_commit' | 'quiz_publish';
 
 interface PendingOperatorPreview {
   kind: OperatorPreviewKind;
@@ -169,14 +171,44 @@ interface LessonPreviewBlockDelta {
   after?: LessonPreviewBlock;
 }
 
+interface CoursePlanLesson {
+  title: string;
+  summary: string;
+  activity?: string;
+  quick_check?: string;
+  duration_minutes?: number;
+  source_references?: WiiiSourceReference[];
+}
+
+interface CoursePlanChapter {
+  title: string;
+  summary: string;
+  learning_objectives: string[];
+  lessons: CoursePlanLesson[];
+  source_references?: WiiiSourceReference[];
+}
+
+interface NormalizedCoursePlan {
+  title: string;
+  description: string;
+  audience?: string;
+  duration?: string;
+  chapters: CoursePlanChapter[];
+  assessment_plan: string[];
+  implementation_checklist: string[];
+  source_document_title?: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class WiiiContextService implements OnDestroy {
   private readonly router = inject(Router);
   private readonly pageDataExtractor = inject(PageDataExtractorService);
   private readonly authService = inject(AuthService);
+  private readonly chapterApi = inject(ChapterApi);
   private readonly lessonApi = inject(LessonApi);
   private readonly sectionApi = inject(SectionApi);
   private readonly quizApi = inject(QuizApi);
+  private readonly courseEditorStore = inject(CourseEditorStore);
   private readonly selectionService = inject(CurriculumSelectionService);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly isBrowser = isPlatformBrowser(this.platformId);
@@ -683,15 +715,59 @@ export class WiiiContextService implements OnDestroy {
             properties: {
               course_id: { type: 'string' },
               action: { type: 'string' },
+              title: { type: 'string' },
+              summary: { type: 'string' },
+              course_plan: {
+                type: 'object',
+                properties: {
+                  title: { type: 'string' },
+                  description: { type: 'string' },
+                  chapters: { type: 'array', items: { type: 'object' } },
+                },
+              },
+              source_references: { type: 'array', items: { type: 'object' } },
             },
           },
           requires_confirmation: false,
           mutates_state: false,
           permission: 'manage:courses',
-          description: 'Mở flow AI để tạo outline/chapter từ tài liệu cho khóa học hiện tại.',
+          description: 'Tạo bản xem trước cây khóa học/chương/bài từ tài liệu upload. Chỉ preview, chưa ghi LMS cho tới khi giáo viên bấm Áp dụng.',
           roles: ['teacher', 'admin'],
-          surface: 'ai_sidebar',
-          result_schema: { type: 'object', properties: { opened: { type: 'boolean' } } },
+          surface: 'preview_panel',
+          result_schema: {
+            type: 'object',
+            properties: {
+              preview_token: { type: 'string' },
+              preview_kind: { type: 'string' },
+              summary: { type: 'string' },
+            },
+          },
+        },
+        {
+          name: 'authoring.apply_course_plan',
+          input_schema: {
+            type: 'object',
+            properties: {
+              preview_token: { type: 'string' },
+              approval_token: { type: 'string' },
+            },
+            required: ['preview_token', 'approval_token'],
+          },
+          requires_confirmation: true,
+          mutates_state: true,
+          permission: 'manage:courses',
+          description: 'Tạo các chương/bài draft từ bản xem trước course_plan sau khi giáo viên xác nhận trong LMS.',
+          roles: ['teacher', 'admin'],
+          surface: 'editor_shell',
+          result_schema: {
+            type: 'object',
+            properties: {
+              applied: { type: 'boolean' },
+              course_id: { type: 'string' },
+              chapters_created: { type: 'number' },
+              lessons_created: { type: 'number' },
+            },
+          },
         },
         {
           name: 'authoring.generate_lesson',
@@ -1017,6 +1093,8 @@ export class WiiiContextService implements OnDestroy {
     switch (kind) {
       case 'lesson_patch':
         return 'authoring.apply_lesson_patch';
+      case 'course_plan':
+        return 'authoring.apply_course_plan';
       case 'quiz_commit':
         return 'assessment.apply_quiz_commit';
       case 'quiz_publish':
@@ -1034,7 +1112,7 @@ export class WiiiContextService implements OnDestroy {
       createdAt: preview.createdAt,
       summary: String(data['summary'] || preview.summary || '').trim(),
       applyAction: String(data['apply_action'] || this.applyActionForPreviewKind(preview.kind)).trim(),
-      targetLabel: String(data['target_label'] || data['lesson_title'] || data['quiz_title'] || preview.kind).trim(),
+      targetLabel: String(data['target_label'] || data['course_title'] || data['lesson_title'] || data['quiz_title'] || preview.kind).trim(),
       changedFields: this.normalizeStringArray(data['changed_fields']),
       sourceReferences: this.normalizeSourceReferences(data['source_references']),
       data,
@@ -1153,6 +1231,253 @@ export class WiiiContextService implements OnDestroy {
       return prefix;
     }
     return `${prefix}: ${cleanDetails.join(', ')}.`;
+  }
+
+  private normalizeCoursePlan(raw: unknown): NormalizedCoursePlan {
+    const record = raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? raw as Record<string, unknown>
+      : {};
+    const chapters = this.normalizeCoursePlanChapters(record['chapters']);
+    return {
+      title: this.normalizeString(record['title']) || this.normalizeString(record['course_title']) || 'Khóa học từ tài liệu',
+      description: this.normalizeString(record['description']) || this.normalizeString(record['summary']) || '',
+      audience: this.normalizeString(record['audience']),
+      duration: this.normalizeString(record['duration']),
+      chapters,
+      assessment_plan: this.normalizeStringArray(record['assessment_plan'] || record['assessmentPlan']),
+      implementation_checklist: this.normalizeStringArray(record['implementation_checklist'] || record['implementationChecklist']),
+      source_document_title: this.normalizeString(record['source_document_title'] || record['sourceDocumentTitle']),
+    };
+  }
+
+  private normalizeCoursePlanChapters(raw: unknown): CoursePlanChapter[] {
+    if (!Array.isArray(raw)) {
+      return [];
+    }
+    return raw
+      .filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item))
+      .slice(0, 6)
+      .map((item, index) => ({
+        title: this.normalizeString(item['title']) || `Chương ${index + 1}`,
+        summary: this.normalizeString(item['summary'] || item['description']) || '',
+        learning_objectives: this.normalizeStringArray(item['learning_objectives'] || item['learningObjectives']).slice(0, 6),
+        lessons: this.normalizeCoursePlanLessons(item['lessons']),
+        source_references: this.normalizeSourceReferences(item['source_references'] || item['sourceReferences']),
+      }))
+      .filter((chapter) => chapter.lessons.length > 0);
+  }
+
+  private normalizeCoursePlanLessons(raw: unknown): CoursePlanLesson[] {
+    if (!Array.isArray(raw)) {
+      return [];
+    }
+    return raw
+      .filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item))
+      .slice(0, 6)
+      .map((item, index) => ({
+        title: this.normalizeString(item['title']) || `Bài ${index + 1}`,
+        summary: this.normalizeString(item['summary'] || item['description'] || item['content']) || '',
+        activity: this.normalizeString(item['activity']),
+        quick_check: this.normalizeString(item['quick_check'] || item['quickCheck']),
+        duration_minutes: this.normalizeOptionalNumber(item['duration_minutes'] || item['durationMinutes']),
+        source_references: this.normalizeSourceReferences(item['source_references'] || item['sourceReferences']),
+      }));
+  }
+
+  private collectCoursePlanSourceReferences(plan: NormalizedCoursePlan, explicit: unknown): WiiiSourceReference[] {
+    const refs: WiiiSourceReference[] = [
+      ...this.normalizeSourceReferences(explicit),
+    ];
+    for (const [chapterIndex, chapter] of plan.chapters.entries()) {
+      refs.push(...(chapter.source_references || []).map((ref) => ({
+        ...ref,
+        chapter_index: ref.chapter_index ?? chapterIndex + 1,
+      })));
+      for (const [lessonIndex, lesson] of chapter.lessons.entries()) {
+        refs.push(...(lesson.source_references || []).map((ref) => ({
+          ...ref,
+          chapter_index: ref.chapter_index ?? chapterIndex + 1,
+          lesson_index: ref.lesson_index ?? lessonIndex + 1,
+        })));
+      }
+    }
+    const seen = new Set<string>();
+    return refs.filter((ref) => {
+      const key = [
+        ref.kind || '',
+        ref.title || '',
+        ref.page || '',
+        ref.page_start || '',
+        ref.page_end || '',
+        ref.chapter_index || '',
+        ref.lesson_index || '',
+      ].join('|');
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    }).slice(0, 12);
+  }
+
+  private buildCoursePlanLessonContent(
+    lesson: CoursePlanLesson,
+    chapter: CoursePlanChapter,
+    plan: NormalizedCoursePlan,
+  ): string {
+    const references = lesson.source_references?.length
+      ? lesson.source_references
+      : chapter.source_references || [];
+    const sourceLines = references
+      .slice(0, 4)
+      .map((ref, index) => {
+        const pageStart = ref.page_start ?? ref.page;
+        const pageText = pageStart
+          ? ref.page_end && ref.page_end !== pageStart
+            ? `, trang ${pageStart}-${ref.page_end}`
+            : `, trang ${pageStart}`
+          : '';
+        return `${index + 1}. ${ref.title || ref.label || plan.source_document_title || 'Tài liệu nguồn'}${pageText}${ref.excerpt ? ` - ${ref.excerpt}` : ''}`;
+      });
+    return [
+      `# ${lesson.title}`,
+      '',
+      lesson.summary ? `## Tóm tắt\n${lesson.summary}` : '',
+      chapter.learning_objectives.length
+        ? `## Mục tiêu học tập\n${chapter.learning_objectives.map((item) => `- ${item}`).join('\n')}`
+        : '',
+      lesson.activity ? `## Hoạt động thực hành\n${lesson.activity}` : '',
+      lesson.quick_check ? `## Câu hỏi kiểm tra nhanh\n${lesson.quick_check}` : '',
+      sourceLines.length ? `## Nguồn đối chiếu\n${sourceLines.join('\n')}` : '',
+    ].filter((part) => part.trim().length > 0).join('\n\n');
+  }
+
+  private async previewCoursePlan(
+    params: Record<string, unknown>,
+  ): Promise<{ success: boolean; data: Record<string, unknown> }> {
+    const courseId = this.resolveCurrentCourseId(params);
+    if (!courseId) {
+      throw new Error('Missing course_id for course plan preview');
+    }
+    const rawPlan = params['course_plan'] || params['coursePlan'] || params['outline'];
+    const plan = this.normalizeCoursePlan(rawPlan || params);
+    if (plan.chapters.length === 0) {
+      throw new Error('Course plan preview needs at least one chapter with lessons');
+    }
+    const sourceReferences = this.collectCoursePlanSourceReferences(
+      plan,
+      params['source_references'] || params['sourceReferences'],
+    );
+    const lessonCount = plan.chapters.reduce((sum, chapter) => sum + chapter.lessons.length, 0);
+    const summary = this.normalizeString(params['summary'])
+      || `Course plan preview ready: ${plan.chapters.length} chapters, ${lessonCount} lessons.`;
+    const preview = this.rememberPreview('course_plan', summary, {
+      course_id: courseId,
+      course_plan: plan,
+      source_references: sourceReferences,
+      changed_fields: ['course_structure'],
+    });
+    const data = {
+      preview_token: preview.token,
+      preview_kind: preview.kind,
+      course_id: courseId,
+      course_title: plan.title,
+      target_label: plan.title,
+      apply_action: 'authoring.apply_course_plan',
+      summary: `${summary} Giáo viên cần xem cây chương/bài và nguồn trích dẫn trước khi áp dụng.`,
+      changed_fields: ['course_structure'],
+      source_references: sourceReferences,
+      course_plan: plan,
+    };
+    this.announceOperatorPreview(preview, data);
+    return { success: true, data };
+  }
+
+  private async applyCoursePlan(
+    params: Record<string, unknown>,
+  ): Promise<{ success: boolean; data: Record<string, unknown> }> {
+    const previewToken = this.normalizeString(params['preview_token']);
+    if (!previewToken) {
+      throw new Error('Missing preview_token for course plan apply');
+    }
+    const preview = this.requirePreview(previewToken, 'course_plan');
+    this.requireHostApproval(preview, this.normalizeString(params['approval_token'] || params['approvalToken']));
+    const courseId = String(preview.payload['course_id'] || '').trim();
+    const plan = preview.payload['course_plan'] as NormalizedCoursePlan | undefined;
+    if (!courseId || !plan || !Array.isArray(plan.chapters) || plan.chapters.length === 0) {
+      throw new Error('Course plan preview is missing course structure');
+    }
+
+    let chaptersCreated = 0;
+    let lessonsCreated = 0;
+    const createdChapters: Array<{ id: string; title: string; lesson_count: number }> = [];
+    for (const [chapterIndex, chapter] of plan.chapters.entries()) {
+      const chapterResponse: any = await firstValueFrom(this.chapterApi.createChapter(courseId, {
+        title: chapter.title,
+        description: chapter.summary || undefined,
+        orderIndex: chapterIndex,
+      }));
+      const createdChapter = chapterResponse?.data || chapterResponse;
+      const chapterId = typeof createdChapter === 'string' ? createdChapter : String(createdChapter?.id || '').trim();
+      if (!chapterId) {
+        throw new Error(`Course plan apply could not create chapter ${chapterIndex + 1}`);
+      }
+      chaptersCreated += 1;
+      createdChapters.push({ id: chapterId, title: chapter.title, lesson_count: chapter.lessons.length });
+      if (this.courseEditorStore.courseTree()?.id === courseId) {
+        this.courseEditorStore.addChapterLocal({
+          id: chapterId,
+          title: (typeof createdChapter === 'object' ? createdChapter?.title : null) || chapter.title,
+          description: (typeof createdChapter === 'object' ? createdChapter?.description : null) || chapter.summary || '',
+          orderIndex: (typeof createdChapter === 'object' ? createdChapter?.orderIndex : null) ?? chapterIndex,
+          lessons: [],
+        });
+      }
+
+      for (const [lessonIndex, lesson] of chapter.lessons.entries()) {
+        const lessonResponse: any = await firstValueFrom(this.lessonApi.createLesson(chapterId, {
+          title: lesson.title,
+          description: lesson.summary || undefined,
+          content: this.buildCoursePlanLessonContent(lesson, chapter, plan),
+          durationMinutes: lesson.duration_minutes || 15,
+          orderIndex: lessonIndex,
+          type: 'LECTURE',
+        }));
+        const createdLesson = lessonResponse?.data || lessonResponse;
+        const lessonId = typeof createdLesson === 'string' ? createdLesson : String(createdLesson?.id || '').trim();
+        if (lessonId) {
+          lessonsCreated += 1;
+          if (this.courseEditorStore.courseTree()?.id === courseId) {
+            this.courseEditorStore.addLessonLocal(chapterId, {
+              id: lessonId,
+              title: (typeof createdLesson === 'object' ? createdLesson?.title : null) || lesson.title,
+              type: (typeof createdLesson === 'object' ? (createdLesson?.type || createdLesson?.lessonType) : null) || 'LECTURE',
+              orderIndex: (typeof createdLesson === 'object' ? createdLesson?.orderIndex : null) ?? lessonIndex,
+              isRequired: (typeof createdLesson === 'object' ? createdLesson?.isRequired : null) ?? false,
+              sections: (typeof createdLesson === 'object' ? createdLesson?.sections : null) || [],
+            });
+          }
+        }
+      }
+    }
+    this.pendingOperatorPreviews.delete(previewToken);
+    if (this.courseEditorStore.courseTree()?.id === courseId) {
+      this.courseEditorStore.invalidateCache(courseId);
+      this.courseEditorStore.loadCourse(courseId, true);
+    }
+
+    return {
+      success: true,
+      data: {
+        applied: true,
+        course_id: courseId,
+        course_title: plan.title,
+        chapters_created: chaptersCreated,
+        lessons_created: lessonsCreated,
+        chapters: createdChapters,
+        summary: `Đã tạo ${chaptersCreated} chương và ${lessonsCreated} bài học draft từ tài liệu.`,
+      },
+    };
   }
 
   private extractLessonPreviewBlocks(source: unknown): LessonPreviewBlock[] {
@@ -1972,8 +2297,14 @@ export class WiiiContextService implements OnDestroy {
         await this.router.navigate(['/teacher/courses', courseId, 'editor', tab]);
         return { success: true, data: { navigated: true, tab } };
       }
-      case 'authoring.generate_course_from_document':
-        return this.dispatchSidebarAction('generate_lesson', String(params['courseId'] || this.lastContext?.course_id || ''));
+      case 'authoring.generate_course_from_document': {
+        if (params['course_plan'] || params['coursePlan'] || params['outline'] || params['chapters']) {
+          return this.previewCoursePlan(params);
+        }
+        return this.dispatchSidebarAction('generate_course_from_document', this.resolveCurrentCourseId(params));
+      }
+      case 'authoring.apply_course_plan':
+        return this.applyCoursePlan(params);
       case 'authoring.generate_lesson':
         return this.dispatchSidebarAction('generate_lesson', String(params['courseId'] || this.lastContext?.course_id || ''));
       case 'authoring.improve_lesson_experience':

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.html
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.html
@@ -83,6 +83,58 @@
           }
         }
 
+        @if (preview.kind === 'course_plan') {
+          <div class="wiii-preview-section">
+            <h3>Cấu trúc khóa học đề xuất</h3>
+            <dl class="wiii-preview-kv wiii-preview-kv--course">
+              <div><dt>Tên khóa</dt><dd>{{ coursePlanValue(preview, 'title') || preview.targetLabel }}</dd></div>
+              <div><dt>Đối tượng</dt><dd>{{ coursePlanValue(preview, 'audience') || 'Giáo viên xác nhận trong LMS' }}</dd></div>
+              <div><dt>Thời lượng</dt><dd>{{ coursePlanValue(preview, 'duration') || 'Theo tiến độ lớp học' }}</dd></div>
+              <div><dt>Số chương</dt><dd>{{ courseChapters(preview).length }}</dd></div>
+            </dl>
+
+            @if (coursePlanValue(preview, 'description')) {
+              <p class="wiii-preview-course-description">{{ coursePlanValue(preview, 'description') }}</p>
+            }
+
+            <div class="wiii-preview-course-tree">
+              @for (chapter of courseChapters(preview); track chapterTrack(chapter, $index)) {
+                <article class="wiii-preview-course-chapter">
+                  <div class="wiii-preview-course-chapter__header">
+                    <span>Chương {{ $index + 1 }}</span>
+                    <strong>{{ itemValue(chapter, 'title') || 'Chương chưa đặt tên' }}</strong>
+                    @if (itemValue(chapter, 'summary')) {
+                      <p>{{ itemValue(chapter, 'summary') }}</p>
+                    }
+                  </div>
+
+                  @if (chapterObjectives(chapter).length > 0) {
+                    <ul class="wiii-preview-objectives">
+                      @for (objective of chapterObjectives(chapter); track objective) {
+                        <li>{{ objective }}</li>
+                      }
+                    </ul>
+                  }
+
+                  <ol class="wiii-preview-lesson-list">
+                    @for (lesson of chapterLessons(chapter); track lessonTrack(lesson, $index)) {
+                      <li>
+                        <strong>{{ itemValue(lesson, 'title') || 'Bài học chưa đặt tên' }}</strong>
+                        @if (itemValue(lesson, 'summary')) {
+                          <p>{{ itemValue(lesson, 'summary') }}</p>
+                        }
+                        @if (itemValue(lesson, 'activity')) {
+                          <span>Hoạt động: {{ itemValue(lesson, 'activity') }}</span>
+                        }
+                      </li>
+                    }
+                  </ol>
+                </article>
+              }
+            </div>
+          </div>
+        }
+
         @if (preview.kind === 'quiz_commit') {
           <div class="wiii-preview-section">
             <h3>Kế hoạch bài kiểm tra</h3>

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.scss
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.scss
@@ -235,6 +235,88 @@ h3 {
   font-weight: 700;
 }
 
+.wiii-preview-kv--course {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.wiii-preview-course-description {
+  margin-top: 12px;
+  color: #334155;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.wiii-preview-course-tree {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.wiii-preview-course-chapter {
+  border: 1px solid #dbeafe;
+  border-radius: 10px;
+  padding: 14px;
+  background:
+    linear-gradient(180deg, rgba(239, 246, 255, 0.82), rgba(255, 255, 255, 0.96));
+}
+
+.wiii-preview-course-chapter__header span {
+  display: inline-flex;
+  margin-bottom: 6px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.wiii-preview-course-chapter__header strong {
+  display: block;
+  color: #0f172a;
+  font-size: 15px;
+}
+
+.wiii-preview-course-chapter__header p,
+.wiii-preview-objectives,
+.wiii-preview-lesson-list p,
+.wiii-preview-lesson-list span {
+  color: #475569;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.wiii-preview-objectives,
+.wiii-preview-lesson-list {
+  margin: 10px 0 0;
+  padding-left: 20px;
+}
+
+.wiii-preview-objectives {
+  display: grid;
+  gap: 4px;
+}
+
+.wiii-preview-lesson-list {
+  display: grid;
+  gap: 8px;
+}
+
+.wiii-preview-lesson-list li {
+  padding: 8px 10px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.wiii-preview-lesson-list strong {
+  display: block;
+  margin-bottom: 4px;
+  color: #0f172a;
+  font-size: 13px;
+}
+
 .wiii-preview-icon-button,
 .wiii-preview-secondary,
 .wiii-preview-primary {

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
@@ -65,6 +65,8 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
     switch (kind) {
       case 'lesson_patch':
         return 'Wiii - xem trước bài học';
+      case 'course_plan':
+        return 'Wiii - xem trước cấu trúc khóa học';
       case 'quiz_commit':
         return 'Wiii - xem trước bài kiểm tra';
       case 'quiz_publish':
@@ -160,6 +162,50 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
     return this.objectValue(preview.data[planKey], field);
   }
 
+  protected coursePlan(preview: WiiiOperatorPreviewPanel): Record<string, unknown> {
+    const plan = preview.data['course_plan'];
+    return plan && typeof plan === 'object' && !Array.isArray(plan)
+      ? plan as Record<string, unknown>
+      : {};
+  }
+
+  protected coursePlanValue(preview: WiiiOperatorPreviewPanel, field: string): string {
+    return this.objectValue(preview.data['course_plan'], field);
+  }
+
+  protected courseChapters(preview: WiiiOperatorPreviewPanel): Array<Record<string, unknown>> {
+    const chapters = this.coursePlan(preview)['chapters'];
+    return Array.isArray(chapters)
+      ? chapters.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item))
+      : [];
+  }
+
+  protected chapterLessons(chapter: Record<string, unknown>): Array<Record<string, unknown>> {
+    const lessons = chapter['lessons'];
+    return Array.isArray(lessons)
+      ? lessons.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item))
+      : [];
+  }
+
+  protected chapterObjectives(chapter: Record<string, unknown>): string[] {
+    const objectives = chapter['learning_objectives'] || chapter['learningObjectives'];
+    return Array.isArray(objectives)
+      ? objectives.map((item) => String(item || '').trim()).filter(Boolean)
+      : [];
+  }
+
+  protected itemValue(item: Record<string, unknown>, field: string): string {
+    return String(item[field] || '').trim();
+  }
+
+  protected chapterTrack(chapter: Record<string, unknown>, index: number): string {
+    return `${index}-${chapter['title'] || 'chapter'}`;
+  }
+
+  protected lessonTrack(lesson: Record<string, unknown>, index: number): string {
+    return `${index}-${lesson['title'] || 'lesson'}`;
+  }
+
   protected sourceTrack(ref: WiiiSourceReference, index: number): string {
     return `${ref.kind || 'source'}-${ref.page || ref.page_start || index}`;
   }
@@ -183,6 +229,8 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
         return 'Mô tả';
       case 'content':
         return 'Nội dung';
+      case 'course_structure':
+        return 'Cấu trúc khóa học';
       default:
         return field;
     }


### PR DESCRIPTION
## Summary
- Extends LMS host capabilities with `authoring.generate_course_from_document` preview schema and `authoring.apply_course_plan` approval-gated mutation.
- Adds a course-plan preview flow that normalizes Wiii chapters/lessons/source references and displays them in the Wiii operator preview dialog.
- Applies an approved course plan by creating draft chapters and lessons via existing LMS APIs, then refreshes CourseEditorStore.
- Keeps dangerous actions out of scope: no publish/delete/enroll/grade/payment.

## Safety / rollback
- Course plan application requires `preview_token` + LMS-generated `approval_token` from the teacher dialog.
- Apply creates additive draft chapter/lesson content only; it does not publish or delete anything.
- Rollback: revert this PR; existing lesson/quiz preview/apply flows are unchanged and tested.

## Visual evidence
- No live screenshot committed: the preview dialog is event-driven behind authenticated course editor state. UI is covered by Angular template build plus service-level browser/Karma tests. Manual product screenshot should be captured after Wiii #309 and this PR are deployed together.

## Verification
- `cd fe && npm test -- --watch=false --include src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts` -> 29 SUCCESS.
- `cd fe && npx tsc --noEmit` -> pass.
- `cd fe && npm run build` -> success, only pre-existing Angular/Sass/CommonJS warnings.
- `git diff --check` -> pass.

Closes #435
Related: https://github.com/meiiie/wiii/issues/308