### PR TITLE
fix(wiii): recognize configured AI health

### DIFF
--- a/fe/src/app/features/ai-chat/application/services/ai-availability.service.ts
+++ b/fe/src/app/features/ai-chat/application/services/ai-availability.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, computed, inject, signal } from '@angular/core';
 import { ChatApiClient } from '../../infrastructure/api/chat-api.client';
+import { isAiHealthReady } from './ai-health.util';
 
 type AiAvailabilityStatus = 'checking' | 'available' | 'unavailable';
 
@@ -20,8 +21,7 @@ export class AiAvailabilityService {
   refresh(): void {
     this.apiClient.checkHealth().subscribe({
       next: (health) => {
-        const isAvailable = health.status === 'healthy'
-          && health.aiServiceStatus === 'available';
+        const isAvailable = isAiHealthReady(health);
         this._status.set(isAvailable ? 'available' : 'unavailable');
       },
       error: () => {

--- a/fe/src/app/features/ai-chat/application/services/ai-health.util.spec.ts
+++ b/fe/src/app/features/ai-chat/application/services/ai-health.util.spec.ts
@@ -1,0 +1,12 @@
+import { isAiHealthReady } from './ai-health.util';
+
+describe('isAiHealthReady', () => {
+  it('treats the production configured status as ready when the API is healthy', () => {
+    expect(isAiHealthReady({ status: 'healthy', aiServiceStatus: 'configured' })).toBeTrue();
+  });
+
+  it('keeps unavailable or unhealthy states disabled', () => {
+    expect(isAiHealthReady({ status: 'healthy', aiServiceStatus: 'unknown' })).toBeFalse();
+    expect(isAiHealthReady({ status: 'unhealthy', aiServiceStatus: 'configured' })).toBeFalse();
+  });
+});

--- a/fe/src/app/features/ai-chat/application/services/ai-health.util.ts
+++ b/fe/src/app/features/ai-chat/application/services/ai-health.util.ts
@@ -1,0 +1,10 @@
+import { HealthStatus } from '../../domain/types';
+
+const READY_AI_SERVICE_STATUSES = new Set(['available', 'configured', 'ready']);
+
+export function isAiHealthReady(health: Pick<HealthStatus, 'status' | 'aiServiceStatus'> | null | undefined): boolean {
+  const apiStatus = health?.status?.trim().toLowerCase();
+  const aiServiceStatus = health?.aiServiceStatus?.trim().toLowerCase();
+
+  return apiStatus === 'healthy' && READY_AI_SERVICE_STATUSES.has(aiServiceStatus ?? '');
+}

--- a/fe/src/app/features/ai-chat/application/services/chat.service.ts
+++ b/fe/src/app/features/ai-chat/application/services/chat.service.ts
@@ -10,6 +10,7 @@ import { Injectable, signal, computed, inject, effect } from '@angular/core';
 import { ChatMessage, ChatData, SessionSummary, Source } from '../../domain/types';
 import { ChatApiClient, ClientApiError } from '../../infrastructure/api/chat-api.client';
 import { SessionManagementService } from './session-management.service';
+import { isAiHealthReady } from './ai-health.util';
 import {
   createUserMessage,
   createAiMessage,
@@ -1346,7 +1347,7 @@ export class ChatService {
       next: (health) => {
         this._serviceState.update((state) => ({
           ...state,
-          isHealthy: health.status === 'healthy' && health.aiServiceStatus === 'available',
+          isHealthy: isAiHealthReady(health),
         }));
       },
       error: () => {


### PR DESCRIPTION
## Summary
- Treat healthy AI health responses with aiServiceStatus=configured as available for Wiii UI visibility.
- Reuse the same readiness rule for chat send health state.
- Add regression coverage for the production configured health response.

Fixes #464

## Verification
- npx ng test --watch=false --include=src/app/features/ai-chat/application/services/ai-health.util.spec.ts -> TOTAL: 2 SUCCESS
- npm run build -> success; existing Angular/Sass/CommonJS warnings only
- git diff --check -> pass

## Risk / rollback
- Low frontend-only compatibility fix. If backend uses a truly disabled state it still remains unavailable unless API status is healthy and service status is one of available/configured/ready.
- Rollback by reverting this PR if Wiii is shown when the backend is intentionally disabled.