### PR TITLE
fix(wiii): avoid duplicate preview review copy

### DIFF
--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts
@@ -396,6 +396,7 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     });
     const preview = await (service as any).handleActionRequest('authoring.generate_course_from_document', {
       course_id: 'course-1',
+      summary: 'Wiii đã dựng cây khóa học nháp. Giáo viên cần xem citation trước khi áp dụng vào LMS.',
       course_plan: {
         title: 'Khai thác HoLiLiHu LMS',
         description: 'Khóa học từ tài liệu hướng dẫn',
@@ -437,6 +438,7 @@ describe('WiiiContextService - operator preview/apply flows', () => {
     expect(preview.success).toBeTrue();
     expect(preview.data?.preview_kind).toBe('course_plan');
     expect(preview.data?.apply_action).toBe('authoring.apply_course_plan');
+    expect(String(preview.data?.summary).match(/Giáo viên cần xem/g)?.length).toBe(1);
     expect(preview.data?.course_plan).toEqual(jasmine.objectContaining({
       title: 'Khai thác HoLiLiHu LMS',
       chapters: jasmine.any(Array),

--- a/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
+++ b/fe/src/app/features/ai-chat/infrastructure/api/wiii-context.service.ts
@@ -1432,6 +1432,21 @@ export class WiiiContextService implements OnDestroy {
     ].filter((part) => part.trim().length > 0).join('\n\n');
   }
 
+  private withCoursePlanReviewInstruction(summary: string): string {
+    const clean = summary.replace(/\s+/g, ' ').trim();
+    const lower = clean.toLocaleLowerCase('vi-VN');
+    const alreadyAsksForReview = (
+      lower.includes('giáo viên cần xem')
+      || (lower.includes('citation') && lower.includes('áp dụng'))
+      || (lower.includes('nguồn trích dẫn') && lower.includes('áp dụng'))
+      || (lower.includes('source') && lower.includes('apply'))
+    );
+    if (alreadyAsksForReview) {
+      return clean;
+    }
+    return `${clean.replace(/[.!?。]+$/u, '')}. Giáo viên cần xem cây chương/bài và nguồn trích dẫn trước khi áp dụng.`;
+  }
+
   private async previewCoursePlan(
     params: Record<string, unknown>,
   ): Promise<{ success: boolean; data: Record<string, unknown> }> {
@@ -1464,7 +1479,7 @@ export class WiiiContextService implements OnDestroy {
       course_title: plan.title,
       target_label: plan.title,
       apply_action: 'authoring.apply_course_plan',
-      summary: `${summary} Giáo viên cần xem cây chương/bài và nguồn trích dẫn trước khi áp dụng.`,
+      summary: this.withCoursePlanReviewInstruction(summary),
       changed_fields: ['course_structure'],
       source_references: sourceReferences,
       course_plan: plan,


### PR DESCRIPTION
## Summary
- Link #475.
- Deduplicate the Wiii course-plan review instruction when the generated preview summary already asks the teacher to review citations before applying.
- Add regression coverage for the product-smoke copy case.

## Verification
- cd fe && npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include src/app/features/ai-chat/infrastructure/api/wiii-context.service.spec.ts -> TOTAL: 31 SUCCESS
- cd fe && npm run build -> success; existing Angular/Sass/CommonJS warnings only
- git diff --check -> pass

## Risk and rollback
- Low risk: display-copy helper only affects preview summary text, not preview tokens or apply mutation behavior.
- Rollback: revert d577fc85 if preview copy needs to return to unconditional appended instruction.