### PR TITLE
[codex] Publish Unity WebGPU simulation v2026.05.16.1

### DIFF
--- a/docs/runbooks/UNITY_WEBGL_R2_PROD_RUNBOOK.md
+++ b/docs/runbooks/UNITY_WEBGL_R2_PROD_RUNBOOK.md
@@ -1,7 +1,7 @@
 # Unity WebGL R2 Production Runbook
 
-Date: 2026-05-14
-Status: Unity WebGPU package `colreg-rule-15-crossing/v2026.05.14.1` is published to the existing `lms-storage` R2 bucket for staging and production. Production Worker/R2 access is verified through Cloudflare; live same-origin `/simulations/*` on `holilihu.online` remains gated by the root-domain proxy state.
+Date: 2026-05-16
+Status: Unity WebGPU package `colreg-rule-15-crossing/v2026.05.16.1` is published to the existing `lms-storage` R2 bucket for staging and production. Production Worker/R2 access is verified through Cloudflare on the proxied media host; live same-origin `/simulations/*` on `holilihu.online` remains gated by the root-domain proxy state.
 
 ## Decision
 
@@ -139,10 +139,10 @@ simulations/colreg-rule-15-crossing/v2026.05.12.1/holilihu-simulation.json
 Current published package:
 
 ```text
-simulations/colreg-rule-15-crossing/v2026.05.14.1/index.html
-simulations/colreg-rule-15-crossing/v2026.05.14.1/Build/HoliLihuWebGPU_Full.wasm
-simulations/colreg-rule-15-crossing/v2026.05.14.1/Build/HoliLihuWebGPU_Full.data
-simulations/colreg-rule-15-crossing/v2026.05.14.1/holilihu-simulation.json
+simulations/colreg-rule-15-crossing/v2026.05.16.1/index.html
+simulations/colreg-rule-15-crossing/v2026.05.16.1/Build/HoliLihuWebGPU_Full.wasm
+simulations/colreg-rule-15-crossing/v2026.05.16.1/Build/HoliLihuWebGPU_Full.data
+simulations/colreg-rule-15-crossing/v2026.05.16.1/holilihu-simulation.json
 ```
 
 Never mutate a version after publishing to learners. If Unity exports a fix, publish a new version folder and update the LMS package record.
@@ -225,6 +225,13 @@ Then open the staging lesson in a desktop Chrome/Edge browser and confirm:
 - Production manifest, `index.html`, and `.wasm` return `200 OK` with `Server: cloudflare` and `X-HoliLihu-Simulation-Origin: r2` when served through Cloudflare.
 - `.wasm` returns `Content-Type: application/wasm` and immutable cache headers.
 - Direct root-domain requests still reach VM/Caddy until `holilihu.online` is proxied.
+
+2026-05-16 verification for `v2026.05.16.1`:
+
+- Staging and production packages were uploaded to `lms-storage`.
+- `media.holilihu.online/simulations-staging/.../holilihu-simulation.json` and `media.holilihu.online/simulations/.../holilihu-simulation.json` return `200 OK`, `Server: cloudflare`, and `X-HoliLihu-Simulation-Origin: r2`.
+- Production `index.html` returns `Content-Type: text/html; charset=utf-8` and short-cache headers.
+- Production `.wasm` returns `Content-Type: application/wasm`, immutable cache headers, and `X-HoliLihu-Simulation-Origin: r2`.
 
 ## LMS Environment
 

--- a/fe/src/app/features/student/pages/student-simulation-courses-beta.component.ts
+++ b/fe/src/app/features/student/pages/student-simulation-courses-beta.component.ts
@@ -154,8 +154,8 @@ interface ChecklistItem {
 })
 export class StudentSimulationCoursesBetaComponent {
   readonly packageId = 'colreg-rule-15-crossing';
-  readonly version = 'v2026.05.14.1';
-  readonly packageSizeLabel = '84.4 MB';
+  readonly version = 'v2026.05.16.1';
+  readonly packageSizeLabel = '61.1 MB';
   readonly canonicalEntryUrl = `/simulations/${this.packageId}/${this.version}/index.html`;
   readonly canonicalManifestUrl = `/simulations/${this.packageId}/${this.version}/holilihu-simulation.json`;
   readonly publicLaunchUrl = `https://media.holilihu.online${this.canonicalEntryUrl}`;


### PR DESCRIPTION
## Summary
- Point the student simulation beta page at Unity WebGPU package `colreg-rule-15-crossing/v2026.05.16.1`.
- Update the Unity WebGL/R2 production runbook with the new immutable package path and Cloudflare/R2 verification notes.

## Validation
- `cd fe && npm run build` completed successfully.
- Verified production and staging R2 objects through `media.holilihu.online` return `200 OK`, `Server: cloudflare`, and `X-HoliLihu-Simulation-Origin: r2`.
- Verified production `.wasm` returns `Content-Type: application/wasm` and immutable cache headers.

## Notes
- The Unity package itself is already uploaded to the existing `lms-storage` bucket for staging and production.
- Same-origin `/simulations/*` on root `holilihu.online` is still gated by the root-domain Cloudflare proxy cutover described in the runbook.