### PR TITLE
fix(ai): align health message with configured status

### DIFF
--- a/backend/src/main/java/com/example/lms/ai_assistant/infrastructure/web/AiAssistantControllerV3.java
+++ b/backend/src/main/java/com/example/lms/ai_assistant/infrastructure/web/AiAssistantControllerV3.java
@@ -81,8 +81,11 @@ public class AiAssistantControllerV3 {
         health.put("webhookEnabled", webhookEnabled);
         health.put("version", "3.0");
 
-        String msg = "available".equals(aiStatus) ? "Dịch vụ AI đang hoạt động"
-                : "Dịch vụ AI chưa được cấu hình";
+        String msg = switch (aiStatus) {
+            case "available" -> "Dịch vụ AI đang hoạt động";
+            case "configured" -> "Dịch vụ AI đã được cấu hình";
+            default -> "Dịch vụ AI chưa được cấu hình";
+        };
         return ResponseEntity.ok(ApiResponse.success(health, msg));
     }
 


### PR DESCRIPTION
## Summary
- align `/api/v3/ai/health` message with `aiServiceStatus=configured`
- keep `not_configured` message only for missing Wiii secret/config

## Issue
Fixes #473

## Verification
- `mvn -q -DskipTests compile` -> pass
- `git diff --check` -> pass

## Risk / rollback
- Low risk: response shape is unchanged; only user-facing message text changes.
- Rollback: revert this PR to restore previous message behavior.