### PR TITLE
[codex] Web bug audit fixes

### DIFF
--- a/fe/src/app/features/teacher/assignment-hub/components/quiz-list.component.html
+++ b/fe/src/app/features/teacher/assignment-hub/components/quiz-list.component.html
@@ -470,10 +470,6 @@
         }
       }
     </div>
-    <div dialogFooter>
-      <button type="button" (click)="closeCreateModal()" class="rounded-lg border border-gray-200 px-3.5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">Hủy</button>
-      <button type="button" (click)="proceedToStep2()" [disabled]="!createSelectedCourseId()" class="rounded-lg bg-[#0056D2] px-3.5 py-2 text-sm font-medium text-white hover:bg-[#004BB5] disabled:opacity-40">Tiếp tục</button>
-    </div>
   } @else {
     <div class="space-y-4">
       <div class="flex items-center gap-2 text-sm">
@@ -511,11 +507,16 @@
         <p class="text-sm text-red-600">{{ createError() }}</p>
       }
     </div>
-    <div dialogFooter>
+  }
+  <div dialogFooter>
+    @if (createStep() === 1) {
+      <button type="button" (click)="closeCreateModal()" class="rounded-lg border border-gray-200 px-3.5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">Hủy</button>
+      <button type="button" (click)="proceedToStep2()" [disabled]="!createSelectedCourseId()" class="rounded-lg bg-[#0056D2] px-3.5 py-2 text-sm font-medium text-white hover:bg-[#004BB5] disabled:opacity-40">Tiếp tục</button>
+    } @else {
       <button type="button" (click)="backToStep1()" class="rounded-lg border border-gray-200 px-3.5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">Quay lại</button>
       <button type="button" (click)="submitCreate()" [disabled]="createLoading() || !createSelectedChapterId() || !createTitle().trim()" class="rounded-lg bg-[#0056D2] px-3.5 py-2 text-sm font-medium text-white hover:bg-[#004BB5] disabled:opacity-40">
         {{ createLoading() ? 'Đang tạo...' : 'Tạo bài kiểm tra' }}
       </button>
-    </div>
-  }
+    }
+  </div>
 </app-dialog>


### PR DESCRIPTION
## Description
Fixes the create-quiz dialog footer projection in the teacher assignment hub. Angular reported that `dialogFooter` was inside a control-flow block with multiple root nodes, so the modal action buttons could fail to project into the dialog footer slot.

## Motivation
The create quiz modal should keep its action buttons in the dialog footer across both creation steps. The previous template structure could place those controls in the wrong part of the dialog and produced Angular template warning NG8011.

## Type of Change
- Bug fix

## Related Issues
- None linked. Found during web bug audit/build verification.

## Changes Made
- Moved the `dialogFooter` node in `quiz-list.component.html` to be a direct child of `app-dialog`.
- Kept the step-specific buttons conditional inside the footer so step 1 and step 2 behavior stays the same.

## Scope Note
Focused frontend template fix only. I did not touch unrelated local changes in the main worktree.

## Testing Guide
1. Open the teacher assignment/quiz area.
2. Open the create quiz modal.
3. Confirm step 1 shows `Hủy` and `Tiếp tục` in the footer.
4. Continue to step 2 and confirm `Quay lại` and `Tạo bài kiểm tra` stay in the footer.

## Local Checks
- `npm ci` passed locally, with existing Node engine warnings because local Node is `v22.12.0`.
- `npx ng build --configuration development --progress=false` passed after the fix; the NG8011 warning for `quiz-list.component.html` is gone.
- `mvn -DskipTests compile -B` passed for the backend.
- `git diff --check` passed.

## Checklist
- [x] PR was opened before applying the fix, as requested.
- [x] Fix is committed and pushed to `codex/web-bug-audit-fixes`.
- [x] Build verification completed locally.