### PR TITLE
fix(wiii): mount one operator preview dialog

### DIFF
--- a/fe/src/app/features/ai-chat/presentation/components/chat-panel/chat-panel.component.ts
+++ b/fe/src/app/features/ai-chat/presentation/components/chat-panel/chat-panel.component.ts
@@ -33,11 +33,9 @@ import { SessionManagementService } from '../../../application/services/session-
 import { WiiiContextService } from '../../../infrastructure/api/wiii-context.service';
 import { AuthService } from '../../../../../core/services/auth.service';
 import { environment } from '../../../../../../environments/environment';
-import { WiiiOperatorPreviewDialogComponent } from '../operator-preview-dialog/operator-preview-dialog.component';
 
 @Component({
   selector: 'app-chat-panel',
-  imports: [WiiiOperatorPreviewDialogComponent],
   template: `
     <div
       class="chat-panel"
@@ -99,8 +97,6 @@ import { WiiiOperatorPreviewDialogComponent } from '../operator-preview-dialog/o
         </div>
       }
     </div>
-
-    <app-wiii-operator-preview-dialog />
   `,
   styles: [`
     /* Host element — must stretch inside flex-column parents (sidebar) */


### PR DESCRIPTION
## Summary
- keep the Wiii operator preview dialog mounted only once at app root
- remove the duplicate dialog from `app-chat-panel`
- prevent duplicate preview buttons from intercepting apply clicks in product smoke

## Issue
Fixes #471

## Verification
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include src/app/features/ai-chat/presentation/components/chat-widget/chat-widget.component.spec.ts --include src/app/features/ai-chat/presentation/components/operator-preview-dialog/operator-preview-dialog.component.spec.ts` -> 5 SUCCESS
- `npm run build` -> success, existing Angular/Sass/CommonJS warnings only
- `git diff --check` -> pass

## Risk / rollback
- Risk is low: preview dialog remains globally mounted in `app-root`; chat panel no longer owns an extra duplicate overlay.
- Rollback: revert this PR to restore panel-local dialog mounting.