### PR TITLE
fix(video): harden youtube offline boundaries

### DIFF
--- a/fe/src/app/core/services/course-download.service.spec.ts
+++ b/fe/src/app/core/services/course-download.service.spec.ts
@@ -1,0 +1,85 @@
+import { offlineDb, type OfflineLesson } from '../db/lms-offline.db';
+import { CourseDownloadService } from './course-download.service';
+
+type OfflineLessonSection = NonNullable<OfflineLesson['sections']>[number];
+
+describe('CourseDownloadService repairLessonVideoFallbackInStorage', () => {
+  const buildService = (): CourseDownloadService => {
+    const service = Object.create(CourseDownloadService.prototype) as CourseDownloadService;
+    spyOn<any>(service, 'resolveLessonQuizMetadataRepair').and.resolveTo(null);
+    return service;
+  };
+
+  const buildLesson = (sectionOverrides: Partial<OfflineLessonSection>): OfflineLesson => ({
+    id: 'lesson-1',
+    courseId: 'course-1',
+    chapterId: 'chapter-1',
+    title: 'Lesson',
+    contentHtml: '',
+    lessonType: 'LECTURE',
+    quizType: 'PRACTICE',
+    countsTowardCertificate: false,
+    quizAllowOffline: true,
+    videoOfflineUri: '/offline-video/lesson-1',
+    sections: [{
+      id: 'section-1',
+      lessonId: 'lesson-1',
+      title: 'Video section',
+      type: 'VIDEO',
+      ...sectionOverrides,
+    }],
+    sortOrder: 0,
+    downloadedAt: new Date('2026-05-24T00:00:00.000Z'),
+    userId: 'user-1',
+  });
+
+  it('does not repair explicit external section sources with a lesson offline URI', async () => {
+    const service = buildService();
+    const updateSpy = spyOn(offlineDb.lessons, 'update').and.resolveTo(0);
+    const lesson = buildLesson({
+      videoUrl: 'https://video.example-cdn.com/watch/abc',
+      videoSourceKind: 'EXTERNAL',
+    });
+
+    const repaired = await (service as any).repairLessonVideoFallbackInStorage('user-1', lesson) as OfflineLesson;
+
+    expect(repaired.sections?.[0].videoOfflineUri).toBeUndefined();
+    expect(repaired.sections?.[0].videoUrl).toBe('https://video.example-cdn.com/watch/abc');
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not repair youtube-nocookie section URLs with a lesson offline URI', async () => {
+    const service = buildService();
+    const updateSpy = spyOn(offlineDb.lessons, 'update').and.resolveTo(0);
+    const lesson = buildLesson({
+      videoUrl: 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+    });
+
+    const repaired = await (service as any).repairLessonVideoFallbackInStorage('user-1', lesson) as OfflineLesson;
+
+    expect(repaired.sections?.[0].videoOfflineUri).toBeUndefined();
+    expect(repaired.sections?.[0].videoUrl).toBe('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ');
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('still repairs internal direct video sections with the lesson offline URI', async () => {
+    const service = buildService();
+    const updateSpy = spyOn(offlineDb.lessons, 'update').and.resolveTo(1);
+    const lesson = buildLesson({
+      videoUrl: '/media/lesson-1.mp4',
+      videoSourceKind: 'LEGACY_DIRECT',
+    });
+
+    const repaired = await (service as any).repairLessonVideoFallbackInStorage('user-1', lesson) as OfflineLesson;
+
+    expect(repaired.sections?.[0].videoOfflineUri).toBe('/offline-video/lesson-1');
+    expect(repaired.sections?.[0].videoUrl).toBe('/offline-video/lesson-1');
+    expect(updateSpy).toHaveBeenCalledWith(['user-1', 'lesson-1'], jasmine.objectContaining({
+      sections: [jasmine.objectContaining({
+        id: 'section-1',
+        videoUrl: '/offline-video/lesson-1',
+        videoOfflineUri: '/offline-video/lesson-1',
+      })],
+    }));
+  });
+});

--- a/fe/src/app/core/services/course-download.service.ts
+++ b/fe/src/app/core/services/course-download.service.ts
@@ -2056,14 +2056,11 @@ export class CourseDownloadService {
 
     let changed = false;
     const repairedSections = lesson.sections.map((section) => {
-      const isYoutube = section.videoType === 'YOUTUBE'
-        || (typeof section.videoUrl === 'string' && /(youtube\.com|youtu\.be)/i.test(section.videoUrl));
-
       if (
         section.type !== 'VIDEO'
         || section.videoOfflineUri
         || section.streamVideoUid
-        || isYoutube
+        || isOnlineOnlyVideoSource(section)
       ) {
         return section;
       }

--- a/fe/src/app/core/services/course-download.service.ts
+++ b/fe/src/app/core/services/course-download.service.ts
@@ -39,6 +39,7 @@ import {
   type OfflineVideoProfileId,
   type VideoSourceKind,
 } from '../models/video-quality';
+import { isOnlineOnlyVideoSource } from '../utils/video-offline-policy';
 import { environment } from '../../../environments/environment';
 
 export type { OfflineCourse, OfflineChapter, OfflineLesson };
@@ -359,6 +360,14 @@ export class CourseDownloadService {
 
           const vl = videoLessons[vi];
           try {
+            if (isOnlineOnlyVideoSource({
+              videoUrl: vl.videoManifestUrl,
+              videoSourceKind: vl.videoSourceKind,
+            })) {
+              this.recordVideoSkip(videoSkipSummary, 'unsupported');
+              continue;
+            }
+
             let downloadUrl = vl.videoManifestUrl!;
             let downloadedVideoProfileId: OfflineVideoProfileId | null = null;
             let downloadedVideoProfileLabel: string | null = null;
@@ -1431,7 +1440,7 @@ export class CourseDownloadService {
     section: OfflineLessonSection,
     profile: OfflineVideoProfileId,
   ): Promise<OfflineVideoDownloadDescriptor> {
-    if (section.videoType === 'YOUTUBE' || section.videoSourceKind === 'EXTERNAL') {
+    if (isOnlineOnlyVideoSource(section)) {
       return { downloadUrl: null };
     }
 

--- a/fe/src/app/core/services/offline-video.service.ts
+++ b/fe/src/app/core/services/offline-video.service.ts
@@ -8,6 +8,7 @@ import {
   type OfflineLessonSection,
 } from '../db/lms-offline.db';
 import type { OfflineVideoProfileId, VideoSourceKind } from '../models/video-quality';
+import { isOnlineOnlyVideoSource } from '../utils/video-offline-policy';
 
 export const OFFLINE_VIDEO_MAX_CACHE_BYTES = 500 * 1024 * 1024;
 
@@ -320,15 +321,11 @@ export class OfflineVideoService {
 
     let changed = false;
     const updatedSections = sections.map((section) => {
-      const isYoutube = section?.videoType === 'YOUTUBE'
-        || (typeof section?.videoUrl === 'string'
-          && /(youtube\.com|youtu\.be)/i.test(section.videoUrl));
-
       if (
         section?.type !== 'VIDEO'
         || section?.videoOfflineUri
         || section?.streamVideoUid
-        || isYoutube
+        || isOnlineOnlyVideoSource(section)
       ) {
         return section;
       }

--- a/fe/src/app/core/utils/video-offline-policy.spec.ts
+++ b/fe/src/app/core/utils/video-offline-policy.spec.ts
@@ -1,0 +1,24 @@
+import {
+  isOnlineOnlyVideoSource,
+  isYoutubeVideoUrl,
+} from './video-offline-policy';
+
+describe('video-offline-policy', () => {
+  it('detects common YouTube URL forms as online-only sources', () => {
+    expect(isYoutubeVideoUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBeTrue();
+    expect(isYoutubeVideoUrl('https://youtu.be/dQw4w9WgXcQ')).toBeTrue();
+    expect(isYoutubeVideoUrl('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ')).toBeTrue();
+  });
+
+  it('treats YouTube metadata and explicit external sources as online-only', () => {
+    expect(isOnlineOnlyVideoSource({ videoType: 'YOUTUBE' })).toBeTrue();
+    expect(isOnlineOnlyVideoSource({ videoSourceKind: 'EXTERNAL' })).toBeTrue();
+    expect(isOnlineOnlyVideoSource({ videoUrl: 'https://youtu.be/dQw4w9WgXcQ' })).toBeTrue();
+  });
+
+  it('keeps internal adaptive and direct LMS sources eligible for offline handling', () => {
+    expect(isOnlineOnlyVideoSource({ videoSourceKind: 'ADAPTIVE_R2' })).toBeFalse();
+    expect(isOnlineOnlyVideoSource({ videoSourceKind: 'STREAM' })).toBeFalse();
+    expect(isOnlineOnlyVideoSource({ videoUrl: '/api/v3/media/video.mp4' })).toBeFalse();
+  });
+});

--- a/fe/src/app/core/utils/video-offline-policy.ts
+++ b/fe/src/app/core/utils/video-offline-policy.ts
@@ -1,0 +1,29 @@
+export type VideoOfflinePolicySource = {
+  videoUrl?: string | null;
+  videoType?: string | null;
+  videoSourceKind?: string | null;
+};
+
+export function isYoutubeVideoUrl(url: string | null | undefined): boolean {
+  return typeof url === 'string'
+    && /(?:youtube(?:-nocookie)?\.com|youtu\.be)/i.test(url);
+}
+
+export function isOnlineOnlyVideoSource(
+  source: VideoOfflinePolicySource | null | undefined,
+): boolean {
+  if (!source) {
+    return false;
+  }
+
+  const videoType = normalizeVideoPolicyToken(source.videoType);
+  const sourceKind = normalizeVideoPolicyToken(source.videoSourceKind);
+
+  return videoType === 'YOUTUBE'
+    || sourceKind === 'EXTERNAL'
+    || isYoutubeVideoUrl(source.videoUrl);
+}
+
+function normalizeVideoPolicyToken(value: string | null | undefined): string {
+  return typeof value === 'string' ? value.trim().toUpperCase() : '';
+}

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.html
@@ -216,10 +216,18 @@
       @if (section.type === 'VIDEO') {
       <div class="lesson-video-frame relative aspect-video w-full rounded-lg overflow-hidden shadow-sm bg-black border border-gray-100 mb-6">
         @if (!section.streamVideoUid && isYouTubeUrl(section.videoUrl || lesson().videoUrl)) {
-        <app-youtube-player [videoUrl]="(section.videoUrl || lesson().videoUrl)!" [lessonId]="lesson().id" [sectionId]="section.id"
-          [completionThreshold]="section.completionThreshold"
-          [interactiveVideoSpec]="section.interactiveVideoSpec || null"
-          (videoEnded)="onVideoEnd()" />
+          @if (isSectionOnlineOnlyVideoBlocked(section)) {
+          <div class="absolute inset-0 z-20 flex flex-col items-center justify-center gap-2 bg-slate-950 px-6 text-center text-white">
+            <app-icon name="play-circle" size="xl" class="text-white/80"></app-icon>
+            <p class="text-sm font-semibold">Video YouTube chỉ phát trực tuyến</p>
+            <p class="max-w-md text-xs leading-5 text-white/70">Thiết bị đang offline. Kết nối mạng để phát video này; nội dung đã tải trong bài vẫn có thể học ngoại tuyến.</p>
+          </div>
+          } @else {
+          <app-youtube-player [videoUrl]="(section.videoUrl || lesson().videoUrl)!" [lessonId]="lesson().id" [sectionId]="section.id"
+            [completionThreshold]="section.completionThreshold"
+            [interactiveVideoSpec]="section.interactiveVideoSpec || null"
+            (videoEnded)="onVideoEnd()" />
+          }
         } @else {
         <app-adaptive-video-player [lessonId]="lesson().id" [sectionId]="section.id"
           [videoAssetId]="section.videoAssetId || null" [videoSourceKind]="section.videoSourceKind || null"
@@ -358,8 +366,16 @@
       @if (shouldShowLessonLevelVideo()) {
       <div class="lesson-video-frame relative aspect-video w-full rounded-lg overflow-hidden shadow-sm bg-black border border-gray-100">
         @if (!lesson().streamVideoUid && isYouTubeUrl(lesson().videoUrl)) {
-        <app-youtube-player [videoUrl]="lesson().videoUrl!" [lessonId]="lesson().id"
-          [sectionId]="'lesson-' + lesson().id" (videoEnded)="onVideoEnd()" />
+          @if (isLessonOnlineOnlyVideoBlocked()) {
+          <div class="absolute inset-0 z-20 flex flex-col items-center justify-center gap-2 bg-slate-950 px-6 text-center text-white">
+            <app-icon name="play-circle" size="xl" class="text-white/80"></app-icon>
+            <p class="text-sm font-semibold">Video YouTube chỉ phát trực tuyến</p>
+            <p class="max-w-md text-xs leading-5 text-white/70">Thiết bị đang offline. Kết nối mạng để phát video này; nội dung đã tải trong bài vẫn có thể học ngoại tuyến.</p>
+          </div>
+          } @else {
+          <app-youtube-player [videoUrl]="lesson().videoUrl!" [lessonId]="lesson().id"
+            [sectionId]="'lesson-' + lesson().id" (videoEnded)="onVideoEnd()" />
+          }
         } @else {
         <app-adaptive-video-player [lessonId]="lesson().id" [sectionId]="null"
           [rawVideoUrl]="lesson().videoUrl || null" [streamVideoUid]="lesson().streamVideoUid || null"

--- a/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
+++ b/fe/src/app/features/learning/components/lesson-content/lesson-content.component.ts
@@ -7,7 +7,7 @@ import { FormsModule } from '@angular/forms';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { firstValueFrom, Subscription } from 'rxjs';
-import { LessonDetail } from '../../models/learning.models';
+import { LessonDetail, SectionContent } from '../../models/learning.models';
 import { LessonType } from '../../models/lesson-types.enum';
 import { WatchedSegmentsTracker } from '../../services/watched-segments-tracker.service';
 import { HeartbeatTracker } from '../../services/heartbeat-tracker.service';
@@ -25,6 +25,10 @@ import { IconComponent } from '../../../../shared/components/icon/icon.component
 import { SideDrawerComponent } from '../../../../shared/components/side-drawer/side-drawer.component';
 import { CompetencyBadgeComponent } from '../competency-badge/competency-badge.component';
 import { PdfSlideViewerComponent } from '../../../../shared/components/pdf-slide-viewer/pdf-slide-viewer.component';
+import {
+  isOnlineOnlyVideoSource,
+  isYoutubeVideoUrl,
+} from '../../../../core/utils/video-offline-policy';
 
 interface DocumentPreviewResponse {
   status: 'PROCESSING' | 'READY' | 'FAILED' | string;
@@ -902,8 +906,23 @@ export class LessonContentComponent implements AfterViewInit {
   }
 
   isYouTubeUrl(url: string | undefined): boolean {
-    if (!url) return false;
-    return url.includes('youtube.com') || url.includes('youtu.be');
+    return isYoutubeVideoUrl(url);
+  }
+
+  isSectionOnlineOnlyVideoBlocked(section: SectionContent): boolean {
+    return !this.network.online()
+      && isOnlineOnlyVideoSource({
+        videoUrl: section.videoUrl || this.lesson().videoUrl,
+        videoType: section.videoType,
+        videoSourceKind: section.videoSourceKind,
+      });
+  }
+
+  isLessonOnlineOnlyVideoBlocked(): boolean {
+    return !this.network.online()
+      && isOnlineOnlyVideoSource({
+        videoUrl: this.lesson().videoUrl,
+      });
   }
 
   // Mark lesson as complete

--- a/fe/src/app/features/learning/services/learning.service.spec.ts
+++ b/fe/src/app/features/learning/services/learning.service.spec.ts
@@ -399,6 +399,42 @@ describe('LearningService — videoOfflineUri preservation', () => {
     });
   });
 
+  describe('YouTube/offline video boundaries', () => {
+    it('does not apply lesson-level offline fallback to YouTube section URLs', () => {
+      const sections = [
+        buildSection({
+          id: 'youtube-section',
+          videoUrl: 'https://youtu.be/dQw4w9WgXcQ',
+        }),
+      ];
+
+      const result = (service as any).applyLessonOfflineVideoFallback(
+        sections,
+        '/offline-video/lesson-1',
+      ) as SectionContent[];
+
+      expect(result[0].videoOfflineUri).toBeUndefined();
+      expect(result[0].videoUrl).toBe('https://youtu.be/dQw4w9WgXcQ');
+    });
+
+    it('keeps internal video sections eligible for lesson-level offline fallback', () => {
+      const sections = [
+        buildSection({
+          id: 'internal-section',
+          videoUrl: '/media/lesson-1.mp4',
+        }),
+      ];
+
+      const result = (service as any).applyLessonOfflineVideoFallback(
+        sections,
+        '/offline-video/lesson-1',
+      ) as SectionContent[];
+
+      expect(result[0].videoOfflineUri).toBe('/offline-video/lesson-1');
+      expect(result[0].videoUrl).toBe('/offline-video/lesson-1');
+    });
+  });
+
   describe('Test 5: fetchLessonFromApi merges from IndexedDB on fresh load', () => {
     /**
      * NOTE: Test này depends on sub-agent A's pending fix — apply

--- a/fe/src/app/features/learning/services/learning.service.ts
+++ b/fe/src/app/features/learning/services/learning.service.ts
@@ -22,6 +22,7 @@ import { CourseDownloadService } from '../../../core/services/course-download.se
 import { NetworkStatusService } from '../../../core/services/network-status.service';
 import { offlineDb, getCurrentUserId } from '../../../core/db/lms-offline.db';
 import { normalizeInteractiveVideoSpecV2 } from '../../../core/utils/interactive-video-normalizer';
+import { isOnlineOnlyVideoSource } from '../../../core/utils/video-offline-policy';
 
 /**
  * Learning Service
@@ -463,7 +464,12 @@ export class LearningService {
     }
 
     return sections.map(section => {
-      if (section.type !== 'VIDEO' || section.videoOfflineUri || section.videoType === 'YOUTUBE' || section.streamVideoUid) {
+      if (
+        section.type !== 'VIDEO'
+        || section.videoOfflineUri
+        || section.streamVideoUid
+        || isOnlineOnlyVideoSource(section)
+      ) {
         return section;
       }
 


### PR DESCRIPTION
## Description

Hardens the video offline boundary so YouTube/external sources stay online-only while internal LMS video remains eligible for offline fallback and caching.

## Motivation

The project already supports CDN-style playback for stored video and metadata-based YouTube embeds, but YouTube cannot be guaranteed offline and some embeds are restricted by platform rules. Section-level YouTube was mostly guarded, while lesson-level YouTube could still enter the offline video download loop and surface as a failed download instead of a clear online-only skip.

## Type of Change

- Bug fix
- UX/reliability hardening
- Test coverage

## Related Issues

Refs: none

## Changes Made

- Added a shared `video-offline-policy` utility to identify YouTube, youtube-nocookie, youtu.be, and explicit `EXTERNAL` video sources as online-only.
- Reused that policy in course downloads, offline video fallback repair, and learning-service fallback mapping so lesson-level and section-level video boundaries stay consistent.
- Added an offline learner-state message for YouTube video frames instead of attempting to mount the YouTube iframe while the device is offline.
- Added regression tests for the policy and for lesson-level offline fallback not being applied to YouTube section URLs.

## Scope Note

This PR does not change the R2/CDN storage governance work from PR #493, does not download YouTube videos into R2, and does not add a third-party video provider. It keeps YouTube as online-only and internal/adaptive video as the offline-capable path.

## Testing Guide

1. Open a downloaded lesson that contains an internal uploaded/adaptive video while offline; the cached/internal video path should still be eligible for offline playback.
2. Open a lesson or section that contains a YouTube URL while offline; the video frame should show the online-only message instead of a blank/broken YouTube iframe.
3. Download a course that contains lesson-level YouTube video; the package should skip that video as online-only instead of trying to fetch/cache it.

## Local Checks

- `git diff --check`
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --include=src/app/core/utils/video-offline-policy.spec.ts --include=src/app/features/learning/services/learning.service.spec.ts`
- `npm run build` (passes; existing Angular/Sass/CommonJS warnings remain outside this change)

## Checklist

- [x] Focused fix with no unrelated refactor
- [x] Regression test added or risk-appropriate validation completed
- [x] Typecheck/build/smoke pass
- [x] PR opened as draft for review bot/human review
