### PR TITLE
fix(wiii): surface teacher AI entry and apply feedback

### DIFF
--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
@@ -468,8 +468,11 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     }));
     expect(courseEditorStore.invalidateCache).toHaveBeenCalledWith('course-1');
     expect(courseEditorStore.loadCourse).toHaveBeenCalledWith('course-1', true);
+    expect(router.navigate).toHaveBeenCalledWith(['/teacher/courses', 'course-1', 'editor', 'curriculum']);
     expect(applied.data?.['chapters_created']).toBe(2);
     expect(applied.data?.['lessons_created']).toBe(2);
+    expect(applied.data?.['next_route']).toBe('/teacher/courses/course-1/editor/curriculum');
+    expect(applied.data?.['navigated_to_curriculum']).toBeTrue();
   });
 
   it('previews and commits a new quiz through the host action flow', async () => {

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -465,6 +465,15 @@ export class WiiiContextService implements OnDestroy {
       };
     }
 
+    // ── Teacher course creation wizard: /teacher/course-creation ──
+    if (path.match(/\/teacher\/course-creation$/)) {
+      return {
+        page_type: 'teacher_course_creation',
+        page_title: 'Tạo khóa học mới',
+        workflow_stage: 'authoring',
+      };
+    }
+
     // ── Teacher / Admin catch-all ──
     if (path.includes('/teacher')) return { page_type: 'teacher_page', page_title: 'Cổng giảng viên' };
     if (path.includes('/admin')) return { page_type: 'admin_page', page_title: 'Quản trị' };
@@ -1536,6 +1545,11 @@ export class WiiiContextService implements OnDestroy {
       this.courseEditorStore.invalidateCache(courseId);
       this.courseEditorStore.loadCourse(courseId, true);
     }
+    const nextRoute = `/teacher/courses/${courseId}/editor/curriculum`;
+    const navigatedToCurriculum = await this.router.navigate(['/teacher/courses', courseId, 'editor', 'curriculum']);
+    const nextStep = navigatedToCurriculum
+      ? 'LMS đã mở tab Nội dung để rà soát chương/bài nháp, kiểm tra nguồn trích dẫn, rồi mới xuất bản.'
+      : 'Mở tab Nội dung để rà soát chương/bài nháp, kiểm tra nguồn trích dẫn, rồi mới xuất bản.';
 
     return {
       success: true,
@@ -1546,7 +1560,10 @@ export class WiiiContextService implements OnDestroy {
         chapters_created: chaptersCreated,
         lessons_created: lessonsCreated,
         chapters: createdChapters,
-        summary: `Đã tạo ${chaptersCreated} chương và ${lessonsCreated} bài học draft từ tài liệu.`,
+        next_route: nextRoute,
+        navigated_to_curriculum: navigatedToCurriculum,
+        next_step: nextStep,
+        summary: `Đã tạo ${chaptersCreated} chương và ${lessonsCreated} bài học nháp từ tài liệu. ${nextStep}`,
       },
     };
   }
