### PR TITLE
fix(org): seed VMU learning package from curriculum plan

### DIFF
--- a/backend/src/main/resources/db/migration/V147__seed_vmu_learning_package_default_org_fix.sql
+++ b/backend/src/main/resources/db/migration/V147__seed_vmu_learning_package_default_org_fix.sql
@@ -1,0 +1,68 @@
+-- V146 selected VMU by org code/name, but the existing VMU demo catalog is seeded
+-- under the default organization. Seed from the curriculum plan itself so the
+-- package always belongs to the same org as the plan.
+
+WITH plan AS (
+    SELECT cp.id AS curriculum_plan_id, cp.organization_id
+    FROM curriculum_plans cp
+    WHERE cp.code = 'DKT-K63-CDIO'
+    ORDER BY cp.created_at
+    LIMIT 1
+),
+pkg AS (
+    INSERT INTO learning_packages (
+        organization_id,
+        curriculum_plan_id,
+        code,
+        name,
+        description,
+        package_type,
+        price,
+        currency,
+        enrollment_policy
+    )
+    SELECT
+        organization_id,
+        curriculum_plan_id,
+        'VMU-DKT-K63-FOUNDATION',
+        'Gói nền tảng Điều khiển tàu biển K63',
+        'Gói học mẫu theo khung chương trình Điều khiển tàu biển K63, dùng để trình diễn quản lý học phí và ghi danh theo tổ chức.',
+        'CURRICULUM_BUNDLE',
+        0,
+        'VND',
+        'ORG_APPROVAL'
+    FROM plan
+    ON CONFLICT (organization_id, code) DO UPDATE
+    SET curriculum_plan_id = EXCLUDED.curriculum_plan_id,
+        name = EXCLUDED.name,
+        description = EXCLUDED.description,
+        package_type = EXCLUDED.package_type,
+        price = EXCLUDED.price,
+        currency = EXCLUDED.currency,
+        enrollment_policy = EXCLUDED.enrollment_policy,
+        status = 'ACTIVE',
+        updated_at = CURRENT_TIMESTAMP
+    RETURNING id AS package_id, organization_id
+),
+subject_candidates AS (
+    SELECT s.id AS subject_id, s.organization_id, row_number() OVER (ORDER BY s.code) AS display_order
+    FROM academic_subjects s
+    JOIN plan p ON p.organization_id = s.organization_id
+    WHERE s.code IN ('HH-SAF101', 'HH-NAV101', 'HH-ENG102', 'HH-LAW101', 'HH-NAV201', 'HH-NAV301')
+)
+INSERT INTO learning_package_items (
+    organization_id,
+    package_id,
+    subject_id,
+    display_order,
+    is_required
+)
+SELECT
+    p.organization_id,
+    p.package_id,
+    s.subject_id,
+    s.display_order,
+    TRUE
+FROM pkg p
+JOIN subject_candidates s ON s.organization_id = p.organization_id
+ON CONFLICT DO NOTHING;

--- a/docs/architecture/ORG_LOGIC_COMPLETION_GOAL.md
+++ b/docs/architecture/ORG_LOGIC_COMPLETION_GOAL.md
@@ -1142,3 +1142,20 @@ Debt còn lại sau Phase 4.1:
 - Cần thêm `organization_capabilities` để bật/tắt module như academic catalog, curriculum plan, learning packages theo từng ORG.
 - Cần thiết kế package enrollment/payment flow sau khi rule nghiệp vụ được chốt: miễn phí, cần ORG duyệt, invite-only, hoặc bắt buộc thanh toán.
 - Cần browser/API smoke sau khi branch được merge/deploy để xác nhận VMU package seed hiển thị trên review runtime.
+
+## 32. Phase 4.2 VMU learning package seed hotfix - 2026-06-26
+
+Production smoke sau khi merge Phase 4.1 cho thấy API mới hoạt động nhưng `learningPackages = 0`. Root cause là V146 chọn tổ chức theo `code = 'VMU'` hoặc tên chứa `Hàng hải`, trong khi dữ liệu academic demo đang nằm ở default organization từ V144.
+
+Thay đổi hotfix:
+
+- Thêm migration forward-only `V147__seed_vmu_learning_package_default_org_fix.sql`.
+- Chọn org từ chính `curriculum_plans.code = 'DKT-K63-CDIO'`, không phụ thuộc tên/code organization.
+- Insert/update package `VMU-DKT-K63-FOUNDATION`.
+- Insert sáu item subject thuộc cùng org với curriculum plan.
+
+Verification cần chạy trước khi coi vòng này xong:
+
+- Flyway migrate qua V147 trên DB tạm.
+- Merge/deploy lên review runtime.
+- Smoke catalog để xác nhận `learningPackages = 1` và `learningPackageItems = 6`.

--- a/docs/architecture/VMU_ORG_DOMAIN_ROADMAP_2026-06-26.md
+++ b/docs/architecture/VMU_ORG_DOMAIN_ROADMAP_2026-06-26.md
@@ -451,3 +451,26 @@ Debt after Phase B:
 - Add org capabilities / feature flags as the next minimal control layer so ORG_ADMIN UI can be shown only when an org has the relevant module enabled.
 - Add package enrollment/payment workflow only after the business rule is explicit: direct free assignment, ORG approval, invite-only, or payment-required package purchase.
 - Add search/debounce to package selectors if catalog size grows beyond the current demo volume.
+
+## 12. Phase B seed hotfix - default-org package data
+
+Status on 2026-06-26: implemented in branch `codex/vmu-package-seed-fix`.
+
+Issue found during production smoke:
+
+- V145 schema and API deployed successfully.
+- V146 ran successfully, but inserted `0` learning packages on the review runtime.
+- Root cause: V146 selected VMU by `organizations.code = 'VMU'` or organization name containing `Hàng hải`, while the existing demo academic catalog from V144 is seeded under the default organization.
+
+Fix:
+
+- Add `V147__seed_vmu_learning_package_default_org_fix.sql`.
+- Select the target organization from curriculum plan `DKT-K63-CDIO` itself.
+- Insert/update package `VMU-DKT-K63-FOUNDATION` in the same organization as the curriculum plan.
+- Insert six package subject items from the same organization.
+
+Why this is cleaner:
+
+- It avoids fragile dependence on organization display name/code.
+- It keeps the seed aligned to the academic plan that the package is meant to wrap.
+- It is forward-only and idempotent with `ON CONFLICT` guards.


### PR DESCRIPTION
## Summary
- Add V147 forward-only seed hotfix for `VMU-DKT-K63-FOUNDATION`.
- Seed the package from curriculum plan `DKT-K63-CDIO` instead of org code/name.
- Document the production smoke finding and root cause.

## Verification
- Flyway migrated through V147 on a temporary PostgreSQL 16 database.
- Post-migrate query returned `1,6` for package count and package item count.
- `git diff --check`

## Notes
- V145/V146 deployed successfully, but V146 inserted zero rows because the demo academic catalog is under the default organization.
- This keeps the fix data-driven and idempotent with `ON CONFLICT` guards.
