### PR TITLE
Polish Wiii preview summary punctuation

### DIFF
--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
@@ -147,6 +147,7 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     expect(preview.data?.target_label).toBe('Bai hoc moi');
     expect(String(preview.data?.summary)).toContain('Bai hoc moi');
     expect(String(preview.data?.summary)).not.toContain('Bai hoc goc"');
+    expect(String(preview.data?.summary)).not.toContain('..');
     expect(preview.data?.changed_fields).toEqual(['title', 'content']);
     expect(preview.data?.lesson_before).toEqual(jasmine.objectContaining({
       title: 'Bai hoc goc',

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -1780,6 +1780,7 @@ export class WiiiContextService implements OnDestroy {
       `Bản xem trước bài học đã sẵn sàng cho "${proposedLessonTitle}"`,
       changedFields,
     );
+    const reviewSummary = `${summary.replace(/[.!?。]+$/u, '')}. Giáo viên cần xem diff/citation trong LMS trước khi áp dụng.`;
     const beforeBlocks = this.extractLessonPreviewBlocks(
       (lesson as Record<string, unknown> | undefined)?.['sections']
       ?? (lesson as Record<string, unknown> | undefined)?.['contentBlocks']
@@ -1814,7 +1815,7 @@ export class WiiiContextService implements OnDestroy {
       proposed_lesson_title: proposedLessonTitle,
       course_id: String(lesson?.courseId || this.resolveCurrentCourseId(params) || '').trim() || undefined,
       apply_action: 'authoring.apply_lesson_patch',
-      summary: `${summary}. Giáo viên cần xem diff/citation trong LMS trước khi áp dụng.`,
+      summary: reviewSummary,
       changed_fields: changedFields,
       content_target: targetContentSectionId
         ? {


### PR DESCRIPTION
Closes #442.\n\n## Summary\n- Normalize Wiii lesson preview summary punctuation before adding the teacher-review sentence.\n- Prevent .. in the operator preview dialog after uildActionSummary() returns a sentence.\n- Add focused regression coverage.\n\n## Verification\n- 
pm run test -- --watch=false --include src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts -> 29 passed.\n- git diff --check -> pass.\n\n## Risk / rollback\n- Very low risk: copy-only polish for uthoring.preview_lesson_patch; approval-token apply behavior is unchanged.\n- Rollback: revert this commit.