### PR TITLE
fix(wiii): route AI CTA to document course generation

### DIFF
--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/course-curriculum.component.ts
@@ -1727,7 +1727,7 @@ export class CourseCurriculumComponent implements OnDestroy {
     // Dispatch custom event that the ChatWidgetComponent listens for
     // to open the Wiii sidebar with course generation context
     window.dispatchEvent(new CustomEvent('wiii:open-sidebar', {
-      detail: { action: 'generate_lesson', courseId: this.store.courseTree()?.id }
+      detail: { action: 'generate_course_from_document', courseId: this.store.courseTree()?.id }
     }));
   }
 


### PR DESCRIPTION
## Summary

Fixes the empty-course `Tạo bằng AI` CTA so the LMS sends Wiii the document-to-course intent instead of the generic lesson-generation intent.

Closes #459.

## Scope

- Change `openAiCourseGeneration()` detail action from `generate_lesson` to `generate_course_from_document`.
- No mutation behavior changed; Wiii/LMS approval-token flow remains the owner of any apply action.

## Verification

- Chrome product smoke on `https://holilihu.online/teacher/courses/3e5a62d7-ede2-4171-aa35-7d1b94cb4a78/editor/curriculum`: verified `generate-course-from-document` target is visible/safe-clickable and opens Wiii widget.
- `git diff --check` in clean PR worktree: passed.
- `cd fe && npm run build` in the primary LMS worktree with the same source change: passed. Existing Angular/Sass/CommonJS warnings only.

## Risk / Rollback

Risk is low: one string literal aligns the CTA with the existing Wiii action contract. Rollback by reverting this commit; the previous behavior opens Wiii with the less specific `generate_lesson` action.