### PR TITLE
[codex] Improve Wiii preview readability

### DIFF
--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
@@ -131,10 +131,18 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     const previewSub = service.operatorPreview$.subscribe((previewPanel) => {
       panelPreview = previewPanel;
     });
+    const proposedContent = [
+      '# Bài học mới',
+      '## Mục tiêu học tập',
+      '- Giáo viên kiểm tra diff trước khi áp dụng',
+      '- Giáo viên đối chiếu citation với tài liệu gốc',
+      '## Nội dung',
+      'Nội dung đã chỉnh sửa',
+    ].join('\n');
     const preview = await (service as any).handleActionRequest('authoring.preview_lesson_patch', {
       lesson_id: 'lesson-1',
       title: 'Bai hoc moi',
-      content: 'Noi dung da chinh sua',
+      content: proposedContent,
       source_references: [{ kind: 'chapter', page_start: 2, page_end: 3, excerpt: 'Nguon tai lieu' }],
     });
     previewSub.unsubscribe();
@@ -158,7 +166,12 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     expect(preview.data?.lesson_after).toEqual(jasmine.objectContaining({
       title: 'Bai hoc moi',
       description: 'Mo ta cu',
-      content_excerpt: 'Noi dung da chinh sua',
+      content_excerpt: jasmine.stringContaining('Bài học mới'),
+      content_preview: jasmine.stringContaining('## Mục tiêu học tập'),
+      learning_objectives: [
+        'Giáo viên kiểm tra diff trước khi áp dụng',
+        'Giáo viên đối chiếu citation với tài liệu gốc',
+      ],
       blocks: jasmine.any(Array),
     }));
     expect(preview.data?.block_diff).toEqual(jasmine.objectContaining({
@@ -190,7 +203,7 @@ describe('WiiiContextService - operator preview/apply flows', () => {
       courseId: 'course-1',
       chapterId: 'chapter-1',
       title: 'Bai hoc moi',
-      content: 'Noi dung da chinh sua',
+      content: proposedContent,
     }));
   });
 

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
@@ -147,6 +147,7 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     expect(preview.data?.target_label).toBe('Bai hoc moi');
     expect(String(preview.data?.summary)).toContain('Bai hoc moi');
     expect(String(preview.data?.summary)).not.toContain('Bai hoc goc"');
