### PR TITLE
Polish Wiii preview dialog copy

### DIFF
--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -1850,7 +1850,7 @@ export class WiiiContextService implements OnDestroy {
       `Bản xem trước bài học đã sẵn sàng cho "${proposedLessonTitle}"`,
       changedFields,
     );
-    const reviewSummary = `${summary.replace(/[.!?。]+$/u, '')}. Giáo viên cần xem diff/citation trong LMS trước khi áp dụng.`;
+    const reviewSummary = `${summary.replace(/[.!?。]+$/u, '')}. Giáo viên cần xem phần so sánh thay đổi và nguồn trích dẫn trong LMS trước khi áp dụng.`;
     const beforeBlocks = this.extractLessonPreviewBlocks(
       (lesson as Record<string, unknown> | undefined)?.['sections']
       ?? (lesson as Record<string, unknown> | undefined)?.['contentBlocks']


### PR DESCRIPTION
## Summary
- Replace the remaining mixed English diff/citation wording in Wiii lesson preview summary with Vietnamese-first copy.
- Preserve preview_token, approval_token, data-wiii-id, and host action behavior.

## Verification
- cd fe; npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts -> 29 SUCCESS
- git diff --check -> pass

Fixes #446