### PR TITLE
Add stable Wiii widget Pointy target

### DIFF
--- a/fe/src/app/features/ai-chat/presentation/components/floating-chat-bubble/floating-chat-bubble.component.spec.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/floating-chat-bubble/floating-chat-bubble.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FloatingChatBubbleComponent } from './floating-chat-bubble.component';
+
+describe('FloatingChatBubbleComponent', () => {
+  let fixture: ComponentFixture<FloatingChatBubbleComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FloatingChatBubbleComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FloatingChatBubbleComponent);
+  });
+
+  it('exposes a safe stable Pointy target for opening Wiii', () => {
+    fixture.componentRef.setInput('isPanelOpen', false);
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+
+    expect(button.getAttribute('data-wiii-id')).toBe('open-wiii-widget');
+    expect(button.getAttribute('data-wiii-click-safe')).toBe('true');
+    expect(button.getAttribute('aria-label')).toBe('Mở trợ lý AI');
+  });
+
+  it('exposes a safe stable Pointy target for closing Wiii', () => {
+    fixture.componentRef.setInput('isPanelOpen', true);
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+
+    expect(button.getAttribute('data-wiii-id')).toBe('close-wiii-widget');
+    expect(button.getAttribute('data-wiii-click-safe')).toBe('true');
+    expect(button.getAttribute('aria-label')).toBe('Đóng chat');
+  });
+});

--- a/fe/src/app/features/ai-chat/presentation/components/floating-chat-bubble/floating-chat-bubble.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/floating-chat-bubble/floating-chat-bubble.component.ts
@@ -33,6 +33,8 @@ import {
       <button
         class="floating-bubble"
         [class.mobile]="isMobile()"
+        [attr.data-wiii-id]="isPanelOpen() ? 'close-wiii-widget' : 'open-wiii-widget'"
+        data-wiii-click-safe="true"
         (click)="onBubbleClick()"
         (mouseenter)="showTooltip.set(true)"
         (mouseleave)="showTooltip.set(false)"


### PR DESCRIPTION
Closes #454.

## What changed
- Adds stable data-wiii-id values to the Wiii floating bubble: open-wiii-widget when closed and close-wiii-widget when open.
- Marks the bubble data-wiii-click-safe=true because this only opens/closes the assistant panel and does not mutate LMS data.
- Adds component tests for both open and close target states.

## Verification
- npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/features/ai-chat/presentation/components/floating-chat-bubble/floating-chat-bubble.component.spec.ts -> 2 SUCCESS
- npm run build -> success; existing Angular/Sass/CommonJS warnings only
- git diff --cached --check -> pass

## Risk / rollback
- Low-risk DOM metadata change for Pointy/test stability. Rollback by reverting this PR if the floating widget target contract causes unexpected host behavior.