### PR TITLE
[codex] Publish WebGPU COLREG visual refresh

### DIFF
--- a/docs/runbooks/UNITY_WEBGL_R2_PROD_RUNBOOK.md
+++ b/docs/runbooks/UNITY_WEBGL_R2_PROD_RUNBOOK.md
@@ -1,7 +1,7 @@
 # Unity WebGL R2 Production Runbook
 
 Date: 2026-05-16
-Status: Unity WebGPU package `colreg-rule-15-crossing/v2026.05.16.1` is published to the existing `lms-storage` R2 bucket for staging and production. Production Worker/R2 access is verified through Cloudflare on the proxied media host; live same-origin `/simulations/*` on `holilihu.online` remains gated by the root-domain proxy state.
+Status: Unity WebGPU package `colreg-rule-15-crossing/v2026.05.16.2` is published to the existing `lms-storage` R2 bucket for staging and production. Production Worker/R2 access is verified through Cloudflare on the proxied media host; live same-origin `/simulations/*` on `holilihu.online` remains gated by the root-domain proxy state.
 
 ## Decision
 
@@ -139,10 +139,10 @@ simulations/colreg-rule-15-crossing/v2026.05.12.1/holilihu-simulation.json
 Current published package:
 
 ```text
-simulations/colreg-rule-15-crossing/v2026.05.16.1/index.html
-simulations/colreg-rule-15-crossing/v2026.05.16.1/Build/HoliLihuWebGPU_Full.wasm
-simulations/colreg-rule-15-crossing/v2026.05.16.1/Build/HoliLihuWebGPU_Full.data
-simulations/colreg-rule-15-crossing/v2026.05.16.1/holilihu-simulation.json
+simulations/colreg-rule-15-crossing/v2026.05.16.2/index.html
+simulations/colreg-rule-15-crossing/v2026.05.16.2/Build/HoliLihuWebGPU_Full.wasm
+simulations/colreg-rule-15-crossing/v2026.05.16.2/Build/HoliLihuWebGPU_Full.data
+simulations/colreg-rule-15-crossing/v2026.05.16.2/holilihu-simulation.json
 ```
 
 Never mutate a version after publishing to learners. If Unity exports a fix, publish a new version folder and update the LMS package record.
@@ -229,6 +229,14 @@ Then open the staging lesson in a desktop Chrome/Edge browser and confirm:
 2026-05-16 verification for `v2026.05.16.1`:
 
 - Staging and production packages were uploaded to `lms-storage`.
+- `media.holilihu.online/simulations-staging/.../holilihu-simulation.json` and `media.holilihu.online/simulations/.../holilihu-simulation.json` return `200 OK`, `Server: cloudflare`, and `X-HoliLihu-Simulation-Origin: r2`.
+- Production `index.html` returns `Content-Type: text/html; charset=utf-8` and short-cache headers.
+- Production `.wasm` returns `Content-Type: application/wasm`, immutable cache headers, and `X-HoliLihu-Simulation-Origin: r2`.
+
+2026-05-16 visual refresh for `v2026.05.16.2`:
+
+- Staging and production packages were uploaded to `lms-storage`.
+- Local Chrome WebGPU QA loaded the Unity canvas successfully and captured `VR_Maritime_LMS/Logs/chrome-webgpu-frames-only-v6.png`.
 - `media.holilihu.online/simulations-staging/.../holilihu-simulation.json` and `media.holilihu.online/simulations/.../holilihu-simulation.json` return `200 OK`, `Server: cloudflare`, and `X-HoliLihu-Simulation-Origin: r2`.
 - Production `index.html` returns `Content-Type: text/html; charset=utf-8` and short-cache headers.
 - Production `.wasm` returns `Content-Type: application/wasm`, immutable cache headers, and `X-HoliLihu-Simulation-Origin: r2`.

--- a/docs/runbooks/UNITY_WEBGL_R2_PROD_RUNBOOK.md
+++ b/docs/runbooks/UNITY_WEBGL_R2_PROD_RUNBOOK.md
@@ -1,7 +1,7 @@
 # Unity WebGL R2 Production Runbook
 
-Date: 2026-05-14
-Status: Unity WebGPU package `colreg-rule-15-crossing/v2026.05.14.1` is published to the existing `lms-storage` R2 bucket for staging and production. Production Worker/R2 access is verified through Cloudflare; live same-origin `/simulations/*` on `holilihu.online` remains gated by the root-domain proxy state.
+Date: 2026-05-16
+Status: Unity WebGPU package `colreg-rule-15-crossing/v2026.05.16.1` is published to the existing `lms-storage` R2 bucket for staging and production. Production Worker/R2 access is verified through Cloudflare on the proxied media host; live same-origin `/simulations/*` on `holilihu.online` remains gated by the root-domain proxy state.
 
 ## Decision
 
