### PR TITLE
docs(org): record deployment smoke results

### DIFF
--- a/docs/architecture/ORG_LOGIC_COMPLETION_GOAL.md
+++ b/docs/architecture/ORG_LOGIC_COMPLETION_GOAL.md
@@ -1037,3 +1037,65 @@ Debt còn lại sau Phase 3.11:
 - Chưa chạy production smoke vì chưa có image mới trên GHCR.
 - Cần tạo payout sample thật cho demo nếu muốn trình bày approve/reject/complete rõ ràng.
 - Curriculum/package/tuition policy vẫn là bước sau, chỉ thêm khi workflow học thuật và gói học được chốt.
+
+## 30. Phase 3.12 merge, deploy, and production smoke - 2026-06-26
+
+Mục tiêu của vòng này là đóng loop từ branch sạch đến runtime thật, thay vì chỉ dừng ở code đã build được.
+
+GitHub flow:
+
+- PR: `#517` - `ORG tenant workflows: academic catalog, scoped ownership, payments`.
+- Merge commit: `9e6e09401804e75e472b95da948b860c2bcfd2e9`.
+- PR CI: backend, frontend, compose, Cloudflare Worker, Docker smoke đều pass.
+- Main `Build & Deploy`: build/push backend + frontend GHCR image pass.
+
+Sự cố deploy đã gặp và cách xử lý:
+
+- Lần deploy đầu fail ở SSH vì GitHub Environment `production` vẫn trỏ VM cũ `35.187.245.201` và app dir cũ `/home/Admin/LMS_hohulili`.
+- Đã cập nhật Environment variables:
+  - `DEPLOY_HOST=34.87.45.168`
+  - `DEPLOY_USER=Admin`
+  - `DEPLOY_APP_DIR=/home/Admin/apps/LMS_hohulili`
+- Đã cập nhật Environment secrets:
+  - `DEPLOY_SSH_PRIVATE_KEY` theo key quản trị VM mới.
+  - `DEPLOY_KNOWN_HOSTS` theo host key của `34.87.45.168`.
+- Rerun `Build & Deploy` thành công.
+
+Production runtime sau deploy:
+
+```text
+VM HEAD: 9e6e09401804e75e472b95da948b860c2bcfd2e9
+containers: db, gotenberg, backend, frontend, caddy, video-worker healthy
+```
+
+Production smoke:
+
+```text
+GET https://holilihu.online/actuator/health -> 200 / UP
+GET https://holilihu.online/api/v3/courses?page=0&size=3 -> 200, totalElements=174
+HEAD https://holilihu.online/org-admin/academic -> 200
+```
+
+ORG_ADMIN smoke:
+
+```text
+login: orgadmin@maritime.edu / orgadmin123
+role: ORG_ADMIN
+organizationId: a0000000-0000-0000-0000-000000000001
+GET /api/v3/organizations/{orgId}/academic/catalog -> 200
+catalog counts: 4 departments, 4 programs, 3 cohorts, 4 class groups, 9 subjects, 9 subject-course links
+GET /api/v3/payments/admin/all?page=0&size=1 -> 200
+GET /api/v3/admin/revenue/payouts?page=0&size=1 -> 200
+```
+
+Kết luận:
+
+- Mục tiêu nền tảng của logic ORG đã vào main và chạy được trên production review runtime.
+- ORG_ADMIN đã có luồng demo thật: đăng nhập, vào route org-admin, đọc catalog học thuật VMU, xem payment/payout theo organization.
+- Chưa chuyển sang microservice; đây là quyết định đúng hiện tại theo `ponytail` và `karpathy-guidelines`: giữ monolith sạch, tenant-scoped, có test và deploy được.
+
+Debt còn lại:
+
+- Cần tạo dữ liệu payout pending/approved/completed có chủ ý nếu muốn demo thao tác duyệt rút tiền end-to-end.
+- Cần smoke UI bằng browser cho các màn `/org-admin/academic`, payment config và payout queue sau khi người dùng mở web.
+- Package/tuition/enrollment policy theo từng ORG vẫn là phase sau, chỉ thiết kế khi rule nghiệp vụ VMU được chốt cụ thể.

--- a/docs/deployment/GCP_REDEPLOY_PLAN_2026-06-23.md
+++ b/docs/deployment/GCP_REDEPLOY_PLAN_2026-06-23.md
@@ -696,3 +696,48 @@ curl -fsS https://holilihu.online/api/v3/courses?page=0\&size=1
 - `/org-admin/organization?tab=payment-config` loads config, validates negative percentages and low minimum payout.
 - `/org-admin/payouts` loads payout queue and all status filters return `200`.
 - Course/class/payment API responses remain scoped to the signed-in organization.
+
+## ORG deployment result - 2026-06-26
+
+The ORG branch was merged and deployed to the current review runtime.
+
+| Item | Value |
+|---|---|
+| PR | `#517` |
+| Merge commit | `9e6e09401804e75e472b95da948b860c2bcfd2e9` |
+| Runtime URL | `https://holilihu.online` |
+| VM IP | `34.87.45.168` |
+| VM app dir | `/home/Admin/apps/LMS_hohulili` |
+| GitHub deploy env | `production` |
+
+GitHub Environment `production` was corrected after the first failed deploy attempt:
+
+- `DEPLOY_HOST=34.87.45.168`
+- `DEPLOY_USER=Admin`
+- `DEPLOY_APP_DIR=/home/Admin/apps/LMS_hohulili`
+- `DEPLOY_SSH_PRIVATE_KEY` refreshed from the current VM admin SSH key.
+- `DEPLOY_KNOWN_HOSTS` refreshed from the current VM host key.
+
+Why this matters:
+
+- The first deploy tried the archived VM IP `35.187.245.201` and timed out.
+- Future deploys now target the active review VM and use the app directory created during the 2026-06-23 redeploy.
+
+Post-deploy production smoke:
+
+```text
+VM HEAD: 9e6e09401804e75e472b95da948b860c2bcfd2e9
+Docker: db, gotenberg, backend, frontend, caddy, video-worker healthy
+GET /actuator/health -> UP
+GET /api/v3/courses?page=0&size=3 -> 200, totalElements=174
+HEAD /org-admin/academic -> 200
+ORG_ADMIN login orgadmin@maritime.edu/orgadmin123 -> role ORG_ADMIN
+GET /api/v3/organizations/{orgId}/academic/catalog -> 200
+GET /api/v3/payments/admin/all?page=0&size=1 -> 200
+GET /api/v3/admin/revenue/payouts?page=0&size=1 -> 200
+```
+
+Important demo note:
+
+- Use `orgadmin@maritime.edu / orgadmin123` for ORG_ADMIN smoke and demo.
+- `nguyenlanhuong@maritime.edu` is currently a restored production teacher account, not the ORG_ADMIN demo account.


### PR DESCRIPTION
## Summary

Record the actual ORG deployment result after PR #517:

- merge SHA and runtime target
- corrected GitHub production deploy variables/secrets
- first deploy failure cause and fix
- production smoke results for health, courses, ORG_ADMIN login, academic catalog, payment list, and payouts

## Verification

- `git diff --check`
- Documentation-only change; deploy workflow ignores docs paths.