### PR TITLE
fix(video): bound CDN manifest cache TTL

### DIFF
--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/VideoPipelineHealthIndicator.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/VideoPipelineHealthIndicator.java
@@ -30,8 +30,27 @@ public class VideoPipelineHealthIndicator implements HealthIndicator {
         boolean shakaAvailable = isShakaPackagerAvailable();
         boolean targetStackReady = r2Enabled && privateVideoStorageReady && shakaAvailable;
         boolean mediaDomainConfigured = hasText(environment.getProperty("app.video.media-domain", ""));
-        boolean edgeAuthConfigured = isEdgeAuthConfigured();
+        String edgeAuthMode = environment.getProperty("app.video.edge-auth-mode", "disabled");
+        String edgeHmacSecret = environment.getProperty("app.video.edge-hmac-secret", "");
+        long edgeTokenExpirySeconds = longProperty("app.video.edge-token-expiry-seconds", 300L);
+        boolean edgeAuthConfigured = VideoPlaybackDeliveryPolicy.isMediaDomainEdgeAuthEnabled(
+                edgeAuthMode,
+                edgeHmacSecret,
+                edgeTokenExpirySeconds
+        );
         boolean cdnSegmentDeliveryReady = mediaDomainConfigured && edgeAuthConfigured;
+        long manifestCacheSeconds = longProperty("app.video.manifest-cache-seconds", 60L);
+        long objectRedirectCacheSeconds = longProperty("app.video.object-redirect-cache-seconds", 30L);
+        long segmentPresignTtlSeconds = longProperty("app.video.segment-presign-ttl-seconds", 120L);
+        long effectiveManifestCacheSeconds = VideoPlaybackDeliveryPolicy.effectiveManifestCacheSeconds(
+                manifestCacheSeconds,
+                edgeAuthConfigured,
+                edgeTokenExpirySeconds
+        );
+        long effectiveObjectRedirectCacheSeconds = VideoPlaybackDeliveryPolicy.effectiveObjectRedirectCacheSeconds(
+                objectRedirectCacheSeconds,
+                segmentPresignTtlSeconds
+        );
 
         Health.Builder builder = (privateVideoStorageReady || localFallbackAvailable) && shakaAvailable
                 ? Health.up()
@@ -48,8 +67,11 @@ public class VideoPipelineHealthIndicator implements HealthIndicator {
                 .withDetail("cdnSegmentDeliveryReady", cdnSegmentDeliveryReady)
                 .withDetail("mediaDomainConfigured", mediaDomainConfigured)
                 .withDetail("edgeAuthConfigured", edgeAuthConfigured)
-                .withDetail("manifestCacheSeconds", longProperty("app.video.manifest-cache-seconds", 60L))
-                .withDetail("objectRedirectCacheSeconds", longProperty("app.video.object-redirect-cache-seconds", 30L))
+                .withDetail("edgeTokenExpirySeconds", edgeTokenExpirySeconds)
+                .withDetail("manifestCacheSeconds", manifestCacheSeconds)
+                .withDetail("effectiveManifestCacheSeconds", effectiveManifestCacheSeconds)
+                .withDetail("objectRedirectCacheSeconds", objectRedirectCacheSeconds)
+                .withDetail("effectiveObjectRedirectCacheSeconds", effectiveObjectRedirectCacheSeconds)
                 .withDetail("adaptiveSegmentDurationSeconds", longProperty("app.video.adaptive-segment-duration-seconds", 6L))
                 .withDetail("binaryStorage", privateVideoStorageReady
                         ? "R2 private video bucket"
@@ -61,22 +83,6 @@ public class VideoPipelineHealthIndicator implements HealthIndicator {
                 .withDetail("shakaAvailable", shakaAvailable)
                 .withDetail("localFallbackAvailable", localFallbackAvailable)
                 .build();
-    }
-
-    private boolean isEdgeAuthConfigured() {
-        String mode = environment.getProperty("app.video.edge-auth-mode", "disabled");
-        String secret = environment.getProperty("app.video.edge-hmac-secret", "");
-        long ttl = longProperty("app.video.edge-token-expiry-seconds", 300L);
-        return "media_hmac_query".equals(normalizeEdgeAuthMode(mode)) && hasText(secret) && ttl > 0;
-    }
-
-    private String normalizeEdgeAuthMode(String mode) {
-        String normalized = mode == null ? "" : mode.trim().toLowerCase(java.util.Locale.ROOT);
-        return switch (normalized) {
-            case "media_hmac_query", "query_hmac", "hmac_query", "waf_hmac_query", "worker_hmac_query" ->
-                    "media_hmac_query";
-            default -> "disabled";
-        };
     }
 
     private long longProperty(String key, long fallback) {

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/VideoPlaybackDeliveryPolicy.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/VideoPlaybackDeliveryPolicy.java
@@ -1,0 +1,61 @@
+package com.example.lms.learning_delivery.infrastructure.service;
+
+import java.util.Locale;
+
+public final class VideoPlaybackDeliveryPolicy {
+
+    private static final long CACHE_EXPIRY_SAFETY_SECONDS = 5L;
+
+    private VideoPlaybackDeliveryPolicy() {
+    }
+
+    public static boolean isMediaDomainEdgeAuthEnabled(
+            String edgeAuthMode,
+            String edgeHmacSecret,
+            long edgeTokenExpirySeconds
+    ) {
+        return "media_hmac_query".equals(normalizeEdgeAuthMode(edgeAuthMode))
+                && edgeHmacSecret != null
+                && !edgeHmacSecret.isBlank()
+                && edgeTokenExpirySeconds > 0;
+    }
+
+    public static String normalizeEdgeAuthMode(String mode) {
+        String normalized = mode == null ? "" : mode.trim().toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "media_hmac_query", "query_hmac", "hmac_query", "waf_hmac_query", "worker_hmac_query" ->
+                    "media_hmac_query";
+            default -> "disabled";
+        };
+    }
+
+    public static long effectiveManifestCacheSeconds(
+            long configuredSeconds,
+            boolean edgeAuthEnabled,
+            long edgeTokenExpirySeconds
+    ) {
+        long ttlSeconds = Math.max(0, configuredSeconds);
+        if (!edgeAuthEnabled) {
+            return ttlSeconds;
+        }
+        return Math.min(ttlSeconds, ttlBelowSignedUrlExpiry(edgeTokenExpirySeconds));
+    }
+
+    public static long effectiveObjectRedirectCacheSeconds(
+            long configuredSeconds,
+            long segmentPresignTtlSeconds
+    ) {
+        return Math.min(Math.max(0, configuredSeconds), ttlBelowSignedUrlExpiry(segmentPresignTtlSeconds));
+    }
+
+    public static String privatePlaybackCacheControl(long ttlSeconds) {
+        if (ttlSeconds <= 0) {
+            return "private, no-store, max-age=0, s-maxage=0, must-revalidate";
+        }
+        return "private, max-age=" + ttlSeconds + ", s-maxage=0, must-revalidate";
+    }
+
+    private static long ttlBelowSignedUrlExpiry(long signedUrlExpirySeconds) {
+        return Math.max(0, signedUrlExpirySeconds - CACHE_EXPIRY_SAFETY_SECONDS);
+    }
+}

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/VideoPlaybackTokenService.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/service/VideoPlaybackTokenService.java
@@ -16,7 +16,6 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.Date;
-import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -77,19 +76,15 @@ public class VideoPlaybackTokenService {
     }
 
     public boolean isMediaDomainEdgeAuthEnabled() {
-        return "media_hmac_query".equals(normalizeEdgeAuthMode(edgeAuthMode))
-                && edgeTokenExpirySeconds > 0
-                && edgeHmacSecret != null
-                && !edgeHmacSecret.isBlank();
+        return VideoPlaybackDeliveryPolicy.isMediaDomainEdgeAuthEnabled(
+                edgeAuthMode,
+                edgeHmacSecret,
+                edgeTokenExpirySeconds
+        );
     }
 
     public String normalizeEdgeAuthMode(String mode) {
-        String normalized = mode == null ? "" : mode.trim().toLowerCase(Locale.ROOT);
-        return switch (normalized) {
-            case "media_hmac_query", "query_hmac", "hmac_query", "waf_hmac_query", "worker_hmac_query" ->
-                    "media_hmac_query";
-            default -> "disabled";
-        };
+        return VideoPlaybackDeliveryPolicy.normalizeEdgeAuthMode(mode);
     }
 
     public String mintEdgeObjectToken(String requestPath) {

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackController.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackController.java
@@ -1,7 +1,9 @@
 package com.example.lms.learning_delivery.infrastructure.web;
 
 import com.example.lms.learning_delivery.infrastructure.service.AdaptiveVideoPlaybackService;
+import com.example.lms.learning_delivery.infrastructure.service.VideoPlaybackDeliveryPolicy;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -23,6 +25,12 @@ import java.util.UUID;
 public class AdaptiveVideoPlaybackController {
 
     private final AdaptiveVideoPlaybackService adaptiveVideoPlaybackService;
+
+    @Value("${app.video.object-redirect-cache-seconds:30}")
+    private long backendObjectCacheSeconds = 30L;
+
+    @Value("${app.video.segment-presign-ttl-seconds:120}")
+    private long segmentPresignTtlSeconds = 120L;
 
     @GetMapping(value = "/{assetId}/adaptive/{token}/hls/master.m3u8", produces = "application/vnd.apple.mpegurl")
     public ResponseEntity<String> getHlsMasterManifest(
@@ -67,7 +75,9 @@ public class AdaptiveVideoPlaybackController {
         ResponseEntity.BodyBuilder builder = ResponseEntity.status(status)
                 .contentLength(object.contentLength())
                 .header(HttpHeaders.ACCEPT_RANGES, "bytes")
-                .header(HttpHeaders.CACHE_CONTROL, "private, max-age=30");
+                .header(HttpHeaders.CACHE_CONTROL, backendObjectCacheControl())
+                .header("X-Content-Type-Options", "nosniff")
+                .header(HttpHeaders.VARY, "Authorization, Cookie");
 
         if (object.contentRange() != null && !object.contentRange().isBlank()) {
             builder.header(HttpHeaders.CONTENT_RANGE, object.contentRange());
@@ -100,12 +110,22 @@ public class AdaptiveVideoPlaybackController {
         ResponseEntity.BodyBuilder builder = ResponseEntity.ok()
                 .contentLength(meta.size())
                 .header(HttpHeaders.ACCEPT_RANGES, "bytes")
-                .header(HttpHeaders.CACHE_CONTROL, "private, max-age=30");
+                .header(HttpHeaders.CACHE_CONTROL, backendObjectCacheControl())
+                .header("X-Content-Type-Options", "nosniff")
+                .header(HttpHeaders.VARY, "Authorization, Cookie");
         MediaType contentType = normalizePlaybackContentType(meta.contentType());
         if (contentType != null) {
             builder.contentType(contentType);
         }
         return builder.build();
+    }
+
+    private String backendObjectCacheControl() {
+        long effectiveSeconds = VideoPlaybackDeliveryPolicy.effectiveObjectRedirectCacheSeconds(
+                backendObjectCacheSeconds,
+                segmentPresignTtlSeconds
+        );
+        return VideoPlaybackDeliveryPolicy.privatePlaybackCacheControl(effectiveSeconds);
     }
 
     private MediaType normalizePlaybackContentType(String rawContentType) {

--- a/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/VideoPlaybackCacheHeaderFilter.java
+++ b/backend/src/main/java/com/example/lms/learning_delivery/infrastructure/web/VideoPlaybackCacheHeaderFilter.java
@@ -1,5 +1,6 @@
 package com.example.lms.learning_delivery.infrastructure.web;
 
+import com.example.lms.learning_delivery.infrastructure.service.VideoPlaybackDeliveryPolicy;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,10 +19,22 @@ import java.time.Instant;
 public class VideoPlaybackCacheHeaderFilter extends OncePerRequestFilter {
 
     @Value("${app.video.manifest-cache-seconds:60}")
-    private long manifestCacheSeconds;
+    private long manifestCacheSeconds = 60L;
 
     @Value("${app.video.object-redirect-cache-seconds:30}")
-    private long objectRedirectCacheSeconds;
+    private long objectRedirectCacheSeconds = 30L;
+
+    @Value("${app.video.segment-presign-ttl-seconds:120}")
+    private long segmentPresignTtlSeconds = 120L;
+
+    @Value("${app.video.edge-auth-mode:disabled}")
+    private String edgeAuthMode = "disabled";
+
+    @Value("${app.video.edge-hmac-secret:}")
+    private String edgeHmacSecret = "";
+
+    @Value("${app.video.edge-token-expiry-seconds:300}")
+    private long edgeTokenExpirySeconds = 300L;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
@@ -41,11 +54,11 @@ public class VideoPlaybackCacheHeaderFilter extends OncePerRequestFilter {
 
         String uri = request.getRequestURI();
         if (response.getStatus() == HttpStatus.OK.value() && isManifestPath(uri)) {
-            applyCacheHeaders(response, Math.max(10, manifestCacheSeconds));
+            applyCacheHeaders(response, effectiveManifestCacheSeconds());
             return;
         }
         if (response.getStatus() == HttpStatus.FOUND.value() && uri.endsWith("/object")) {
-            applyCacheHeaders(response, Math.max(10, objectRedirectCacheSeconds));
+            applyCacheHeaders(response, effectiveObjectRedirectCacheSeconds());
         }
     }
 
@@ -56,9 +69,38 @@ public class VideoPlaybackCacheHeaderFilter extends OncePerRequestFilter {
     }
 
     private void applyCacheHeaders(HttpServletResponse response, long ttlSeconds) {
+        response.setHeader(HttpHeaders.CACHE_CONTROL, VideoPlaybackDeliveryPolicy.privatePlaybackCacheControl(ttlSeconds));
+        response.setHeader("X-Content-Type-Options", "nosniff");
+        response.setHeader(HttpHeaders.VARY, "Authorization, Cookie");
+
+        if (ttlSeconds <= 0) {
+            response.setHeader(HttpHeaders.PRAGMA, "no-cache");
+            response.setDateHeader(HttpHeaders.EXPIRES, 0);
+            return;
+        }
+
         Instant expiresAt = Instant.now().plus(Duration.ofSeconds(ttlSeconds));
-        response.setHeader(HttpHeaders.CACHE_CONTROL, "private, max-age=" + ttlSeconds);
         response.setHeader(HttpHeaders.PRAGMA, "");
         response.setDateHeader(HttpHeaders.EXPIRES, expiresAt.toEpochMilli());
+    }
+
+    private long effectiveManifestCacheSeconds() {
+        boolean edgeAuthEnabled = VideoPlaybackDeliveryPolicy.isMediaDomainEdgeAuthEnabled(
+                edgeAuthMode,
+                edgeHmacSecret,
+                edgeTokenExpirySeconds
+        );
+        return VideoPlaybackDeliveryPolicy.effectiveManifestCacheSeconds(
+                manifestCacheSeconds,
+                edgeAuthEnabled,
+                edgeTokenExpirySeconds
+        );
+    }
+
+    private long effectiveObjectRedirectCacheSeconds() {
+        return VideoPlaybackDeliveryPolicy.effectiveObjectRedirectCacheSeconds(
+                objectRedirectCacheSeconds,
+                segmentPresignTtlSeconds
+        );
     }
 }

--- a/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/service/VideoPipelineHealthIndicatorTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/service/VideoPipelineHealthIndicatorTest.java
@@ -27,6 +27,7 @@ class VideoPipelineHealthIndicatorTest {
         when(environment.getProperty("app.video.edge-token-expiry-seconds")).thenReturn("300");
         when(environment.getProperty("app.video.manifest-cache-seconds")).thenReturn("60");
         when(environment.getProperty("app.video.object-redirect-cache-seconds")).thenReturn("30");
+        when(environment.getProperty("app.video.segment-presign-ttl-seconds")).thenReturn("120");
         when(environment.getProperty("app.video.adaptive-segment-duration-seconds")).thenReturn("6");
 
         VideoPipelineHealthIndicator indicator = new VideoPipelineHealthIndicator(
@@ -48,6 +49,9 @@ class VideoPipelineHealthIndicatorTest {
                 .containsEntry("targetStackReady", true)
                 .containsEntry("cdnSegmentDeliveryReady", true)
                 .containsEntry("cdnDeliveryMode", "Custom media domain + edge HMAC segment delivery")
+                .containsEntry("edgeTokenExpirySeconds", 300L)
+                .containsEntry("effectiveManifestCacheSeconds", 60L)
+                .containsEntry("effectiveObjectRedirectCacheSeconds", 30L)
                 .containsEntry("onlinePlayback", "R2 + Shaka adaptive playback")
                 .containsEntry("binaryStorage", "R2 private video bucket");
     }

--- a/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackControllerTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/AdaptiveVideoPlaybackControllerTest.java
@@ -46,7 +46,11 @@ class AdaptiveVideoPlaybackControllerTest {
         assertThat(response.getStatusCode().value()).isEqualTo(206);
         assertThat(response.getHeaders().getFirst(HttpHeaders.LOCATION)).isNull();
         assertThat(response.getHeaders().getFirst(HttpHeaders.ACCEPT_RANGES)).isEqualTo("bytes");
+        assertThat(response.getHeaders().getFirst(HttpHeaders.CACHE_CONTROL))
+                .isEqualTo("private, max-age=30, s-maxage=0, must-revalidate");
         assertThat(response.getHeaders().getFirst(HttpHeaders.CONTENT_RANGE)).isEqualTo("bytes 0-2/10");
+        assertThat(response.getHeaders().getFirst(HttpHeaders.VARY)).isEqualTo("Authorization, Cookie");
+        assertThat(response.getHeaders().getFirst("X-Content-Type-Options")).isEqualTo("nosniff");
         assertThat(response.getHeaders().getContentLength()).isEqualTo(bytes.length);
         assertThat(response.getHeaders().getContentType().toString()).isEqualTo("video/iso.segment");
         assertThat(response.getBody()).containsExactly(bytes);
@@ -70,6 +74,8 @@ class AdaptiveVideoPlaybackControllerTest {
         var response = controller.getObject(assetId, token, key, null);
 
         assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.CACHE_CONTROL))
+                .isEqualTo("private, max-age=30, s-maxage=0, must-revalidate");
         assertThat(response.getHeaders().getContentType().toString()).isEqualTo("video/iso.segment");
     }
 
@@ -89,6 +95,9 @@ class AdaptiveVideoPlaybackControllerTest {
         var response = controller.headObject(assetId, token, key);
 
         assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.CACHE_CONTROL))
+                .isEqualTo("private, max-age=30, s-maxage=0, must-revalidate");
+        assertThat(response.getHeaders().getFirst("X-Content-Type-Options")).isEqualTo("nosniff");
         assertThat(response.getHeaders().getContentType().toString()).isEqualTo("video/mp4");
     }
 }

--- a/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/VideoPlaybackCacheHeaderFilterTest.java
+++ b/backend/src/test/java/com/example/lms/learning_delivery/infrastructure/web/VideoPlaybackCacheHeaderFilterTest.java
@@ -3,6 +3,7 @@ package com.example.lms.learning_delivery.infrastructure.web;
 import jakarta.servlet.FilterChain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -16,8 +17,7 @@ class VideoPlaybackCacheHeaderFilterTest {
     @Test
     @DisplayName("manifest responses get short-lived private cache headers")
     void manifestResponsesGetPrivateCacheHeaders() throws Exception {
-        ReflectionTestUtils.setField(filter, "manifestCacheSeconds", 60L);
-        ReflectionTestUtils.setField(filter, "objectRedirectCacheSeconds", 30L);
+        configureDefaults();
 
         MockHttpServletRequest request = new MockHttpServletRequest("GET",
                 "/api/v3/video-assets/asset-id/adaptive/token/hls/master.m3u8");
@@ -26,15 +26,59 @@ class VideoPlaybackCacheHeaderFilterTest {
         FilterChain chain = (req, res) -> ((MockHttpServletResponse) res).setStatus(200);
         filter.doFilter(request, response, chain);
 
-        assertThat(response.getHeader("Cache-Control")).isEqualTo("private, max-age=60");
-        assertThat(response.getHeader("Pragma")).isEmpty();
+        assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL))
+                .isEqualTo("private, max-age=60, s-maxage=0, must-revalidate");
+        assertThat(response.getHeader(HttpHeaders.PRAGMA)).isEmpty();
+        assertThat(response.getHeader(HttpHeaders.VARY)).isEqualTo("Authorization, Cookie");
+        assertThat(response.getHeader("X-Content-Type-Options")).isEqualTo("nosniff");
+    }
+
+    @Test
+    @DisplayName("manifest cache is bounded below edge token expiry when media-domain auth is enabled")
+    void manifestCacheIsBoundedBelowEdgeTokenExpiry() throws Exception {
+        configureDefaults();
+        ReflectionTestUtils.setField(filter, "manifestCacheSeconds", 120L);
+        ReflectionTestUtils.setField(filter, "edgeAuthMode", "media_hmac_query");
+        ReflectionTestUtils.setField(filter, "edgeHmacSecret", "secret");
+        ReflectionTestUtils.setField(filter, "edgeTokenExpirySeconds", 30L);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET",
+                "/api/v3/video-assets/asset-id/adaptive/token/dash/manifest.mpd");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        FilterChain chain = (req, res) -> ((MockHttpServletResponse) res).setStatus(200);
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL))
+                .isEqualTo("private, max-age=25, s-maxage=0, must-revalidate");
+    }
+
+    @Test
+    @DisplayName("manifest cache is disabled when edge token expiry leaves no safe cache window")
+    void manifestCacheIsDisabledWhenEdgeTokenExpiryLeavesNoSafeWindow() throws Exception {
+        configureDefaults();
+        ReflectionTestUtils.setField(filter, "manifestCacheSeconds", 60L);
+        ReflectionTestUtils.setField(filter, "edgeAuthMode", "media_hmac_query");
+        ReflectionTestUtils.setField(filter, "edgeHmacSecret", "secret");
+        ReflectionTestUtils.setField(filter, "edgeTokenExpirySeconds", 4L);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET",
+                "/api/v3/video-assets/asset-id/adaptive/token/hls/master.m3u8");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        FilterChain chain = (req, res) -> ((MockHttpServletResponse) res).setStatus(200);
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL))
+                .isEqualTo("private, no-store, max-age=0, s-maxage=0, must-revalidate");
+        assertThat(response.getHeader(HttpHeaders.PRAGMA)).isEqualTo("no-cache");
+        assertThat(response.getDateHeader(HttpHeaders.EXPIRES)).isZero();
     }
 
     @Test
     @DisplayName("object redirect responses get shorter cache headers")
     void objectRedirectResponsesGetShorterCacheHeaders() throws Exception {
-        ReflectionTestUtils.setField(filter, "manifestCacheSeconds", 60L);
-        ReflectionTestUtils.setField(filter, "objectRedirectCacheSeconds", 30L);
+        configureDefaults();
 
         MockHttpServletRequest request = new MockHttpServletRequest("GET",
                 "/api/v3/video-assets/asset-id/adaptive/token/object");
@@ -43,6 +87,34 @@ class VideoPlaybackCacheHeaderFilterTest {
         FilterChain chain = (req, res) -> ((MockHttpServletResponse) res).setStatus(302);
         filter.doFilter(request, response, chain);
 
-        assertThat(response.getHeader("Cache-Control")).isEqualTo("private, max-age=30");
+        assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL))
+                .isEqualTo("private, max-age=30, s-maxage=0, must-revalidate");
+    }
+
+    @Test
+    @DisplayName("object redirect cache is bounded below the presigned segment TTL")
+    void objectRedirectCacheIsBoundedBelowPresignedSegmentTtl() throws Exception {
+        configureDefaults();
+        ReflectionTestUtils.setField(filter, "objectRedirectCacheSeconds", 60L);
+        ReflectionTestUtils.setField(filter, "segmentPresignTtlSeconds", 20L);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET",
+                "/api/v3/video-assets/asset-id/adaptive/token/object");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        FilterChain chain = (req, res) -> ((MockHttpServletResponse) res).setStatus(302);
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL))
+                .isEqualTo("private, max-age=15, s-maxage=0, must-revalidate");
+    }
+
+    private void configureDefaults() {
+        ReflectionTestUtils.setField(filter, "manifestCacheSeconds", 60L);
+        ReflectionTestUtils.setField(filter, "objectRedirectCacheSeconds", 30L);
+        ReflectionTestUtils.setField(filter, "segmentPresignTtlSeconds", 120L);
+        ReflectionTestUtils.setField(filter, "edgeAuthMode", "disabled");
+        ReflectionTestUtils.setField(filter, "edgeHmacSecret", "");
+        ReflectionTestUtils.setField(filter, "edgeTokenExpirySeconds", 300L);
     }
 }