@@ -2563,8 +2580,11 @@ export class WiiiContextService implements OnDestroy {
   private sendContext(ctx: WiiiPageContext): void {
     if (!this.iframeEl || !this.embedOrigin) return;
     try {
+      const shouldApplyTransientPatch =
+        !!this.transientContextPatch
+        && (ctx.page_type === 'course_editor' || ctx.page_type === 'teacher_course_creation');
       const payload = this.decorateContext(
-        this.transientContextPatch && ctx.page_type === 'course_editor'
+        shouldApplyTransientPatch
           ? { ...ctx, ...this.transientContextPatch }
           : ctx,
       );

--- a/fe/src/app/features/ai-chat/presentation/components/chat-panel/chat-panel.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/chat-panel/chat-panel.component.ts
@@ -33,10 +33,11 @@ import { SessionManagementService } from '../../../application/services/session-
 import { WiiiContextService } from '../../../infrastructure/api/wiii-context.service';
 import { AuthService } from '../../../../../core/services/auth.service';
 import { environment } from '../../../../../../environments/environment';
+import { WiiiOperatorPreviewDialogComponent } from '../operator-preview-dialog/operator-preview-dialog.component';
 
 @Component({
   selector: 'app-chat-panel',
-  imports: [],
+  imports: [WiiiOperatorPreviewDialogComponent],
   template: `
     <div
       class="chat-panel"
@@ -98,6 +99,8 @@ import { environment } from '../../../../../../environments/environment';
         </div>
       }
     </div>
+
+    <app-wiii-operator-preview-dialog />
   `,
   styles: [`
     /* Host element — must stretch inside flex-column parents (sidebar) */

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.html
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.html
@@ -235,6 +235,17 @@
         @if (message()) {
           <p class="wiii-preview-message">{{ message() }}</p>
         }
+
+        @if (status() === 'applied') {
+          <div class="wiii-preview-next-step" data-wiii-id="wiii-apply-next-step">
+            <h3>Tiếp theo</h3>
+            <ul>
+              @for (item of nextStepItems(preview); track item) {
+                <li>{{ item }}</li>
+              }
+            </ul>
+          </div>
+        }
       </div>
 
       <footer class="wiii-preview-footer">
@@ -245,14 +256,14 @@
           [disabled]="status() === 'applying'"
           (click)="close()"
         >
-          Hủy
+          {{ secondaryActionLabel() }}
         </button>
         <button
           type="button"
           class="wiii-preview-primary"
           data-wiii-id="apply-wiii-preview"
-          [disabled]="status() === 'applying' || status() === 'applied'"
-          (click)="approve()"
+          [disabled]="status() === 'applying'"
+          (click)="status() === 'applied' ? close() : approve()"
         >
           {{ primaryActionLabel() }}
         </button>

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.scss
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.scss
@@ -131,6 +131,30 @@ h3 {
   color: #991b1b;
 }
 
+.wiii-preview-next-step {
+  margin-top: 14px;
+  padding: 14px;
+  border: 1px solid #bbf7d0;
+  border-radius: 10px;
+  background:
+    linear-gradient(180deg, rgba(240, 253, 244, 0.96), rgba(255, 255, 255, 0.98));
+}
+
+.wiii-preview-next-step h3 {
+  margin-bottom: 8px;
+  color: #166534;
+}
+
+.wiii-preview-next-step ul {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+  color: #14532d;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
 .wiii-preview-dot {
   width: 8px;
   height: 8px;

--- a/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.ts
@@ -22,12 +22,14 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
   protected readonly activePreview = signal<WiiiOperatorPreviewPanel | null>(null);
   protected readonly status = signal<PreviewStatus>('idle');
   protected readonly message = signal('');
+  protected readonly appliedData = signal<Record<string, unknown> | null>(null);
 
   ngOnInit(): void {
     this.sub = this.contextService.operatorPreview$.subscribe((preview) => {
       this.activePreview.set(preview);
       this.status.set('idle');
       this.message.set('');
+      this.appliedData.set(null);
     });
   }
 
@@ -42,6 +44,7 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
     this.activePreview.set(null);
     this.status.set('idle');
     this.message.set('');
+    this.appliedData.set(null);
   }
 
   protected async approve(): Promise<void> {
@@ -51,12 +54,16 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
     }
     this.status.set('applying');
     this.message.set('');
+    this.appliedData.set(null);
+
     const result = await this.contextService.approveOperatorPreview(preview.token);
     if (result.success) {
       this.status.set('applied');
-      this.message.set('Đã áp dụng thành công. LMS đang tải lại nội dung liên quan.');
+      this.appliedData.set(result.data ?? null);
+      this.message.set(String(result.data?.['summary'] || 'Đã áp dụng thành công. LMS đang tải lại nội dung liên quan.'));
       return;
     }
+
     this.status.set('error');
     this.message.set(result.error || 'Không thể áp dụng bản xem trước này.');
   }
@@ -94,10 +101,45 @@ export class WiiiOperatorPreviewDialogComponent implements OnInit, OnDestroy {
       case 'applying':
         return 'Đang áp dụng...';
       case 'applied':
-        return 'Đã áp dụng';
+        return 'Xong, về LMS';
       default:
         return 'Áp dụng vào LMS';
     }
+  }
+
+  protected secondaryActionLabel(): string {
+    return this.status() === 'applied' ? 'Đóng' : 'Hủy';
+  }
+
+  protected nextStepItems(preview: WiiiOperatorPreviewPanel): string[] {
+    if (preview.kind === 'course_plan') {
+      const data = this.appliedData();
+      const chapterCount = Number(data?.['chapters_created'] || 0);
+      const lessonCount = Number(data?.['lessons_created'] || 0);
+      return [
+        chapterCount || lessonCount
+          ? `Wiii đã tạo ${chapterCount} chương và ${lessonCount} bài học ở trạng thái nháp.`
+          : 'Wiii đã áp dụng cây chương/bài vào khóa học.',
+        'LMS đã mở tab Nội dung để bạn rà soát từng bài, thêm học liệu/video/quiz nếu cần.',
+        'Chỉ xuất bản sau khi giáo viên kiểm tra xong nội dung và nguồn trích dẫn.',
+      ];
+    }
+    if (preview.kind === 'lesson_patch') {
+      return [
+        'Nội dung bài học đã được cập nhật sau khi bạn duyệt.',
+        'Hãy đọc lại bài trong trình soạn, kiểm tra nguồn trích dẫn rồi lưu/xuất bản khi sẵn sàng.',
+      ];
+    }
+    if (preview.kind === 'quiz_commit') {
+      return [
+        'Bài kiểm tra đã được tạo hoặc cập nhật ở trạng thái nháp.',
+        'Hãy mở phần quiz để kiểm tra câu hỏi, đáp án và điểm đạt trước khi phát hành.',
+      ];
+    }
+    return [
+      'Thay đổi đã được áp dụng trong LMS.',
+      'Hãy kiểm tra lại trạng thái hiển thị với học viên trước khi tiếp tục.',
+    ];
   }
 
   protected changedFields(preview: WiiiOperatorPreviewPanel): string[] {

--- a/fe/src/app/features/teacher/courses/course-creation.component.ts
+++ b/fe/src/app/features/teacher/courses/course-creation.component.ts
@@ -13,7 +13,7 @@ import { ToastService } from '../../../core/services/toast.service';
   selector: 'app-course-creation',
   imports: [CommonModule, ReactiveFormsModule, RouterModule],
   template: `
-    <div class="h-screen flex flex-col bg-slate-50 overflow-hidden">
+    <div class="h-screen flex flex-col bg-slate-50 overflow-hidden" data-wiii-id="teacher-course-creation">
 
       <!-- Sticky top bar -->
       <div class="flex-shrink-0 bg-white border-b border-slate-200/80 z-10">
@@ -77,6 +77,9 @@ import { ToastService } from '../../../core/services/toast.service';
                       <label class="block text-sm font-medium text-slate-700 mb-2">Hình thức giảng dạy</label>
                       <div class="grid grid-cols-2 gap-3">
                         <button type="button" (click)="setDeliveryMode('SELF_PACED')"
+                                data-wiii-id="course-creation-mode-self-paced"
+                                data-wiii-click-safe="true"
+                                data-wiii-click-kind="form_option"
                                 class="group relative text-left px-4 py-3 rounded-lg border-2 transition-all"
                                 [class]="selectedMode() === 'SELF_PACED'
                                   ? 'border-[#0056D2] bg-[#0056D2]/[0.03]'
@@ -101,6 +104,9 @@ import { ToastService } from '../../../core/services/toast.service';
                         </button>
 
                         <button type="button" (click)="setDeliveryMode('INSTRUCTOR_LED')"
+                                data-wiii-id="course-creation-mode-instructor-led"
+                                data-wiii-click-safe="true"
+                                data-wiii-click-kind="form_option"
                                 class="group relative text-left px-4 py-3 rounded-lg border-2 transition-all"
                                 [class]="selectedMode() === 'INSTRUCTOR_LED'
                                   ? 'border-emerald-500 bg-emerald-50/50'
@@ -130,6 +136,7 @@ import { ToastService } from '../../../core/services/toast.service';
                     <div>
                       <label for="courseTitle" class="block text-sm font-medium text-slate-700 mb-1.5">Tên khóa học</label>
                       <input id="courseTitle" [formControl]="titleControl" type="text"
+                             data-wiii-id="course-creation-title-input"
                              class="w-full border border-slate-300 rounded-lg px-3.5 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/40 focus:border-[#0056D2] transition-all"
                              placeholder="VD: Điều khiển tàu biển nâng cao" />
                       @if (titleControl.invalid && titleControl.touched) {
@@ -147,6 +154,7 @@ import { ToastService } from '../../../core/services/toast.service';
                           <div>
                             <label class="block text-xs text-slate-500 mb-1">Lĩnh vực</label>
                             <select class="w-full border border-slate-300 rounded-lg px-3.5 py-2 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/40 focus:border-[#0056D2] transition-all text-sm"
+                                    data-wiii-id="course-creation-root-category"
                                     (change)="onRootCategoryChange($any($event.target).value)">
                               <option value="" [selected]="!selectedRootId()">Chọn lĩnh vực</option>
                               @for (root of categoryTree(); track root.id) {
@@ -157,6 +165,7 @@ import { ToastService } from '../../../core/services/toast.service';
                           <div>
                             <label class="block text-xs text-slate-500 mb-1">Chuyên ngành</label>
                             <select [formControl]="categoryControl"
+                                    data-wiii-id="course-creation-subcategory"
                                     class="w-full border border-slate-300 rounded-lg px-3.5 py-2 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/40 focus:border-[#0056D2] transition-all text-sm"
                                     [class.text-slate-400]="!subcategories().length"
                                     [class.opacity-60]="!subcategories().length">
@@ -184,6 +193,9 @@ import { ToastService } from '../../../core/services/toast.service';
                   <div class="flex items-center justify-between px-5 sm:px-6 py-3 border-t border-slate-100 bg-slate-50/60 rounded-b-xl">
                     <button type="button" (click)="onCancel()" class="text-sm text-slate-500 hover:text-slate-700 transition-colors">Hủy</button>
                     <button type="button" (click)="nextStep()" [disabled]="!canProceed()"
+                            data-wiii-id="course-creation-next-step"
+                            data-wiii-click-safe="true"
+                            data-wiii-click-kind="form_step"
                             class="px-5 py-2 text-sm font-semibold text-white bg-[#0056D2] rounded-lg hover:bg-[#004BB5] disabled:opacity-40 disabled:cursor-not-allowed transition-all">
                       Tiếp theo
                     </button>
@@ -214,6 +226,7 @@ import { ToastService } from '../../../core/services/toast.service';
                         <span class="text-xs text-slate-400">Không bắt buộc</span>
                       </div>
                       <textarea id="courseDesc" [formControl]="descriptionControl" rows="3"
+                                data-wiii-id="course-creation-description"
                                 class="w-full border border-slate-300 rounded-lg px-3.5 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/40 focus:border-[#0056D2] transition-all resize-none"
                                 placeholder="Học viên sẽ học được gì từ khóa học này?"></textarea>
                     </div>
@@ -223,6 +236,9 @@ import { ToastService } from '../../../core/services/toast.service';
                       <label class="block text-sm font-medium text-slate-700 mb-2">Giá khóa học</label>
                       <div class="grid grid-cols-2 gap-3">
                         <button type="button" (click)="priceType.set('FREE')"
+                                data-wiii-id="course-creation-price-free"
+                                data-wiii-click-safe="true"
+                                data-wiii-click-kind="form_option"
                                 class="group flex items-center gap-2.5 px-4 py-3 rounded-lg border-2 transition-all text-left"
                                 [class]="priceType() === 'FREE' ? 'border-green-500 bg-green-50/50' : 'border-slate-200 hover:border-slate-300'">
                           <div class="w-8 h-8 rounded-md flex items-center justify-center flex-shrink-0 transition-colors"
@@ -238,6 +254,9 @@ import { ToastService } from '../../../core/services/toast.service';
                         </button>
 
                         <button type="button" (click)="priceType.set('PAID')"
+                                data-wiii-id="course-creation-price-paid"
+                                data-wiii-click-safe="true"
+                                data-wiii-click-kind="form_option"
                                 class="group flex items-center gap-2.5 px-4 py-3 rounded-lg border-2 transition-all text-left"
                                 [class]="priceType() === 'PAID' ? 'border-amber-500 bg-amber-50/50' : 'border-slate-200 hover:border-slate-300'">
                           <div class="w-8 h-8 rounded-md flex items-center justify-center flex-shrink-0 transition-colors"
@@ -260,6 +279,7 @@ import { ToastService } from '../../../core/services/toast.service';
                         <div>
                           <label class="block text-xs text-slate-600 mb-1">Giá gốc (VND)</label>
                           <input [formControl]="priceControl" type="number" min="0" step="10000"
+                                 data-wiii-id="course-creation-price-input"
                                  class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/40 focus:border-[#0056D2] text-sm bg-white placeholder:text-slate-400"
                                  placeholder="VD: 500000" />
                           @if (priceControl.touched && (!priceControl.value || priceControl.value <= 0)) {
@@ -269,6 +289,7 @@ import { ToastService } from '../../../core/services/toast.service';
                         <div>
                           <label class="block text-xs text-slate-600 mb-1">Giá khuyến mãi (VND)</label>
                           <input [formControl]="salePriceControl" type="number" min="0" step="10000"
+                                 data-wiii-id="course-creation-sale-price-input"
                                  class="w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#0056D2]/40 focus:border-[#0056D2] text-sm bg-white placeholder:text-slate-400"
                                  placeholder="VD: 400000" />
                           @if (salePriceControl.value && salePriceControl.value > 0 && priceControl.value && priceControl.value > 0 && salePriceControl.value >= priceControl.value) {
@@ -293,6 +314,7 @@ import { ToastService } from '../../../core/services/toast.service';
                   <div class="flex items-center justify-between px-5 sm:px-6 py-3 border-t border-slate-100 bg-slate-50/60 rounded-b-xl">
                     <button type="button" (click)="prevStep()" class="text-sm text-slate-500 hover:text-slate-700 transition-colors">Quay lại</button>
                     <button type="button" (click)="onSubmit()" [disabled]="isSubmitting() || !canSubmit()"
+                            data-wiii-id="course-creation-submit"
                             class="px-5 py-2 text-sm font-semibold text-white bg-[#0056D2] rounded-lg hover:bg-[#004BB5] disabled:opacity-40 disabled:cursor-not-allowed transition-all inline-flex items-center gap-2">
                       @if (isSubmitting()) {
                         <svg class="animate-spin h-3.5 w-3.5" fill="none" viewBox="0 0 24 24">
@@ -409,6 +431,31 @@ import { ToastService } from '../../../core/services/toast.service';
                         Sửa thông tin
                       </button>
                     }
+                  </div>
+                </div>
+              </div>
+
+              <div class="mt-4 rounded-xl border border-blue-200 bg-gradient-to-br from-blue-50 via-white to-sky-50 p-4 shadow-sm"
+                   data-wiii-id="course-creation-wiii-helper">
+                <div class="flex items-start gap-3">
+                  <div class="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-[#0056D2] text-white">
+                    <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path fill-rule="evenodd" d="M9 4.5a.75.75 0 01.721.544l.813 2.846a3.75 3.75 0 002.576 2.576l2.846.813a.75.75 0 010 1.442l-2.846.813a3.75 3.75 0 00-2.576 2.576l-.813 2.846a.75.75 0 01-1.442 0l-.813-2.846a3.75 3.75 0 00-2.576-2.576l-2.846-.813a.75.75 0 010-1.442l2.846-.813A3.75 3.75 0 007.466 7.89l.813-2.846A.75.75 0 019 4.5z" clip-rule="evenodd"/>
+                    </svg>
+                  </div>
+                  <div class="min-w-0">
+                    <h2 class="text-sm font-bold text-slate-900">Có tài liệu Word/PDF?</h2>
+                    <p class="mt-1 text-xs leading-5 text-slate-600">
+                      Tạo khung khóa học trước, rồi dùng Wiii trong tab Nội dung để tạo chương/bài từ tài liệu với bản xem trước và nguồn trích dẫn.
+                    </p>
+                    <button type="button"
+                            class="mt-3 inline-flex items-center rounded-lg bg-[#0056D2] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#004BB5] focus:outline-none focus:ring-2 focus:ring-[#0056D2]/30"
+                            data-wiii-id="course-creation-open-wiii-ai"
+                            data-wiii-click-safe="true"
+                            data-wiii-click-kind="open_panel"
+                            (click)="openWiiiAssistant()">
+                      Mở Wiii AI
+                    </button>
                   </div>
                 </div>
               </div>
@@ -564,6 +611,15 @@ export class CourseCreationComponent implements OnInit {
     this.router.navigate(['/teacher/courses/library']);
   }
 
+  openWiiiAssistant(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    window.dispatchEvent(new CustomEvent('wiii:open-sidebar', {
+      detail: { action: 'course_creation_support' }
+    }));
+  }
+
   hasUnsavedData(): boolean {
     if (this.submitted()) return false;
     return !!(this.titleControl.value || this.categoryControl.value || this.descriptionControl.value ||
@@ -606,8 +662,8 @@ export class CourseCreationComponent implements OnInit {
       const res = await firstValueFrom(this.api.createCourse(payload));
       const course = res?.data;
       if (course?.id) {
-        this.toast.success('Tạo khóa học thành công! Đang chuyển đến trang chỉnh sửa...');
-        await this.router.navigate(['/teacher/courses', course.id, 'editor']);
+        this.toast.success('Đã tạo khóa học. Đang mở tab Nội dung để thêm chương/bài hoặc dùng Wiii từ tài liệu.');
+        await this.router.navigate(['/teacher/courses', course.id, 'editor', 'curriculum']);
       } else {
         this.toast.error('Phản hồi không hợp lệ từ máy chủ');
       }

--- a/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
+++ b/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
@@ -12,6 +12,7 @@ import { NotificationService } from '../../../core/services/notification.service
 import { MessagingService } from '../../../core/services/messaging.service';
 import { ChatPanelComponent } from '../../ai-chat/presentation/components/chat-panel/chat-panel.component';
 import { AiAvailabilityService } from '../../ai-chat/application/services/ai-availability.service';
+import { WiiiContextService, type WiiiSidebarOpenDetail } from '../../ai-chat/infrastructure/api/wiii-context.service';
 
 @Component({
   selector: 'app-teacher-layout-simple',
@@ -162,7 +163,9 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
 
         <!-- AI Sidebar (Desktop) — always rendered, animated via CSS -->
         @if (enableAssistant()) {
-        <aside class="ai-sidebar hidden md:flex md:flex-col"
+        <aside id="teacher-ai-sidebar"
+               class="ai-sidebar hidden md:flex md:flex-col"
+               data-wiii-id="teacher-ai-sidebar"
                [class.ai-sidebar-open]="isAiSidebarOpen()"
                [class.ai-sidebar-resizing]="isResizing()"
                [style.width.px]="isAiSidebarOpen() ? aiSidebarWidth() : null"
@@ -196,14 +199,23 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       <!-- Desktop: Toggle tab — always rendered, animated -->
       @if (enableAssistant()) {
       <button
-        class="ai-sidebar-toggle hidden md:flex"
-        [class.ai-toggle-hidden]="isAiSidebarOpen()"
-        (click)="toggleAiSidebar()"
-        title="Mở trợ lý AI"
-        aria-label="Mở trợ lý AI">
+        class="ai-sidebar-launcher hidden md:flex"
+        [class.ai-launcher-hidden]="isAiSidebarOpen()"
+        (click)="openAiSidebar()"
+        title="Mở trợ lý Wiii AI"
+        aria-label="Mở trợ lý Wiii AI"
+        aria-controls="teacher-ai-sidebar"
+        [attr.aria-expanded]="isAiSidebarOpen()"
+        data-wiii-id="open-wiii-ai"
+        data-wiii-click-safe="true"
+        data-wiii-click-kind="open_panel">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="toggle-icon">
           <path fill-rule="evenodd" d="M9 4.5a.75.75 0 01.721.544l.813 2.846a3.75 3.75 0 002.576 2.576l2.846.813a.75.75 0 010 1.442l-2.846.813a3.75 3.75 0 00-2.576 2.576l-.813 2.846a.75.75 0 01-1.442 0l-.813-2.846a3.75 3.75 0 00-2.576-2.576l-2.846-.813a.75.75 0 010-1.442l2.846-.813A3.75 3.75 0 007.466 7.89l.813-2.846A.75.75 0 019 4.5zM18 1.5a.75.75 0 01.728.568l.258 1.036c.236.94.97 1.674 1.91 1.91l1.036.258a.75.75 0 010 1.456l-1.036.258c-.94.236-1.674.97-1.91 1.91l-.258 1.036a.75.75 0 01-1.456 0l-.258-1.036a2.625 2.625 0 00-1.91-1.91l-1.036-.258a.75.75 0 010-1.456l1.036-.258a2.625 2.625 0 001.91-1.91l.258-1.036A.75.75 0 0118 1.5z" clip-rule="evenodd" />
         </svg>
+        <span class="launcher-copy">
+          <strong>Wiii AI</strong>
+          <small>Soạn bài từ tài liệu</small>
+        </span>
       </button>
       }
 
@@ -407,48 +419,73 @@ import { AiAvailabilityService } from '../../ai-chat/application/services/ai-ava
       transition: none !important;
     }
 
-    /* ── Toggle tab — subtle, professional ── */
-    .ai-sidebar-toggle {
+    /* ── Desktop Wiii launcher — visible enough for real teacher workflows ── */
+    .ai-sidebar-launcher {
       position: fixed;
-      right: 0;
-      top: 50%;
-      transform: translateY(-50%);
+      right: 18px;
+      bottom: 22px;
+      transform: translateY(0);
       z-index: 50;
       align-items: center;
       justify-content: center;
-      width: 28px;
-      height: 72px;
-      background: white;
-      color: #9ca3af;
-      border: 1px solid #e5e7eb;
-      border-right: none;
-      border-radius: 8px 0 0 8px;
+      gap: 10px;
+      min-width: 172px;
+      min-height: 54px;
+      padding: 10px 14px 10px 12px;
+      background: #ffffff;
+      color: #0f172a;
+      border: 1px solid rgba(0, 86, 210, 0.22);
+      border-radius: 999px;
       cursor: pointer;
-      box-shadow: -2px 0 8px rgba(0, 0, 0, 0.04);
-      transition: transform 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94),
-                  opacity 0.25s ease,
-                  width 0.15s ease,
-                  color 0.15s ease,
-                  background 0.15s ease,
-                  box-shadow 0.15s ease;
+      box-shadow: 0 16px 40px rgba(15, 23, 42, 0.14), 0 0 0 4px rgba(0, 86, 210, 0.05);
+      transition:
+        transform 0.22s ease,
+        opacity 0.18s ease,
+        border-color 0.16s ease,
+        box-shadow 0.16s ease;
     }
 
-    .ai-sidebar-toggle:hover {
-      width: 32px;
-      background: #f9fafb;
-      color: #0056D2;
-      box-shadow: -3px 0 12px rgba(0, 0, 0, 0.08);
+    .ai-sidebar-launcher:hover {
+      transform: translateY(-2px);
+      border-color: rgba(0, 86, 210, 0.42);
+      box-shadow: 0 20px 48px rgba(15, 23, 42, 0.18), 0 0 0 5px rgba(0, 86, 210, 0.08);
     }
 
-    .ai-sidebar-toggle.ai-toggle-hidden {
-      transform: translateY(-50%) translateX(100%);
+    .ai-sidebar-launcher:focus-visible {
+      outline: 3px solid rgba(0, 86, 210, 0.28);
+      outline-offset: 3px;
+    }
+
+    .ai-sidebar-launcher.ai-launcher-hidden {
+      transform: translateY(12px) scale(0.96);
       opacity: 0;
       pointer-events: none;
     }
 
-    .toggle-icon {
-      width: 18px;
-      height: 18px;
+    .ai-sidebar-launcher .toggle-icon {
+      width: 22px;
+      height: 22px;
+      color: #0056D2;
+      flex: 0 0 auto;
+    }
+
+    .launcher-copy {
+      display: grid;
+      gap: 1px;
+      text-align: left;
+      line-height: 1.1;
+    }
+
+    .launcher-copy strong {
+      font-size: 14px;
+      font-weight: 800;
+      letter-spacing: -0.01em;
+    }
+
+    .launcher-copy small {
+      color: #64748b;
+      font-size: 11px;
+      font-weight: 700;
     }
 
     /* Respect reduced motion preference */
@@ -466,6 +503,7 @@ export class TeacherLayoutSimpleComponent implements OnInit, OnDestroy {
   private router = inject(Router);
   private notificationService = inject(NotificationService);
   private messagingService = inject(MessagingService);
+  private wiiiContextService = inject(WiiiContextService);
   protected readonly enableAssistant = this.aiAvailability.isAvailable;
   protected isMobileSidebarOpen = signal(false);
   /** Sidebar collapsed/mobileOpen/hidden state — single source of truth shared
@@ -505,6 +543,7 @@ export class TeacherLayoutSimpleComponent implements OnInit, OnDestroy {
   private sidebarHidden = signal<boolean>(false);
   protected readonly hideMobileChrome = signal(false);
   private routerSubscription?: Subscription;
+  private sidebarOpenListener?: (event: Event) => void;
 
   protected shouldHideSidebar = computed(() => this.sidebarHidden());
   protected shouldHideMobileChrome = computed(() => this.sidebarHidden() || this.hideMobileChrome());
@@ -533,11 +572,24 @@ export class TeacherLayoutSimpleComponent implements OnInit, OnDestroy {
 
     // Handle initial route
     this.handleRouteChange(this.router.url);
+
+    if (typeof window !== 'undefined') {
+      this.sidebarOpenListener = (event: Event) => {
+        if (event instanceof CustomEvent) {
+          this.wiiiContextService.applySidebarIntent((event as CustomEvent<WiiiSidebarOpenDetail>).detail);
+        }
+        this.openAiSidebar();
+      };
+      window.addEventListener('wiii:open-sidebar', this.sidebarOpenListener);
+    }
   }
 
   ngOnDestroy() {
     if (this.routerSubscription) {
       this.routerSubscription.unsubscribe();
+    }
+    if (typeof window !== 'undefined' && this.sidebarOpenListener) {
+      window.removeEventListener('wiii:open-sidebar', this.sidebarOpenListener);
     }
   }
 
@@ -562,6 +614,11 @@ export class TeacherLayoutSimpleComponent implements OnInit, OnDestroy {
   }
 
   // --- AI Sidebar (Desktop) ---
+
+  openAiSidebar(): void {
+    this.isAiSidebarOpen.set(true);
+    this.saveAiSidebarState(true);
+  }
 
   toggleAiSidebar(): void {
     this.isAiSidebarOpen.update(v => !v);


### PR DESCRIPTION
## Summary
Closes #464.

This fixes the product UX break where teachers could miss Wiii entirely on /teacher/course-creation, and where course-plan preview/apply could look like it did nothing.

Changes:
- Replace the tiny desktop Wiii edge tab in the teacher layout with a visible accessible Wiii AI launcher.
- Add a course-creation helper card explaining the Word/PDF flow and a safe Wiii launcher action.
- Mount the Wiii operator preview dialog inside the chat host so uthoring.generate_course_from_document previews actually render in LMS.
- After uthoring.apply_course_plan, route to the course editor Nội dung tab and return clear next-step metadata/summary.
- Add page context for /teacher/course-creation and preserve safe data-wiii-id markers for non-mutating guidance.

## Verification
- 
px ng test --watch=false --include=src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts --include=src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.spec.ts -> TOTAL: 33 SUCCESS
- 
pm run build -> success; existing Angular/Sass/CommonJS warnings only
- git diff --check -> pass

## Risk / rollback
- Risk is limited to teacher Wiii entry UI and Wiii host approval/apply UX. It does not add auto-publish, auto-submit, delete, enroll, grade, or payment actions.
- Rollback: revert commit d8f6f9ea to restore the previous teacher launcher and apply behavior.