### PR TITLE
[codex] fix thumbnail snapshot cleanup

### DIFF
--- a/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/repository/FileAttachmentJpaRepository.java
+++ b/backend/src/main/java/com/example/lms/shared/infrastructure/persistence/repository/FileAttachmentJpaRepository.java
@@ -24,9 +24,9 @@ public interface FileAttachmentJpaRepository extends JpaRepository<FileAttachmen
      * The query is REFERENTIAL rather than date-based: it explicitly checks every consumer
      * column ({@code courses.thumbnail_attachment_id}, {@code courses.intro_video_attachment_id},
      * {@code users.avatar_attachment_id}, {@code assignment_submissions.file_attachment_id},
-     * {@code video_assets.source_attachment_id}) so a file in active use cannot be deleted
-     * even if its {@code entity_id} got accidentally cleared. PostgreSQL ON DELETE RESTRICT
-     * adds a second physical safety layer at the table level.
+     * {@code video_assets.source_attachment_id}) and published course snapshots so a file in
+     * active use cannot be deleted even if its {@code entity_id} got accidentally cleared.
+     * PostgreSQL ON DELETE RESTRICT adds a second physical safety layer at the table level.
      *
      * Records tagged with {@code entity_type = 'PENDING_LINK_REVIEW'} are excluded as a
      * legacy safeguard from the V129 tactical backfill — they will be reviewed manually
@@ -42,6 +42,11 @@ public interface FileAttachmentJpaRepository extends JpaRepository<FileAttachmen
           AND NOT EXISTS (SELECT 1 FROM users u                  WHERE u.avatar_attachment_id      = f.id)
           AND NOT EXISTS (SELECT 1 FROM assignment_submissions s WHERE s.file_attachment_id        = f.id)
           AND NOT EXISTS (SELECT 1 FROM video_assets v           WHERE v.source_attachment_id      = f.id)
+          AND NOT EXISTS (
+              SELECT 1 FROM course_publications cp
+              WHERE strpos(cp.snapshot::text, f.storage_path) > 0
+                 OR strpos(cp.snapshot::text, f.stored_filename) > 0
+          )
         """,
         nativeQuery = true)
     List<FileAttachmentJpaEntity> findOrphanedBefore(@Param("cutoff") Instant cutoff);

--- a/fe/src/app/features/student/student-my-courses.component.ts
+++ b/fe/src/app/features/student/student-my-courses.component.ts
@@ -172,8 +172,12 @@ interface EnhancedEnrolledCourse extends EnrolledCourse {
               <div class="course-card-wrapper">
                 <!-- Course Thumbnail -->
                 <div class="course-thumbnail">
-                  @if (course.thumbnail) {
-                    <img [src]="course.thumbnail" [alt]="course.title" class="thumbnail-image" />
+                  @if (course.thumbnail && !brokenThumbnailUrls().has(course.thumbnail)) {
+                    <img
+                      [src]="course.thumbnail"
+                      [alt]="course.title"
+                      class="thumbnail-image"
+                      (error)="markThumbnailBroken(course.thumbnail)" />
                   } @else {
                     <div class="thumbnail-placeholder">
                       <app-icon name="academic-cap" size="lg" />
@@ -1107,6 +1111,7 @@ export class StudentMyCoursesComponent implements OnInit {
   filterNotStarted = signal<boolean>(false);
   filterInProgress = signal<boolean>(false);
   filterCompleted = signal<boolean>(false);
+  brokenThumbnailUrls = signal<Set<string>>(new Set());
   error = signal<string | null>(null);
 
   // Computed
@@ -1341,6 +1346,15 @@ export class StudentMyCoursesComponent implements OnInit {
   onTabChange(tabId: string): void {
     this.activeTab.set(tabId);
     this.resetPagination();
+  }
+
+  markThumbnailBroken(thumbnailUrl: string): void {
+    this.brokenThumbnailUrls.update(urls => {
+      if (urls.has(thumbnailUrl)) {
+        return urls;
+      }
+      return new Set(urls).add(thumbnailUrl);
+    });
   }
 
   goToPage(page: number): void {


### PR DESCRIPTION
﻿## Summary
- Prevent orphan attachment cleanup from deleting files still referenced by published course snapshots.
- Fall back to the course thumbnail placeholder when a student course thumbnail fails to load.

## Root Cause
Production course publication snapshots can keep older thumbnail URLs after a course thumbnail is replaced. The orphan attachment cleanup only checked direct FK consumers, so it deleted thumbnail objects that were no longer referenced by `courses.thumbnail_attachment_id` but were still used by `course_publications.snapshot`.

## Production Remediation Already Applied
- Hotfix deployed on production VM.
- Backed up DB at `/home/Admin/LMS_hohulili/backups/lms-pre-thumbnail-fix-20260615-021519.sql.gz`.
- Backfilled 166 latest publication snapshots where old thumbnail returned 404 and current course thumbnail returned 200.
- Smoke after remediation: student enrolled course thumbnails `BROKEN=0 TOTAL=6`.

## Verification
- `mvn -Dtest=UploadCleanupSchedulerTest test`
- `npm ci --prefer-offline --no-audit`
- `npx ng build`
- Production smoke: `curl https://holilihu.online/actuator/health` -> `{"status":"UP"}`
- Production smoke: `https://holilihu.online/student/courses` -> HTTP 200