--- a/docs/runbooks/CLOUDFLARE_MEDIA_DOMAIN_EDGE_AUTH_RUNBOOK.md
+++ b/docs/runbooks/CLOUDFLARE_MEDIA_DOMAIN_EDGE_AUTH_RUNBOOK.md
@@ -216,6 +216,15 @@ Doc ket qua dung muc:
 - nhung day van la synthetic distributed test, khong phai many-region real-user benchmark
 - manifest/control plane van cham hon data plane qua `media.holilihu.online`, nen phase tiep theo neu can scale nua se tiep tuc toi uu manifest path
 
+### Manifest/control-plane cache guardrails
+
+Tu phase cache-policy hardening, backend manifest/control-plane khong duoc coi la CDN data-plane:
+
+- HLS/DASH manifest response chi cache private tren client, co `s-maxage=0` de shared cache/proxy khong giu manifest co playback token.
+- Khi `VIDEO_EDGE_AUTH_MODE=media_hmac_query`, effective manifest TTL bi gioi han nho hon `VIDEO_EDGE_TOKEN_EXPIRY_SECONDS` 5 giay. Vi du edge token 300s thi manifest TTL toi da la 295s, du cau hinh `VIDEO_MANIFEST_CACHE_SECONDS` cao hon.
+- Backend `/object` fallback va object redirect cache TTL bi gioi han nho hon `VIDEO_SEGMENT_PRESIGN_TTL_SECONDS` 5 giay.
+- `/actuator/health` group `videoPipeline` expose `effectiveManifestCacheSeconds` va `effectiveObjectRedirectCacheSeconds` de smoke checklist doi chieu config that.
+
 ### Package-path nuance quan trong
 
 Shaka Packager trong repo nay ghi media references theo package root:


