### PR TITLE
[codex] Align Wiii section title on apply

### DIFF
--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
@@ -279,6 +279,68 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     expect(applied.data?.['verified']).toBeTrue();
   });
 
+  it('renames the target text section when lesson title and content change together', async () => {
+    const nextTitle = 'Bai hoc moi tu tai lieu';
+    const nextSectionTitle = 'N\u1ed9i dung: Bai hoc moi tu tai lieu';
+    const nextContent = 'Noi dung moi co marker Wiii';
+    let lessonReadCount = 0;
+    lessonApi.getLessonById.and.callFake(() => {
+      lessonReadCount += 1;
+      return of({
+        data: {
+          id: 'lesson-1',
+          title: lessonReadCount === 1 ? 'Bai hoc cu' : nextTitle,
+          description: 'Mo ta cu',
+          content: lessonReadCount === 1 ? 'Noi dung cu' : nextContent,
+          courseId: 'course-1',
+          sectionId: 'chapter-1',
+          lessonType: 'LECTURE',
+          durationMinutes: 15,
+          orderIndex: 2,
+          isRequired: true,
+          sections: [
+            {
+              id: 'section-1',
+              type: 'TEXT',
+              title: lessonReadCount === 1 ? 'Tieu de section cu' : nextSectionTitle,
+              content: lessonReadCount === 1 ? 'Noi dung cu' : nextContent,
+              isRequired: true,
+            },
+          ],
+        },
+      } as any);
+    });
+    sectionApi.updateSection.and.returnValue(of({ success: true, data: { id: 'section-1' } } as any));
+    lessonApi.updateLesson.and.returnValue(of({ success: true } as any));
+
+    const preview = await (service as any).handleActionRequest('authoring.preview_lesson_patch', {
+      lesson_id: 'lesson-1',
+      title: nextTitle,
+      content: nextContent,
+    });
+
+    expect(preview.success).toBeTrue();
+    expect(preview.data?.content_target).toEqual(jasmine.objectContaining({
+      section_id: 'section-1',
+      title: 'Tieu de section cu',
+      proposed_title: nextSectionTitle,
+    }));
+
+    const applied = await service.approveOperatorPreview(String(preview.data?.preview_token));
+
+    expect(applied.success).toBeTrue();
+    const formData = sectionApi.updateSection.calls.mostRecent().args[2] as FormData;
+    const payload = JSON.parse(await (formData.get('data') as Blob).text());
+    expect(payload).toEqual(jasmine.objectContaining({
+      title: nextSectionTitle,
+      content: nextContent,
+    }));
+    expect(lessonApi.updateLesson).toHaveBeenCalledWith('lesson-1', jasmine.objectContaining({
+      title: nextTitle,
+    }), jasmine.objectContaining({ headers: jasmine.anything() }));
+    expect(applied.data?.['verified']).toBeTrue();
+  });
+
   it('keeps a lesson patch preview retryable when post-apply verification fails', async () => {
     let lessonReadCount = 0;
     lessonApi.getLessonById.and.callFake(() => {

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -1862,11 +1862,24 @@ export class WiiiContextService implements OnDestroy {
     if (!this.lessonContentContainsExpected(actualContent, expectedContent)) {
       throw new Error('host_preview_apply_verification_failed:content');
     }
+
+    const expectedSectionTitle = String(payload['content_section_next_title'] || '').trim();
+    if (contentSectionId && expectedSectionTitle) {
+      const actualSectionTitle = String(this.findLessonSection(lesson, contentSectionId)?.['title'] || '').trim();
+      if (actualSectionTitle !== expectedSectionTitle) {
+        throw new Error('host_preview_apply_verification_failed:section_title');
+      }
+    }
+  }
+
+  private findLessonSection(lesson: unknown, sectionId: string): Record<string, unknown> | null {
+    return this.normalizeLessonSections(lesson)
+      .find((section) => String(section['id'] || '').trim() === sectionId)
+      || null;
   }
 
   private findLessonSectionContent(lesson: unknown, sectionId: string): string {
-    const target = this.normalizeLessonSections(lesson)
-      .find((section) => String(section['id'] || '').trim() === sectionId);
+    const target = this.findLessonSection(lesson, sectionId);
     return String(target?.['content'] || '').trim();
   }
 
@@ -1921,6 +1934,17 @@ export class WiiiContextService implements OnDestroy {
       .trim();
   }
 
+  private buildContentSectionTitle(lessonTitle: unknown): string {
+    const title = String(lessonTitle || '')
+      .replace(/^Bản nháp:\s*/i, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (!title) {
+      return '';
+    }
+    return `Nội dung: ${title}`.slice(0, 120).trim();
+  }
+
   private async resolveQuizIdForLesson(lessonId: string, explicitQuizId?: string): Promise<string> {
     if (explicitQuizId && explicitQuizId.trim().length > 0) {
       return explicitQuizId.trim();
@@ -1947,6 +1971,9 @@ export class WiiiContextService implements OnDestroy {
       ? this.resolveLessonContentSection(lesson, params)
       : null;
     const targetContentSectionId = this.normalizeString(targetContentSection?.['id']);
+    const nextContentSectionTitle = targetContentSectionId && title
+      ? this.buildContentSectionTitle(title)
+      : '';
     const changedFields = [
       ...(title ? ['title'] : []),
       ...(description ? ['description'] : []),
@@ -1982,6 +2009,7 @@ export class WiiiContextService implements OnDestroy {
       content: content ?? lesson?.content ?? '',
       content_section_id: targetContentSectionId || '',
       content_section_title: this.normalizeString(targetContentSection?.['title']) || '',
+      content_section_next_title: nextContentSectionTitle,
       duration_minutes: Number(lesson?.durationMinutes || 0),
       order_index: Number(lesson?.orderIndex || 0),
       is_required: Boolean((lesson as any)?.isRequired ?? false),
@@ -2003,6 +2031,7 @@ export class WiiiContextService implements OnDestroy {
         ? {
           section_id: targetContentSectionId,
           title: this.normalizeString(targetContentSection?.['title']) || targetContentSectionId,
+          proposed_title: nextContentSectionTitle || undefined,
           type: this.normalizeString(targetContentSection?.['type']) || 'TEXT',
         }
         : undefined,
@@ -2054,6 +2083,7 @@ export class WiiiContextService implements OnDestroy {
     const changedFields = this.normalizeStringArray(payload['changed_fields']);
     const content = String(payload['content'] || '').trim();
     const contentSectionId = String(payload['content_section_id'] || '').trim();
+    const contentSectionTitle = String(payload['content_section_next_title'] || '').trim();
     const metadataChanged = changedFields.some((field) => field === 'title' || field === 'description');
     const contentChanged = changedFields.includes('content');
     const requestOptions = this.buildWiiiAuthoringRequestOptions();
@@ -2063,6 +2093,7 @@ export class WiiiContextService implements OnDestroy {
         lessonId,
         contentSectionId,
         this.buildSectionFormData({
+          ...(contentSectionTitle ? { title: contentSectionTitle } : {}),
           content,
         }),
         requestOptions,


### PR DESCRIPTION
﻿## Summary
- derive a coherent Vietnamese text-section title when Wiii changes both lesson title and section content
- send that section title in the teacher-approved `authoring.apply_lesson_patch` section update payload
- verify the persisted authenticated draft now matches content and section title after Apply

## Why
The latest product smoke passed functionally, but the evidence showed a confusing UX artifact: a text section kept an old unrelated title from previous lesson material while Wiii applied new HoLiLiHu LMS manual content. This keeps the curriculum tree and section metadata aligned with the generated draft.

## Safety
- Approval token flow is unchanged.
- Applies only to the already-selected text section inside an approved lesson patch.
- Keeps post-apply verification fail-closed.

## Verification
- `cd fe; npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts` -> 31 SUCCESS
- `cd fe; npm run build` -> success, existing Angular/Sass/CommonJS warnings only
- `git diff --check` -> pass

Closes #450
