### PR TITLE
Use Wiii right sidebar in course editor

### DIFF
--- a/fe/src/app/features/ai-chat/presentation/components/chat-widget/chat-widget.component.spec.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/chat-widget/chat-widget.component.spec.ts
@@ -1,0 +1,82 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AuthService } from '../../../../../core/services/auth.service';
+import { SessionManagementService } from '../../../application/services/session-management.service';
+import { AiTokenService } from '../../../infrastructure/api/ai-token.service';
+import { WiiiContextService } from '../../../infrastructure/api/wiii-context.service';
+import { ChatWidgetComponent } from './chat-widget.component';
+
+describe('ChatWidgetComponent', () => {
+  let fixture: ComponentFixture<ChatWidgetComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChatWidgetComponent],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: {
+            currentUser: () => ({ id: 'teacher-1', role: 'teacher' }),
+          },
+        },
+        {
+          provide: SessionManagementService,
+          useValue: {
+            setUser: jasmine.createSpy('setUser'),
+            updateContextFromRoute: jasmine.createSpy('updateContextFromRoute'),
+          },
+        },
+        {
+          provide: WiiiContextService,
+          useValue: {
+            applySidebarIntent: jasmine.createSpy('applySidebarIntent'),
+            connectIframe: jasmine.createSpy('connectIframe'),
+            disconnectIframe: jasmine.createSpy('disconnectIframe'),
+          },
+        },
+        {
+          provide: AiTokenService,
+          useValue: {
+            getToken: jasmine.createSpy('getToken').and.resolveTo(null),
+            clearToken: jasmine.createSpy('clearToken'),
+            organizationId: jasmine.createSpy('organizationId').and.returnValue('org-1'),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChatWidgetComponent);
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('renders the desktop right-rail trigger for course editor sidebar mode', () => {
+    fixture.componentRef.setInput('variant', 'responsive-sidebar');
+    fixture.detectChanges();
+
+    const rail = fixture.nativeElement.querySelector('[data-wiii-id="open-wiii-right-sidebar"]') as HTMLButtonElement;
+
+    expect(rail).not.toBeNull();
+    expect(rail.getAttribute('data-wiii-click-safe')).toBe('true');
+    expect(rail.getAttribute('aria-label')).toBe('Mở trợ lý Wiii');
+  });
+
+  it('opens the sidebar panel when LMS dispatches a Wiii open event', () => {
+    fixture.componentRef.setInput('variant', 'responsive-sidebar');
+    fixture.detectChanges();
+
+    window.dispatchEvent(new CustomEvent('wiii:open-sidebar', {
+      detail: { action: 'generate_course_from_document', courseId: 'course-1' },
+    }));
+    fixture.detectChanges();
+
+    const contextService = TestBed.inject(WiiiContextService) as jasmine.SpyObj<WiiiContextService>;
+    expect(contextService.applySidebarIntent).toHaveBeenCalledWith({
+      action: 'generate_course_from_document',
+      courseId: 'course-1',
+    });
+    expect(fixture.nativeElement.querySelector('.wiii-sidebar-host--open')).not.toBeNull();
+  });
+});

