### PR TITLE
[codex] Clarify student activity column

### DIFF
--- a/fe/src/app/features/admin/presentation/components/student-management.component.html
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.html
@@ -94,9 +94,9 @@
                 </th>
                 <th>Học viên</th>
                 <th>Vai trò</th>
-                <th>Trạng thái</th>
+                <th>Trạng thái tài khoản</th>
                 <th>Khóa học</th>
-                <th>Hoạt động</th>
+                <th>Đăng nhập cuối</th>
                 <th class="text-center">Thao tác</th>
               </tr>
             </thead>
@@ -150,13 +150,16 @@
                       {{ student.coursesEnrolled || 0 }} khóa học
                     </button>
                   </td>
-                  <!-- Last Login — relative time (Linear/GitHub/Stripe pattern,
-                       đồng bộ users/all PR #224). cursor-help + title chỉ khi
-                       có lastLogin (tránh hand cursor + tooltip rỗng). -->
+                  <!-- Last Login — explicit account activity timestamp, not account status. -->
                   <td>
-                    <span class="badge" [class]="getStatusBadgeClass(student.accountStatus)">
-                      <span class="status-dot" [class]="getStatusDotClass(student.accountStatus)"></span>
-                      {{ getActivityLabel(student) }}
+                    <span class="last-login-text"
+                          [class.last-login-text--empty]="!student.lastLogin"
+                          [class.cursor-help]="student.lastLogin"
+                          [attr.title]="formatExactDateTime(student.lastLogin)">
+                      <svg aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6l4 2m6-2a10 10 0 11-20 0 10 10 0 0120 0z"></path>
+                      </svg>
+                      {{ student.lastLogin ? formatRelativeTime(student.lastLogin) : 'Chưa đăng nhập' }}
                     </span>
                   </td>
                   <!-- Actions — CC-10: shared kebab replaces inline status

--- a/fe/src/app/features/admin/presentation/components/student-management.component.scss
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.scss
@@ -378,6 +378,32 @@
   color: $text-secondary;
 }
 
+.last-login-text {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: $text-xs;
+  font-weight: $font-medium;
+  color: $text-secondary;
+  white-space: nowrap;
+
+  svg {
+    width: 14px;
+    height: 14px;
+    color: $gray-400;
+    flex-shrink: 0;
+  }
+
+  &--empty {
+    color: $text-muted;
+    font-weight: $font-normal;
+  }
+
+  &.cursor-help {
+    cursor: help;
+  }
+}
+
 /* Actions cell */
 .actions-cell {
   text-align: center;

--- a/fe/src/app/features/admin/presentation/components/student-management.component.ts
+++ b/fe/src/app/features/admin/presentation/components/student-management.component.ts
@@ -13,6 +13,7 @@ import { KpiCardComponent } from '../../../../shared/components/admin/kpi-card/k
 import { BulkActionBarComponent, BulkAction } from '../../../../shared/components/admin/bulk-action-bar/bulk-action-bar.component';
 import { KebabMenuComponent, KebabAction } from '../../../../shared/components/admin/kebab-menu/kebab-menu.component';
 import { initialsAvatar } from '../../../../shared/utils/avatar.util';
+import { formatRelativeTimeVN } from '../../../../shared/utils/relative-time.util';
 
 /**
  * Student Management Component
@@ -519,10 +520,26 @@ export class StudentManagementComponent implements OnInit {
     }
   }
 
-  getActivityLabel(student: AdminUser): string {
-    if (student.accountStatus === 'ACTIVE' && student.isActive) {
-      return 'Hoạt động';
+  formatRelativeTime(input: Date | string | null | undefined): string {
+    return formatRelativeTimeVN(input);
+  }
+
+  formatExactDateTime(input: Date | string | null | undefined): string | null {
+    if (!input) {
+      return null;
     }
-    return this.getStatusLabel(student.accountStatus);
+
+    const date = typeof input === 'string' ? new Date(input) : input;
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return date.toLocaleString('vi-VN', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
   }
 }


### PR DESCRIPTION
## Description
Clarifies the org-admin student table so account status and login activity no longer look like the same signal.

## Motivation
On `/org-admin/users/students`, both `Tr?ng th?i` and `Ho?t ??ng` could display the same green `Ho?t ??ng` badge. That made users think there were two duplicated status columns, while the intended second signal should be the student's last login/activity timestamp.

## Type of Change
- Bug fix
- UI clarity improvement

## Changes Made
- Renamed the status header to `Tr?ng th?i t?i kho?n`.
- Renamed the activity header to `??ng nh?p cu?i`.
- Replaced the activity badge logic with real `lastLogin` rendering.
- Shows relative Vietnamese time when `lastLogin` exists and `Ch?a ??ng nh?p` when it does not.
- Added a subtle clock icon and tooltip with the exact login datetime.

## Scope Note
This is scoped to the student management table used by org-admin/system-admin student listing. It does not change backend data contracts or account status behavior.

## Local Checks
- `git diff --check`
- `npx ng build --configuration development --progress=false`

## Notes
The Angular build passes. Existing unrelated Angular extended-diagnostic warnings remain in other modules.
