### PR TITLE
fix(video): recover adaptive streams after cdn errors

### DIFF
--- a/fe/src/app/core/utils/video-stream-recovery.spec.ts
+++ b/fe/src/app/core/utils/video-stream-recovery.spec.ts
@@ -1,0 +1,73 @@
+import {
+  extractAdaptivePlaybackHttpStatus,
+  isRecoverableAdaptiveStreamError,
+  resolvePlaybackManifestFormat,
+  shouldRefreshAdaptivePlaybackUrl,
+} from './video-stream-recovery';
+
+describe('video-stream-recovery', () => {
+  it('detects DASH manifests from signed playback URLs', () => {
+    expect(
+      resolvePlaybackManifestFormat('/api/v3/video-assets/a/adaptive/t/dash/manifest.mpd?token=1'),
+    ).toBe('dash');
+    expect(
+      resolvePlaybackManifestFormat('/api/v3/video-assets/a/adaptive/t/hls/master.m3u8'),
+    ).toBe('hls');
+  });
+
+  it('extracts Shaka BAD_HTTP_STATUS style numeric data', () => {
+    expect(extractAdaptivePlaybackHttpStatus({
+      category: 1,
+      code: 1001,
+      data: ['/segment-1.m4s', 403, 'Forbidden'],
+    })).toBe(403);
+  });
+
+  it('extracts nested response status values', () => {
+    expect(extractAdaptivePlaybackHttpStatus({
+      detail: {
+        response: {
+          status: '503',
+        },
+      },
+    })).toBe(503);
+  });
+
+  it('classifies signed URL and CDN edge failures as recoverable', () => {
+    expect(isRecoverableAdaptiveStreamError({ data: ['/manifest.m3u8', 401] })).toBeTrue();
+    expect(isRecoverableAdaptiveStreamError({ response: { status: 429 } })).toBeTrue();
+    expect(isRecoverableAdaptiveStreamError({ status: 504 })).toBeTrue();
+  });
+
+  it('does not classify unsupported media responses as refreshable stream expiry', () => {
+    expect(isRecoverableAdaptiveStreamError({ status: 415 })).toBeFalse();
+  });
+
+  it('allows one adaptive playback URL refresh when the video element hides HTTP detail', () => {
+    expect(shouldRefreshAdaptivePlaybackUrl({
+      activeAdaptiveManifestUrl: '/api/v3/video-assets/a/adaptive/t/hls/master.m3u8',
+      attemptedRefresh: false,
+      hasOfflineSource: false,
+    })).toBeTrue();
+  });
+
+  it('blocks refresh when there is no adaptive source, an offline source, or a previous refresh', () => {
+    expect(shouldRefreshAdaptivePlaybackUrl({
+      activeAdaptiveManifestUrl: null,
+      attemptedRefresh: false,
+      hasOfflineSource: false,
+    })).toBeFalse();
+
+    expect(shouldRefreshAdaptivePlaybackUrl({
+      activeAdaptiveManifestUrl: '/manifest.m3u8',
+      attemptedRefresh: true,
+      hasOfflineSource: false,
+    })).toBeFalse();
+
+    expect(shouldRefreshAdaptivePlaybackUrl({
+      activeAdaptiveManifestUrl: '/manifest.m3u8',
+      attemptedRefresh: false,
+      hasOfflineSource: true,
+    })).toBeFalse();
+  });
+});