### PR DESCRIPTION
﻿## Description

Hardens the adaptive video CDN/control-plane cache policy so tokenized HLS/DASH manifests and backend object fallbacks stay private and cannot outlive their signed media URLs.

## Motivation

PR #495 made the player refresh playback URLs after recoverable stream/CDN failures. The next weak point is cache policy: manifests embed tokenized segment URLs, so they should remain client-private, should not be stored by shared CDN/proxy caches, and should be bounded below the edge-auth token TTL.

## Type of Change

- Reliability hardening
- CDN/cache policy improvement
- Test coverage
- Runbook documentation

## Related Issues

Refs: #495

## Changes Made

- Added `VideoPlaybackDeliveryPolicy` as the shared source of truth for edge-auth normalization, effective cache TTLs, and private playback `Cache-Control` values.
- Bound manifest cache TTL below `VIDEO_EDGE_TOKEN_EXPIRY_SECONDS` when media-domain HMAC auth is enabled.
- Bound backend `/object` fallback and redirect cache TTL below `VIDEO_SEGMENT_PRESIGN_TTL_SECONDS`.
- Added `s-maxage=0`, `must-revalidate`, `Vary: Authorization, Cookie`, and `X-Content-Type-Options: nosniff` to tokenized playback responses.
- Exposed effective playback cache TTLs in the `videoPipeline` health details.
- Updated CDN runbook notes and regression tests for manifest/object cache headers.

