### PR TITLE
[codex] Show student interactive video markers

### DIFF
--- a/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
+++ b/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
@@ -99,8 +99,9 @@ export function shouldShowMediaNetworkHint(state: MediaNetworkHintState): boolea
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [InteractiveVideoLayerComponent, InteractiveVideoOverlayComponent, InteractiveVideoMarkersComponent],
   template: `
-    <div class="relative h-full w-full bg-black" data-testid="adaptive-video-player"
+    <div class="flex h-full w-full flex-col bg-black" data-testid="adaptive-video-player"
          (click)="showQualityMenu() && showQualityMenu.set(false)">
+      <div class="relative min-h-0 flex-1 bg-black">
       <video
         #videoElement
         data-testid="adaptive-video-element"
@@ -189,13 +190,6 @@ export function shouldShowMediaNetworkHint(state: MediaNetworkHintState): boolea
         [activeInteractionId]="activeInteraction()?.id ?? null"
         (interactionSelected)="openInteractiveInteraction($event)" />
 
-      <app-interactive-video-markers
-        [timeline]="interactiveVideoSpec()?.enabled === false ? [] : (interactiveVideoSpec()?.timeline ?? [])"
-        [durationSeconds]="videoDurationSeconds()"
-        [currentTimeSeconds]="currentTimeSeconds()"
-        [activeInteractionId]="activeInteraction()?.id ?? null"
-        (markerSelected)="seekToInteractiveSecond($event)" />
-
       @if (showNetworkHint()) {
         <div
           class="pointer-events-none absolute left-3 z-10 rounded-full bg-amber-400/95 px-3 py-1 text-[11px] font-semibold text-slate-950 shadow-lg shadow-black/20"
@@ -216,6 +210,15 @@ export function shouldShowMediaNetworkHint(state: MediaNetworkHintState): boolea
           (reviewRequested)="onInteractiveReviewRequested()"
           (continueRequested)="onInteractiveContinue()" />
       }
+      </div>
+
+      <app-interactive-video-markers
+        [timeline]="interactiveVideoSpec()?.enabled === false ? [] : (interactiveVideoSpec()?.timeline ?? [])"
+        [durationSeconds]="videoDurationSeconds()"
+        [currentTimeSeconds]="currentTimeSeconds()"
+        [activeInteractionId]="activeInteraction()?.id ?? null"
+        [showUpcomingHint]="false"
+        (markerSelected)="seekToInteractiveSecond($event)" />
     </div>
   `,
 })

--- a/fe/src/app/shared/blocks/block-types.ts
+++ b/fe/src/app/shared/blocks/block-types.ts
@@ -1,3 +1,5 @@
+import type { InteractiveVideoSpec } from '../../api/types/interactive-video.types';
+
 export type BlockType = 'text' | 'paragraph' | 'image' | 'formula' | 'table' | 'video';
 
 export interface ContentBlock {
@@ -36,4 +38,5 @@ export interface VideoBlockData {
     mimeType?: string;       // e.g. 'video/mp4'
     status?: string;         // VideoAsset processing status: PENDING, PROCESSING, READY, FAILED
     isYouTube?: boolean;     // True if video is a YouTube URL embed
+    interactiveVideoSpec?: InteractiveVideoSpec | null;
 }

--- a/fe/src/app/shared/blocks/video-block/interactive-video-markers.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-markers.component.ts
@@ -13,8 +13,9 @@ interface InteractiveVideoMarker {
   template: `
     @if (visibleMarkers().length > 0) {
       <div class="pointer-events-none border-t border-white/10 bg-slate-950/95 px-3 py-2 text-white">
-        @if (upcomingInteraction(); as next) {
-          <div class="mb-1.5 flex justify-end">
+        @if (showUpcomingHint()) {
+          @if (upcomingInteraction(); as next) {
+            <div class="mb-1.5 flex justify-end">
             <button
               type="button"
               class="pointer-events-auto inline-flex max-w-md items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold text-white shadow-sm transition-colors hover:bg-white/15 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-200"
@@ -25,7 +26,8 @@ interface InteractiveVideoMarker {
                 Sắp tới: {{ interactionLabel(next) }} tại {{ formatTime(next.atSeconds) }}
               </span>
             </button>
-          </div>
+            </div>
+          }
         }
 
         <div class="pointer-events-auto relative h-4 rounded-full bg-white/10 px-1 shadow-inner">
@@ -52,6 +54,7 @@ export class InteractiveVideoMarkersComponent {
   readonly durationSeconds = input<number | null>(null);
   readonly currentTimeSeconds = input(0);
   readonly activeInteractionId = input<string | null>(null);
+  readonly showUpcomingHint = input(true);
   readonly markerSelected = output<number>();
 
   readonly scaleSeconds = computed(() => {

--- a/fe/src/app/shared/blocks/video-block/video-block.component.ts
+++ b/fe/src/app/shared/blocks/video-block/video-block.component.ts
@@ -20,11 +20,12 @@ import { QuizVideoPlayerComponent } from './quiz-video-player.component';
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen>
         </iframe>
-      } @else if (assetId()) {
+      } @else if (assetId() || (videoUrl() && interactiveVideoSpec())) {
         <!-- Adaptive streaming via Shaka Player -->
         <app-quiz-video-player
           [videoAssetId]="assetId()"
           [rawVideoUrl]="videoUrl()"
+          [interactiveVideoSpec]="interactiveVideoSpec()"
         />
       } @else if (videoUrl()) {
         <!-- Native fallback for legacy/dev mode -->
@@ -65,6 +66,8 @@ export class VideoBlockComponent {
     const d = this.data();
     return d.rawUrl || d.url || d.file?.url || null;
   });
+
+  interactiveVideoSpec = computed(() => this.data().interactiveVideoSpec ?? null);
 
   youtubeEmbedUrl = computed<SafeResourceUrl | null>(() => {
     const d = this.data();


### PR DESCRIPTION
## Summary

- Show the interactive video marker rail in the student adaptive video player by reserving a visible marker row below the video area.
- Keep the student UI compact by hiding the teacher-style upcoming-interaction hint in this context.
- Pass `interactiveVideoSpec` through shared video blocks so block-rendered adaptive videos can also receive marker/interaction data.

## Root Cause

The marker component was already rendered in the student adaptive player, but it was placed after a full-height video inside an `overflow-hidden` aspect-ratio frame. That pushed the marker row outside the visible player area, so students could not see the blue interaction dots.

## Validation

- `npx ng build --configuration development`

Build passes. Existing Angular/Sass warnings are unrelated to this PR.