### PR TITLE
fix(wiii): overlay teacher sidebar on laptop widths

### DIFF
--- a/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
+++ b/fe/src/app/features/teacher/shared/teacher-layout-simple.component.ts
@@ -380,6 +380,17 @@ import { WiiiContextService, type WiiiSidebarOpenDetail } from '../../ai-chat/in
       border-left-color: #e5e7eb;
     }
 
+    @media (max-width: 1535px) {
+      .ai-sidebar.ai-sidebar-open {
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 55;
+        box-shadow: -24px 0 60px rgba(15, 23, 42, 0.16);
+      }
+    }
+
     /* ── Resize handle — fixed at sidebar left edge ── */
     .resize-handle-track {
       position: fixed;


### PR DESCRIPTION
## Summary
- Make the teacher Wiii sidebar use a fixed right overlay on laptop/medium desktop widths (`<=1535px`) so opening Wiii does not squeeze the course creation/editor form.
- Keep the existing docked sidebar behavior for wider desktop screens.

## Verification
- `npm run build` in `fe/` -> success.
- `git diff --check` -> success.

## Risk and rollback
- Risk: low; CSS-only change scoped to teacher Wiii sidebar open state below 1536px.
- Rollback: revert this commit; sidebar returns to previous flex/docked behavior at all desktop widths.

Closes #477.