## Scope Note

This PR does not change Shaka packaging, R2 object layout, media-domain HMAC token format, storage retention, YouTube handling, or offline package generation. CDN data-plane caching still belongs on immutable media objects under `media.holilihu.online`; manifests remain backend control-plane responses.

## Testing Guide

1. Request a HLS or DASH adaptive manifest with media-domain edge auth enabled.
2. Confirm `Cache-Control` is private, contains `s-maxage=0`, and uses a max-age lower than the edge-token expiry.
3. Lower `VIDEO_EDGE_TOKEN_EXPIRY_SECONDS` below the safety window and confirm manifest responses become `no-store`.
4. Request a backend `/object` fallback with a `Range` header and confirm the response is still `206` with private bounded cache headers.
5. Check `/actuator/health` for `effectiveManifestCacheSeconds` and `effectiveObjectRedirectCacheSeconds`.

## Local Checks

- `mvn -q "-Dtest=VideoPlaybackCacheHeaderFilterTest,AdaptiveVideoPlaybackControllerTest,VideoPipelineHealthIndicatorTest,VideoPlaybackTokenServiceTest" test`
- `git diff --check`

## Checklist

- [x] Focused fix with no unrelated refactor
- [x] Regression tests added for CDN/control-plane cache policy
- [x] Backend targeted tests pass
- [x] PR opened ready for teammate review
