### PR TITLE
Hong: Fix interactive video mobile review UX

### DIFF
--- a/fe/src/app/core/utils/interactive-video-runtime.spec.ts
+++ b/fe/src/app/core/utils/interactive-video-runtime.spec.ts
@@ -139,6 +139,28 @@ describe('interactive-video-runtime', () => {
     )).toBe(5);
   });
 
+  it('prefers the per-answer review target over a default branch review action', () => {
+    const interaction: InteractiveVideoInteraction = {
+      id: 'review-branch',
+      type: 'branch',
+      atSeconds: 47,
+      adaptivity: {
+        requireCorrectBeforeContinue: true,
+        onWrong: { type: 'seek', targetTimeSeconds: 0 },
+      },
+      choices: [
+        { id: 'wrong', label: 'Wrong', isCorrect: false, targetTimeSeconds: 17 },
+        { id: 'right', label: 'Right', isCorrect: true },
+      ],
+    };
+
+    expect(resolveInteractiveVideoReviewTarget(
+      interaction,
+      interaction.choices![0],
+      timeline,
+    )).toBe(17);
+  });
+
   it('does not invent a review target when no seek destination is configured', () => {
     const interaction: InteractiveVideoInteraction = {
       id: 'review-without-target',

--- a/fe/src/app/core/utils/interactive-video-runtime.ts
+++ b/fe/src/app/core/utils/interactive-video-runtime.ts
@@ -204,6 +204,11 @@ export function resolveInteractiveVideoReviewTarget(
   const adaptivityAction = choice.isCorrect === true
     ? interaction.adaptivity?.onCorrect
     : interaction.adaptivity?.onWrong;
+  const choiceTarget = resolveInteractiveVideoChoiceTarget(
+    choice,
+    timeline,
+    { sourceTimeSeconds: interaction.atSeconds, allowBackwardSeek: true },
+  );
   const adaptivityTarget = adaptivityAction?.type === 'seek'
     ? resolveInteractiveVideoChoiceTarget(
         {
@@ -216,12 +221,7 @@ export function resolveInteractiveVideoReviewTarget(
         { sourceTimeSeconds: interaction.atSeconds, allowBackwardSeek: true },
       )
     : null;
-  const choiceTarget = resolveInteractiveVideoChoiceTarget(
-    choice,
-    timeline,
-    { sourceTimeSeconds: interaction.atSeconds, allowBackwardSeek: true },
-  );
-  const target = adaptivityTarget ?? choiceTarget;
+  const target = choiceTarget ?? adaptivityTarget;
 
   return target == null ? null : Math.max(0, target);
 }

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.html
@@ -840,23 +840,36 @@
                             class="h-3.5 w-3.5 rounded text-[#0056D2] focus:ring-[#0056D2]" />
                           Đáp án đúng
                         </label>
-                        <input type="number" min="0" step="1"
-                          [attr.max]="maxInteractiveTimeSeconds() ?? null"
-                          [ngModel]="choice.targetTimeSeconds"
-                          (ngModelChange)="onInteractiveChoiceTargetChange(interaction.id, choice.id, $event)"
-                          placeholder="Xem lại từ giây"
-                          class="rounded-lg border border-slate-200 px-3 py-2 text-sm tabular-nums focus:border-[#0056D2] focus:ring-[#0056D2]"
-                          aria-label="Mốc xem lại khi trả lời sai" />
-                        <select
-                          [ngModel]="choice.targetInteractionId ?? ''"
-                          (ngModelChange)="onInteractiveChoiceTargetInteractionChange(interaction.id, choice.id, $event)"
-                          class="rounded-lg border border-slate-200 bg-white px-2.5 py-2 text-sm text-slate-700 focus:border-[#0056D2] focus:ring-[#0056D2]"
-                          aria-label="Điểm xem lại">
-                          <option [ngValue]="''">Theo giây</option>
-                          @for (target of getInteractiveBranchTargets(interaction.id); track target.id) {
-                            <option [ngValue]="target.id">{{ formatInteractiveBranchTargetLabel(target) }}</option>
-                          }
-                        </select>
+                        <div class="flex min-w-[13rem] items-stretch overflow-hidden rounded-lg border border-slate-200 bg-white focus-within:border-[#0056D2] focus-within:ring-1 focus-within:ring-[#0056D2]">
+                          <span class="flex shrink-0 items-center border-r border-slate-200 bg-slate-50 px-2 text-[11px] font-semibold text-slate-500">
+                            Xem lại từ
+                          </span>
+                          <input type="text"
+                            inputmode="numeric"
+                            pattern="[0-9:]*"
+                            [value]="formatInteractiveBranchTargetInput(choice)"
+                            (change)="onInteractiveChoiceTargetInputChange(interaction.id, choice.id, $event)"
+                            (keydown.enter)="onInteractiveChoiceTargetInputChange(interaction.id, choice.id, $event)"
+                            (keydown.arrowup)="stepInteractiveChoiceTarget(interaction.id, choice.id, 1); $event.preventDefault()"
+                            (keydown.arrowdown)="stepInteractiveChoiceTarget(interaction.id, choice.id, -1); $event.preventDefault()"
+                            placeholder="00:00:17"
+                            class="min-w-0 flex-1 border-0 px-3 py-2 text-sm tabular-nums text-slate-800 placeholder:text-slate-400 focus:ring-0"
+                            aria-label="Xem lại từ giờ phút giây khi trả lời sai" />
+                          <div class="flex w-8 shrink-0 flex-col border-l border-slate-200 bg-slate-50">
+                            <button type="button"
+                              class="flex flex-1 items-center justify-center text-slate-500 hover:bg-slate-100 hover:text-[#0056D2]"
+                              aria-label="Tăng mốc xem lại 1 giây"
+                              (click)="stepInteractiveChoiceTarget(interaction.id, choice.id, 1)">
+                              <lucide-icon name="chevron-up" [size]="12"></lucide-icon>
+                            </button>
+                            <button type="button"
+                              class="flex flex-1 items-center justify-center border-t border-slate-200 text-slate-500 hover:bg-slate-100 hover:text-[#0056D2]"
+                              aria-label="Giảm mốc xem lại 1 giây"
+                              (click)="stepInteractiveChoiceTarget(interaction.id, choice.id, -1)">
+                              <lucide-icon name="chevron-down" [size]="12"></lucide-icon>
+                            </button>
+                          </div>
+                        </div>
                       } @else {
                         <label class="inline-flex items-center justify-center gap-1.5 rounded-lg border border-slate-200 px-2 text-xs font-medium text-slate-600">
                           <input type="checkbox"

--- a/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
+++ b/fe/src/app/features/teacher/course-editor/pages/course-curriculum/components/section-editor/interactive-video-authoring-panel.component.ts
@@ -299,26 +299,42 @@ export class InteractiveVideoAuthoringPanelComponent {
     });
   }
 
-  onInteractiveChoiceTargetChange(
+  private updateInteractiveChoiceTarget(
     interactionId: string,
     choiceId: string,
     value: unknown,
   ): void {
+    const targetTimeSeconds = this.normalizeOptionalInteractiveTime(value);
     this.svc.updateInteractiveVideoChoice(interactionId, choiceId, {
-      targetTimeSeconds: this.normalizeOptionalInteractiveTime(value),
+      targetTimeSeconds,
       targetInteractionId: null,
     });
   }
 
-  onInteractiveChoiceTargetInteractionChange(
+  onInteractiveChoiceTargetInputChange(
     interactionId: string,
     choiceId: string,
-    value: string,
+    event: Event,
   ): void {
+    const input = event.target as HTMLInputElement | null;
+    const targetTimeSeconds = this.normalizeOptionalInteractiveTime(input?.value ?? '');
     this.svc.updateInteractiveVideoChoice(interactionId, choiceId, {
-      targetInteractionId: value || null,
-      targetTimeSeconds: value ? null : undefined,
+      targetTimeSeconds,
+      targetInteractionId: null,
     });
+    if (input) {
+      input.value = targetTimeSeconds == null ? '' : this.formatInteractiveDurationInput(targetTimeSeconds);
+    }
+  }
+
+  stepInteractiveChoiceTarget(
+    interactionId: string,
+    choiceId: string,
+    deltaSeconds: number,
+  ): void {
+    const choice = this.findInteractiveChoice(interactionId, choiceId);
+    const currentSeconds = choice ? this.resolveInteractiveChoiceTargetSeconds(choice) ?? 0 : 0;
+    this.updateInteractiveChoiceTarget(interactionId, choiceId, currentSeconds + deltaSeconds);
   }
 
   async onInteractiveImportSelected(event: Event): Promise<void> {
@@ -790,11 +806,6 @@ export class InteractiveVideoAuthoringPanelComponent {
     });
   }
 
-  getInteractiveBranchTargets(sourceInteractionId: string): InteractiveVideoInteraction[] {
-    return this.sortInteractiveTimeline(this.svc.sectionInteractiveVideoTimeline())
-      .filter(interaction => interaction.id !== sourceInteractionId);
-  }
-
   getInteractiveTypeLabel(type: InteractiveVideoInteractionType): string {
     switch (type) {
       case 'single_choice': return 'Câu hỏi';
@@ -875,15 +886,15 @@ export class InteractiveVideoAuthoringPanelComponent {
     return this.formatInteractiveFlowTime(seconds);
   }
 
-  formatInteractiveBranchTargetLabel(target: InteractiveVideoInteraction): string {
-    const title = target.title?.trim() || this.getInteractiveTypeLabel(target.type);
-    return `${this.formatInteractiveFlowTime(target.atSeconds)} · ${title}`;
+  formatInteractiveBranchTargetInput(choice: InteractiveVideoChoice): string {
+    const seconds = this.resolveInteractiveChoiceTargetSeconds(choice);
+    return seconds == null ? '' : this.formatInteractiveDurationInput(seconds);
   }
 
   getInteractiveChoiceRowClass(type: InteractiveVideoInteractionType): string {
     const base = 'grid gap-2 px-3 py-2';
     return type === 'branch'
-      ? `${base} sm:grid-cols-[minmax(0,1fr)_7rem_7rem_minmax(8rem,10rem)_auto]`
+      ? `${base} sm:grid-cols-[minmax(0,1fr)_7rem_minmax(13rem,16rem)_auto]`
       : `${base} sm:grid-cols-[minmax(0,1fr)_8rem_auto]`;
   }
 
@@ -1069,7 +1080,67 @@ export class InteractiveVideoAuthoringPanelComponent {
     if (value == null || value === '') {
       return null;
     }
-    return this.clampInteractiveTime(value);
+    const seconds = this.parseInteractiveTimeInput(value);
+    return seconds == null ? null : this.clampInteractiveTime(seconds);
+  }
+
+  private parseInteractiveTimeInput(value: unknown): number | null {
+    if (typeof value === 'number') {
+      return value;
+    }
+
+    const text = String(value).trim();
+    if (!text) {
+      return null;
+    }
+
+    if (!text.includes(':')) {
+      return /^\d+$/.test(text) ? this.toNonNegativeInteger(text) : null;
+    }
+
+    const parts = text.split(':').map(part => part.trim());
+    if (parts.length < 2 || parts.length > 3 || parts.some(part => !/^\d+$/.test(part))) {
+      return null;
+    }
+
+    const [hours, minutes, seconds] = parts.length === 3
+      ? parts.map(part => Number(part))
+      : [0, Number(parts[0]), Number(parts[1])];
+    return (hours * 3600) + (minutes * 60) + seconds;
+  }
+
+  private formatInteractiveDurationInput(seconds: number | null | undefined): string {
+    const safeSeconds = this.clampInteractiveTime(seconds ?? 0);
+    const hours = Math.floor(safeSeconds / 3600);
+    const minutes = Math.floor((safeSeconds % 3600) / 60);
+    const rest = safeSeconds % 60;
+    return [
+      hours.toString().padStart(2, '0'),
+      minutes.toString().padStart(2, '0'),
+      rest.toString().padStart(2, '0'),
+    ].join(':');
+  }
+
+  private resolveInteractiveChoiceTargetSeconds(choice: InteractiveVideoChoice): number | null {
+    if (choice.targetTimeSeconds != null) {
+      return this.clampInteractiveTime(choice.targetTimeSeconds);
+    }
+    if (!choice.targetInteractionId) {
+      return null;
+    }
+    const target = this.svc.sectionInteractiveVideoTimeline()
+      .find(interaction => interaction.id === choice.targetInteractionId);
+    return target ? this.clampInteractiveTime(target.atSeconds) : null;
+  }
+
+  private findInteractiveChoice(
+    interactionId: string,
+    choiceId: string,
+  ): InteractiveVideoChoice | null {
+    return this.svc.sectionInteractiveVideoTimeline()
+      .find(interaction => interaction.id === interactionId)
+      ?.choices
+      ?.find(choice => choice.id === choiceId) ?? null;
   }
 
   private getTimelineSecondsFromPointer(event: PointerEvent): number {

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.spec.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.spec.ts
@@ -24,6 +24,14 @@ describe('interactive-video-authoring', () => {
     expect(created.pause).toBeTrue();
   });
 
+  it('does not default new review branches to seek back to the video start', () => {
+    const created = createInteractiveVideoInteraction([], 'branch');
+
+    expect(created.adaptivity?.requireCorrectBeforeContinue).toBeTrue();
+    expect(created.adaptivity?.onWrong?.type).toBe('continue');
+    expect(created.adaptivity?.onWrong?.targetTimeSeconds).toBeUndefined();
+  });
+
   it('creates a default fill-blank interaction with editable blanks', () => {
     const created = createInteractiveVideoInteraction([], 'fill_blank', {
       durationSeconds: 90,

--- a/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
+++ b/fe/src/app/features/teacher/course-editor/utils/interactive-video-authoring.ts
@@ -83,9 +83,7 @@ export function createInteractiveVideoInteraction(
       ? {
           requireCorrectBeforeContinue: true,
           onWrong: {
-            type: 'seek',
-            targetTimeSeconds: 0,
-            targetInteractionId: null,
+            type: 'continue',
             message: 'Hãy xem lại đoạn video trước khi thử trả lời lại.',
           },
           onCorrect: {

--- a/fe/src/app/shared/blocks/video-block/interactive-video-drag-drop.component.spec.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-drag-drop.component.spec.ts
@@ -39,7 +39,7 @@ describe('InteractiveVideoDragDropComponent', () => {
     });
   });
 
-  it('places draggables by click fallback and treats unplaced distractors as correct', () => {
+  it('places draggables by click fallback and shows distractors as red after checking', () => {
     fixture.detectChanges();
 
     click('[data-testid="interactive-video-drag-drop-draggable-vest"]');
@@ -52,8 +52,9 @@ describe('InteractiveVideoDragDropComponent', () => {
       .toContain('2/2');
     expect(element.querySelector('[data-testid="interactive-video-drag-drop-draggable-vest"]')?.getAttribute('data-state'))
       .toBe('correct');
-    expect(element.querySelector('[data-testid="interactive-video-drag-drop-draggable-anchor"]')?.getAttribute('data-state'))
-      .toBe('correct');
+    const distractor = element.querySelector('[data-testid="interactive-video-drag-drop-draggable-anchor"]') as HTMLElement;
+    expect(distractor.getAttribute('data-state')).toBe('wrong');
+    expect(distractor.className).toContain('bg-red-50');
   });
 
   it('marks a distractor wrong when it is placed in the answer zone', () => {
@@ -71,6 +72,25 @@ describe('InteractiveVideoDragDropComponent', () => {
       .toContain('1/2');
     expect(element.querySelector('[data-testid="interactive-video-drag-drop-draggable-anchor"]')?.getAttribute('data-state'))
       .toBe('wrong');
+  });
+
+  it('keeps the drag canvas and answer tray side by side on tablet and desktop widths', () => {
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.layoutClass()).toContain('md:grid-cols-');
+    expect(fixture.componentInstance.layoutClass()).not.toContain('xl:grid-cols-');
+    expect(fixture.componentInstance.draggableGridClass()).toContain('sm:grid-cols-2');
+  });
+
+  it('keeps compact answer cards readable in the teacher preview overlay', () => {
+    fixture.componentRef.setInput('density', 'compact');
+    fixture.detectChanges();
+
+    const cardClass = fixture.componentInstance.draggableCardClass(fixture.componentInstance.draggables()[0]);
+
+    expect(fixture.componentInstance.draggableMediaClass()).toContain('h-14');
+    expect(cardClass).toContain('min-h-[4.5rem]');
+    expect(cardClass).not.toContain('min-h-[6.5rem]');
   });
 
   it('keeps continue disabled before checking when the interaction is required', () => {

--- a/fe/src/app/shared/blocks/video-block/interactive-video-drag-drop.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-drag-drop.component.ts
@@ -128,7 +128,16 @@ interface DragDropResultState {
                           </span>
                           @if (isChecked()) {
                             <span [class]="placedStatusClass(draggable)" aria-hidden="true">
-                              {{ isDraggableCorrect(draggable) ? '✓' : '×' }}
+                              @if (isDraggableCorrect(draggable)) {
+                                <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.75" stroke-linecap="round" stroke-linejoin="round">
+                                  <path d="m5 12 5 5L20 7" />
+                                </svg>
+                              } @else {
+                                <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.75" stroke-linecap="round" stroke-linejoin="round">
+                                  <path d="M18 6 6 18" />
+                                  <path d="m6 6 12 12" />
+                                </svg>
+                              }
                             </span>
                           }
                         </span>
@@ -205,7 +214,16 @@ interface DragDropResultState {
                   </span>
                   @if (isChecked()) {
                     <span [class]="draggableStatusClass(draggable)" aria-hidden="true">
-                      {{ draggableResultIcon(draggable) }}
+                      @if (isDraggableDisplayedAsCorrect(draggable)) {
+                        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.75" stroke-linecap="round" stroke-linejoin="round">
+                          <path d="m5 12 5 5L20 7" />
+                        </svg>
+                      } @else {
+                        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.75" stroke-linecap="round" stroke-linejoin="round">
+                          <path d="M18 6 6 18" />
+                          <path d="m6 6 12 12" />
+                        </svg>
+                      }
                     </span>
                   }
                 </button>
@@ -498,10 +516,6 @@ export class InteractiveVideoDragDropComponent {
     return this.evaluation().states.find(state => state.draggableId === draggable.id)?.isCorrect === true;
   }
 
-  draggableResultIcon(draggable: InteractiveVideoDragDropDraggable): string {
-    return this.isDraggableDisplayedAsCorrect(draggable) ? '✓' : '×';
-  }
-
   dropZoneClass(zone: InteractiveVideoDragDropZone): string {
     const base = [
       'drag-drop-zone absolute flex -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center rounded-2xl border-2 px-2 py-1 text-center',
@@ -633,7 +647,7 @@ export class InteractiveVideoDragDropComponent {
       .map(zone => zone.id);
   }
 
-  private isDraggableDisplayedAsCorrect(draggable: InteractiveVideoDragDropDraggable): boolean {
+  isDraggableDisplayedAsCorrect(draggable: InteractiveVideoDragDropDraggable): boolean {
     return this.getCorrectZoneIds(draggable).length > 0 && this.isDraggableCorrect(draggable);
   }
 }

--- a/fe/src/app/shared/blocks/video-block/interactive-video-drag-drop.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-drag-drop.component.ts
@@ -159,7 +159,7 @@ interface DragDropResultState {
             </div>
           </div>
 
-          <aside class="min-w-0 rounded-2xl border border-slate-200 bg-slate-50/90 p-3">
+          <aside class="min-w-0 self-start rounded-2xl border border-slate-200 bg-slate-50/90 p-3 md:max-h-[min(32rem,calc(100dvh-12rem))] md:overflow-y-auto">
             <div class="flex items-start justify-between gap-2">
               <div>
                 <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Vật dụng</p>
@@ -199,11 +199,13 @@ interface DragDropResultState {
                     }
                   </span>
                   <span class="min-w-0 flex-1 text-left">
-                    <span class="block text-sm font-extrabold leading-snug text-slate-800">{{ draggable.label }}</span>
+                    <span class="block whitespace-normal text-sm font-extrabold leading-snug text-slate-800 [overflow-wrap:normal]">
+                      {{ draggable.label }}
+                    </span>
                   </span>
                   @if (isChecked()) {
                     <span [class]="draggableStatusClass(draggable)" aria-hidden="true">
-                      {{ isDraggableCorrect(draggable) ? '✓' : '×' }}
+                      {{ draggableResultIcon(draggable) }}
                     </span>
                   }
                 </button>
@@ -484,7 +486,7 @@ export class InteractiveVideoDragDropComponent {
 
   draggableState(draggable: InteractiveVideoDragDropDraggable): 'idle' | 'placed' | 'selected' | 'correct' | 'wrong' {
     if (this.isChecked()) {
-      return this.isDraggableCorrect(draggable) ? 'correct' : 'wrong';
+      return this.isDraggableDisplayedAsCorrect(draggable) ? 'correct' : 'wrong';
     }
     if (this.selectedDraggableId() === draggable.id) {
       return 'selected';
@@ -494,6 +496,10 @@ export class InteractiveVideoDragDropComponent {
 
   isDraggableCorrect(draggable: InteractiveVideoDragDropDraggable): boolean {
     return this.evaluation().states.find(state => state.draggableId === draggable.id)?.isCorrect === true;
+  }
+
+  draggableResultIcon(draggable: InteractiveVideoDragDropDraggable): string {
+    return this.isDraggableDisplayedAsCorrect(draggable) ? '✓' : '×';
   }
 
   dropZoneClass(zone: InteractiveVideoDragDropZone): string {
@@ -539,8 +545,8 @@ export class InteractiveVideoDragDropComponent {
 
   layoutClass(): string {
     return this.density() === 'compact'
-      ? 'grid gap-4 lg:grid-cols-[minmax(0,1.05fr)_minmax(22rem,0.95fr)] lg:items-center'
-      : 'grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(22rem,0.72fr)] xl:items-start';
+      ? 'grid gap-3 md:grid-cols-[minmax(0,1.2fr)_minmax(20rem,0.9fr)] md:items-center'
+      : 'grid gap-4 md:grid-cols-[minmax(0,1.35fr)_minmax(22rem,1fr)] md:items-start';
   }
 
   stageClass(): string {
@@ -551,26 +557,20 @@ export class InteractiveVideoDragDropComponent {
   }
 
   draggableGridClass(): string {
-    return this.density() === 'compact'
-      ? 'mt-3 grid gap-2 grid-cols-[repeat(auto-fit,minmax(13.5rem,1fr))]'
-      : 'mt-3 grid gap-2 sm:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2';
+    return 'mt-3 grid gap-2 sm:grid-cols-2';
   }
 
   draggableMediaClass(): string {
-    return this.density() === 'compact'
-      ? 'flex h-24 w-24 shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm'
-      : 'flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm';
+    return 'flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm';
   }
 
   draggableImageClass(): string {
-    return this.density() === 'compact'
-      ? 'max-h-[5.25rem] max-w-full object-contain'
-      : 'max-h-12 max-w-full object-contain';
+    return 'max-h-12 max-w-full object-contain';
   }
 
   draggableCardClass(draggable: InteractiveVideoDragDropDraggable): string {
     const base = this.density() === 'compact'
-      ? 'drag-drop-item flex min-h-[6.5rem] w-full min-w-0 cursor-grab items-center gap-3 rounded-2xl border px-3 py-2.5 text-left disabled:cursor-not-allowed'
+      ? 'drag-drop-item flex min-h-[4.5rem] w-full min-w-0 cursor-grab items-center gap-2 rounded-xl border px-2.5 py-2 text-left disabled:cursor-not-allowed'
       : 'drag-drop-item flex w-full min-w-0 cursor-grab items-center gap-2 rounded-xl border px-2.5 py-2 text-left disabled:cursor-not-allowed';
     switch (this.draggableState(draggable)) {
       case 'selected':
@@ -605,7 +605,7 @@ export class InteractiveVideoDragDropComponent {
 
   draggableStatusClass(draggable: InteractiveVideoDragDropDraggable): string {
     const base = 'flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-sm font-black shadow-sm';
-    return this.isDraggableCorrect(draggable)
+    return this.isDraggableDisplayedAsCorrect(draggable)
       ? `${base} bg-emerald-100 text-emerald-700`
       : `${base} bg-red-100 text-red-700`;
   }
@@ -631,5 +631,9 @@ export class InteractiveVideoDragDropComponent {
     return this.dropZones()
       .filter(zone => zone.correctDraggableIds.includes(draggable.id))
       .map(zone => zone.id);
+  }
+
+  private isDraggableDisplayedAsCorrect(draggable: InteractiveVideoDragDropDraggable): boolean {
+    return this.getCorrectZoneIds(draggable).length > 0 && this.isDraggableCorrect(draggable);
   }
 }

--- a/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.spec.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.spec.ts
@@ -33,6 +33,8 @@ describe('InteractiveVideoOverlayComponent', () => {
       .find(button => button.textContent?.includes('Tiếp tục')) as HTMLButtonElement;
 
     expect(dialog.getAttribute('aria-modal')).toBe('true');
+    expect(dialog.parentElement?.classList).toContain('interactive-video-overlay');
+    expect(dialog.classList).toContain('interactive-video-overlay__panel');
     expect(dialog.getAttribute('aria-labelledby')).toBe('interactive-video-title-q1');
     expect(dialog.getAttribute('aria-describedby')).toBe('interactive-video-body-q1');
     expect(continueButton.disabled).toBeTrue();
@@ -49,6 +51,26 @@ describe('InteractiveVideoOverlayComponent', () => {
     expect(continueButton.disabled).toBeFalse();
     expect(continueButton.hasAttribute('aria-describedby')).toBeFalse();
     expect(element.querySelector('#interactive-video-choice-hint-q1')).toBeNull();
+  });
+
+  it('gives drag/drop interactions a wide scrollable panel for the two-column workspace', () => {
+    fixture.componentRef.setInput('interaction', {
+      id: 'drag-layout',
+      type: 'drag_drop',
+      atSeconds: 12,
+      title: 'Drag layout',
+      dragDrop: {
+        instruction: 'Pick the right item.',
+        backgroundImage: null,
+        dropZones: [],
+        draggables: [],
+      },
+    });
+    fixture.detectChanges();
+
+    const dialog = fixture.nativeElement.querySelector('[role="dialog"]') as HTMLElement;
+    expect(dialog.classList).toContain('max-w-6xl');
+    expect(dialog.classList).toContain('overflow-y-auto');
   });
 
   it('keeps continue disabled until the selected choice is correct when required by adaptivity', () => {

--- a/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
@@ -29,6 +29,47 @@ type ChoiceAnswerState = 'idle' | 'selected' | 'selected-correct' | 'selected-wr
   selector: 'app-interactive-video-overlay',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [InteractiveVideoDragDropComponent, InteractiveVideoFillBlankComponent],
+  styles: [`
+    :host {
+      display: contents;
+    }
+
+    .interactive-video-overlay {
+      overscroll-behavior: contain;
+    }
+
+    .interactive-video-overlay__panel {
+      overflow-wrap: anywhere;
+      overscroll-behavior: contain;
+    }
+
+    @media (max-width: 640px) {
+      .interactive-video-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 60;
+        align-items: flex-end;
+        justify-content: center;
+        padding: 0.75rem 0.75rem calc(5.25rem + env(safe-area-inset-bottom));
+        overflow-y: auto;
+      }
+
+      .interactive-video-overlay__panel {
+        width: 100%;
+        max-width: calc(100vw - 1.5rem);
+        max-height: calc(100vh - 7rem);
+        border-radius: 1rem;
+      }
+    }
+
+    @supports (height: 100dvh) {
+      @media (max-width: 640px) {
+        .interactive-video-overlay__panel {
+          max-height: calc(100dvh - 7rem);
+        }
+      }
+    }
+  `],
   template: `
     <div [class]="overlayClass()">
       <section
@@ -303,24 +344,24 @@ export class InteractiveVideoOverlayComponent implements OnDestroy {
   });
 
   readonly overlayClass = computed(() => {
-    const base = 'absolute inset-0 z-20 flex bg-slate-950/70';
+    const base = 'interactive-video-overlay absolute inset-0 z-20 flex bg-slate-950/70';
     if (this.density() === 'compact') {
       return `${base} items-end justify-center overflow-y-auto p-2 sm:items-center sm:p-3`;
     }
-    return `${base} items-center justify-center px-4`;
+    return `${base} items-center justify-center overflow-y-auto px-4 py-3`;
   });
 
   readonly panelClass = computed(() => {
-    const base = 'w-full rounded-lg border border-white/10 bg-white text-slate-900 shadow-2xl';
+    const base = 'interactive-video-overlay__panel w-full min-w-0 max-h-full overflow-x-hidden overflow-y-auto rounded-lg border border-white/10 bg-white text-slate-900 shadow-2xl';
     if (this.density() === 'compact') {
       return this.isDragDropInteraction()
-        ? `${base} max-h-full max-w-[72rem] overflow-y-auto p-3 sm:p-4`
+        ? `${base} max-w-[72rem] p-3 sm:p-4`
         : this.isFillBlankInteraction()
-        ? `${base} max-h-full max-w-xl overflow-y-auto p-3 sm:p-4`
-        : `${base} max-h-full max-w-lg overflow-y-auto p-3 sm:p-4`;
+        ? `${base} max-w-xl p-3 sm:p-4`
+        : `${base} max-w-lg p-3 sm:p-4`;
     }
     return this.isDragDropInteraction()
-      ? `${base} max-w-5xl p-4 sm:p-5`
+      ? `${base} max-w-6xl p-3 sm:p-5`
       : this.isFillBlankInteraction()
       ? `${base} max-w-2xl p-4 sm:p-5`
       : `${base} max-w-xl p-4 sm:p-5`;

--- a/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
+++ b/fe/src/app/shared/blocks/video-block/interactive-video-overlay.component.ts
@@ -129,9 +129,18 @@ type ChoiceAnswerState = 'idle' | 'selected' | 'selected-correct' | 'selected-wr
                 [attr.data-answer-state]="choiceAnswerState(item.choice)"
                 (click)="choiceSelected.emit(item.choice)">
                 <span class="flex items-center gap-2">
-                  @if (choiceStateIcon(item.choice); as stateIcon) {
+                  @if (choiceStateIconName(item.choice); as stateIcon) {
                     <span [class]="choiceStateIconClass(item.choice)" aria-hidden="true">
-                      {{ stateIcon }}
+                      @if (stateIcon === 'check') {
+                        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                          <path d="m5 12 5 5L20 7" />
+                        </svg>
+                      } @else {
+                        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                          <path d="M18 6 6 18" />
+                          <path d="m6 6 12 12" />
+                        </svg>
+                      }
                     </span>
                   }
                   <span class="min-w-0" [innerHTML]="item.html"></span>
@@ -167,7 +176,10 @@ type ChoiceAnswerState = 'idle' | 'selected' | 'selected-correct' | 'selected-wr
               class="ml-auto inline-flex shrink-0 items-center gap-2 rounded-lg bg-[#0056D2] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#004BB5] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#0056D2]/40"
               data-testid="interactive-video-review-button"
               (click)="reviewRequested.emit()">
-              <span aria-hidden="true">↺</span>
+              <svg class="h-4 w-4" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                <path d="M3 3v5h5" />
+              </svg>
               Xem lại video
             </button>
           } @else {
@@ -422,13 +434,13 @@ export class InteractiveVideoOverlayComponent implements OnDestroy {
     }
   }
 
-  choiceStateIcon(choice: InteractiveVideoChoice): string | null {
+  choiceStateIconName(choice: InteractiveVideoChoice): 'check' | 'x' | null {
     switch (this.choiceAnswerState(choice)) {
       case 'selected-correct':
       case 'correct-answer':
-        return '✓';
+        return 'check';
       case 'selected-wrong':
-        return '×';
+        return 'x';
       default:
         return null;
     }


### PR DESCRIPTION
﻿## Summary
- Improve interactive video overlays so mobile learners can scroll and interact with the prompt instead of being blocked by a cramped video-level panel.
- Restore the drag/drop quiz workspace toward the original H5P-like layout: stage on the left, answer tray on the right for tablet/desktop, with readable compact cards and red styling for wrong/distractor answers after checking.
- Simplify branch review authoring by replacing the seconds input + "Theo giây" select with one HH:MM:SS review-time input and step controls.
- Fix branch review playback so per-answer review targets win over the default branch adaptivity action instead of always seeking back to the start.

## Root Cause
- Drag/drop only switched to a side-by-side layout at wider breakpoints and compact answer cards used oversized thumbnails, causing labels to collapse vertically and making mobile/tablet interaction difficult.
- Drag/drop result styling reused scoring correctness for display correctness, so distractor/wrong options could appear green after checking.
- Branch review resolution preferred default adaptivity seek targets before per-choice targets, causing wrong answers to seek to `0s` even when the teacher entered a specific review time.
- The branch authoring UI exposed two competing controls for review target selection, making the workflow confusing.

## Validation
- `npm run test:ci -- --include=src/app/shared/blocks/video-block/interactive-video-overlay.component.spec.ts --include=src/app/shared/blocks/video-block/interactive-video-drag-drop.component.spec.ts --include=src/app/core/utils/interactive-video-runtime.spec.ts --include=src/app/features/teacher/course-editor/utils/interactive-video-authoring.spec.ts` (`TOTAL: 501 SUCCESS`)
- `npm run build`
- `git diff --cached --check`
