### PR TITLE
Show proposed Wiii lesson title in preview

### DIFF
--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
@@ -143,6 +143,10 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     expect(preview.data?.preview_kind).toBe('lesson_patch');
     expect(preview.data?.apply_action).toBe('authoring.apply_lesson_patch');
     expect(preview.data?.lesson_title).toBe('Bai hoc goc');
+    expect(preview.data?.proposed_lesson_title).toBe('Bai hoc moi');
+    expect(preview.data?.target_label).toBe('Bai hoc moi');
+    expect(String(preview.data?.summary)).toContain('Bai hoc moi');
+    expect(String(preview.data?.summary)).not.toContain('Bai hoc goc"');
     expect(preview.data?.changed_fields).toEqual(['title', 'content']);
     expect(preview.data?.lesson_before).toEqual(jasmine.objectContaining({
       title: 'Bai hoc goc',
@@ -169,6 +173,7 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     expect(panelPreview).toEqual(jasmine.objectContaining({
       token: preview.data?.preview_token,
       kind: 'lesson_patch',
+      targetLabel: 'Bai hoc moi',
       sourceReferences: [jasmine.objectContaining({ page_start: 2 })],
     }));
 

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -1774,8 +1774,10 @@ export class WiiiContextService implements OnDestroy {
       throw new Error('Lesson patch preview needs at least one field to change');
     }
 
+    const currentLessonTitle = String(lesson?.title || lessonId).trim();
+    const proposedLessonTitle = title ?? currentLessonTitle;
     const summary = this.buildActionSummary(
-      `Lesson patch preview ready for "${lesson?.title || lessonId}"`,
+      `Bản xem trước bài học đã sẵn sàng cho "${proposedLessonTitle}"`,
       changedFields,
     );
     const beforeBlocks = this.extractLessonPreviewBlocks(
@@ -1808,10 +1810,11 @@ export class WiiiContextService implements OnDestroy {
       preview_token: preview.token,
       preview_kind: preview.kind,
       lesson_id: lessonId,
-      lesson_title: String(lesson?.title || lessonId).trim(),
+      lesson_title: currentLessonTitle,
+      proposed_lesson_title: proposedLessonTitle,
       course_id: String(lesson?.courseId || this.resolveCurrentCourseId(params) || '').trim() || undefined,
       apply_action: 'authoring.apply_lesson_patch',
-      summary: `${summary} Review the LMS preview panel before applying it.`,
+      summary: `${summary}. Giáo viên cần xem diff/citation trong LMS trước khi áp dụng.`,
       changed_fields: changedFields,
       content_target: targetContentSectionId
         ? {
@@ -1820,7 +1823,7 @@ export class WiiiContextService implements OnDestroy {
           type: this.normalizeString(targetContentSection?.['type']) || 'TEXT',
         }
         : undefined,
-      target_label: String(lesson?.title || lessonId).trim(),
+      target_label: proposedLessonTitle,
       source_references: sourceReferences,
       lesson_before: {
         title: String(lesson?.title || '').trim(),


### PR DESCRIPTION
Closes #440.\n\n## Summary\n- Use Wiii's proposed lesson title for the operator preview target label and summary.\n- Keep the current lesson title in lesson_title / lesson_before so the diff remains honest.\n- Add focused coverage that the preview panel header uses the proposed title.\n\n## Verification\n- 
pm run test -- --watch=false --include src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts -> 29 passed.\n- 
pm run build -> success; existing Angular/Sass/CommonJS warnings only.\n- git diff --check -> pass.\n\n## Risk / rollback\n- Low risk: UI metadata/copy only for uthoring.preview_lesson_patch; apply still requires the existing approval token.\n- Rollback: revert this commit to restore the previous target label/summary behavior.\n\n## Product evidence\n- Product E2E showed Wiii proposed title was correct, but the preview header still displayed the current title (Bản nháp: Parser provenance). This patch makes the most prominent dialog label match the proposed lesson patch.