### PR TITLE
Polish Wiii preview diff focus

### DIFF
--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.html
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.html
@@ -52,15 +52,37 @@
             <div class="wiii-preview-diff-grid">
               <article>
                 <span>Hiện tại</span>
-                <strong>{{ lessonBefore(preview, 'title') || 'Chưa có tiêu đề' }}</strong>
-                <p>{{ lessonBefore(preview, 'description') || 'Không có mô tả' }}</p>
-                <p>{{ lessonBefore(preview, 'content_excerpt') || 'Không có nội dung' }}</p>
+                <dl class="wiii-preview-diff-fields">
+                  <div>
+                    <dt>Tiêu đề</dt>
+                    <dd>{{ lessonBefore(preview, 'title') || 'Chưa có tiêu đề' }}</dd>
+                  </div>
+                  <div>
+                    <dt>Mô tả</dt>
+                    <dd>{{ compactText(lessonBefore(preview, 'description'), 240) || 'Không có mô tả' }}</dd>
+                  </div>
+                </dl>
+                <details class="wiii-preview-diff-details">
+                  <summary>Xem tóm tắt nội dung hiện tại</summary>
+                  <p>{{ compactText(lessonBefore(preview, 'content_excerpt'), 420) || 'Không có nội dung' }}</p>
+                </details>
               </article>
               <article>
                 <span>Wiii đề xuất</span>
-                <strong>{{ lessonAfter(preview, 'title') || 'Chưa có tiêu đề' }}</strong>
-                <p>{{ lessonAfter(preview, 'description') || 'Không có mô tả' }}</p>
-                <p>{{ lessonAfter(preview, 'content_excerpt') || 'Không có nội dung' }}</p>
+                <dl class="wiii-preview-diff-fields">
+                  <div>
+                    <dt>Tiêu đề</dt>
+                    <dd>{{ lessonAfter(preview, 'title') || 'Chưa có tiêu đề' }}</dd>
+                  </div>
+                  <div>
+                    <dt>Mô tả</dt>
+                    <dd>{{ compactText(lessonAfter(preview, 'description'), 240) || 'Không có mô tả' }}</dd>
+                  </div>
+                  <div>
+                    <dt>Nội dung</dt>
+                    <dd>{{ compactText(lessonAfter(preview, 'content_excerpt'), 420) || 'Không có nội dung' }}</dd>
+                  </div>
+                </dl>
               </article>
             </div>
           </div>

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.scss
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.scss
@@ -179,12 +179,55 @@ h3 {
   text-transform: uppercase;
 }
 
