### PR TITLE
[codex] Harden Wiii lesson apply verification

### DIFF
--- a/fe/src/app/api/client/lesson.api.ts
+++ b/fe/src/app/api/client/lesson.api.ts
@@ -44,16 +44,16 @@ export class LessonApi {
     return this.api.postWithResponse<LessonDetail>(LESSON_ENDPOINTS.CREATE(sectionId), requestPayload);
   }
 
-  updateLesson(lessonId: string, payload: UpdateLessonRequest) {
-    return this.api.put<ApiResponse<LessonDetail>>(LESSON_ENDPOINTS.UPDATE(lessonId), payload);
+  updateLesson(lessonId: string, payload: UpdateLessonRequest, options?: any) {
+    return this.api.put<ApiResponse<LessonDetail>>(LESSON_ENDPOINTS.UPDATE(lessonId), payload, options);
   }
 
   deleteLesson(lessonId: string, courseId: string) {
     return this.api.delete<ApiResponse<string>>(`${LESSON_ENDPOINTS.DELETE(lessonId)}?courseId=${courseId}`);
   }
 
-  getLessonById(lessonId: string) {
-    return this.api.getWithResponse<LessonDetail>(LESSON_ENDPOINTS.BY_ID(lessonId));
+  getLessonById(lessonId: string, options?: any) {
+    return this.api.getWithResponse<LessonDetail>(LESSON_ENDPOINTS.BY_ID(lessonId), options);
   }
 
   listBySection(sectionId: string) {

--- a/fe/src/app/api/client/section.api.ts
+++ b/fe/src/app/api/client/section.api.ts
@@ -12,8 +12,8 @@ export class SectionApi {
     return this.api.postWithResponse<SectionDetail>(SECTION_ENDPOINTS.CREATE(lessonId), payload);
   }
 
-  updateSection(lessonId: string, sectionId: string, payload: UpdateSectionRequest | FormData) {
-    return this.api.putWithResponse<SectionDetail>(SECTION_ENDPOINTS.UPDATE(lessonId, sectionId), payload);
+  updateSection(lessonId: string, sectionId: string, payload: UpdateSectionRequest | FormData, options?: any) {
+    return this.api.putWithResponse<SectionDetail>(SECTION_ENDPOINTS.UPDATE(lessonId, sectionId), payload, options);
   }
 
   deleteSection(lessonId: string, sectionId: string) {

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
@@ -111,20 +111,25 @@ describe('WiiiContextService - operator preview/apply flows', () => {
   });
 
   it('previews and applies a lesson patch through the host action flow', async () => {
-    lessonApi.getLessonById.and.returnValue(of({
-      data: {
-        id: 'lesson-1',
-        title: 'Bai hoc goc',
-        description: 'Mo ta cu',
-        content: 'Noi dung cu',
-        courseId: 'course-1',
-        sectionId: 'chapter-1',
-        lessonType: 'LECTURE',
-        durationMinutes: 15,
-        orderIndex: 2,
-        isRequired: true,
-      },
-    } as any));
+    let previewedContent = '';
+    let lessonReadCount = 0;
+    lessonApi.getLessonById.and.callFake(() => {
+      lessonReadCount += 1;
+      return of({
+        data: {
+          id: 'lesson-1',
+          title: lessonReadCount === 1 ? 'Bai hoc goc' : 'Bai hoc moi',
+          description: 'Mo ta cu',
+          content: lessonReadCount === 1 ? 'Noi dung cu' : previewedContent,
+          courseId: 'course-1',
+          sectionId: 'chapter-1',
+          lessonType: 'LECTURE',
+          durationMinutes: 15,
+          orderIndex: 2,
+          isRequired: true,
+        },
+      } as any);
+    });
     lessonApi.updateLesson.and.returnValue(of({ success: true } as any));
 
     let panelPreview: any;
@@ -139,6 +144,7 @@ describe('WiiiContextService - operator preview/apply flows', () => {
       '## Nội dung',
       'Nội dung đã chỉnh sửa',
     ].join('\n');
+    previewedContent = proposedContent;
     const preview = await (service as any).handleActionRequest('authoring.preview_lesson_patch', {
       lesson_id: 'lesson-1',
       title: 'Bai hoc moi',
@@ -204,39 +210,50 @@ describe('WiiiContextService - operator preview/apply flows', () => {
       chapterId: 'chapter-1',
       title: 'Bai hoc moi',
       content: proposedContent,
+    }), jasmine.objectContaining({
+      headers: jasmine.anything(),
     }));
+    expect(lessonApi.getLessonById).toHaveBeenCalledWith('lesson-1', jasmine.objectContaining({
+      headers: jasmine.anything(),
+    }));
+    expect(applied.data?.['verified']).toBeTrue();
   });
 
   it('applies content patches to the selected lesson text section for modern lessons', async () => {
-    lessonApi.getLessonById.and.returnValue(of({
-      data: {
-        id: 'lesson-1',
-        title: 'Bai hoc co section',
-        description: 'Mo ta cu',
-        content: 'Noi dung cu',
-        courseId: 'course-1',
-        sectionId: 'chapter-1',
-        lessonType: 'LECTURE',
-        durationMinutes: 15,
-        orderIndex: 2,
-        isRequired: true,
-        sections: [
-          {
-            id: 'section-1',
-            type: 'TEXT',
-            title: 'Noi dung chinh',
-            content: 'Noi dung cu',
-            isRequired: true,
-          },
-        ],
-      },
-    } as any));
+    const nextContent = 'Noi dung moi tu tai lieu Wiii';
+    let lessonReadCount = 0;
+    lessonApi.getLessonById.and.callFake(() => {
+      lessonReadCount += 1;
+      return of({
+        data: {
+          id: 'lesson-1',
+          title: 'Bai hoc co section',
+          description: 'Mo ta cu',
+          content: lessonReadCount === 1 ? 'Noi dung cu' : nextContent,
+          courseId: 'course-1',
+          sectionId: 'chapter-1',
+          lessonType: 'LECTURE',
+          durationMinutes: 15,
+          orderIndex: 2,
+          isRequired: true,
+          sections: [
+            {
+              id: 'section-1',
+              type: 'TEXT',
+              title: 'Noi dung chinh',
+              content: lessonReadCount === 1 ? 'Noi dung cu' : nextContent,
+              isRequired: true,
+            },
+          ],
+        },
+      } as any);
+    });
     sectionApi.updateSection.and.returnValue(of({ success: true, data: { id: 'section-1' } } as any));
     lessonApi.updateLesson.and.returnValue(of({ success: true } as any));
 
     const preview = await (service as any).handleActionRequest('authoring.preview_lesson_patch', {
       lesson_id: 'lesson-1',
-      content: 'Noi dung moi tu tai lieu Wiii',
+      content: nextContent,
     });
 
     expect(preview.success).toBeTrue();
@@ -252,8 +269,53 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     const applied = await service.approveOperatorPreview(String(preview.data?.preview_token));
 
     expect(applied.success).toBeTrue();
-    expect(sectionApi.updateSection).toHaveBeenCalledWith('lesson-1', 'section-1', jasmine.any(FormData));
+    expect(sectionApi.updateSection).toHaveBeenCalledWith(
+      'lesson-1',
+      'section-1',
+      jasmine.any(FormData),
+      jasmine.objectContaining({ headers: jasmine.anything() }),
+    );
     expect(lessonApi.updateLesson).not.toHaveBeenCalled();
+    expect(applied.data?.['verified']).toBeTrue();
+  });
+
+  it('keeps a lesson patch preview retryable when post-apply verification fails', async () => {
+    let lessonReadCount = 0;
+    lessonApi.getLessonById.and.callFake(() => {
+      lessonReadCount += 1;
+      return of({
+        data: {
+          id: 'lesson-1',
+          title: lessonReadCount >= 3 ? 'Bai hoc da verify' : 'Bai hoc cu',
+          description: 'Mo ta cu',
+          content: 'Noi dung cu',
+          courseId: 'course-1',
+          sectionId: 'chapter-1',
+          lessonType: 'LECTURE',
+          durationMinutes: 15,
+          orderIndex: 2,
+          isRequired: true,
+        },
+      } as any);
+    });
+    lessonApi.updateLesson.and.returnValue(of({ success: true } as any));
+
+    const preview = await (service as any).handleActionRequest('authoring.preview_lesson_patch', {
+      lesson_id: 'lesson-1',
+      title: 'Bai hoc da verify',
+    });
+
+    const failed = await service.approveOperatorPreview(String(preview.data?.preview_token));
+
+    expect(failed.success).toBeFalse();
+    expect(failed.error).toContain('host_preview_apply_verification_failed:title');
+    expect(lessonApi.updateLesson).toHaveBeenCalledTimes(1);
+
+    const retried = await service.approveOperatorPreview(String(preview.data?.preview_token));
+
+    expect(retried.success).toBeTrue();
+    expect(retried.data?.['verified']).toBeTrue();
+    expect(lessonApi.updateLesson).toHaveBeenCalledTimes(2);
   });
 
   it('previews and applies a document course plan through teacher approval', async () => {

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -15,6 +15,7 @@
  */
 import { Injectable, OnDestroy, PLATFORM_ID, effect, inject } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
+import { HttpHeaders } from '@angular/common/http';
 import { Router, NavigationEnd } from '@angular/router';
 import { Subject, Subscription, filter, firstValueFrom } from 'rxjs';
 import { environment } from '../../../../../environments/environment';
@@ -1804,9 +1805,120 @@ export class WiiiContextService implements OnDestroy {
     };
   }
 
-  private async getLessonDetail(lessonId: string): Promise<any> {
-    const response = await firstValueFrom(this.lessonApi.getLessonById(lessonId));
+  private buildWiiiAuthoringRequestOptions(): { headers: HttpHeaders } {
+    return {
+      headers: new HttpHeaders({
+        'ngsw-bypass': 'true',
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+      }),
+    };
+  }
+
+  private async getLessonDetail(lessonId: string, options?: any): Promise<any> {
+    const request = options === undefined
+      ? this.lessonApi.getLessonById(lessonId)
+      : this.lessonApi.getLessonById(lessonId, options);
+    const response = await firstValueFrom(request);
     return (response as any)?.data || response;
+  }
+
+  private async verifyLessonPatchApplied(
+    lessonId: string,
+    payload: Record<string, unknown>,
+    changedFields: string[],
+    contentSectionId: string,
+    expectedContent: string,
+    options: any,
+  ): Promise<void> {
+    const lesson = await this.getLessonDetail(lessonId, options);
+
+    if (changedFields.includes('title')) {
+      const expectedTitle = String(payload['title'] || '').trim();
+      const actualTitle = String(lesson?.title || '').trim();
+      if (expectedTitle && actualTitle !== expectedTitle) {
+        throw new Error('host_preview_apply_verification_failed:title');
+      }
+    }
+
+    if (changedFields.includes('description')) {
+      const expectedDescription = String(payload['description'] || '').trim();
+      const actualDescription = String(lesson?.description || '').trim();
+      if (expectedDescription && actualDescription !== expectedDescription) {
+        throw new Error('host_preview_apply_verification_failed:description');
+      }
+    }
+
+    if (!changedFields.includes('content')) {
+      return;
+    }
+
+    const actualContent = contentSectionId
+      ? this.findLessonSectionContent(lesson, contentSectionId)
+      : String(lesson?.content || '');
+    if (contentSectionId && !actualContent) {
+      throw new Error('host_preview_apply_verification_failed:section_missing');
+    }
+    if (!this.lessonContentContainsExpected(actualContent, expectedContent)) {
+      throw new Error('host_preview_apply_verification_failed:content');
+    }
+  }
+
+  private findLessonSectionContent(lesson: unknown, sectionId: string): string {
+    const target = this.normalizeLessonSections(lesson)
+      .find((section) => String(section['id'] || '').trim() === sectionId);
+    return String(target?.['content'] || '').trim();
+  }
+
+  private lessonContentContainsExpected(actual: unknown, expected: unknown): boolean {
+    const actualText = this.normalizeVerificationText(actual);
+    const expectedText = this.normalizeVerificationText(expected);
+    if (!expectedText) {
+      return true;
+    }
+    if (actualText === expectedText || actualText.includes(expectedText)) {
+      return true;
+    }
+    return this.buildVerificationAnchors(expectedText)
+      .some((anchor) => actualText.includes(anchor));
+  }
+
+  private buildVerificationAnchors(expectedText: string): string[] {
+    const minAnchorLength = expectedText.length < 40 ? Math.max(4, expectedText.length) : 24;
+    const lineAnchors = expectedText
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length >= minAnchorLength)
+      .slice(0, 4)
+      .map((line) => line.slice(0, 220).trim());
+    const windowAnchors = [
+      expectedText.slice(0, 800).trim(),
+      expectedText.slice(Math.max(0, expectedText.length - 800)).trim(),
+    ].filter((anchor) => anchor.length >= minAnchorLength);
+    return [...new Set([...lineAnchors, ...windowAnchors])];
+  }
+
+  private normalizeVerificationText(value: unknown): string {
+    return String(value ?? '')
+      .normalize('NFC')
+      .replace(/\r\n?/g, '\n')
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/p>/gi, '\n')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;/gi, ' ')
+      .replace(/&amp;/gi, '&')
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>')
+      .split('\n')
+      .map((line) => line
+        .replace(/^#{1,6}\s+/, '')
+        .replace(/^[-*\u2022]\s+/, '')
+        .replace(/[ \t]+/g, ' ')
+        .trim())
+      .filter((line) => line.length > 0)
+      .join('\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim();
   }
 
   private async resolveQuizIdForLesson(lessonId: string, explicitQuizId?: string): Promise<string> {
@@ -1944,6 +2056,7 @@ export class WiiiContextService implements OnDestroy {
     const contentSectionId = String(payload['content_section_id'] || '').trim();
     const metadataChanged = changedFields.some((field) => field === 'title' || field === 'description');
     const contentChanged = changedFields.includes('content');
+    const requestOptions = this.buildWiiiAuthoringRequestOptions();
 
     if (contentChanged && contentSectionId) {
       await firstValueFrom(this.sectionApi.updateSection(
@@ -1952,6 +2065,7 @@ export class WiiiContextService implements OnDestroy {
         this.buildSectionFormData({
           content,
         }),
+        requestOptions,
       ));
     }
 
@@ -1967,19 +2081,28 @@ export class WiiiContextService implements OnDestroy {
         isRequired: Boolean(payload['is_required'] ?? false),
         isPreview: false,
         orderIndex: Number(payload['order_index'] || 0),
-      }));
+      }, requestOptions));
     }
+    await this.verifyLessonPatchApplied(
+      lessonId,
+      payload,
+      changedFields,
+      contentSectionId,
+      content,
+      requestOptions,
+    );
     this.pendingOperatorPreviews.delete(previewToken);
 
     return {
       success: true,
       data: {
         applied: true,
+        verified: true,
         lesson_id: lessonId,
         course_id: courseId,
         content_section_id: contentSectionId || undefined,
         lesson_title: String(payload['title'] || lessonId).trim() || lessonId,
-        summary: `Applied lesson patch to lesson ${lessonId}.`,
+        summary: `Applied and verified lesson patch for lesson ${lessonId}.`,
       },
     };
   }


### PR DESCRIPTION
﻿## Summary
- harden Wiii lesson patch Apply so LMS only reports success after a service-worker-bypassed verification read confirms the authenticated teacher draft changed
- pass request options through lesson/section API wrappers for critical Wiii authoring calls
- keep the preview retryable when post-apply verification fails instead of deleting teacher context

## Why
Product smoke proved Apply persisted correctly for authenticated teacher reads, but also exposed that public/unauthenticated reads can show an older published snapshot. This patch makes the LMS host flow self-check persistence before telling Wiii/teacher that Apply succeeded.

## Safety
- Preserves the approval_token gate before mutation.
- Does not add any direct publish/delete/quiz-submit path.
- Uses Angular's official `ngsw-bypass` mechanism plus no-cache headers for mutation + verification requests.

## Verification
- `cd fe; npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts` -> 30 SUCCESS
- `cd fe; npm run build` -> success, existing Angular/Sass/CommonJS warnings only
- `git diff --check` -> pass

Closes #448