--- a/fe/src/app/core/utils/video-stream-recovery.ts
+++ b/fe/src/app/core/utils/video-stream-recovery.ts
@@ -1,0 +1,126 @@
+export type VideoPlaybackManifestFormat = 'hls' | 'dash';
+
+export interface AdaptivePlaybackRefreshState {
+  activeAdaptiveManifestUrl: string | null;
+  attemptedRefresh: boolean;
+  hasOfflineSource: boolean;
+  error?: unknown;
+}
+
+const RECOVERABLE_HTTP_STATUSES = new Set([
+  401,
+  403,
+  404,
+  408,
+  409,
+  410,
+  425,
+  429,
+  500,
+  502,
+  503,
+  504,
+]);
+
+const HTTP_STATUS_FIELDS = [
+  'status',
+  'statusCode',
+  'httpStatus',
+  'responseStatus',
+  'responseCode',
+];
+
+const NESTED_ERROR_FIELDS = [
+  'detail',
+  'error',
+  'cause',
+  'response',
+  'originalError',
+];
+
+export function resolvePlaybackManifestFormat(
+  manifestUrl: string | null | undefined,
+): VideoPlaybackManifestFormat {
+  return /\.mpd(?:[?#]|$)/i.test(manifestUrl ?? '') ? 'dash' : 'hls';
+}
+
+export function shouldRefreshAdaptivePlaybackUrl(state: AdaptivePlaybackRefreshState): boolean {
+  if (!state.activeAdaptiveManifestUrl || state.attemptedRefresh || state.hasOfflineSource) {
+    return false;
+  }
+
+  if (state.error == null) {
+    return true;
+  }
+
+  return isRecoverableAdaptiveStreamError(state.error);
+}
+
+export function isRecoverableAdaptiveStreamError(error: unknown): boolean {
+  const status = extractAdaptivePlaybackHttpStatus(error);
+  return status != null && RECOVERABLE_HTTP_STATUSES.has(status);
+}
+
+export function extractAdaptivePlaybackHttpStatus(error: unknown): number | null {
+  const queue: unknown[] = [error];
+  const seen = new Set<object>();
+
+  while (queue.length > 0) {
+    const value = queue.shift();
+    const directStatus = coerceHttpStatus(value);
+    if (directStatus != null) {
+      return directStatus;
+    }
+
+    if (!isRecord(value)) {
+      continue;
+    }
+
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+
+    for (const field of HTTP_STATUS_FIELDS) {
+      const fieldStatus = coerceHttpStatus(value[field]);
+      if (fieldStatus != null) {
+        return fieldStatus;
+      }
+    }
+
+    const data = value['data'];
+    if (Array.isArray(data)) {
+      queue.push(...data);
+    }
+
+    for (const field of NESTED_ERROR_FIELDS) {
+      const nestedValue = value[field];
+      if (nestedValue != null) {
+        queue.push(nestedValue);
+      }
+    }
+  }
+
+  return null;
+}
+
+function coerceHttpStatus(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 100 && value <= 599) {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!/^[1-5]\d\d$/.test(trimmed)) {
+    return null;
+  }
+
+  return Number(trimmed);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.spec.ts
+++ b/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.spec.ts
@@ -1,4 +1,19 @@
-import { shouldShowMediaNetworkHint, type MediaNetworkHintState } from './adaptive-video-player.component';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { SectionApi } from '../../../../api/client/section.api';
+import { LearningActivityApi } from '../../../../api/client/learning-activity.api';
+import { VideoProgressApi } from '../../../../api/client/video-progress.api';
+import { NetworkStatusService } from '../../../../core/services/network-status.service';
+import { QoETrackerService } from '../../../../core/services/qoe-tracker.service';
+import { HeartbeatTracker } from '../../services/heartbeat-tracker.service';
+import { WatchedSegmentsTracker } from '../../services/watched-segments-tracker.service';
+import {
+  AdaptiveVideoPlayerComponent,
+  shouldShowMediaNetworkHint,
+  type MediaNetworkHintState,
+} from './adaptive-video-player.component';
 
 describe('shouldShowMediaNetworkHint', () => {
   const baseState: MediaNetworkHintState = {
@@ -55,5 +70,105 @@ describe('shouldShowMediaNetworkHint', () => {
       effectiveNetworkType: '2g',
       saveDataEnabled: true,
     }))).toBeFalse();
+  });
+});
+
+describe('AdaptiveVideoPlayerComponent stream recovery', () => {
+  let fixture: ComponentFixture<AdaptiveVideoPlayerComponent>;
+  let component: AdaptiveVideoPlayerComponent;
+  let qoe: jasmine.SpyObj<QoETrackerService>;
+
+  beforeEach(async () => {
+    qoe = jasmine.createSpyObj<QoETrackerService>('QoETrackerService', [
+      'finishSession',
+      'recordBitrateChange',
+      'recordBufferEnd',
+      'recordBufferStart',
+      'recordError',
+      'recordStartup',
+      'startSession',
+    ]);
+    (qoe as any).metrics = signal(null);
+    qoe.finishSession.and.returnValue(null);
+
+    await TestBed.configureTestingModule({
+      imports: [AdaptiveVideoPlayerComponent, HttpClientTestingModule],
+      providers: [
+        {
+          provide: SectionApi,
+          useValue: {
+            getVideoPlayUrl: jasmine.createSpy('getVideoPlayUrl').and.returnValue(of(null)),
+          },
+        },
+        {
+          provide: VideoProgressApi,
+          useValue: {
+            getResumePosition: jasmine.createSpy('getResumePosition').and.returnValue(of(null)),
+          },
+        },
+        {
+          provide: LearningActivityApi,
+          useValue: {
+            recordInteractiveVideoEvent: jasmine
+              .createSpy('recordInteractiveVideoEvent')
+              .and.returnValue(of(null)),
+          },
+        },
+        {
+          provide: WatchedSegmentsTracker,
+          useValue: {
+            recordSecond: jasmine.createSpy('recordSecond'),
+            startTracking: jasmine.createSpy('startTracking'),
+            stopTracking: jasmine.createSpy('stopTracking'),
+          },
+        },
+        {
+          provide: HeartbeatTracker,
+          useValue: {
+            start: jasmine.createSpy('start'),
+            stop: jasmine.createSpy('stop'),
+          },
+        },
+        {
+          provide: QoETrackerService,
+          useValue: qoe,
+        },
+        {
+          provide: NetworkStatusService,
+          useValue: {
+            online: () => true,
+            saveDataEnabled: () => false,
+            effectiveNetworkType: () => '4g',
+            reportedDownlinkMbps: () => 12,
+            effectiveBandwidthMbps: () => 10,
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdaptiveVideoPlayerComponent);
+    fixture.componentRef.setInput('lessonId', 'lesson-1');
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('shows a playback error when a Shaka CDN error happens after the refresh attempt is exhausted', async () => {
+    const instance = component as any;
+    const resolveAdaptivePlayUrl = spyOn(instance, 'resolveAdaptivePlayUrl')
+      .and.returnValue(Promise.resolve('/fresh-master.m3u8'));
+    instance.activeAdaptiveManifestUrl = '/api/v3/video-assets/a/adaptive/token/hls/master.m3u8';
+    instance.attemptedPlaybackUrlRefresh = true;
+
+    await instance.handleShakaPlayerError(document.createElement('video'), {
+      data: ['/segment-1.m4s', 403, 'Forbidden'],
+    });
+
+    expect(resolveAdaptivePlayUrl).not.toHaveBeenCalled();
+    expect(qoe.recordError).toHaveBeenCalledTimes(1);
+    expect(component.error()).toBe('Không thể phát video này. Vui lòng thử lại.');
+    expect(component.isLoading()).toBeFalse();
   });
 });

--- a/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
+++ b/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
@@ -42,6 +42,11 @@ import {
   canUseNativeHlsForManifest,
   shouldPreferNativeHlsForManifest,
 } from '../../../../core/utils/video-playback-platform';
+import {
+  resolvePlaybackManifestFormat,
+  shouldRefreshAdaptivePlaybackUrl,
+} from '../../../../core/utils/video-stream-recovery';
+import type { VideoPlaybackManifestFormat } from '../../../../core/utils/video-stream-recovery';
 import type {
   InteractiveVideoChoice,
   InteractiveVideoInteraction,
@@ -280,6 +285,8 @@ export class AdaptiveVideoPlayerComponent {
   private startupRecorded = false;
   private offlineBlobUrl: string | null = null;
   private attemptedOfflineBlobFallback = false;
+  private activeAdaptiveManifestUrl: string | null = null;
+  private attemptedPlaybackUrlRefresh = false;
   private readonly offlineBlobFallbackLimitBytes = 220 * 1024 * 1024;
   private readonly shownInteractionIds = new Set<string>();
   private readonly completedInteractionIds = new Set<string>();
@@ -449,6 +456,8 @@ export class AdaptiveVideoPlayerComponent {
     this.qualityLabel.set(null);
     this.startupRecorded = false;
     this.attemptedOfflineBlobFallback = false;
+    this.activeAdaptiveManifestUrl = null;
+    this.attemptedPlaybackUrlRefresh = false;
     this.videoDurationSeconds.set(null);
     this.currentTimeSeconds.set(0);
     this.resetInteractiveRuntime();
@@ -568,7 +577,17 @@ export class AdaptiveVideoPlayerComponent {
       return;
     }
 
-    this.qoe.recordError();
+    if (await this.tryRefreshAdaptivePlaybackUrl(video)) {
+      return;
+    }
+
+    this.showVideoPlaybackError();
+  }
+
+  private showVideoPlaybackError(recordError = true): void {
+    if (recordError) {
+      this.qoe.recordError();
+    }
     const hasOfflineSource = !!this.normalizeOfflineVideoUrl(this.offlineVideoUrl());
     this.error.set(
       hasOfflineSource
@@ -576,6 +595,69 @@ export class AdaptiveVideoPlayerComponent {
         : 'Không thể phát video này. Vui lòng thử lại.'
     );
     this.isLoading.set(false);
+  }
+
+  private async handleShakaPlayerError(video: HTMLVideoElement, error: unknown): Promise<void> {
+    this.qoe.recordError();
+    if (!this.canRefreshAdaptivePlaybackUrl(error)) {
+      return;
+    }
+
+    if (!(await this.tryRefreshAdaptivePlaybackUrl(video, error))) {
+      this.showVideoPlaybackError(false);
+    }
+  }
+
+  private canRefreshAdaptivePlaybackUrl(error?: unknown): boolean {
+    return shouldRefreshAdaptivePlaybackUrl({
+      activeAdaptiveManifestUrl: this.activeAdaptiveManifestUrl,
+      attemptedRefresh: this.attemptedPlaybackUrlRefresh,
+      hasOfflineSource: !!this.normalizeOfflineVideoUrl(this.offlineVideoUrl()),
+      error,
+    });
+  }
+
+  private async tryRefreshAdaptivePlaybackUrl(
+    video: HTMLVideoElement | null,
+    error?: unknown,
+  ): Promise<boolean> {
+    if (!video || !this.canRefreshAdaptivePlaybackUrl(error)) {
+      return false;
+    }
+
+    const manifestUrl = this.activeAdaptiveManifestUrl;
+    if (!manifestUrl) {
+      return false;
+    }
+
+    this.attemptedPlaybackUrlRefresh = true;
+    const refreshToken = this.sourceLoadToken();
+    const format: VideoPlaybackManifestFormat = resolvePlaybackManifestFormat(manifestUrl);
+    const resumeAtSeconds = Number.isFinite(video.currentTime) && video.currentTime > 0
+      ? video.currentTime
+      : 0;
+
+    try {
+      const refreshedUrl = await this.resolveAdaptivePlayUrl(format);
+      if (refreshToken !== this.sourceLoadToken()) {
+        return true;
+      }
+      if (!refreshedUrl) {
+        return false;
+      }
+
+      this.error.set(null);
+      this.isLoading.set(true);
+      await this.destroyShakaPlayer();
+      if (refreshToken !== this.sourceLoadToken()) {
+        return true;
+      }
+
+      await this.initializeShaka(video, refreshedUrl, resumeAtSeconds);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private async tryOfflineBlobFallback(video: HTMLVideoElement | null): Promise<boolean> {
@@ -673,9 +755,15 @@ export class AdaptiveVideoPlayerComponent {
     return this.resolveAdaptivePlayUrl('hls');
   }
 
-  private async initializeShaka(videoElement: HTMLVideoElement, manifestUrl: string): Promise<void> {
+  private async initializeShaka(
+    videoElement: HTMLVideoElement,
+    manifestUrl: string,
+    startTimeSeconds = 0,
+  ): Promise<void> {
+    this.activeAdaptiveManifestUrl = manifestUrl;
+
     if (canUseNativeHlsForManifest(manifestUrl, videoElement)) {
-      this.loadNativeHls(videoElement, manifestUrl);
+      this.loadNativeHls(videoElement, manifestUrl, startTimeSeconds);
       return;
     }
 
@@ -684,9 +772,7 @@ export class AdaptiveVideoPlayerComponent {
     shaka.polyfill.installAll();
 
     if (!shaka.Player.isBrowserSupported()) {
-      videoElement.src = manifestUrl;
-      videoElement.load();
-      this.isLoading.set(false);
+      this.loadNativeHls(videoElement, manifestUrl, startTimeSeconds);
       return;
     }
 
@@ -730,18 +816,24 @@ export class AdaptiveVideoPlayerComponent {
       }
     });
 
-    player.addEventListener('error', () => {
-      this.qoe.recordError();
+    player.addEventListener('error', (event: any) => {
+      if (this.shakaPlayer !== player) {
+        this.qoe.recordError();
+        return;
+      }
+      void this.handleShakaPlayerError(videoElement, event?.detail ?? event);
     });
 
     try {
-      await player.load(manifestUrl);
+      await player.load(manifestUrl, startTimeSeconds > 0 ? startTimeSeconds : undefined);
+      this.activeAdaptiveManifestUrl = manifestUrl;
     } catch {
       // HLS failed — try DASH fallback
       const dashUrl = await this.resolveAdaptivePlayUrl('dash');
       if (dashUrl && dashUrl !== manifestUrl) {
         try {
-          await player.load(dashUrl);
+          await player.load(dashUrl, startTimeSeconds > 0 ? startTimeSeconds : undefined);
+          this.activeAdaptiveManifestUrl = dashUrl;
         } catch {
           this.error.set('Không thể phát video thích ứng. Vui lòng thử lại.');
           this.isLoading.set(false);
@@ -758,11 +850,26 @@ export class AdaptiveVideoPlayerComponent {
     this.isLoading.set(false);
   }
 
-  private loadNativeHls(videoElement: HTMLVideoElement, manifestUrl: string): void {
+  private loadNativeHls(
+    videoElement: HTMLVideoElement,
+    manifestUrl: string,
+    startTimeSeconds = 0,
+  ): void {
     this.shakaPlayer = null;
+    this.activeAdaptiveManifestUrl = manifestUrl;
     this.availableQualities.set([]);
     this.isAutoQuality.set(true);
     this.qualityLabel.set(null);
+    if (startTimeSeconds > 0) {
+      videoElement.addEventListener('loadedmetadata', () => {
+        try {
+          videoElement.currentTime = startTimeSeconds;
+          this.currentTimeSeconds.set(startTimeSeconds);
+        } catch {
+          // Browser may reject seeks before its native HLS timeline is ready.
+        }
+      }, { once: true });
+    }
     videoElement.src = manifestUrl;
     videoElement.load();
     this.isLoading.set(false);

--- a/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
+++ b/fe/src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.ts
@@ -43,6 +43,7 @@ import {
   shouldPreferNativeHlsForManifest,
 } from '../../../../core/utils/video-playback-platform';
 import {
+  isRecoverableAdaptiveStreamError,
   resolvePlaybackManifestFormat,
   shouldRefreshAdaptivePlaybackUrl,
 } from '../../../../core/utils/video-stream-recovery';
@@ -599,13 +600,20 @@ export class AdaptiveVideoPlayerComponent {
 
   private async handleShakaPlayerError(video: HTMLVideoElement, error: unknown): Promise<void> {
     this.qoe.recordError();
-    if (!this.canRefreshAdaptivePlaybackUrl(error)) {
+    if (await this.tryRefreshAdaptivePlaybackUrl(video, error)) {
       return;
     }
 
-    if (!(await this.tryRefreshAdaptivePlaybackUrl(video, error))) {
+    if (this.shouldShowPlaybackErrorAfterRefreshExhausted(error)) {
       this.showVideoPlaybackError(false);
     }
+  }
+
+  private shouldShowPlaybackErrorAfterRefreshExhausted(error: unknown): boolean {
+    return !!this.activeAdaptiveManifestUrl
+      && this.attemptedPlaybackUrlRefresh
+      && !this.normalizeOfflineVideoUrl(this.offlineVideoUrl())
+      && isRecoverableAdaptiveStreamError(error);
   }
 
   private canRefreshAdaptivePlaybackUrl(error?: unknown): boolean {


### PR DESCRIPTION
## Description
Refresh signed adaptive video playback URLs when an active HLS/DASH stream hits recoverable CDN or HTTP failures. This keeps the existing R2/adaptive packaging architecture intact and improves playback resilience when a token, manifest, segment redirect, or CDN edge response goes stale.

## Motivation
The current player already uses backend-issued playback URLs for adaptive video, but those URLs and rewritten segment/object paths can fail after expiry or transient CDN conditions. Learners should get one automatic recovery attempt before seeing a hard playback error.

## Type of Change
- [x] Bug fix
- [x] Frontend resilience improvement
- [ ] Backend/API change
- [ ] Storage schema change

## Changes Made
- Added `video-stream-recovery` utilities to classify recoverable adaptive stream errors from Shaka/browser error shapes.
- Updated `AdaptiveVideoPlayerComponent` to remember the active adaptive manifest and refresh the playback URL once per source load.
- Preserved resume time when reloading via Shaka or native HLS where possible.
- Kept offline blob fallback first, so downloaded/offline video behavior remains unchanged.
- Added focused unit coverage for manifest format detection, HTTP status extraction, and refresh gating.

## Scope Note
This PR does not change R2 quota policy, storage rotation, YouTube download behavior, or backend authorization. It only improves runtime playback recovery for the existing CDN/R2 stream path.

## Testing Guide
1. Open a lesson with an `ADAPTIVE_R2` or legacy stream-backed video.
2. Start playback, then simulate a signed manifest/segment failure such as 401/403/404/429/5xx from the active stream request.
3. Confirm the player calls the existing `/video/play` endpoint again and reloads once instead of immediately showing the playback error.
4. Confirm offline video sources still use the offline blob fallback first.

## Local Checks
- `npm ci`
- `npm run test:ci -- --include=src/app/core/utils/video-stream-recovery.spec.ts --include=src/app/features/learning/components/adaptive-video-player/adaptive-video-player.component.spec.ts` -> `TOTAL: 520 SUCCESS` (npm treated `--include` as config, so the full Karma suite ran)
- `npm run build` -> success

## Notes
Build/test warnings observed are pre-existing project warnings: Sass `@import` deprecations, Angular template optional-chain/nullish warnings, CommonJS dependency warnings, and npm audit/engine warnings.