-.wiii-preview-diff-grid strong,
 .wiii-preview-source-list strong {
   display: block;
   margin-bottom: 8px;
   color: #0f172a;
   font-size: 14px;
+}
+
+.wiii-preview-diff-fields {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+}
+
+.wiii-preview-diff-fields div {
+  display: grid;
+  gap: 4px;
+}
+
+.wiii-preview-diff-fields dt {
+  color: #64748b;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.wiii-preview-diff-fields dd {
+  margin: 0;
+  color: #0f172a;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.55;
+}
+
+.wiii-preview-diff-details {
+  margin-top: 12px;
+  border-top: 1px dashed #cbd5e1;
+  padding-top: 10px;
+}
+
+.wiii-preview-diff-details summary {
+  cursor: pointer;
+  color: #17406f;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.wiii-preview-diff-details p {
+  margin-top: 8px;
 }
 
 .wiii-preview-diff-grid p,

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.spec.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.spec.ts
@@ -1,0 +1,76 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+
+import {
+  WiiiContextService,
+  type WiiiOperatorPreviewPanel,
+} from '../../../infrastructure/api/wiii-context.service';
+import { WiiiOperatorPreviewDialogComponent } from './operator-preview-dialog.component';
+
+describe('WiiiOperatorPreviewDialogComponent', () => {
+  let fixture: ComponentFixture<WiiiOperatorPreviewDialogComponent>;
+  let previewSubject: BehaviorSubject<WiiiOperatorPreviewPanel | null>;
+
+  beforeEach(async () => {
+    previewSubject = new BehaviorSubject<WiiiOperatorPreviewPanel | null>(null);
+
+    await TestBed.configureTestingModule({
+      imports: [WiiiOperatorPreviewDialogComponent],
+      providers: [
+        {
+          provide: WiiiContextService,
+          useValue: {
+            operatorPreview$: previewSubject.asObservable(),
+            approveOperatorPreview: jasmine.createSpy('approveOperatorPreview').and.resolveTo({ success: true }),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WiiiOperatorPreviewDialogComponent);
+    fixture.detectChanges();
+  });
+
+  it('keeps old lesson content compact while the proposed draft stays easy to review', () => {
+    const currentLongContent = `CURRENT_START ${'nội dung cũ rất dài '.repeat(80)} CURRENT_SENTINEL_END`;
+    const preview: WiiiOperatorPreviewPanel = {
+      token: 'preview-token',
+      kind: 'lesson_patch',
+      createdAt: Date.now(),
+      summary: 'Giáo viên cần xem phần so sánh và nguồn trước khi áp dụng.',
+      applyAction: 'authoring.apply_lesson_patch',
+      targetLabel: 'Bản nháp: Hướng dẫn sử dụng HoLiLiHu LMS',
+      changedFields: ['title', 'description', 'content'],
+      sourceReferences: [{ title: 'Manual', page_start: 1, excerpt: 'Nguồn trích dẫn' }],
+      data: {
+        lesson_before: {
+          title: 'Bài cũ',
+          description: 'Mô tả cũ',
+          content_excerpt: currentLongContent,
+        },
+        lesson_after: {
+          title: 'Bản nháp: Hướng dẫn sử dụng HoLiLiHu LMS',
+          description: 'Mô tả mới cho giáo viên',
+          content_excerpt: 'PROPOSED_DIFF_EXCERPT',
+          content_preview: 'PROPOSED_FULL_DRAFT giáo viên đọc trước khi áp dụng.',
+          learning_objectives: ['Giáo viên kiểm tra nguồn trước khi áp dụng.'],
+        },
+      },
+    };
+
+    previewSubject.next(preview);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const currentDetails = host.querySelector('.wiii-preview-diff-details') as HTMLDetailsElement;
+    const proposedDetails = host.querySelector('.wiii-preview-content-preview') as HTMLDetailsElement;
+
+    expect(currentDetails).toBeTruthy();
+    expect(currentDetails.open).toBeFalse();
+    expect(currentDetails.textContent).toContain('CURRENT_START');
+    expect(currentDetails.textContent).not.toContain('CURRENT_SENTINEL_END');
+    expect(proposedDetails).toBeTruthy();
+    expect(proposedDetails.open).toBeTrue();
+    expect(proposedDetails.textContent).toContain('PROPOSED_FULL_DRAFT');
+  });
+});

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
@@ -135,6 +135,14 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
     return this.objectValue(source, 'content_preview') || this.objectValue(source, 'content_excerpt');
   }
 
+  protected compactText(value: string, maxLength = 360): string {
+    const normalized = String(value || '').replace(/\s+/g, ' ').trim();
+    if (!normalized || normalized.length <= maxLength) {
+      return normalized;
+    }
+    return `${normalized.slice(0, maxLength).trimEnd()}…`;
+  }
+
   protected blockDiffItems(preview: WiiiOperatorPreviewPanel): Array<Record<string, unknown>> {
     const diff = preview.data['block_diff'];
     if (!diff || typeof diff !== 'object' || Array.isArray(diff)) {


### PR DESCRIPTION
Closes #452.\n\n## What changed\n- Makes lesson patch diff easier for teachers to scan by turning before/after text into labeled fields.\n- Collapses long current lesson content behind a details control so stale previous content does not dominate the review.\n- Keeps the proposed Wiii draft open in the review section before Apply.\n- Adds component coverage for compact old content and visible proposed draft review.\n\n## Verification\n- npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.spec.ts -> 1 SUCCESS\n- npm run build -> success; existing Angular/Sass/CommonJS warnings only\n- git diff --cached --check -> pass\n\n## Risk / rollback\n- Low-risk presentation-only change to the LMS operator preview dialog. Approval token and host mutation paths are unchanged. Rollback by reverting this PR if the preview layout regresses.