### PR TITLE
fix(wiii): mount one responsive sidebar panel

### DIFF
--- a/fe/src/app/features/ai-chat/presentation/components/chat-widget/chat-widget.component.spec.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/chat-widget/chat-widget.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { AuthService } from '../../../../../core/services/auth.service';
 import { SessionManagementService } from '../../../application/services/session-management.service';
@@ -9,7 +10,26 @@ import { ChatWidgetComponent } from './chat-widget.component';
 describe('ChatWidgetComponent', () => {
   let fixture: ComponentFixture<ChatWidgetComponent>;
 
+  const installMatchMedia = (matches: boolean): void => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: jasmine.createSpy('matchMedia').and.returnValue({
+        matches,
+        media: '(max-width: 767px)',
+        onchange: null,
+        addEventListener: jasmine.createSpy('addEventListener'),
+        removeEventListener: jasmine.createSpy('removeEventListener'),
+        addListener: jasmine.createSpy('addListener'),
+        removeListener: jasmine.createSpy('removeListener'),
+        dispatchEvent: jasmine.createSpy('dispatchEvent').and.returnValue(true),
+      } as unknown as MediaQueryList),
+    });
+  };
+
   beforeEach(async () => {
+    installMatchMedia(false);
+
     await TestBed.configureTestingModule({
       imports: [ChatWidgetComponent],
       providers: [
@@ -32,6 +52,8 @@ describe('ChatWidgetComponent', () => {
             applySidebarIntent: jasmine.createSpy('applySidebarIntent'),
             connectIframe: jasmine.createSpy('connectIframe'),
             disconnectIframe: jasmine.createSpy('disconnectIframe'),
+            operatorPreview$: of(null),
+            approveOperatorPreview: jasmine.createSpy('approveOperatorPreview'),
           },
         },
         {
@@ -78,5 +100,17 @@ describe('ChatWidgetComponent', () => {
       courseId: 'course-1',
     });
     expect(fixture.nativeElement.querySelector('.wiii-sidebar-host--open')).not.toBeNull();
+  });
+
+  it('mounts only one Wiii panel in desktop responsive-sidebar mode', () => {
+    fixture.componentRef.setInput('variant', 'responsive-sidebar');
+    fixture.detectChanges();
+
+    window.dispatchEvent(new CustomEvent('wiii:open-sidebar'));
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelectorAll('app-chat-panel').length).toBe(1);
+    expect(fixture.nativeElement.querySelector('.wiii-sidebar-host app-chat-panel')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.wiii-mobile-widget app-chat-panel')).toBeNull();
   });
 });

--- a/fe/src/app/features/ai-chat/presentation/components/chat-widget/chat-widget.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/chat-widget/chat-widget.component.ts
@@ -32,7 +32,7 @@ import { WiiiContextService, type WiiiSidebarOpenDetail } from '../../../infrast
           aria-label="Trợ lý Wiii"
           data-wiii-id="wiii-right-sidebar"
         >
-          @if (isPanelOpen()) {
+          @if (isPanelOpen() && !isMobileViewport()) {
             <app-chat-panel
               mode="sidebar"
               (closePanel)="closePanel()"
@@ -54,7 +54,7 @@ import { WiiiContextService, type WiiiSidebarOpenDetail } from '../../../infrast
         </aside>
 
         <div class="wiii-mobile-widget">
-          @if (isPanelOpen()) {
+          @if (isPanelOpen() && isMobileViewport()) {
             <app-chat-panel
               mode="widget"
               (closePanel)="closePanel()"
@@ -183,9 +183,12 @@ export class ChatWidgetComponent implements OnInit, OnDestroy {
   // State
   isPanelOpen = signal(false);
   isEnabled = signal(true);
+  isMobileViewport = signal(this.getInitialMobileViewport());
 
   // Listener for sidebar open requests (from Course Editor AI button)
   private sidebarOpenListener: ((event: Event) => void) | null = null;
+  private viewportQuery: MediaQueryList | null = null;
+  private viewportQueryListener: ((event: MediaQueryListEvent) => void) | null = null;
 
   ngOnInit(): void {
     // Set user info from auth service
@@ -207,6 +210,8 @@ export class ChatWidgetComponent implements OnInit, OnDestroy {
       this.isPanelOpen.set(true);
     };
     window.addEventListener('wiii:open-sidebar', this.sidebarOpenListener);
+
+    this.bindViewportMode();
   }
 
   ngOnDestroy(): void {
@@ -214,6 +219,12 @@ export class ChatWidgetComponent implements OnInit, OnDestroy {
       window.removeEventListener('wiii:open-sidebar', this.sidebarOpenListener);
       this.sidebarOpenListener = null;
     }
+    if (this.viewportQuery && this.viewportQueryListener) {
+      this.viewportQuery.removeEventListener?.('change', this.viewportQueryListener);
+      this.viewportQuery.removeListener?.(this.viewportQueryListener);
+    }
+    this.viewportQuery = null;
+    this.viewportQueryListener = null;
   }
 
   togglePanel(): void {
@@ -226,5 +237,25 @@ export class ChatWidgetComponent implements OnInit, OnDestroy {
 
   closePanel(): void {
     this.isPanelOpen.set(false);
+  }
+
+  private getInitialMobileViewport(): boolean {
+    return typeof window !== 'undefined'
+      && typeof window.matchMedia === 'function'
+      && window.matchMedia('(max-width: 767px)').matches;
+  }
+
+  private bindViewportMode(): void {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      this.isMobileViewport.set(false);
+      return;
+    }
+    this.viewportQuery = window.matchMedia('(max-width: 767px)');
+    this.isMobileViewport.set(this.viewportQuery.matches);
+    this.viewportQueryListener = (event: MediaQueryListEvent) => {
+      this.isMobileViewport.set(event.matches);
+    };
+    this.viewportQuery.addEventListener?.('change', this.viewportQueryListener);
+    this.viewportQuery.addListener?.(this.viewportQueryListener);
   }
 }


### PR DESCRIPTION
## Summary
- mount only one Wiii `app-chat-panel` for `responsive-sidebar` based on viewport
- avoid hidden mobile iframe staying in the DOM on desktop
- add regression coverage for one-panel desktop sidebar behavior

## Issue
Fixes #469

## Verification
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include src/app/features/ai-chat/presentation/components/chat-widget/chat-widget.component.spec.ts` -> 3 SUCCESS
- `npm run build` -> success, existing Angular/Sass/CommonJS warnings only
- `git diff --check` -> pass

## Risk / rollback
- Risk is limited to Wiii chat widget rendering. Desktop uses sidebar panel; mobile uses widget panel via `matchMedia('(max-width: 767px)')`.
- Rollback: revert this PR to restore prior dual-mounted panel behavior.