### PR TITLE
Reduce Wiii preview block diff noise

### DIFF
--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.html
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.html
@@ -120,9 +120,19 @@
                 @for (item of blockDiffItems(preview); track blockTrack(item)) {
                   <article class="wiii-preview-block">
                     <span [class]="blockStatusClass(item['status'])">{{ blockStatusLabel(item['status']) }}</span>
-                    <div>
-                      <p>{{ blockText(item['before']) || 'Trống' }}</p>
-                      <p>{{ blockText(item['after']) || 'Trống' }}</p>
+                    <div class="wiii-preview-block__content">
+                      @if (blockText(item['before'])) {
+                        <details class="wiii-preview-block__before">
+                          <summary>Hiện tại</summary>
+                          <p>{{ compactText(blockText(item['before']), 280) }}</p>
+                        </details>
+                      }
+                      @if (blockText(item['after'])) {
+                        <div class="wiii-preview-block__after">
+                          <strong>Wiii đề xuất</strong>
+                          <p>{{ compactText(blockText(item['after']), 420) }}</p>
+                        </div>
+                      }
                     </div>
                   </article>
                 }

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.scss
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.scss
@@ -251,6 +251,11 @@ h3 {
   gap: 12px;
 }
 
+.wiii-preview-block__content {
+  display: grid;
+  gap: 10px;
+}
+
 .wiii-preview-block span {
   align-self: start;
   justify-self: start;
@@ -258,6 +263,27 @@ h3 {
   border-radius: 999px;
   font-size: 11px;
   font-weight: 800;
+}
+
+.wiii-preview-block__before {
+  border-bottom: 1px dashed #cbd5e1;
+  padding-bottom: 8px;
+}
+
+.wiii-preview-block__before summary,
+.wiii-preview-block__after strong {
+  color: #17406f;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.wiii-preview-block__before summary {
+  cursor: pointer;
+}
+
+.wiii-preview-block__before p,
+.wiii-preview-block__after p {
+  margin-top: 6px;
 }
 
 .wiii-preview-block__added {

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.spec.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.spec.ts
@@ -73,4 +73,53 @@ describe('WiiiOperatorPreviewDialogComponent', () => {
     expect(proposedDetails.open).toBeTrue();
     expect(proposedDetails.textContent).toContain('PROPOSED_FULL_DRAFT');
   });
+
+  it('shows only changed block diff items and keeps before text collapsed', () => {
+    const changedBefore = `BEFORE_START ${'old block text '.repeat(80)} BEFORE_SENTINEL_END`;
+    const preview: WiiiOperatorPreviewPanel = {
+      token: 'preview-token',
+      kind: 'lesson_patch',
+      createdAt: Date.now(),
+      summary: 'Giáo viên cần xem thay đổi khối nội dung.',
+      applyAction: 'authoring.apply_lesson_patch',
+      targetLabel: 'Bản nháp bài học',
+      changedFields: ['content'],
+      sourceReferences: [],
+      data: {
+        lesson_before: { title: 'Bài cũ' },
+        lesson_after: { title: 'Bài mới' },
+        block_diff: {
+          items: [
+            {
+              index: 0,
+              status: 'changed',
+              before: { label: 'Khối cũ', excerpt: changedBefore },
+              after: { label: 'Khối mới', excerpt: 'AFTER_VISIBLE_TEXT' },
+            },
+            {
+              index: 1,
+              status: 'unchanged',
+              before: { label: 'Giữ nguyên', excerpt: 'UNCHANGED_SENTINEL' },
+              after: { label: 'Giữ nguyên', excerpt: 'UNCHANGED_SENTINEL' },
+            },
+          ],
+        },
+      },
+    };
+
+    previewSubject.next(preview);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const blocks = host.querySelectorAll('.wiii-preview-block');
+    const beforeDetails = host.querySelector('.wiii-preview-block__before') as HTMLDetailsElement;
+
+    expect(blocks.length).toBe(1);
+    expect(host.textContent).not.toContain('UNCHANGED_SENTINEL');
+    expect(beforeDetails).toBeTruthy();
+    expect(beforeDetails.open).toBeFalse();
+    expect(beforeDetails.textContent).toContain('BEFORE_START');
+    expect(beforeDetails.textContent).not.toContain('BEFORE_SENTINEL_END');
+    expect(host.textContent).toContain('AFTER_VISIBLE_TEXT');
+  });
 });

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
@@ -150,7 +150,12 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
     }
     const items = (diff as Record<string, unknown>)['items'];
     return Array.isArray(items)
-      ? items.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item))
+      ? items.filter((item): item is Record<string, unknown> => {
+        if (!item || typeof item !== 'object' || Array.isArray(item)) {
+          return false;
+        }
+        return String(item['status'] || 'unchanged') !== 'unchanged';
+      })
       : [];
   }
 


### PR DESCRIPTION
Closes #456.

## What changed
- Hides unchanged block diff rows from the Wiii operator preview so teachers only review actual changes.
- Collapses current/before block text and keeps Wiii proposed/after block text visible.
- Adds component coverage for noisy block diff behavior.

## Verification
- npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.spec.ts -> 2 SUCCESS
- npm run build -> success; existing Angular/Sass/CommonJS warnings only
- git diff --cached --check -> pass

## Risk / rollback
- Low-risk presentation-only preview polish. Approval token and apply paths are unchanged. Rollback by reverting this PR if preview readability regresses.