+    expect(String(preview.data?.summary)).not.toContain('..');
     expect(preview.data?.changed_fields).toEqual(['title', 'content']);
     expect(preview.data?.lesson_before).toEqual(jasmine.objectContaining({
       title: 'Bai hoc goc',

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -1225,6 +1225,76 @@ export class WiiiContextService implements OnDestroy {
     return `${normalized.slice(0, Math.max(0, maxLength - 1)).trim()}…`;
   }
 
+  private buildPreviewText(value: unknown, maxLength = 1800): string {
+    const normalized = String(value ?? '')
+      .replace(/\r\n?/g, '\n')
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/p>/gi, '\n\n')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;/gi, ' ')
+      .replace(/&amp;/gi, '&')
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>')
+      .split('\n')
+      .map((line) => line.replace(/[ \t]+/g, ' ').trim())
+      .join('\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim();
+    if (!normalized) {
+      return '';
+    }
+    if (normalized.length <= maxLength) {
+      return normalized;
+    }
+    return `${normalized.slice(0, Math.max(0, maxLength - 1)).trim()}…`;
+  }
+
+  private extractLearningObjectivesFromContent(value: unknown): string[] {
+    const text = this.buildPreviewText(value, 5000);
+    if (!text) {
+      return [];
+    }
+
+    const lines = text.split('\n');
+    const objectives: string[] = [];
+    let inObjectiveSection = false;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      const normalizedHeading = trimmed
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '')
+        .toLowerCase();
+
+      if (/^#{1,3}\s*muc tieu hoc tap\b/.test(normalizedHeading)) {
+        inObjectiveSection = true;
+        continue;
+      }
+      if (inObjectiveSection && /^#{1,3}\s+/.test(trimmed)) {
+        break;
+      }
+      if (!inObjectiveSection) {
+        continue;
+      }
+
+      const objective = trimmed
+        .replace(/^[-*•]\s+/, '')
+        .replace(/^\d+[.)-]\s+/, '')
+        .trim();
+      if (objective.length > 0) {
+        objectives.push(objective);
+      }
+      if (objectives.length >= 6) {
+        break;
+      }
+    }
+
+    return objectives;
+  }
+
   private buildActionSummary(prefix: string, details: string[]): string {
     const cleanDetails = details.filter((detail) => detail.trim().length > 0);
     if (cleanDetails.length === 0) {
@@ -1830,12 +1900,16 @@ export class WiiiContextService implements OnDestroy {
         title: String(lesson?.title || '').trim(),
         description: String(lesson?.description || '').trim(),
         content_excerpt: this.buildPreviewExcerpt(lesson?.content),
+        content_preview: this.buildPreviewText(lesson?.content),
+        learning_objectives: this.extractLearningObjectivesFromContent(lesson?.content),
         blocks: beforeBlocks,
       },
       lesson_after: {
         title: title ?? String(lesson?.title || '').trim(),
         description: description ?? String(lesson?.description || '').trim(),
         content_excerpt: this.buildPreviewExcerpt(content ?? lesson?.content),
+        content_preview: this.buildPreviewText(content ?? lesson?.content),
+        learning_objectives: this.extractLearningObjectivesFromContent(content ?? lesson?.content),
         blocks: afterBlocks,
       },
       block_diff: blockDiff,

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -1780,6 +1780,7 @@ export class WiiiContextService implements OnDestroy {
       `Bản xem trước bài học đã sẵn sàng cho "${proposedLessonTitle}"`,
       changedFields,
     );
+    const reviewSummary = `${summary.replace(/[.!?。]+$/u, '')}. Giáo viên cần xem diff/citation trong LMS trước khi áp dụng.`;
     const beforeBlocks = this.extractLessonPreviewBlocks(
       (lesson as Record<string, unknown> | undefined)?.['sections']
       ?? (lesson as Record<string, unknown> | undefined)?.['contentBlocks']
@@ -1814,7 +1815,7 @@ export class WiiiContextService implements OnDestroy {
       proposed_lesson_title: proposedLessonTitle,
       course_id: String(lesson?.courseId || this.resolveCurrentCourseId(params) || '').trim() || undefined,
       apply_action: 'authoring.apply_lesson_patch',
-      summary: `${summary}. Giáo viên cần xem diff/citation trong LMS trước khi áp dụng.`,
+      summary: reviewSummary,
       changed_fields: changedFields,
       content_target: targetContentSectionId
         ? {

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.html
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.html
@@ -65,6 +65,32 @@
             </div>
           </div>
 
+          @if (lessonLearningObjectives(preview, 'after').length > 0 || lessonContentPreview(preview, 'after')) {
+            <div class="wiii-preview-section wiii-preview-section--review">
+              <div class="wiii-preview-review-header">
+                <div>
+                  <h3>Nội dung Wiii sẽ áp dụng</h3>
+                  <p>Giáo viên nên đọc phần này cùng nguồn trích dẫn trước khi bấm Áp dụng.</p>
+                </div>
+              </div>
+
+              @if (lessonLearningObjectives(preview, 'after').length > 0) {
+                <ul class="wiii-preview-objective-cards" aria-label="Mục tiêu học tập Wiii đề xuất">
+                  @for (objective of lessonLearningObjectives(preview, 'after'); track objective) {
+                    <li>{{ objective }}</li>
+                  }
+                </ul>
+              }
+
+              @if (lessonContentPreview(preview, 'after')) {
+                <details class="wiii-preview-content-preview" open>
+                  <summary>Đọc bản nháp nội dung</summary>
+                  <pre>{{ lessonContentPreview(preview, 'after') }}</pre>
+                </details>
+              }
+            </div>
+          }
+
           @if (blockDiffItems(preview).length > 0) {
             <div class="wiii-preview-section">
               <h3>Thay đổi khối nội dung</h3>

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.scss
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.scss
@@ -83,6 +83,28 @@ h3 {
   margin-top: 18px;
 }
 
+.wiii-preview-section--review {
+  padding: 14px;
+  border: 1px solid #bfdbfe;
+  border-radius: 10px;
+  background:
+    linear-gradient(180deg, rgba(239, 246, 255, 0.92), rgba(255, 255, 255, 0.98));
+}
+
+.wiii-preview-review-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.wiii-preview-review-header p {
+  margin-top: 4px;
+  color: #475569;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
 .wiii-preview-status,
 .wiii-preview-message {
   display: flex;
@@ -315,6 +337,62 @@ h3 {
   margin-bottom: 4px;
   color: #0f172a;
   font-size: 13px;
+}
+
+.wiii-preview-objective-cards {
+  display: grid;
+  gap: 8px;
+  margin: 0 0 12px;
+  padding: 0;
+  list-style: none;
+}
+
+.wiii-preview-objective-cards li {
+  position: relative;
+  padding: 9px 10px 9px 30px;
+  border: 1px solid #dbeafe;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #1e293b;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.wiii-preview-objective-cards li::before {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: #0056d2;
+  content: '';
+}
+
+.wiii-preview-content-preview {
+  border: 1px solid #dbeafe;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.wiii-preview-content-preview summary {
+  cursor: pointer;
+  padding: 10px 12px;
+  color: #17406f;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.wiii-preview-content-preview pre {
+  max-height: 260px;
+  overflow: auto;
+  margin: 0;
+  padding: 0 12px 12px;
+  color: #334155;
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
 }
 
 .wiii-preview-icon-button,

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
@@ -116,6 +116,25 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
     return this.objectValue(preview.data['lesson_after'], field);
   }
 
+  protected lessonLearningObjectives(preview: WiiiOperatorPreviewPanel, side: 'before' | 'after'): string[] {
+    const source = preview.data[side === 'after' ? 'lesson_after' : 'lesson_before'];
+    if (!source || typeof source !== 'object' || Array.isArray(source)) {
+      return [];
+    }
+    const objectives = (source as Record<string, unknown>)['learning_objectives'];
+    return Array.isArray(objectives)
+      ? objectives.map((item) => String(item || '').trim()).filter(Boolean)
+      : [];
+  }
+
+  protected lessonContentPreview(preview: WiiiOperatorPreviewPanel, side: 'before' | 'after'): string {
+    const source = preview.data[side === 'after' ? 'lesson_after' : 'lesson_before'];
+    if (!source || typeof source !== 'object' || Array.isArray(source)) {
+      return '';
+    }
+    return this.objectValue(source, 'content_preview') || this.objectValue(source, 'content_excerpt');
+  }
+
   protected blockDiffItems(preview: WiiiOperatorPreviewPanel): Array<Record<string, unknown>> {
     const diff = preview.data['block_diff'];
     if (!diff || typeof diff !== 'object' || Array.isArray(diff)) {


### PR DESCRIPTION
Closes #444. Builds on #442 follow-up branch.\n\n## Summary\n- Normalize Wiii lesson preview summary punctuation so the dialog avoids double periods.\n- Add full proposed content preview and extracted learning objectives to lesson preview data.\n- Render a teacher review lane in the approval dialog so teachers can inspect objectives/content before pressing Apply.\n\n## Safety\n- Keeps the existing approval-token flow intact.\n- Does not allow Wiii to auto-apply, publish, delete, enroll, grade, or touch payments.\n- Dialog remains a preview surface; mutation still happens only after teacher approval.\n\n## Verification\n- 
px ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts -> 29/29 passed.\n- 
pm run build -> passed; only pre-existing Angular/Sass/CommonJS warnings.\n- git diff --check -> passed.