### PR TITLE
[codex] Render mobile PPTX/PDF previews as slides

### DIFF
--- a/fe/angular.json
+++ b/fe/angular.json
@@ -25,6 +25,11 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "pdf.worker.min.mjs",
+                "input": "node_modules/pdfjs-dist/build",
+                "output": "assets/pdfjs"
               }
             ],
             "styles": [

--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -71,6 +71,7 @@
         "mammoth": "^1.12.0",
         "ngx-image-cropper": "^9.1.6",
         "ngx-tiptap": "^14.0.1",
+        "pdfjs-dist": "^5.6.205",
         "rxjs": "~7.8.0",
         "shaka-player": "^4.16.18",
         "tslib": "^2.3.0",
@@ -2629,6 +2630,256 @@
       "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
     },
     "node_modules/@napi-rs/nice": {
       "version": "1.1.1",
@@ -10201,6 +10452,13 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
@@ -10673,6 +10931,19 @@
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.6.205",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
+      "integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0 || >=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.96",
+        "node-readable-to-web-readable-stream": "^0.4.2"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/fe/package.json
+++ b/fe/package.json
@@ -95,6 +95,7 @@
     "mammoth": "^1.12.0",
     "ngx-image-cropper": "^9.1.6",
     "ngx-tiptap": "^14.0.1",
+    "pdfjs-dist": "^5.6.205",
     "rxjs": "~7.8.0",
     "shaka-player": "^4.16.18",
     "tslib": "^2.3.0",

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
@@ -211,7 +211,12 @@
         </header>
 
         <!-- Preview area: PDF iframe, or fallback message for unsupported types -->
-        @if (safePdfUrl()) {
+        @if (useMobilePdfSlideViewer() && currentPdfSourceUrl()) {
+          <app-pdf-slide-viewer
+            [sourceUrl]="currentPdfSourceUrl() || ''"
+            [fileName]="displayName"
+            [downloadUrl]="section.fileUrl"></app-pdf-slide-viewer>
+        } @else if (safePdfUrl()) {
           <div #pdfContainer class="relative w-full bg-slate-100 group">
             <iframe [src]="safePdfUrl()"
                     class="w-full h-[520px] md:h-[680px] block"

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
@@ -1,8 +1,8 @@
-import { Component, input, output, model, signal, computed, ChangeDetectionStrategy, inject, effect, ElementRef, viewChild, AfterViewInit } from '@angular/core';
+import { Component, input, output, model, signal, computed, ChangeDetectionStrategy, inject, effect, ElementRef, viewChild, AfterViewInit, DestroyRef, PLATFORM_ID } from '@angular/core';
 import katex from 'katex';
 // KaTeX CSS loaded globally via angular.json styles[]; do NOT import here.
 
-import { CommonModule } from '@angular/common';
+import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { Router } from '@angular/router';
@@ -24,6 +24,7 @@ import { ApiClient } from '../../../../api/client/api-client';
 import { IconComponent } from '../../../../shared/components/icon/icon.component';
 import { SideDrawerComponent } from '../../../../shared/components/side-drawer/side-drawer.component';
 import { CompetencyBadgeComponent } from '../competency-badge/competency-badge.component';
+import { PdfSlideViewerComponent } from '../../../../shared/components/pdf-slide-viewer/pdf-slide-viewer.component';
 
 interface DocumentPreviewResponse {
   status: 'PROCESSING' | 'READY' | 'FAILED' | string;
@@ -44,7 +45,7 @@ interface DocumentPreviewResponse {
  */
 @Component({
   selector: 'app-lesson-content',
-  imports: [AdaptiveVideoPlayerComponent, YouTubePlayerComponent, CommonModule, FormsModule, IconComponent, SideDrawerComponent, CompetencyBadgeComponent],
+  imports: [AdaptiveVideoPlayerComponent, YouTubePlayerComponent, CommonModule, FormsModule, IconComponent, SideDrawerComponent, CompetencyBadgeComponent, PdfSlideViewerComponent],
   templateUrl: './lesson-content.component.html',
   styleUrls: ['./lesson-content.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -62,6 +63,8 @@ export class LessonContentComponent implements AfterViewInit {
   private network = inject(NetworkStatusService);
   private pdfViewer = inject(PdfViewerService);
   private apiClient = inject(ApiClient);
+  private destroyRef = inject(DestroyRef);
+  private platformId = inject(PLATFORM_ID);
   private readingTrackerInitTimer: ReturnType<typeof setTimeout> | null = null;
   private emittedReadCompletionKeys = new Set<string>();
 
@@ -252,7 +255,8 @@ export class LessonContentComponent implements AfterViewInit {
 
   /** Safe PDF URL for iframe embedding */
   readonly safePdfUrl = signal<SafeResourceUrl | null>(null);
-  private readonly currentPdfSourceUrl = signal<string | null>(null);
+  readonly currentPdfSourceUrl = signal<string | null>(null);
+  readonly useMobilePdfSlideViewer = signal(this.detectMobilePdfViewerMode());
   readonly onDemandPreviewStatus = signal<'PROCESSING' | 'READY' | 'FAILED' | null>(null);
   readonly onDemandPreviewMessage = signal<string | null>(null);
 
@@ -281,9 +285,13 @@ export class LessonContentComponent implements AfterViewInit {
       return;
     }
 
+    this.currentPdfSourceUrl.set(urlToPreview);
+    if (this.useMobilePdfSlideViewer()) {
+      return;
+    }
+
     const sub = this.pdfViewer.getSafePdfUrl(urlToPreview).subscribe({
       next: url => {
-        this.currentPdfSourceUrl.set(urlToPreview);
         this.safePdfUrl.set(url);
       },
       error: () => this.safePdfUrl.set(null)
@@ -336,10 +344,14 @@ export class LessonContentComponent implements AfterViewInit {
             this.onDemandPreviewMessage.set(data?.message || null);
 
             if (status === 'READY' && data?.previewPdfUrl) {
+              this.currentPdfSourceUrl.set(data.previewPdfUrl);
+              if (this.useMobilePdfSlideViewer()) {
+                return;
+              }
+
               pdfSub?.unsubscribe();
               pdfSub = this.pdfViewer.getSafePdfUrl(data.previewPdfUrl).subscribe({
                 next: url => {
-                  this.currentPdfSourceUrl.set(data.previewPdfUrl!);
                   this.safePdfUrl.set(url);
                 },
                 error: () => this.onDemandPreviewStatus.set('FAILED')
@@ -366,6 +378,14 @@ export class LessonContentComponent implements AfterViewInit {
   }
 
   private pdfContainer = viewChild<ElementRef>('pdfContainer');
+
+  private detectMobilePdfViewerMode(): boolean {
+    if (!isPlatformBrowser(this.platformId)) {
+      return false;
+    }
+
+    return window.matchMedia('(max-width: 767px), (pointer: coarse) and (max-width: 920px)').matches;
+  }
 
   togglePdfFullscreen(): void {
     const el = this.pdfContainer()?.nativeElement;
@@ -700,7 +720,15 @@ export class LessonContentComponent implements AfterViewInit {
   });
 
   ngAfterViewInit(): void {
-    // Reading tracker initializes via effect when section changes
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    const query = window.matchMedia('(max-width: 767px), (pointer: coarse) and (max-width: 920px)');
+    const updateMobilePdfMode = () => this.useMobilePdfSlideViewer.set(query.matches);
+    updateMobilePdfMode();
+    query.addEventListener('change', updateMobilePdfMode);
+    this.destroyRef.onDestroy(() => query.removeEventListener('change', updateMobilePdfMode));
   }
 
   private initReadingTracker(): void {

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
@@ -1,8 +1,8 @@
-import { Component, input, output, model, signal, computed, ChangeDetectionStrategy, inject, effect, ElementRef, viewChild, AfterViewInit, DestroyRef, PLATFORM_ID } from '@angular/core';
+import { Component, input, output, model, signal, computed, ChangeDetectionStrategy, inject, effect, ElementRef, viewChild, AfterViewInit } from '@angular/core';
 import katex from 'katex';
 // KaTeX CSS loaded globally via angular.json styles[]; do NOT import here.
 
-import { CommonModule, isPlatformBrowser } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { Router } from '@angular/router';
@@ -63,8 +63,6 @@ export class LessonContentComponent implements AfterViewInit {
   private network = inject(NetworkStatusService);
   private pdfViewer = inject(PdfViewerService);
   private apiClient = inject(ApiClient);
-  private destroyRef = inject(DestroyRef);
-  private platformId = inject(PLATFORM_ID);
   private readingTrackerInitTimer: ReturnType<typeof setTimeout> | null = null;
   private emittedReadCompletionKeys = new Set<string>();
 
@@ -256,7 +254,7 @@ export class LessonContentComponent implements AfterViewInit {
   /** Safe PDF URL for iframe embedding */
   readonly safePdfUrl = signal<SafeResourceUrl | null>(null);
   readonly currentPdfSourceUrl = signal<string | null>(null);
-  readonly useMobilePdfSlideViewer = signal(this.detectMobilePdfViewerMode());
+  readonly useMobilePdfSlideViewer = this.pdfViewer.useCanvasViewer;
   readonly onDemandPreviewStatus = signal<'PROCESSING' | 'READY' | 'FAILED' | null>(null);
   readonly onDemandPreviewMessage = signal<string | null>(null);
 
@@ -378,14 +376,6 @@ export class LessonContentComponent implements AfterViewInit {
   }
 
   private pdfContainer = viewChild<ElementRef>('pdfContainer');
-
-  private detectMobilePdfViewerMode(): boolean {
-    if (!isPlatformBrowser(this.platformId)) {
-      return false;
-    }
-
-    return window.matchMedia('(max-width: 767px), (pointer: coarse) and (max-width: 920px)').matches;
-  }
 
   togglePdfFullscreen(): void {
     const el = this.pdfContainer()?.nativeElement;
@@ -720,15 +710,7 @@ export class LessonContentComponent implements AfterViewInit {
   });
 
   ngAfterViewInit(): void {
-    if (!isPlatformBrowser(this.platformId)) {
-      return;
-    }
-
-    const query = window.matchMedia('(max-width: 767px), (pointer: coarse) and (max-width: 920px)');
-    const updateMobilePdfMode = () => this.useMobilePdfSlideViewer.set(query.matches);
-    updateMobilePdfMode();
-    query.addEventListener('change', updateMobilePdfMode);
-    this.destroyRef.onDestroy(() => query.removeEventListener('change', updateMobilePdfMode));
+    // Reading tracker initializes via effect when the section changes.
   }
 
   private initReadingTracker(): void {

--- a/fe/src/app/features/teacher/assignments/assignment-submissions.component.html
+++ b/fe/src/app/features/teacher/assignments/assignment-submissions.component.html
@@ -222,7 +222,14 @@
               @if (isImageFile(previewingFile()!.fileName)) {
                 <img [src]="previewingFile()!.fileUrl" [alt]="previewingFile()!.fileName" class="max-w-full mx-auto"/>
               } @else if (isPdfFile(previewingFile()!.fileName)) {
-                <iframe [src]="previewingFile()!.fileUrl" class="w-full h-[70vh] border-0"></iframe>
+                @if (useMobilePdfSlideViewer()) {
+                  <app-pdf-slide-viewer
+                    [sourceUrl]="previewingFile()!.fileUrl"
+                    [fileName]="previewingFile()!.fileName"
+                    [downloadUrl]="previewingFile()!.fileUrl"></app-pdf-slide-viewer>
+                } @else {
+                  <iframe [src]="previewingFile()!.fileUrl" class="w-full h-[70vh] border-0"></iframe>
+                }
               } @else {
                 <div class="text-center py-8 text-gray-500">
                   <p>Không thể xem trước file này.</p>

--- a/fe/src/app/features/teacher/assignments/assignment-submissions.component.ts
+++ b/fe/src/app/features/teacher/assignments/assignment-submissions.component.ts
@@ -6,6 +6,8 @@ import { AssignmentApi, SubmissionSummary, SubmissionGrade } from '../../../api/
 import { isLateSubmission, formatLateDuration, LateSubmissionResult } from './utils/submission-utils';
 import { validateGrade } from './utils/assignment-validators';
 import { ToastService } from '../../../core/services/toast.service';
+import { PdfViewerService } from '../../../shared/services/pdf-viewer.service';
+import { PdfSlideViewerComponent } from '../../../shared/components/pdf-slide-viewer/pdf-slide-viewer.component';
 
 /** Helper to extract numeric score from grade */
 function getGradeScore(grade: number | SubmissionGrade | undefined): number | undefined {
@@ -56,7 +58,7 @@ interface AssignmentDetail {
  */
 @Component({
   selector: 'app-assignment-submissions',
-  imports: [RouterLink, ReactiveFormsModule],
+  imports: [RouterLink, ReactiveFormsModule, PdfSlideViewerComponent],
   templateUrl: './assignment-submissions.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -65,6 +67,8 @@ export class AssignmentSubmissionsComponent implements OnInit {
   private assignmentApi = inject(AssignmentApi);
   private fb = inject(FormBuilder);
   private toast = inject(ToastService);
+  private pdfViewer = inject(PdfViewerService);
+  readonly useMobilePdfSlideViewer = this.pdfViewer.useCanvasViewer;
 
   // Route params
   assignmentId = '';
@@ -279,4 +283,3 @@ export class AssignmentSubmissionsComponent implements OnInit {
     return texts[status] || status;
   }
 }
-

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/section-editor.component.ts
@@ -30,6 +30,8 @@ import { formatDuration, formatResolution } from '../../../../../../../core/util
 import { buildInteractiveVideoSpec } from '../../../../utils/interactive-video-authoring';
 import { YouTubePlayerComponent } from '../../../../../../learning/components/youtube-player/youtube-player.component';
 import { InteractiveVideoAuthoringPanelComponent } from './interactive-video-authoring-panel.component';
+import { PdfViewerService } from '../../../../../../../shared/services/pdf-viewer.service';
+import { PdfSlideViewerComponent } from '../../../../../../../shared/components/pdf-slide-viewer/pdf-slide-viewer.component';
 
 type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
 
@@ -54,6 +56,7 @@ type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
     BlockRendererComponent,
     YouTubePlayerComponent,
     InteractiveVideoAuthoringPanelComponent,
+    PdfSlideViewerComponent,
   ],
   styleUrls: ['./section-editor-prose.scss'],
   template: `
@@ -634,9 +637,18 @@ type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
                 @if (stagedPdfUrl(); as pdfUrl) {
                   <div>
                     <label class="text-xs font-semibold text-slate-600 mb-2 block">Xem trước</label>
-                    <div class="h-[380px] w-full overflow-hidden rounded-xl border border-slate-200 bg-slate-100">
-                      <iframe [src]="pdfUrl" class="h-full w-full" frameborder="0"></iframe>
-                    </div>
+                    @if (useMobilePdfSlideViewer() && stagedPdfSourceUrl()) {
+                      <div class="min-h-[560px] w-full overflow-hidden rounded-xl border border-slate-200 bg-slate-100">
+                        <app-pdf-slide-viewer
+                          [sourceUrl]="stagedPdfSourceUrl() || ''"
+                          [fileName]="svc.selectedFile()?.name || 'PDF'"
+                          [downloadUrl]="stagedPdfSourceUrl()"></app-pdf-slide-viewer>
+                      </div>
+                    } @else {
+                      <div class="h-[380px] w-full overflow-hidden rounded-xl border border-slate-200 bg-slate-100">
+                        <iframe [src]="pdfUrl" class="h-full w-full" frameborder="0"></iframe>
+                      </div>
+                    }
                   </div>
                 }
               } @else {
@@ -728,14 +740,23 @@ type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
               @if (svc.sectionFileUrl() && !svc.safePdfUrl() && showPdfInlinePreview()) {
                 <div>
                   <label class="text-xs font-semibold text-slate-600 mb-2 block">Xem trước (PDF gốc)</label>
-                  <div class="h-[380px] w-full overflow-hidden rounded-xl border border-slate-200 bg-slate-100">
-                    <object [data]="svc.sectionFileUrl()!" type="application/pdf" class="h-full w-full">
-                      <p class="p-4 text-xs text-slate-500">
-                        Trình duyệt không hiển thị được tài liệu này. Hãy
-                        <a [href]="svc.sectionFileUrl()" target="_blank" rel="noopener" class="text-[#0056D2] underline">mở trong tab mới</a>.
-                      </p>
-                    </object>
-                  </div>
+                  @if (useMobilePdfSlideViewer()) {
+                    <div class="min-h-[560px] w-full overflow-hidden rounded-xl border border-slate-200 bg-slate-100">
+                      <app-pdf-slide-viewer
+                        [sourceUrl]="svc.sectionFileUrl()!"
+                        [fileName]="getFileName(svc.sectionFileUrl()!)"
+                        [downloadUrl]="svc.sectionFileUrl()"></app-pdf-slide-viewer>
+                    </div>
+                  } @else {
+                    <div class="h-[380px] w-full overflow-hidden rounded-xl border border-slate-200 bg-slate-100">
+                      <object [data]="svc.sectionFileUrl()!" type="application/pdf" class="h-full w-full">
+                        <p class="p-4 text-xs text-slate-500">
+                          Trình duyệt không hiển thị được tài liệu này. Hãy
+                          <a [href]="svc.sectionFileUrl()" target="_blank" rel="noopener" class="text-[#0056D2] underline">mở trong tab mới</a>.
+                        </p>
+                      </object>
+                    </div>
+                  }
                 </div>
               }
 
@@ -743,9 +764,18 @@ type CfUploadStatus = 'idle' | 'staged' | 'uploading' | 'done' | 'error';
               @if (svc.safePdfUrl()) {
                 <div>
                   <label class="text-xs font-semibold text-slate-600 mb-2 block">Xem trước (bản đã chuẩn hoá)</label>
-                  <div class="h-[380px] w-full overflow-hidden rounded-xl border border-slate-200 bg-slate-100">
-                    <iframe [src]="svc.safePdfUrl()" class="h-full w-full" frameborder="0"></iframe>
-                  </div>
+                  @if (useMobilePdfSlideViewer() && svc.previewPdfSourceUrl()) {
+                    <div class="min-h-[560px] w-full overflow-hidden rounded-xl border border-slate-200 bg-slate-100">
+                      <app-pdf-slide-viewer
+                        [sourceUrl]="svc.previewPdfSourceUrl() || ''"
+                        [fileName]="getFileName(svc.sectionFileUrl() || svc.previewPdfSourceUrl() || '')"
+                        [downloadUrl]="svc.sectionFileUrl() || svc.previewPdfSourceUrl()"></app-pdf-slide-viewer>
+                    </div>
+                  } @else {
+                    <div class="h-[380px] w-full overflow-hidden rounded-xl border border-slate-200 bg-slate-100">
+                      <iframe [src]="svc.safePdfUrl()" class="h-full w-full" frameborder="0"></iframe>
+                    </div>
+                  }
                   <p class="mt-1.5 inline-flex items-center gap-1 text-[11px] text-slate-400">
                     <lucide-icon name="shield-check" [size]="11" class="text-emerald-500"></lucide-icon>
                     Bản xem trước được tạo từ máy chủ — an toàn cho mọi trình duyệt.
@@ -1598,6 +1628,8 @@ export class SectionEditorComponent {
   readonly isDragOver = signal(false);
   readonly expandedQuestionIds = signal<Set<string>>(new Set());
   private readonly sanitizer = inject(DomSanitizer);
+  private readonly pdfViewer = inject(PdfViewerService);
+  readonly useMobilePdfSlideViewer = this.pdfViewer.useCanvasViewer;
 
   private readonly presignedUpload = inject(PresignedUploadService, { optional: true });
   readonly editorUploadFn = createTiptapUploadFn(this.http, environment.apiUrl, this.presignedUpload ?? undefined);
@@ -2204,7 +2236,7 @@ export class SectionEditorComponent {
     this.showPdfInlinePreview.update(v => !v);
   }
 
-  readonly stagedPdfUrl = computed<SafeResourceUrl | null>(() => {
+  readonly stagedPdfSourceUrl = computed<string | null>(() => {
     const file = this.svc.selectedFile();
     if (!file || !file.name.toLowerCase().endsWith('.pdf')) return null;
     // Revoke previous URL
@@ -2212,7 +2244,12 @@ export class SectionEditorComponent {
       URL.revokeObjectURL(this.stagedPdfObjectUrl);
     }
     this.stagedPdfObjectUrl = URL.createObjectURL(file);
-    return this.sanitizer.bypassSecurityTrustResourceUrl(this.stagedPdfObjectUrl);
+    return this.stagedPdfObjectUrl;
+  });
+
+  readonly stagedPdfUrl = computed<SafeResourceUrl | null>(() => {
+    const objectUrl = this.stagedPdfSourceUrl();
+    return objectUrl ? this.sanitizer.bypassSecurityTrustResourceUrl(objectUrl) : null;
   });
 
   triggerFileReplace(): void {

--- a/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
+++ b/fe/src/app/features/teacher/course-editor/services/curriculum-editor.service.ts
@@ -132,6 +132,7 @@ export class CurriculumEditorService {
   readonly selectedFile = signal<File | null>(null);
   readonly sectionFileUrl = signal<string | null>(null);
   readonly safePdfUrl = signal<SafeResourceUrl | null>(null);
+  readonly previewPdfSourceUrl = signal<string | null>(null);
   readonly sectionPreviewStatus = signal<string | null>(null);
 
   // Quiz
@@ -963,11 +964,14 @@ export class CurriculumEditorService {
       const canEmbedPreview = !!previewUrl && (!section.previewStatus || section.previewStatus === 'READY');
       if (canEmbedPreview) {
         this.safePdfUrl.set(this.sanitizer.bypassSecurityTrustResourceUrl(previewUrl));
+        this.previewPdfSourceUrl.set(previewUrl);
       } else {
         this.safePdfUrl.set(null);
+        this.previewPdfSourceUrl.set(null);
       }
     } else {
       this.safePdfUrl.set(null);
+      this.previewPdfSourceUrl.set(null);
       this.sectionPreviewStatus.set(null);
     }
 
@@ -1034,6 +1038,7 @@ export class CurriculumEditorService {
     this.selectedFile.set(null);
     this.sectionFileUrl.set(null);
     this.safePdfUrl.set(null);
+    this.previewPdfSourceUrl.set(null);
     this.sectionPreviewStatus.set(null);
 
     this.resetQuizFields();

--- a/fe/src/app/shared/components/file-preview/file-preview.component.ts
+++ b/fe/src/app/shared/components/file-preview/file-preview.component.ts
@@ -2,7 +2,9 @@ import { Component, input, signal, inject, effect, OnDestroy, ChangeDetectionStr
 import { CommonModule } from '@angular/common';
 import { DomSanitizer, SafeResourceUrl, SafeHtml } from '@angular/platform-browser';
 import { HttpClient } from '@angular/common/http';
+import { Subscription } from 'rxjs';
 import { PdfViewerService } from '../../services/pdf-viewer.service';
+import { PdfSlideViewerComponent } from '../pdf-slide-viewer/pdf-slide-viewer.component';
 
 /**
  * Shared FilePreviewComponent — detects file type and renders inline preview.
@@ -14,14 +16,19 @@ import { PdfViewerService } from '../../services/pdf-viewer.service';
  */
 @Component({
   selector: 'app-file-preview',
-  imports: [CommonModule],
+  imports: [CommonModule, PdfSlideViewerComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @switch (fileType()) {
       <!-- PDF Preview -->
       @case ('pdf') {
         <div class="w-full rounded-xl border border-gray-200 overflow-hidden bg-white">
-          @if (pdfUrl()) {
+          @if (useMobilePdfSlideViewer() && pdfSourceUrl()) {
+            <app-pdf-slide-viewer
+              [sourceUrl]="pdfSourceUrl() || ''"
+              [fileName]="fileName() || getExtension()"
+              [downloadUrl]="fileUrl()"></app-pdf-slide-viewer>
+          } @else if (pdfUrl()) {
             <iframe [src]="pdfUrl()" class="w-full h-[600px]" frameborder="0"></iframe>
           } @else {
             <div class="h-[600px] flex items-center justify-center">
@@ -94,9 +101,12 @@ export class FilePreviewComponent implements OnDestroy {
   private sanitizer = inject(DomSanitizer);
   private http = inject(HttpClient);
   private pdfViewer = inject(PdfViewerService);
+  private pdfSub?: Subscription;
 
   fileType = signal<'pdf' | 'docx' | 'image' | 'other'>('other');
   pdfUrl = signal<SafeResourceUrl | null>(null);
+  pdfSourceUrl = signal<string | null>(null);
+  readonly useMobilePdfSlideViewer = this.pdfViewer.useCanvasViewer;
   docxHtml = signal<SafeHtml | null>(null);
   docxLoading = signal(false);
   docxError = signal<string | null>(null);
@@ -109,9 +119,15 @@ export class FilePreviewComponent implements OnDestroy {
       const ext = this.detectExtension(name, url);
 
       const normalizedUrl = this.normalizeUrl(url);
+      this.pdfSub?.unsubscribe();
+      this.pdfUrl.set(null);
+      this.pdfSourceUrl.set(null);
       if (ext === 'pdf') {
         this.fileType.set('pdf');
-        this.loadPdf(normalizedUrl);
+        this.pdfSourceUrl.set(normalizedUrl);
+        if (!this.useMobilePdfSlideViewer()) {
+          this.loadPdf(normalizedUrl);
+        }
       } else if (ext === 'docx' || ext === 'doc') {
         this.fileType.set('docx');
         this.loadDocx(normalizedUrl);
@@ -124,6 +140,7 @@ export class FilePreviewComponent implements OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.pdfSub?.unsubscribe();
     this.pdfViewer.cleanup();
   }
 
@@ -152,7 +169,8 @@ export class FilePreviewComponent implements OnDestroy {
 
   private loadPdf(url: string): void {
     this.pdfUrl.set(null);
-    this.pdfViewer.getSafePdfUrl(url).subscribe({
+    this.pdfSub?.unsubscribe();
+    this.pdfSub = this.pdfViewer.getSafePdfUrl(url).subscribe({
       next: (safeUrl) => this.pdfUrl.set(safeUrl),
       error: () => this.pdfUrl.set(null)
     });

--- a/fe/src/app/shared/components/pdf-slide-viewer/pdf-slide-viewer.component.html
+++ b/fe/src/app/shared/components/pdf-slide-viewer/pdf-slide-viewer.component.html
@@ -1,0 +1,81 @@
+<section class="pdf-slide-viewer" [attr.aria-label]="'Xem slide ' + fileName()">
+  <header class="pdf-slide-viewer__toolbar">
+    <button
+      type="button"
+      class="pdf-slide-viewer__button"
+      (click)="previousPage()"
+      [disabled]="!canGoPrevious()"
+      aria-label="Trang trước">
+      <app-icon name="chevron-left" size="sm"></app-icon>
+    </button>
+
+    <div class="pdf-slide-viewer__status">
+      <span class="pdf-slide-viewer__label">Slide</span>
+      @if (totalPages()) {
+        <span class="pdf-slide-viewer__count">{{ pageNumber() }} / {{ totalPages() }}</span>
+      } @else {
+        <span class="pdf-slide-viewer__count">Đang tải</span>
+      }
+    </div>
+
+    <button
+      type="button"
+      class="pdf-slide-viewer__button"
+      (click)="nextPage()"
+      [disabled]="!canGoNext()"
+      aria-label="Trang sau">
+      <app-icon name="chevron-right" size="sm"></app-icon>
+    </button>
+  </header>
+
+  <div
+    class="pdf-slide-viewer__stage"
+    (touchstart)="onTouchStart($event)"
+    (touchend)="onTouchEnd($event)">
+    @if (isLoading()) {
+      <div class="pdf-slide-viewer__state" role="status">
+        <span class="pdf-slide-viewer__spinner" aria-hidden="true"></span>
+        <span>Đang mở slide...</span>
+      </div>
+    } @else if (error()) {
+      <div class="pdf-slide-viewer__state pdf-slide-viewer__state--error">
+        <app-icon name="warning" size="md"></app-icon>
+        <span>{{ error() }}</span>
+        <button type="button" class="pdf-slide-viewer__link" (click)="openInNewTab()">
+          Mở trong tab mới
+        </button>
+      </div>
+    }
+
+    <canvas
+      #canvas
+      class="pdf-slide-viewer__canvas"
+      [class.pdf-slide-viewer__canvas--hidden]="isLoading() || error()"
+      [attr.aria-label]="'Slide ' + pageNumber() + ' / ' + totalPages()"></canvas>
+
+    @if (isRendering() && !isLoading() && !error()) {
+      <div class="pdf-slide-viewer__rendering" role="status">
+        <span class="pdf-slide-viewer__spinner" aria-hidden="true"></span>
+      </div>
+    }
+  </div>
+
+  <footer class="pdf-slide-viewer__footer">
+    <button type="button" class="pdf-slide-viewer__text-button" (click)="openInNewTab()">
+      <app-icon name="external-link" size="sm"></app-icon>
+      <span>Tab mới</span>
+    </button>
+
+    @if (downloadUrl()) {
+      <a
+        class="pdf-slide-viewer__text-button"
+        [href]="downloadUrl()"
+        download
+        target="_blank"
+        rel="noopener noreferrer">
+        <app-icon name="download" size="sm"></app-icon>
+        <span>Tải xuống</span>
+      </a>
+    }
+  </footer>
+</section>

--- a/fe/src/app/shared/components/pdf-slide-viewer/pdf-slide-viewer.component.scss
+++ b/fe/src/app/shared/components/pdf-slide-viewer/pdf-slide-viewer.component.scss
@@ -1,0 +1,167 @@
+.pdf-slide-viewer {
+  display: flex;
+  flex-direction: column;
+  min-height: 560px;
+  background: #f8fafc;
+}
+
+.pdf-slide-viewer__toolbar,
+.pdf-slide-viewer__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  background: #ffffff;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.pdf-slide-viewer__footer {
+  justify-content: center;
+  border-top: 1px solid #e2e8f0;
+  border-bottom: 0;
+}
+
+.pdf-slide-viewer__button,
+.pdf-slide-viewer__text-button,
+.pdf-slide-viewer__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.5rem;
+  color: #0f172a;
+  font-weight: 800;
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+
+.pdf-slide-viewer__button {
+  width: 2.75rem;
+}
+
+.pdf-slide-viewer__text-button,
+.pdf-slide-viewer__link {
+  gap: 0.45rem;
+  padding: 0 0.8rem;
+  font-size: 0.8125rem;
+  text-decoration: none;
+}
+
+.pdf-slide-viewer__button:hover:not(:disabled),
+.pdf-slide-viewer__button:focus-visible:not(:disabled),
+.pdf-slide-viewer__text-button:hover,
+.pdf-slide-viewer__text-button:focus-visible,
+.pdf-slide-viewer__link:hover,
+.pdf-slide-viewer__link:focus-visible {
+  color: #0056d2;
+  background: #f8fbff;
+  border-color: rgba(0, 86, 210, 0.34);
+}
+
+.pdf-slide-viewer__button:focus-visible,
+.pdf-slide-viewer__text-button:focus-visible,
+.pdf-slide-viewer__link:focus-visible {
+  outline: 3px solid rgba(0, 86, 210, 0.22);
+  outline-offset: 2px;
+}
+
+.pdf-slide-viewer__button:disabled {
+  color: #94a3b8;
+  cursor: not-allowed;
+  background: #f8fafc;
+}
+
+.pdf-slide-viewer__status {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  color: #334155;
+  font-size: 0.8125rem;
+  font-weight: 800;
+}
+
+.pdf-slide-viewer__label {
+  color: #64748b;
+}
+
+.pdf-slide-viewer__count {
+  color: #0f172a;
+  font-variant-numeric: tabular-nums;
+}
+
+.pdf-slide-viewer__stage {
+  position: relative;
+  display: flex;
+  flex: 1;
+  align-items: flex-start;
+  justify-content: center;
+  min-height: 460px;
+  padding: 0.75rem;
+  overflow: auto;
+  background: #172033;
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-y pinch-zoom;
+}
+
+.pdf-slide-viewer__canvas {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  background: #ffffff;
+  border-radius: 0.35rem;
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.28);
+}
+
+.pdf-slide-viewer__canvas--hidden {
+  visibility: hidden;
+}
+
+.pdf-slide-viewer__state,
+.pdf-slide-viewer__rendering {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  color: #e2e8f0;
+  font-size: 0.875rem;
+  font-weight: 800;
+  background: rgba(15, 23, 42, 0.82);
+}
+
+.pdf-slide-viewer__state {
+  flex-direction: column;
+  padding: 1rem;
+  text-align: center;
+}
+
+.pdf-slide-viewer__state--error {
+  color: #fee2e2;
+}
+
+.pdf-slide-viewer__rendering {
+  inset: auto 0 0;
+  height: 3.25rem;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 0.76));
+}
+
+.pdf-slide-viewer__spinner {
+  width: 1.4rem;
+  height: 1.4rem;
+  border: 2px solid rgba(226, 232, 240, 0.42);
+  border-top-color: #ffffff;
+  border-radius: 999px;
+  animation: pdf-slide-spin 800ms linear infinite;
+}
+
+@keyframes pdf-slide-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/fe/src/app/shared/components/pdf-slide-viewer/pdf-slide-viewer.component.ts
+++ b/fe/src/app/shared/components/pdf-slide-viewer/pdf-slide-viewer.component.ts
@@ -1,0 +1,257 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Injector,
+  OnDestroy,
+  OnInit,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+  viewChild
+} from '@angular/core';
+import { CommonModule, isPlatformBrowser } from '@angular/common';
+import { PLATFORM_ID } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import type { PDFDocumentProxy, RenderTask } from 'pdfjs-dist';
+import { PdfViewerService } from '../../services/pdf-viewer.service';
+import { IconComponent } from '../icon/icon.component';
+
+type PdfJsModule = typeof import('pdfjs-dist');
+
+@Component({
+  selector: 'app-pdf-slide-viewer',
+  imports: [CommonModule, IconComponent],
+  templateUrl: './pdf-slide-viewer.component.html',
+  styleUrls: ['./pdf-slide-viewer.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PdfSlideViewerComponent implements AfterViewInit, OnInit, OnDestroy {
+  readonly sourceUrl = input.required<string>();
+  readonly fileName = input<string>('');
+  readonly downloadUrl = input<string | null>(null);
+
+  private readonly pdfViewer = inject(PdfViewerService);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly host = inject(ElementRef<HTMLElement>);
+  private readonly injector = inject(Injector);
+  private readonly canvasRef = viewChild<ElementRef<HTMLCanvasElement>>('canvas');
+  private static pdfJsPromise: Promise<PdfJsModule> | null = null;
+
+  readonly isLoading = signal(false);
+  readonly isRendering = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly pageNumber = signal(1);
+  readonly totalPages = signal(0);
+  readonly canGoPrevious = computed(() => this.pageNumber() > 1 && !this.isLoading());
+  readonly canGoNext = computed(() => this.pageNumber() < this.totalPages() && !this.isLoading());
+
+  private pdfDocument: PDFDocumentProxy | null = null;
+  private renderTask: RenderTask | null = null;
+  private resizeObserver: ResizeObserver | null = null;
+  private loadToken = 0;
+  private renderToken = 0;
+  private touchStartX: number | null = null;
+
+  ngOnInit(): void {
+    if (isPlatformBrowser(this.platformId)) {
+      effect(() => {
+        void this.loadDocument(this.sourceUrl());
+      }, { injector: this.injector });
+    }
+  }
+
+  ngAfterViewInit(): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    this.resizeObserver = new ResizeObserver(() => {
+      if (this.pdfDocument) {
+        void this.renderCurrentPage();
+      }
+    });
+    this.resizeObserver.observe(this.host.nativeElement);
+    void this.renderCurrentPage();
+  }
+
+  ngOnDestroy(): void {
+    this.loadToken++;
+    this.cancelRender();
+    this.resizeObserver?.disconnect();
+    this.pdfDocument?.destroy();
+    this.pdfDocument = null;
+  }
+
+  async previousPage(): Promise<void> {
+    if (!this.canGoPrevious()) {
+      return;
+    }
+    this.pageNumber.update(page => page - 1);
+    await this.renderCurrentPage();
+  }
+
+  async nextPage(): Promise<void> {
+    if (!this.canGoNext()) {
+      return;
+    }
+    this.pageNumber.update(page => page + 1);
+    await this.renderCurrentPage();
+  }
+
+  onTouchStart(event: TouchEvent): void {
+    this.touchStartX = event.changedTouches.item(0)?.clientX ?? null;
+  }
+
+  onTouchEnd(event: TouchEvent): void {
+    const startX = this.touchStartX;
+    this.touchStartX = null;
+    const endX = event.changedTouches.item(0)?.clientX ?? null;
+    if (startX === null || endX === null) {
+      return;
+    }
+
+    const delta = endX - startX;
+    if (Math.abs(delta) < 48) {
+      return;
+    }
+
+    if (delta < 0) {
+      void this.nextPage();
+    } else {
+      void this.previousPage();
+    }
+  }
+
+  openInNewTab(): void {
+    const url = this.sourceUrl();
+    if (url) {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
+  }
+
+  private async loadDocument(url: string): Promise<void> {
+    const token = ++this.loadToken;
+    this.cancelRender();
+    this.pdfDocument?.destroy();
+    this.pdfDocument = null;
+    this.isLoading.set(true);
+    this.error.set(null);
+    this.pageNumber.set(1);
+    this.totalPages.set(0);
+
+    try {
+      const buffer = await firstValueFrom(this.pdfViewer.getPdfArrayBuffer(url));
+      if (token !== this.loadToken) {
+        return;
+      }
+      if (!buffer) {
+        throw new Error('empty-pdf');
+      }
+
+      const pdfjs = await this.loadPdfJs();
+      if (token !== this.loadToken) {
+        return;
+      }
+
+      const loadingTask = pdfjs.getDocument({ data: buffer.slice(0) });
+      const pdf = await loadingTask.promise;
+      if (token !== this.loadToken) {
+        await pdf.destroy();
+        return;
+      }
+
+      this.pdfDocument = pdf;
+      this.totalPages.set(pdf.numPages);
+      this.isLoading.set(false);
+      await this.renderCurrentPage();
+    } catch {
+      if (token !== this.loadToken) {
+        return;
+      }
+      this.isLoading.set(false);
+      this.error.set('Không thể mở bản xem trước trên điện thoại.');
+    }
+  }
+
+  private async renderCurrentPage(): Promise<void> {
+    const pdf = this.pdfDocument;
+    const canvas = this.canvasRef()?.nativeElement;
+    if (!pdf || !canvas || this.isLoading()) {
+      return;
+    }
+
+    const token = ++this.renderToken;
+    this.cancelRender();
+    this.isRendering.set(true);
+
+    try {
+      const page = await pdf.getPage(this.pageNumber());
+      if (token !== this.renderToken) {
+        return;
+      }
+
+      const maxStageWidth = Math.max(280, this.host.nativeElement.clientWidth - 28);
+      const baseViewport = page.getViewport({ scale: 1 });
+      const cssScale = maxStageWidth / baseViewport.width;
+      const viewport = page.getViewport({ scale: cssScale });
+      const outputScale = Math.min(window.devicePixelRatio || 1, 2);
+
+      canvas.width = Math.floor(viewport.width * outputScale);
+      canvas.height = Math.floor(viewport.height * outputScale);
+      canvas.style.width = `${Math.floor(viewport.width)}px`;
+      canvas.style.height = `${Math.floor(viewport.height)}px`;
+
+      const context = canvas.getContext('2d');
+      if (!context) {
+        throw new Error('canvas-unavailable');
+      }
+      context.setTransform(outputScale, 0, 0, outputScale, 0, 0);
+      context.clearRect(0, 0, viewport.width, viewport.height);
+
+      const task = page.render({ canvas: null, canvasContext: context, viewport });
+      this.renderTask = task;
+      await task.promise;
+    } catch (error) {
+      if (this.isRenderCancelled(error)) {
+        return;
+      }
+      this.error.set('Không thể hiển thị trang hiện tại.');
+    } finally {
+      if (token === this.renderToken) {
+        this.renderTask = null;
+        this.isRendering.set(false);
+      }
+    }
+  }
+
+  private cancelRender(): void {
+    if (this.renderTask) {
+      this.renderTask.cancel();
+      this.renderTask = null;
+    }
+  }
+
+  private async loadPdfJs(): Promise<PdfJsModule> {
+    if (!PdfSlideViewerComponent.pdfJsPromise) {
+      PdfSlideViewerComponent.pdfJsPromise = import('pdfjs-dist').then(pdfjs => {
+        pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+          'assets/pdfjs/pdf.worker.min.mjs',
+          document.baseURI
+        ).toString();
+        return pdfjs;
+      });
+    }
+    return PdfSlideViewerComponent.pdfJsPromise;
+  }
+
+  private isRenderCancelled(error: unknown): boolean {
+    return typeof error === 'object'
+      && error !== null
+      && 'name' in error
+      && (error as { name?: string }).name === 'RenderingCancelledException';
+  }
+}

--- a/fe/src/app/shared/components/pdf-slide-viewer/pdf-slide-viewer.component.ts
+++ b/fe/src/app/shared/components/pdf-slide-viewer/pdf-slide-viewer.component.ts
@@ -16,7 +16,7 @@ import {
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { PLATFORM_ID } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
-import type { PDFDocumentProxy, RenderTask } from 'pdfjs-dist';
+import type { PDFDocumentLoadingTask, PDFDocumentProxy, RenderTask } from 'pdfjs-dist';
 import { PdfViewerService } from '../../services/pdf-viewer.service';
 import { IconComponent } from '../icon/icon.component';
 
@@ -46,12 +46,14 @@ export class PdfSlideViewerComponent implements AfterViewInit, OnInit, OnDestroy
   readonly error = signal<string | null>(null);
   readonly pageNumber = signal(1);
   readonly totalPages = signal(0);
-  readonly canGoPrevious = computed(() => this.pageNumber() > 1 && !this.isLoading());
-  readonly canGoNext = computed(() => this.pageNumber() < this.totalPages() && !this.isLoading());
+  readonly canGoPrevious = computed(() => this.pageNumber() > 1 && !this.isLoading() && !this.isRendering());
+  readonly canGoNext = computed(() => this.pageNumber() < this.totalPages() && !this.isLoading() && !this.isRendering());
 
   private pdfDocument: PDFDocumentProxy | null = null;
+  private loadingTask: PDFDocumentLoadingTask | null = null;
   private renderTask: RenderTask | null = null;
   private resizeObserver: ResizeObserver | null = null;
+  private resizeFrame: number | null = null;
   private loadToken = 0;
   private renderToken = 0;
   private touchStartX: number | null = null;
@@ -71,7 +73,7 @@ export class PdfSlideViewerComponent implements AfterViewInit, OnInit, OnDestroy
 
     this.resizeObserver = new ResizeObserver(() => {
       if (this.pdfDocument) {
-        void this.renderCurrentPage();
+        this.scheduleRenderCurrentPage();
       }
     });
     this.resizeObserver.observe(this.host.nativeElement);
@@ -80,10 +82,9 @@ export class PdfSlideViewerComponent implements AfterViewInit, OnInit, OnDestroy
 
   ngOnDestroy(): void {
     this.loadToken++;
-    this.cancelRender();
+    this.cancelScheduledRender();
+    this.releaseDocument();
     this.resizeObserver?.disconnect();
-    this.pdfDocument?.destroy();
-    this.pdfDocument = null;
   }
 
   async previousPage(): Promise<void> {
@@ -135,9 +136,7 @@ export class PdfSlideViewerComponent implements AfterViewInit, OnInit, OnDestroy
 
   private async loadDocument(url: string): Promise<void> {
     const token = ++this.loadToken;
-    this.cancelRender();
-    this.pdfDocument?.destroy();
-    this.pdfDocument = null;
+    this.releaseDocument();
     this.isLoading.set(true);
     this.error.set(null);
     this.pageNumber.set(1);
@@ -158,7 +157,11 @@ export class PdfSlideViewerComponent implements AfterViewInit, OnInit, OnDestroy
       }
 
       const loadingTask = pdfjs.getDocument({ data: buffer.slice(0) });
+      this.loadingTask = loadingTask;
       const pdf = await loadingTask.promise;
+      if (this.loadingTask === loadingTask) {
+        this.loadingTask = null;
+      }
       if (token !== this.loadToken) {
         await pdf.destroy();
         return;
@@ -232,6 +235,37 @@ export class PdfSlideViewerComponent implements AfterViewInit, OnInit, OnDestroy
     if (this.renderTask) {
       this.renderTask.cancel();
       this.renderTask = null;
+    }
+  }
+
+  private cancelLoad(): void {
+    if (this.loadingTask) {
+      void this.loadingTask.destroy().catch(() => undefined);
+      this.loadingTask = null;
+    }
+  }
+
+  private cancelScheduledRender(): void {
+    if (this.resizeFrame !== null) {
+      cancelAnimationFrame(this.resizeFrame);
+      this.resizeFrame = null;
+    }
+  }
+
+  private scheduleRenderCurrentPage(): void {
+    this.cancelScheduledRender();
+    this.resizeFrame = requestAnimationFrame(() => {
+      this.resizeFrame = null;
+      void this.renderCurrentPage();
+    });
+  }
+
+  private releaseDocument(): void {
+    this.cancelLoad();
+    this.cancelRender();
+    if (this.pdfDocument) {
+      void this.pdfDocument.destroy();
+      this.pdfDocument = null;
     }
   }
 

--- a/fe/src/app/shared/services/pdf-viewer.service.ts
+++ b/fe/src/app/shared/services/pdf-viewer.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { Observable, map } from 'rxjs';
+import { Observable, map, of } from 'rxjs';
 import { environment } from '../../../environments/environment';
 
 /**
@@ -24,7 +24,7 @@ export class PdfViewerService {
      */
     getSafePdfUrl(fileUrl: string | null): Observable<SafeResourceUrl | null> {
         if (!fileUrl) {
-            return new Observable(observer => observer.next(null));
+            return of(null);
         }
 
         const fullUrl = this.resolveFileUrl(fileUrl);
@@ -38,6 +38,15 @@ export class PdfViewerService {
                 return this.sanitizer.bypassSecurityTrustResourceUrl(this.currentUrl);
             })
         );
+    }
+
+    getPdfArrayBuffer(fileUrl: string | null): Observable<ArrayBuffer | null> {
+        if (!fileUrl) {
+            return of(null);
+        }
+
+        const fullUrl = this.resolveFileUrl(fileUrl);
+        return this.http.get(fullUrl, { responseType: 'arraybuffer' });
     }
 
     private resolveFileUrl(fileUrl: string): string {

--- a/fe/src/app/shared/services/pdf-viewer.service.ts
+++ b/fe/src/app/shared/services/pdf-viewer.service.ts
@@ -58,8 +58,13 @@ export class PdfViewerService {
         }
 
         const fullUrl = this.resolveFileUrl(fileUrl);
-        if (/^blob:/i.test(fullUrl)) {
-            return from(fetch(fullUrl).then(response => response.arrayBuffer()));
+        if (/^(blob:|data:)/i.test(fullUrl)) {
+            return from(fetch(fullUrl).then(response => {
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch PDF source: ${response.status}`);
+                }
+                return response.arrayBuffer();
+            }));
         }
 
         return this.http.get(fullUrl, { responseType: 'arraybuffer' });

--- a/fe/src/app/shared/services/pdf-viewer.service.ts
+++ b/fe/src/app/shared/services/pdf-viewer.service.ts
@@ -1,7 +1,7 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { Observable, map, of } from 'rxjs';
+import { Observable, from, map, of } from 'rxjs';
 import { environment } from '../../../environments/environment';
 
 /**
@@ -14,9 +14,21 @@ export class PdfViewerService {
     private http = inject(HttpClient);
     private sanitizer = inject(DomSanitizer);
     private baseUrl = environment.apiUrl;
+    private readonly canvasViewerQuery =
+        typeof window !== 'undefined'
+            ? window.matchMedia('(max-width: 767px), (pointer: coarse) and (max-width: 920px)')
+            : null;
+
+    readonly useCanvasViewer = signal(this.canvasViewerQuery?.matches ?? false);
 
     // Store current URL to revoke and avoid memory leaks
     private currentUrl?: string;
+
+    constructor() {
+        this.canvasViewerQuery?.addEventListener('change', event => {
+            this.useCanvasViewer.set(event.matches);
+        });
+    }
 
     /**
      * Fetches a PDF file as a blob using authorization headers (provided by HttpClient interceptors)
@@ -46,6 +58,10 @@ export class PdfViewerService {
         }
 
         const fullUrl = this.resolveFileUrl(fileUrl);
+        if (/^blob:/i.test(fullUrl)) {
+            return from(fetch(fullUrl).then(response => response.arrayBuffer()));
+        }
+
         return this.http.get(fullUrl, { responseType: 'arraybuffer' });
     }
 


### PR DESCRIPTION
## Description

Adds a mobile-specific PDF slide viewer for PPTX/Office/PDF previews so phone users can move through every converted PDF page instead of being stuck on the first page in the browser PDF iframe.

## Motivation

PPTX/PDF previews already work on desktop/laptop with the existing iframe/object flow, but mobile browsers can expose only the first page or fail to support embedded PDFs reliably. This PR keeps the desktop/laptop path unchanged and switches only mobile-sized/coarse-pointer clients to a PDF.js canvas renderer with explicit previous/next controls.

## Type of Change

- Bug fix
- Mobile UX/reliability hardening

## Changes Made

- Added reusable `app-pdf-slide-viewer` PDF.js canvas rendering with previous/next and swipe navigation.
- Centralized mobile PDF-viewer detection in `PdfViewerService` using `(max-width: 767px), (pointer: coarse) and (max-width: 920px)`.
- Kept lesson desktop/laptop PDF preview on the existing iframe path while mobile uses the slide viewer.
- Extended the same mobile-only viewer path to shared file preview, assignment submission preview, and course-editor PDF previews.
- Exposed the raw preview PDF URL beside `safePdfUrl` where the course editor needs PDF.js on mobile.
- Hardened the mobile viewer lifecycle by cancelling stale PDF.js loading/render tasks, debouncing resize re-renders, and disabling page navigation while a render is in progress.
- Configured Angular to ship the local PDF.js worker asset and added `pdfjs-dist`.

## Scope Note

Desktop/laptop PDF slideshow/rendering stays on the current iframe/object implementation. This PR only changes mobile/coarse-pointer PDF presentation; it does not change backend conversion, upload validation, Gotenberg, or desktop viewer behavior.

## Testing Guide

1. Open a lesson with a converted PPTX/PDF preview on a phone viewport.
2. Confirm the preview shows the slide/page toolbar and the controls move beyond page 1.
3. Open the same preview on desktop/laptop and confirm it still uses the existing embedded iframe/object flow.
4. Check PDF previews from teacher assignment submissions and course editor on mobile.
5. Use `Tab m?i` or `T?i xu?ng` from the mobile viewer to verify fallback actions remain available.

## Local Checks

- `npx ng build` passes; existing project warnings remain unrelated.
- `git diff --check` passes.

## Checklist

- [x] Focused fix with no unrelated refactor
- [x] Mobile-only PDF.js path added
- [x] Desktop/laptop iframe/object path preserved
- [x] Mobile viewer lifecycle hardened for review/merge readiness
- [x] Ready for teammate review and merge after CI