@@ -139,10 +139,10 @@ simulations/colreg-rule-15-crossing/v2026.05.12.1/holilihu-simulation.json
 Current published package:
 
 ```text
-simulations/colreg-rule-15-crossing/v2026.05.14.1/index.html
-simulations/colreg-rule-15-crossing/v2026.05.14.1/Build/HoliLihuWebGPU_Full.wasm
-simulations/colreg-rule-15-crossing/v2026.05.14.1/Build/HoliLihuWebGPU_Full.data
-simulations/colreg-rule-15-crossing/v2026.05.14.1/holilihu-simulation.json
+simulations/colreg-rule-15-crossing/v2026.05.16.1/index.html
+simulations/colreg-rule-15-crossing/v2026.05.16.1/Build/HoliLihuWebGPU_Full.wasm
+simulations/colreg-rule-15-crossing/v2026.05.16.1/Build/HoliLihuWebGPU_Full.data
+simulations/colreg-rule-15-crossing/v2026.05.16.1/holilihu-simulation.json
 ```
 
 Never mutate a version after publishing to learners. If Unity exports a fix, publish a new version folder and update the LMS package record.
@@ -225,6 +225,13 @@ Then open the staging lesson in a desktop Chrome/Edge browser and confirm:
 - Production manifest, `index.html`, and `.wasm` return `200 OK` with `Server: cloudflare` and `X-HoliLihu-Simulation-Origin: r2` when served through Cloudflare.
 - `.wasm` returns `Content-Type: application/wasm` and immutable cache headers.
 - Direct root-domain requests still reach VM/Caddy until `holilihu.online` is proxied.
+
+2026-05-16 verification for `v2026.05.16.1`:
+
+- Staging and production packages were uploaded to `lms-storage`.
+- `media.holilihu.online/simulations-staging/.../holilihu-simulation.json` and `media.holilihu.online/simulations/.../holilihu-simulation.json` return `200 OK`, `Server: cloudflare`, and `X-HoliLihu-Simulation-Origin: r2`.
+- Production `index.html` returns `Content-Type: text/html; charset=utf-8` and short-cache headers.
+- Production `.wasm` returns `Content-Type: application/wasm`, immutable cache headers, and `X-HoliLihu-Simulation-Origin: r2`.
 
 ## LMS Environment
 

--- a/fe/src/app/features/student/pages/student-simulation-courses-beta.component.ts
+++ b/fe/src/app/features/student/pages/student-simulation-courses-beta.component.ts
@@ -154,8 +154,8 @@ interface ChecklistItem {
 })
 export class StudentSimulationCoursesBetaComponent {
   readonly packageId = 'colreg-rule-15-crossing';
-  readonly version = 'v2026.05.16.1';
-  readonly packageSizeLabel = '61.1 MB';
+  readonly version = 'v2026.05.16.2';
+  readonly packageSizeLabel = '61.2 MB';
   readonly canonicalEntryUrl = `/simulations/${this.packageId}/${this.version}/index.html`;
   readonly canonicalManifestUrl = `/simulations/${this.packageId}/${this.version}/holilihu-simulation.json`;
   readonly publicLaunchUrl = `https://media.holilihu.online${this.canonicalEntryUrl}`;

--- a/fe/src/app/features/student/pages/student-simulation-courses-beta.component.ts
+++ b/fe/src/app/features/student/pages/student-simulation-courses-beta.component.ts
@@ -154,8 +154,8 @@ interface ChecklistItem {
 })
 export class StudentSimulationCoursesBetaComponent {
   readonly packageId = 'colreg-rule-15-crossing';
-  readonly version = 'v2026.05.14.1';
-  readonly packageSizeLabel = '84.4 MB';
+  readonly version = 'v2026.05.16.1';
+  readonly packageSizeLabel = '61.1 MB';
   readonly canonicalEntryUrl = `/simulations/${this.packageId}/${this.version}/index.html`;
   readonly canonicalManifestUrl = `/simulations/${this.packageId}/${this.version}/holilihu-simulation.json`;
   readonly publicLaunchUrl = `https://media.holilihu.online${this.canonicalEntryUrl}`;


### PR DESCRIPTION
## Summary
- Point the student simulation beta page at `colreg-rule-15-crossing/v2026.05.16.2` on the proxied media host.
- Update the Unity WebGL/R2 runbook with the visual-refresh package and smoke-check evidence.

## Validation
- Built the Angular frontend with `npm run build`.
- Published the Unity WebGPU package to `lms-storage` for staging and production.
- Verified Cloudflare/R2 responses for staging manifest, production manifest, production `index.html`, and production `.wasm` with expected content types and `X-HoliLihu-Simulation-Origin: r2`.
- Locally loaded the Unity WebGPU canvas in desktop Chrome and captured the visual QA screenshot after the lighting/HUD fixes.