--- a/fe/src/app/features/ai-chat/presentation/components/chat-widget/chat-widget.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/chat-widget/chat-widget.component.ts
@@ -8,6 +8,7 @@ import {
   Component,
   ChangeDetectionStrategy,
   inject,
+  input,
   signal,
   OnInit,
   OnDestroy,
@@ -24,27 +25,160 @@ import { WiiiContextService, type WiiiSidebarOpenDetail } from '../../../infrast
   imports: [FloatingChatBubbleComponent, ChatPanelComponent],
   template: `
     @if (isEnabled()) {
-      <!-- Chat Panel (iframe embed) -->
-      @if (isPanelOpen()) {
-        <app-chat-panel
-          mode="widget"
-          (closePanel)="closePanel()"
+      @if (variant() === 'responsive-sidebar') {
+        <aside
+          class="wiii-sidebar-host"
+          [class.wiii-sidebar-host--open]="isPanelOpen()"
+          aria-label="Trợ lý Wiii"
+          data-wiii-id="wiii-right-sidebar"
+        >
+          @if (isPanelOpen()) {
+            <app-chat-panel
+              mode="sidebar"
+              (closePanel)="closePanel()"
+            />
+          } @else {
+            <button
+              type="button"
+              class="wiii-sidebar-rail"
+              data-wiii-id="open-wiii-right-sidebar"
+              data-wiii-click-safe="true"
+              data-wiii-click-kind="navigation"
+              aria-label="Mở trợ lý Wiii"
+              (click)="openPanel()"
+            >
+              <span class="wiii-sidebar-rail__spark" aria-hidden="true">W</span>
+              <span class="wiii-sidebar-rail__label">Wiii</span>
+            </button>
+          }
+        </aside>
+
+        <div class="wiii-mobile-widget">
+          @if (isPanelOpen()) {
+            <app-chat-panel
+              mode="widget"
+              (closePanel)="closePanel()"
+            />
+          }
+
+          <app-floating-chat-bubble
+            [isPanelOpen]="isPanelOpen()"
+            (bubbleClick)="togglePanel()"
+          />
+        </div>
+      } @else {
+        <!-- Chat Panel (iframe embed) -->
+        @if (isPanelOpen()) {
+          <app-chat-panel
+            mode="widget"
+            (closePanel)="closePanel()"
+          />
+        }
+
+        <!-- Floating Bubble -->
+        <app-floating-chat-bubble
+          [isPanelOpen]="isPanelOpen()"
+          (bubbleClick)="togglePanel()"
         />
       }
-
-      <!-- Floating Bubble -->
-      <app-floating-chat-bubble
-        [isPanelOpen]="isPanelOpen()"
-        (bubbleClick)="togglePanel()"
-      />
     }
   `,
+  styles: [`
+    :host {
+      display: contents;
+    }
+
+    .wiii-sidebar-host {
+      display: none;
+    }
+
+    .wiii-mobile-widget {
+      display: contents;
+    }
+
+    @media (min-width: 768px) {
+      .wiii-mobile-widget {
+        display: none;
+      }
+
+      .wiii-sidebar-host {
+        display: flex;
+        align-self: stretch;
+        width: 56px;
+        min-width: 56px;
+        height: 100%;
+        min-height: 0;
+        border-left: 1px solid rgb(226 232 240);
+        background:
+          linear-gradient(180deg, rgba(248, 250, 252, 0.92), rgba(255, 255, 255, 0.98)),
+          radial-gradient(circle at top, rgba(0, 86, 210, 0.08), transparent 34%);
+        box-shadow: -16px 0 42px rgba(15, 23, 42, 0.06);
+        transition: width 220ms cubic-bezier(0.4, 0, 0.2, 1);
+      }
+
+      .wiii-sidebar-host--open {
+        width: clamp(360px, 27vw, 460px);
+        min-width: clamp(360px, 27vw, 460px);
+      }
+
+      .wiii-sidebar-rail {
+        width: 100%;
+        min-height: 0;
+        border: 0;
+        border-radius: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        color: #0f3f8f;
+        background: transparent;
+        cursor: pointer;
+        transition: background 160ms ease, color 160ms ease;
+      }
+
+      .wiii-sidebar-rail:hover,
+      .wiii-sidebar-rail:focus-visible {
+        color: #003b95;
+        background: rgba(0, 86, 210, 0.07);
+        outline: none;
+      }
+
+      .wiii-sidebar-rail:focus-visible {
+        box-shadow: inset 0 0 0 3px rgba(0, 86, 210, 0.22);
+      }
+
+      .wiii-sidebar-rail__spark {
+        width: 34px;
+        height: 34px;
+        border-radius: 999px;
+        display: grid;
+        place-items: center;
+        color: white;
+        font-weight: 800;
+        letter-spacing: -0.03em;
+        background: linear-gradient(135deg, #0056d2 0%, #0f766e 100%);
+        box-shadow: 0 12px 28px rgba(0, 86, 210, 0.25);
+      }
+
+      .wiii-sidebar-rail__label {
+        writing-mode: vertical-rl;
+        text-orientation: mixed;
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+    }
+  `],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ChatWidgetComponent implements OnInit, OnDestroy {
   private readonly sessionService = inject(SessionManagementService);
   private readonly authService = inject(AuthService);
   private readonly contextService = inject(WiiiContextService);
+
+  variant = input<'floating' | 'responsive-sidebar'>('floating');
 
   // State
   isPanelOpen = signal(false);
@@ -84,6 +218,10 @@ export class ChatWidgetComponent implements OnInit, OnDestroy {
 
   togglePanel(): void {
     this.isPanelOpen.update((open: boolean) => !open);
+  }
+
+  openPanel(): void {
+    this.isPanelOpen.set(true);
   }
 
   closePanel(): void {

--- a/fe/src/app/features/teacher/course-editor/layouts/course-editor-layout/course-editor-layout.component.scss
+++ b/fe/src/app/features/teacher/course-editor/layouts/course-editor-layout/course-editor-layout.component.scss
@@ -5,6 +5,10 @@
   --editor-nav-padding: 1.5rem;
 }
 
+.editor-main {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 @media (min-width: 1280px) {
   :host {
     --editor-sidebar-width: clamp(13rem, 17vw, 15rem);
@@ -39,6 +43,10 @@
 
 // Desktop/Tablet (≥768px): static grid column, no animation
 @media (min-width: 768px) {
+  .editor-main {
+    grid-template-columns: minmax(0, 1fr) auto !important;
+  }
+
   .sidebar-panel {
     position: static;
     width: auto;
@@ -54,7 +62,7 @@
   }
 
   main.sidebar-open {
-    grid-template-columns: var(--editor-sidebar-width) 1fr !important;
+    grid-template-columns: var(--editor-sidebar-width) minmax(0, 1fr) auto !important;
   }
 }
 

--- a/fe/src/app/features/teacher/course-editor/layouts/course-editor-layout/course-editor-layout.component.ts
+++ b/fe/src/app/features/teacher/course-editor/layouts/course-editor-layout/course-editor-layout.component.ts
@@ -96,7 +96,7 @@ import { distinctUntilChanged, filter, take, map } from 'rxjs/operators';
          </a>
       </nav>
 
-      <main class="flex-grow grid grid-cols-1 overflow-hidden relative"
+      <main class="editor-main flex-grow grid grid-cols-1 overflow-hidden relative"
             [class.sidebar-open]="!sidebarCollapsed()">
 
         <!-- Sidebar: always in DOM for signals/effects/modals -->
@@ -168,9 +168,8 @@ import { distinctUntilChanged, filter, take, map } from 'rxjs/operators';
                 }
             </div>
         </div>
+        <app-chat-widget variant="responsive-sidebar" />
       </main>
-
-      <app-chat-widget />
     </div>
   `
 })


### PR DESCRIPTION
## Summary
- Fixes #461.
- Moves Wiii in the teacher course editor from desktop floating bubble into a right sidebar/rail.
- Keeps the existing floating widget behavior for mobile screens.
- Preserves the existing LMS context bridge/open-sidebar event path so AI generation buttons still open Wiii with intent.
- Adds a targeted Angular test for the right rail safe target and `wiii:open-sidebar` behavior.

## Verification
- `cd fe && npm run build` -> passed. Existing Angular/template/Sass/CommonJS warnings remain unrelated.
- `cd fe && npm run test:ci -- --include src/app/features/ai-chat/presentation/components/chat-widget/chat-widget.component.spec.ts` -> 2 passed.
- `git diff --check` -> passed.

## Risk / rollback
- UI-only shell change around Wiii placement in course editor.
- Mobile remains on the prior floating widget path.
- Rollback: revert this PR to return the course editor to the floating Wiii widget.
