### PR TITLE
Vá ba lỗ hổng: nghe lén hội thoại, refresh token, nội dung không lọc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file follows the spirit of [Keep a Changelog](https://keepachangelog.com/en
 
 ## [Unreleased]
 
+### Security
+
+- Enforced conversation-topic membership, access/refresh JWT type separation, and rich-content sanitization at authoring and delivery boundaries
+
 ### Documentation
 
 - Rebuilt the canonical entrypoint docs: `README.md`, `backend/README.md`, `docs/README.md`, `docs/reference/PRODUCTION_SURFACES.md`, and `docs/testing/*`

--- a/backend/src/main/java/com/example/lms/assessment/application/usecase/CreateQuestionUseCaseV3.java
+++ b/backend/src/main/java/com/example/lms/assessment/application/usecase/CreateQuestionUseCaseV3.java
@@ -5,6 +5,7 @@ import com.example.lms.assessment.domain.model.QuestionBank;
 import com.example.lms.assessment.domain.repository.QuestionBankRepository;
 import com.example.lms.assessment.domain.repository.QuestionRepository;
 import com.example.lms.shared.domain.model.ContentBlock;
+import com.example.lms.shared.domain.service.ContentBlockSanitizer;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +33,7 @@ public class CreateQuestionUseCaseV3 {
     @Transactional
     public UUID execute(Command command) {
         log.info("Creating new question for package: {}", command.packageId());
+        List<ContentBlock> contentBlocks = ContentBlockSanitizer.sanitizeBlocks(command.contentBlocks());
 
         // Build domain model options
         List<Question.QuestionOption> domainOptions = null;
@@ -39,7 +41,7 @@ public class CreateQuestionUseCaseV3 {
             domainOptions = command.options().stream()
                     .map(opt -> Question.QuestionOption.create(
                             opt.key(),
-                            opt.contentBlocks(),
+                            ContentBlockSanitizer.sanitizeBlocks(opt.contentBlocks()),
                             opt.orderIndex() != null ? opt.orderIndex() : 0))
                     .collect(Collectors.toList());
         }
@@ -47,7 +49,7 @@ public class CreateQuestionUseCaseV3 {
         // Build domain model
         Question question = Question.builder()
                 .id(UUID.randomUUID())
-                .contentBlocks(command.contentBlocks())
+                .contentBlocks(contentBlocks)
                 .difficulty(command.difficulty())
                 .tags(command.tags())
                 .status(Question.Status.ACTIVE)

--- a/backend/src/main/java/com/example/lms/assessment/application/usecase/UpdateQuestionUseCaseV3.java
+++ b/backend/src/main/java/com/example/lms/assessment/application/usecase/UpdateQuestionUseCaseV3.java
@@ -4,6 +4,7 @@ import com.example.lms.assessment.domain.model.Question;
 import com.example.lms.assessment.domain.repository.QuestionRepository;
 import com.example.lms.shared.application.port.FileManagementPort;
 import com.example.lms.shared.domain.model.ContentBlock;
+import com.example.lms.shared.domain.service.ContentBlockSanitizer;
 import com.example.lms.shared.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -36,7 +37,7 @@ public class UpdateQuestionUseCaseV3 {
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new EntityNotFoundException("Question", questionId));
 
-        question.updateContentBlocks(command.blocks());
+        question.updateContentBlocks(ContentBlockSanitizer.sanitizeBlocks(command.blocks()));
         question.updateDifficulty(command.difficulty());
         question.updateTags(command.tags());
         question.updateQuestionType(command.questionType());
@@ -53,7 +54,7 @@ public class UpdateQuestionUseCaseV3 {
 
                 Question.QuestionOption option = Question.QuestionOption.create(
                         key,
-                        optionCommand.contentBlocks(),
+                        ContentBlockSanitizer.sanitizeBlocks(optionCommand.contentBlocks()),
                         optionCommand.orderIndex() != null ? optionCommand.orderIndex() : i
                 );
                 domainOptions.add(option);
@@ -69,7 +70,8 @@ public class UpdateQuestionUseCaseV3 {
 
                 Map<String, Object> data = new HashMap<>();
                 data.put("text", optText);
-                ContentBlock block = ContentBlock.create("text", data);
+                ContentBlock block =
+                        ContentBlock.create("text", ContentBlockSanitizer.sanitizeData(data));
 
                 Question.QuestionOption option = Question.QuestionOption.create(
                         key, List.of(block), i

--- a/backend/src/main/java/com/example/lms/assessment/infrastructure/web/QuizControllerV3.java
+++ b/backend/src/main/java/com/example/lms/assessment/infrastructure/web/QuizControllerV3.java
@@ -31,6 +31,7 @@ import com.example.lms.learning_delivery.infrastructure.persistence.JpaEnrollmen
 import com.example.lms.learning_delivery.infrastructure.persistence.JpaLearningClassRepository;
 import com.example.lms.learning_delivery.infrastructure.persistence.entity.EnrollmentJpaEntity;
 import com.example.lms.shared.domain.model.ContentBlock;
+import com.example.lms.shared.domain.service.ContentBlockSanitizer;
 import com.example.lms.shared.infrastructure.persistence.entity.PaymentTransactionJpaEntity;
 import com.example.lms.shared.infrastructure.persistence.repository.PaymentTransactionJpaRepository;
 import com.example.lms.shared.infrastructure.web.ApiResponse;
@@ -1161,10 +1162,11 @@ public class QuizControllerV3 {
     }
 
     private Map<String, Object> toQuestionMap(QuestionJpaEntity q) {
+        List<ContentBlock> contentBlocks = ContentBlockSanitizer.sanitizeBlocks(q.getContentBlocks());
         Map<String, Object> map = new HashMap<>();
         map.put("id", q.getId().toString());
-        map.put("content", extractTextFromBlocks(q.getContentBlocks()));
-        map.put("contentBlocks", q.getContentBlocks());
+        map.put("content", extractTextFromBlocks(contentBlocks));
+        map.put("contentBlocks", contentBlocks);
         map.put("questionType", q.getQuestionType() != null ? q.getQuestionType().name() : "SINGLE_CHOICE");
         map.put("correctOption", q.getCorrectOption());
         map.put("answerKey", q.getAnswerKey());
@@ -1178,11 +1180,13 @@ public class QuizControllerV3 {
 
         if (q.getOptions() != null) {
             var options = q.getOptions().stream().map(opt -> {
+                List<ContentBlock> optionBlocks =
+                        ContentBlockSanitizer.sanitizeBlocks(opt.getContentBlocks());
                 Map<String, Object> optMap = new HashMap<>();
                 optMap.put("id", opt.getId() != null ? opt.getId().toString() : null);
                 optMap.put("optionKey", opt.getKey());
-                optMap.put("content", extractTextFromBlocks(opt.getContentBlocks()));
-                optMap.put("contentBlocks", opt.getContentBlocks());
+                optMap.put("content", extractTextFromBlocks(optionBlocks));
+                optMap.put("contentBlocks", optionBlocks);
                 optMap.put("displayOrder", opt.getOrderIndex());
                 return (Map<String, Object>) optMap;
             }).toList();
@@ -1196,10 +1200,11 @@ public class QuizControllerV3 {
      * to prevent answer key leakage before submission.
      */
     private Map<String, Object> toStudentQuestionMap(QuestionJpaEntity q) {
+        List<ContentBlock> contentBlocks = ContentBlockSanitizer.sanitizeBlocks(q.getContentBlocks());
         Map<String, Object> map = new HashMap<>();
         map.put("id", q.getId().toString());
-        map.put("content", extractTextFromBlocks(q.getContentBlocks()));
-        map.put("contentBlocks", q.getContentBlocks());
+        map.put("content", extractTextFromBlocks(contentBlocks));
+        map.put("contentBlocks", contentBlocks);
         map.put("questionType", q.getQuestionType() != null ? q.getQuestionType().name() : "SINGLE_CHOICE");
         map.put("difficulty", q.getDifficulty() != null ? q.getDifficulty().name() : "MEDIUM");
         map.put("tags", q.getTags());
@@ -1209,11 +1214,13 @@ public class QuizControllerV3 {
 
         if (q.getOptions() != null) {
             var options = q.getOptions().stream().map(opt -> {
+                List<ContentBlock> optionBlocks =
+                        ContentBlockSanitizer.sanitizeBlocks(opt.getContentBlocks());
                 Map<String, Object> optMap = new HashMap<>();
                 optMap.put("id", opt.getId() != null ? opt.getId().toString() : null);
                 optMap.put("optionKey", opt.getKey());
-                optMap.put("content", extractTextFromBlocks(opt.getContentBlocks()));
-                optMap.put("contentBlocks", opt.getContentBlocks());
+                optMap.put("content", extractTextFromBlocks(optionBlocks));
+                optMap.put("contentBlocks", optionBlocks);
                 optMap.put("displayOrder", opt.getOrderIndex());
                 return (Map<String, Object>) optMap;
             }).toList();
@@ -1341,7 +1348,7 @@ public class QuizControllerV3 {
         StringBuilder sb = new StringBuilder();
         for (var block : blocks) {
             if (block.getData() == null) continue;
-            var data = block.getData();
+            var data = ContentBlockSanitizer.sanitizeData(block.getData());
             boolean found = false;
             for (String key : List.of("html", "text", "content")) {
                 Object val = data.get(key);

--- a/backend/src/main/java/com/example/lms/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/lms/config/JwtAuthenticationFilter.java
@@ -68,12 +68,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     )) {
                         return;
                     }
-                } else if (!jwtService.isTokenValid(jwt, userDetails)) {
+                } else if (!jwtService.isAccessToken(jwt) || !jwtService.isTokenValid(jwt, userDetails)) {
                     if (handleAuthenticationFailure(
                             response,
                             publicEndpoint,
                             path,
-                            "JWT token failed validation checks"
+                            "JWT token failed access-token validation checks"
                     )) {
                         return;
                     }

--- a/backend/src/main/java/com/example/lms/config/WebSocketAuthInterceptor.java
+++ b/backend/src/main/java/com/example/lms/config/WebSocketAuthInterceptor.java
@@ -1,5 +1,7 @@
 package com.example.lms.config;
 
+import com.example.lms.communication.domain.model.ConversationId;
+import com.example.lms.communication.domain.repository.ConversationRepository;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
 import com.example.lms.identity.infrastructure.security.JwtService;
 import com.example.lms.identity.infrastructure.security.UserDetailsServiceImpl;
@@ -12,11 +14,13 @@ import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import java.security.Principal;
+import java.util.UUID;
 
 /**
  * Intercepts STOMP CONNECT frames and authenticates via JWT token.
@@ -33,6 +37,9 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
     private final JwtService jwtService;
     @Lazy
     private final UserDetailsServiceImpl userDetailsService;
+    private final ConversationRepository conversationRepository;
+
+    private static final String CONVERSATION_TOPIC_PREFIX = "/topic/conversation/";
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -48,6 +55,7 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
                     UserDetails userDetails = userDetailsService.loadUserByUsername(username);
 
                     if (jwtService.isTokenValid(token, userDetails) &&
+                            jwtService.isAccessToken(token) &&
                             userDetails.isEnabled() && userDetails.isAccountNonLocked()) {
 
                         // Use user ID as Principal name for STOMP user destinations
@@ -72,7 +80,45 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
             }
         }
 
+        if (accessor != null && StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            authorizeSubscription(accessor);
+        }
+
         return message;
+    }
+
+    private void authorizeSubscription(StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+        if (destination == null || !destination.startsWith(CONVERSATION_TOPIC_PREFIX)) {
+            return;
+        }
+
+        UUID userId = authenticatedUserId(accessor);
+        UUID conversationId = parseUuid(
+                destination.substring(CONVERSATION_TOPIC_PREFIX.length()),
+                "Invalid conversation topic"
+        );
+        var conversation = conversationRepository.findById(ConversationId.of(conversationId))
+                .orElseThrow(() -> new AccessDeniedException("Conversation subscription denied"));
+        if (!conversation.hasParticipant(userId)) {
+            throw new AccessDeniedException("Conversation subscription denied");
+        }
+    }
+
+    private UUID authenticatedUserId(StompHeaderAccessor accessor) {
+        Principal user = accessor.getUser();
+        if (user == null || user.getName() == null) {
+            throw new AccessDeniedException("WebSocket subscription requires authentication");
+        }
+        return parseUuid(user.getName(), "Invalid WebSocket principal");
+    }
+
+    private UUID parseUuid(String value, String message) {
+        try {
+            return UUID.fromString(value);
+        } catch (RuntimeException e) {
+            throw new AccessDeniedException(message);
+        }
     }
 
     /**

--- a/backend/src/main/java/com/example/lms/course_authoring/application/usecase/ManageContentBlockUseCaseV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/application/usecase/ManageContentBlockUseCaseV3.java
@@ -4,6 +4,7 @@ import com.example.lms.course_authoring.domain.repository.CourseRepository;
 import com.example.lms.course_authoring.domain.repository.LessonRepositoryPort;
 import com.example.lms.learning_delivery.infrastructure.persistence.ClassTeacherJpaRepository;
 import com.example.lms.shared.domain.model.ContentBlock;
+import com.example.lms.shared.domain.service.ContentBlockSanitizer;
 import com.example.lms.shared.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
@@ -39,7 +40,7 @@ public class ManageContentBlockUseCaseV3 {
         ContentBlock block = ContentBlock.builder()
                 .id(UUID.randomUUID().toString())
                 .type(type)
-                .data(data)
+                .data(ContentBlockSanitizer.sanitizeData(data))
                 .build();
 
         List<ContentBlock> updated = new ArrayList<>(blocks);
@@ -84,7 +85,8 @@ public class ManageContentBlockUseCaseV3 {
         }
         mergedData.putAll(data);
 
-        ContentBlock updatedBlock = existingBlock.withData(mergedData);
+        ContentBlock updatedBlock =
+                existingBlock.withData(ContentBlockSanitizer.sanitizeData(mergedData));
         List<ContentBlock> updated = new ArrayList<>(blocks);
         updated.set(blockIndex, updatedBlock);
         lessonRepository.saveContentBlocks(lessonId, updated);
@@ -95,14 +97,14 @@ public class ManageContentBlockUseCaseV3 {
 
     @Transactional(readOnly = true)
     public List<ContentBlock> getBlocks(UUID lessonId) {
-        return lessonRepository.getContentBlocks(lessonId)
-                .orElseThrow(() -> new EntityNotFoundException("Lesson", lessonId));
+        return ContentBlockSanitizer.sanitizeBlocks(lessonRepository.getContentBlocks(lessonId)
+                .orElseThrow(() -> new EntityNotFoundException("Lesson", lessonId)));
     }
 
     @Transactional
     public void saveBlocks(UUID lessonId, List<ContentBlock> blocks) {
         courseDraftMutationUseCase.requireEditableCourseByLesson(lessonId);
-        lessonRepository.saveContentBlocks(lessonId, blocks);
+        lessonRepository.saveContentBlocks(lessonId, ContentBlockSanitizer.sanitizeBlocks(blocks));
         courseDraftMutationUseCase.markCourseChangedByLesson(lessonId);
     }
 
@@ -165,7 +167,7 @@ public class ManageContentBlockUseCaseV3 {
         int insertAt = (targetIndex == null || targetIndex < 0 || targetIndex > newTarget.size())
                 ? newTarget.size()
                 : targetIndex;
-        newTarget.add(insertAt, movedBlock);
+        newTarget.add(insertAt, ContentBlockSanitizer.sanitizeBlock(movedBlock));
 
         lessonRepository.saveContentBlocks(fromLessonId, newSource);
         lessonRepository.saveContentBlocks(toLessonId, newTarget);
@@ -190,7 +192,7 @@ public class ManageContentBlockUseCaseV3 {
                 }
                 merged.putAll(patch);
                 List<ContentBlock> updated = new ArrayList<>(blocks);
-                updated.set(i, block.withData(merged));
+                updated.set(i, block.withData(ContentBlockSanitizer.sanitizeData(merged)));
                 lessonRepository.saveContentBlocks(lessonId, updated);
                 return;
             }

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/service/CoursePublicationService.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/service/CoursePublicationService.java
@@ -19,6 +19,7 @@ import com.example.lms.identity.infrastructure.persistence.repository.UserJpaRep
 import com.example.lms.learning_delivery.infrastructure.persistence.JpaEnrollmentRepository;
 import com.example.lms.learning_delivery.infrastructure.service.VideoAssetPresentationService;
 import com.example.lms.shared.domain.model.ContentBlock;
+import com.example.lms.shared.domain.service.ContentBlockSanitizer;
 import com.example.lms.shared.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -190,7 +191,7 @@ public class CoursePublicationService {
         Map<String, Object> detail = new LinkedHashMap<>();
         detail.put("id", course.getId().toString());
         detail.put("title", course.getTitle());
-        detail.put("description", course.getDescription());
+        detail.put("description", ContentBlockSanitizer.sanitizeHtml(course.getDescription()));
         detail.put("thumbnailUrl", course.getThumbnailUrl());
         detail.put("status", course.getStatus().name().toLowerCase(Locale.ROOT));
         detail.put("code", course.getCode() != null ? course.getCode().getValue() : null);
@@ -201,9 +202,9 @@ public class CoursePublicationService {
         detail.put("categoryId", course.getCategoryId() != null ? course.getCategoryId().toString() : null);
         detail.put("categoryName", resolveCategoryName(course.getCategoryId()));
         detail.put("tags", course.getTags() != null ? new ArrayList<>(course.getTags()) : List.of());
-        detail.put("welcomeMessage", course.getWelcomeMessage());
-        detail.put("courseInformation", course.getCourseInformation());
-        detail.put("benefits", course.getBenefits());
+        detail.put("welcomeMessage", ContentBlockSanitizer.sanitizeHtml(course.getWelcomeMessage()));
+        detail.put("courseInformation", ContentBlockSanitizer.sanitizeHtml(course.getCourseInformation()));
+        detail.put("benefits", ContentBlockSanitizer.sanitizeHtml(course.getBenefits()));
         detail.put("introVideoUrl", course.getIntroVideoAssetId() == null ? course.getIntroVideoUrl() : null);
         if (course.getIntroVideoAssetId() != null) {
             detail.put("introVideoAssetId", course.getIntroVideoAssetId().toString());
@@ -228,6 +229,7 @@ public class CoursePublicationService {
         }
 
         Map<String, Object> detail = new LinkedHashMap<>(detailSnapshot);
+        sanitizeCourseDetailFields(detail);
         applyIntroVideoAssetView(detail, parseVideoAssetId(detail.get("introVideoAssetId")));
         return detail;
     }
@@ -243,7 +245,18 @@ public class CoursePublicationService {
             return null;
         }
 
-        return new LinkedHashMap<>((Map<String, Object>) detail);
+        Map<String, Object> snapshot = new LinkedHashMap<>((Map<String, Object>) detail);
+        sanitizeCourseDetailFields(snapshot);
+        return snapshot;
+    }
+
+    private void sanitizeCourseDetailFields(Map<String, Object> detail) {
+        for (String key : List.of("description", "welcomeMessage", "courseInformation", "benefits")) {
+            Object value = detail.get(key);
+            if (value instanceof String text) {
+                detail.put(key, ContentBlockSanitizer.sanitizeHtml(text));
+            }
+        }
     }
 
     private List<Map<String, Object>> buildCourseContent(UUID courseId) {
@@ -320,7 +333,7 @@ public class CoursePublicationService {
         );
 
         for (ContentBlock block : lesson.getContentBlocks()) {
-            Map<String, Object> data = block.getData() != null ? block.getData() : new HashMap<>();
+            Map<String, Object> data = ContentBlockSanitizer.sanitizeData(block.getData());
             String streamVideoUid = resolveSectionStreamVideoUid(lesson, block, data, videoSectionCount);
             String videoType = resolveSectionVideoType(data, streamVideoUid);
 
@@ -529,8 +542,8 @@ public class CoursePublicationService {
         Map<String, Object> simulation = new LinkedHashMap<>();
         copyIfPresent(simulation, data, "simulationPackageId");
         copyIfPresent(simulation, data, "simulationVersion");
-        copyIfPresent(simulation, data, "entryUrl");
-        copyIfPresent(simulation, data, "manifestUrl");
+        copyAllowedSimulationUrl(simulation, data, "entryUrl");
+        copyAllowedSimulationUrl(simulation, data, "manifestUrl");
         copyIfPresent(simulation, data, "estimatedSizeBytes");
         copyIfPresent(simulation, data, "allowOffline");
         copyIfPresent(simulation, data, "completionPolicy");
@@ -542,7 +555,14 @@ public class CoursePublicationService {
     private void copyIfPresent(Map<String, Object> target, Map<String, Object> source, String key) {
         Object value = source.get(key);
         if (value != null) {
-            target.put(key, value);
+            target.put(key, ContentBlockSanitizer.sanitizeValue(value));
+        }
+    }
+
+    private void copyAllowedSimulationUrl(Map<String, Object> target, Map<String, Object> source, String key) {
+        Object value = source.get(key);
+        if (ContentBlockSanitizer.isAllowedSimulationUrl(value)) {
+            target.put(key, ContentBlockSanitizer.sanitizeValue(value));
         }
     }
 
@@ -656,8 +676,10 @@ public class CoursePublicationService {
     private Map<String, Object> buildSectionQuizQuestion(QuestionJpaEntity question) {
         Map<String, Object> questionDto = new LinkedHashMap<>();
         questionDto.put("id", question.getId().toString());
-        questionDto.put("content", extractTextFromBlocks(question.getContentBlocks()));
-        questionDto.put("contentBlocks", question.getContentBlocks() != null ? question.getContentBlocks() : List.of());
+        List<ContentBlock> contentBlocks =
+                ContentBlockSanitizer.sanitizeBlocks(question.getContentBlocks());
+        questionDto.put("content", extractTextFromBlocks(contentBlocks));
+        questionDto.put("contentBlocks", contentBlocks != null ? contentBlocks : List.of());
         questionDto.put("questionType", question.getQuestionType() != null ? question.getQuestionType().name() : "SINGLE_CHOICE");
         questionDto.put("difficulty", question.getDifficulty() != null ? question.getDifficulty().name() : "MEDIUM");
         questionDto.put("correctOption", question.getCorrectOption());
@@ -667,8 +689,10 @@ public class CoursePublicationService {
             for (QuestionOptionJpaEntity option : question.getOptions()) {
                 Map<String, Object> optionDto = new LinkedHashMap<>();
                 optionDto.put("optionKey", option.getKey());
-                optionDto.put("content", extractTextFromBlocks(option.getContentBlocks()));
-                optionDto.put("contentBlocks", option.getContentBlocks() != null ? option.getContentBlocks() : List.of());
+                List<ContentBlock> optionBlocks =
+                        ContentBlockSanitizer.sanitizeBlocks(option.getContentBlocks());
+                optionDto.put("content", extractTextFromBlocks(optionBlocks));
+                optionDto.put("contentBlocks", optionBlocks != null ? optionBlocks : List.of());
                 optionDto.put("displayOrder", option.getOrderIndex() != null ? option.getOrderIndex() : 0);
                 options.add(optionDto);
             }
@@ -687,7 +711,7 @@ public class CoursePublicationService {
             if (builder.length() > 0) {
                 builder.append('\n');
             }
-            Map<String, Object> data = block.getData() != null ? block.getData() : Map.of();
+            Map<String, Object> data = ContentBlockSanitizer.sanitizeData(block.getData());
 
             // Text content (html, text, content fields)
             String html = asString(data.get("html"), null);
@@ -784,7 +808,8 @@ public class CoursePublicationService {
             return null;
         }
 
-        Map<String, Object> normalized = new LinkedHashMap<>(spec);
+        Map<String, Object> normalized =
+                new LinkedHashMap<>(ContentBlockSanitizer.sanitizeData(spec));
         normalized.putIfAbsent("version", 1);
         Object timeline = normalized.get("timeline");
         if (!(timeline instanceof List<?>)) {

--- a/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
+++ b/backend/src/main/java/com/example/lms/course_authoring/infrastructure/web/CourseQueryControllerV3.java
@@ -18,6 +18,7 @@ import com.example.lms.learning_delivery.domain.model.LearningClass;
 import com.example.lms.learning_delivery.domain.repository.LearningClassRepository;
 import com.example.lms.learning_delivery.infrastructure.service.VideoAssetPresentationService;
 import com.example.lms.identity.infrastructure.persistence.entity.UserJpaEntity;
+import com.example.lms.shared.domain.service.ContentBlockSanitizer;
 import com.example.lms.shared.infrastructure.web.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -481,7 +482,9 @@ public class CourseQueryControllerV3 {
                                             contentText = lesson.getContentBlocks().stream()
                                                 .filter(b -> "TEXT".equalsIgnoreCase(b.getType()) && b.getData() != null)
                                                 .map(b -> {
-                                                    Object c = b.getData().get("content");
+                                                    Object c = ContentBlockSanitizer
+                                                            .sanitizeData(b.getData())
+                                                            .get("content");
                                                     return c != null ? c.toString() : null;
                                                 })
                                                 .filter(java.util.Objects::nonNull)
@@ -829,7 +832,7 @@ public class CourseQueryControllerV3 {
         return CourseSummaryResponse.builder()
                 .id(course.getId().toString())
                 .title(course.getTitle())
-                .description(course.getDescription())
+                .description(ContentBlockSanitizer.sanitizeHtml(course.getDescription()))
                 .thumbnailUrl(course.getThumbnailUrl())
                 .status(course.getStatus().name().toLowerCase())
                 .teacherName(teacherName)
@@ -905,9 +908,9 @@ public class CourseQueryControllerV3 {
                 .categoryName(categoryName)
                 // Extended info
                 .tags(course.getTags() != null ? new ArrayList<>(course.getTags()) : List.of())
-                .welcomeMessage(course.getWelcomeMessage())
-                .courseInformation(course.getCourseInformation())
-                .benefits(course.getBenefits())
+                .welcomeMessage(ContentBlockSanitizer.sanitizeHtml(course.getWelcomeMessage()))
+                .courseInformation(ContentBlockSanitizer.sanitizeHtml(course.getCourseInformation()))
+                .benefits(ContentBlockSanitizer.sanitizeHtml(course.getBenefits()))
                 .introVideoUrl(introVideoUrl)
                 .introVideoAssetId(course.getIntroVideoAssetId() != null ? course.getIntroVideoAssetId().toString() : null)
                 .introVideoProcessingStatus(introAssetView != null ? introAssetView.status() : null)
@@ -1130,7 +1133,7 @@ public class CourseQueryControllerV3 {
                 extractVideoAssetIds(lesson.getContentBlocks())
         );
         for (var block : lesson.getContentBlocks()) {
-            Map<String, Object> data = block.getData() != null ? block.getData() : new HashMap<>();
+            Map<String, Object> data = ContentBlockSanitizer.sanitizeData(block.getData());
             String streamVideoUid = resolveSectionStreamVideoUid(lesson, block, data, videoSectionCount);
             String videoType = resolveSectionVideoType(data, streamVideoUid);
             SectionResponse response = SectionResponse.builder()
@@ -1183,8 +1186,8 @@ public class CourseQueryControllerV3 {
         Map<String, Object> simulation = new LinkedHashMap<>();
         copyIfPresent(simulation, data, "simulationPackageId");
         copyIfPresent(simulation, data, "simulationVersion");
-        copyIfPresent(simulation, data, "entryUrl");
-        copyIfPresent(simulation, data, "manifestUrl");
+        copyAllowedSimulationUrl(simulation, data, "entryUrl");
+        copyAllowedSimulationUrl(simulation, data, "manifestUrl");
         copyIfPresent(simulation, data, "estimatedSizeBytes");
         copyIfPresent(simulation, data, "allowOffline");
         copyIfPresent(simulation, data, "completionPolicy");
@@ -1196,7 +1199,14 @@ public class CourseQueryControllerV3 {
     private void copyIfPresent(Map<String, Object> target, Map<String, Object> source, String key) {
         Object value = source.get(key);
         if (value != null) {
-            target.put(key, value);
+            target.put(key, ContentBlockSanitizer.sanitizeValue(value));
+        }
+    }
+
+    private void copyAllowedSimulationUrl(Map<String, Object> target, Map<String, Object> source, String key) {
+        Object value = source.get(key);
+        if (ContentBlockSanitizer.isAllowedSimulationUrl(value)) {
+            target.put(key, ContentBlockSanitizer.sanitizeValue(value));
         }
     }
 
@@ -1336,7 +1346,8 @@ public class CourseQueryControllerV3 {
             return null;
         }
 
-        Map<String, Object> normalized = new LinkedHashMap<>(spec);
+        Map<String, Object> normalized =
+                new LinkedHashMap<>(ContentBlockSanitizer.sanitizeData(spec));
         normalized.putIfAbsent("version", 1);
         Object timeline = normalized.get("timeline");
         if (!(timeline instanceof List<?>)) {
@@ -1411,7 +1422,10 @@ public class CourseQueryControllerV3 {
 
             Map<String, Object> item = new LinkedHashMap<>();
             item.put("id", question.get("id") != null ? question.get("id").toString() : null);
-            item.put("content", asString(question.get("content"), ""));
+            item.put(
+                    "content",
+                    ContentBlockSanitizer.sanitizeHtml(asString(question.get("content"), ""))
+            );
             item.put("difficulty", asString(question.get("difficulty"), "MEDIUM"));
             normalized.add(item);
         }
@@ -1465,7 +1479,7 @@ public class CourseQueryControllerV3 {
         StringBuilder sb = new StringBuilder();
         for (var block : blocks) {
             if (block.getData() == null) continue;
-            var data = block.getData();
+            var data = ContentBlockSanitizer.sanitizeData(block.getData());
             Object rawText = firstNonNull(data.get("content"), data.get("text"), data.get("html"));
             if (rawText != null && !rawText.toString().isBlank()) {
                 if (!sb.isEmpty()) sb.append(" ");

--- a/backend/src/main/java/com/example/lms/identity/application/port/TokenService.java
+++ b/backend/src/main/java/com/example/lms/identity/application/port/TokenService.java
@@ -20,6 +20,11 @@ public interface TokenService {
     boolean isTokenValid(String token, String email);
 
     /**
+     * Returns true only when the token is explicitly marked for refresh use.
+     */
+    boolean isRefreshToken(String token);
+
+    /**
      * Generate a new access token for the given user.
      */
     String generateAccessToken(UUID userId, String email, String role);

--- a/backend/src/main/java/com/example/lms/identity/application/usecase/RefreshTokenUseCaseV2.java
+++ b/backend/src/main/java/com/example/lms/identity/application/usecase/RefreshTokenUseCaseV2.java
@@ -31,6 +31,10 @@ public class RefreshTokenUseCaseV2 {
             throw new BusinessRuleException("INVALID_TOKEN", "Token không hợp lệ");
         }
 
+        if (!tokenService.isRefreshToken(refreshToken)) {
+            throw new BusinessRuleException("INVALID_TOKEN_TYPE", "Token không phải refresh token");
+        }
+
         User user = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new BusinessRuleException("USER_NOT_FOUND", "Không tìm thấy người dùng"));
 

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/security/JwtService.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/security/JwtService.java
@@ -22,6 +22,10 @@ import java.util.function.Function;
 @Service
 public class JwtService {
 
+    private static final String TOKEN_TYPE_CLAIM = "typ";
+    private static final String ACCESS_TOKEN_TYPE = "access";
+    private static final String REFRESH_TOKEN_TYPE = "refresh";
+
     @Value("${app.jwt.secret}")
     private String secretKey;
 
@@ -45,15 +49,17 @@ public class JwtService {
     }
 
     public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
-        return buildToken(extraClaims, userDetails, jwtExpiration);
+        Map<String, Object> claims = new HashMap<>(extraClaims);
+        claims.put(TOKEN_TYPE_CLAIM, ACCESS_TOKEN_TYPE);
+        return buildToken(claims, userDetails, jwtExpiration);
     }
 
     public String generateRefreshToken(UserDetails userDetails) {
-        return buildToken(new HashMap<>(), userDetails, refreshExpiration);
+        return buildToken(refreshClaims(), userDetails, refreshExpiration);
     }
 
     public String generateRefreshToken(UserDetails userDetails, long expirationMs) {
-        return buildToken(new HashMap<>(), userDetails, expirationMs);
+        return buildToken(refreshClaims(), userDetails, expirationMs);
     }
 
     private String buildToken(Map<String, Object> extraClaims, UserDetails userDetails, long expiration) {
@@ -78,6 +84,24 @@ public class JwtService {
     public boolean isTokenValid(String token, UserDetails userDetails) {
         final String username = extractUsername(token);
         return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
+    }
+
+    public boolean isAccessToken(String token) {
+        return ACCESS_TOKEN_TYPE.equals(
+                extractClaim(token, claims -> claims.get(TOKEN_TYPE_CLAIM, String.class))
+        );
+    }
+
+    public boolean isRefreshToken(String token) {
+        return REFRESH_TOKEN_TYPE.equals(
+                extractClaim(token, claims -> claims.get(TOKEN_TYPE_CLAIM, String.class))
+        );
+    }
+
+    private Map<String, Object> refreshClaims() {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put(TOKEN_TYPE_CLAIM, REFRESH_TOKEN_TYPE);
+        return claims;
     }
 
     private boolean isTokenExpired(String token) {

--- a/backend/src/main/java/com/example/lms/identity/infrastructure/security/TokenServiceAdapter.java
+++ b/backend/src/main/java/com/example/lms/identity/infrastructure/security/TokenServiceAdapter.java
@@ -42,6 +42,15 @@ public class TokenServiceAdapter implements TokenService {
     }
 
     @Override
+    public boolean isRefreshToken(String token) {
+        try {
+            return jwtService.isRefreshToken(token);
+        } catch (JwtException | IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    @Override
     public String generateAccessToken(UUID userId, String email, String role) {
         Map<String, Object> claims = Map.of(
             "userId", userId.toString(),

--- a/backend/src/main/java/com/example/lms/shared/domain/service/ContentBlockSanitizer.java
+++ b/backend/src/main/java/com/example/lms/shared/domain/service/ContentBlockSanitizer.java
@@ -1,0 +1,148 @@
+package com.example.lms.shared.domain.service;
+
+import com.example.lms.shared.domain.model.ContentBlock;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Sanitizes teacher-authored rich content before it crosses learner/admin browser boundaries.
+ */
+public final class ContentBlockSanitizer {
+
+    private static final Pattern DANGEROUS_ELEMENTS = Pattern.compile(
+            "(?is)<\\s*(script|style|iframe|object|embed|link|meta|base|form)\\b[^>]*>.*?<\\s*/\\s*\\1\\s*>"
+                    + "|<\\s*(script|style|iframe|object|embed|link|meta|base|form)\\b[^>]*/?>"
+    );
+    private static final Pattern EVENT_HANDLER_ATTRIBUTES = Pattern.compile(
+            "(?is)\\s+on[a-z0-9_:-]+\\s*=\\s*(\"[^\"]*\"|'[^']*'|[^\\s>]+)"
+    );
+    private static final Pattern SRCDOC_ATTRIBUTE = Pattern.compile(
+            "(?is)\\s+srcdoc\\s*=\\s*(\"[^\"]*\"|'[^']*'|[^\\s>]+)"
+    );
+    private static final Pattern SCRIPT_PROTOCOL = Pattern.compile("(?is)(java\\s*script|vb\\s*script)\\s*:");
+    private static final Pattern DANGEROUS_DATA_URL = Pattern.compile("(?is)data\\s*:\\s*(text/html|image/svg\\+xml)");
+
+    private ContentBlockSanitizer() {
+    }
+
+    public static List<ContentBlock> sanitizeBlocks(List<ContentBlock> blocks) {
+        if (blocks == null) {
+            return null;
+        }
+        return blocks.stream()
+                .map(ContentBlockSanitizer::sanitizeBlock)
+                .toList();
+    }
+
+    public static ContentBlock sanitizeBlock(ContentBlock block) {
+        if (block == null) {
+            return null;
+        }
+        return block.withData(sanitizeData(block.getData()));
+    }
+
+    public static Map<String, Object> sanitizeData(Map<String, Object> data) {
+        if (data == null || data.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, Object> sanitized = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : data.entrySet()) {
+            String key = entry.getKey();
+            sanitized.put(key, sanitizeValue(entry.getValue(), isUrlField(key)));
+        }
+        return sanitized;
+    }
+
+    public static Object sanitizeValue(Object value) {
+        return sanitizeValue(value, false);
+    }
+
+    private static Object sanitizeValue(Object value, boolean urlField) {
+        if (value instanceof String text) {
+            if (text.indexOf('<') >= 0) {
+                return sanitizeHtml(text);
+            }
+            return urlField && startsWithDangerousProtocol(text) ? "about:blank" : text;
+        }
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> sanitized = new LinkedHashMap<>();
+            map.forEach((key, item) -> {
+                String field = String.valueOf(key);
+                sanitized.put(field, sanitizeValue(item, isUrlField(field)));
+            });
+            return sanitized;
+        }
+        if (value instanceof List<?> list) {
+            List<Object> sanitized = new ArrayList<>(list.size());
+            for (Object item : list) {
+                sanitized.add(sanitizeValue(item, urlField));
+            }
+            return sanitized;
+        }
+        return value;
+    }
+
+    public static String sanitizeHtml(String value) {
+        if (value == null || value.isBlank()) {
+            return value;
+        }
+
+        String sanitized = DANGEROUS_ELEMENTS.matcher(value).replaceAll("");
+        sanitized = SRCDOC_ATTRIBUTE.matcher(sanitized).replaceAll("");
+        sanitized = EVENT_HANDLER_ATTRIBUTES.matcher(sanitized).replaceAll("");
+
+        String trimmed = sanitized.trim();
+        if (startsWithDangerousProtocol(trimmed)) {
+            return "about:blank";
+        }
+        sanitized = SCRIPT_PROTOCOL.matcher(sanitized).replaceAll("#blocked:");
+        sanitized = DANGEROUS_DATA_URL.matcher(sanitized).replaceAll("about:blank");
+        return sanitized;
+    }
+
+    public static boolean isAllowedSimulationUrl(Object value) {
+        if (!(value instanceof String raw) || raw.isBlank()) {
+            return false;
+        }
+
+        String url = raw.trim();
+        try {
+            URI uri = URI.create(url);
+            String path = uri.getPath() != null ? uri.getPath() : "";
+            if (!path.startsWith("/simulations/")) {
+                return false;
+            }
+            if (uri.getScheme() == null) {
+                return url.startsWith("/simulations/");
+            }
+
+            String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+            String host = uri.getHost() != null ? uri.getHost().toLowerCase(Locale.ROOT) : "";
+            if ("https".equals(scheme)) {
+                return "holilihu.online".equals(host) || "media.holilihu.online".equals(host);
+            }
+            return "http".equals(scheme) && ("localhost".equals(host) || "127.0.0.1".equals(host));
+        } catch (IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    private static boolean isUrlField(String key) {
+        return "url".equalsIgnoreCase(key);
+    }
+
+    private static boolean startsWithDangerousProtocol(String value) {
+        String normalized = value.replaceAll("\\s+", "").toLowerCase(Locale.ROOT);
+        return normalized.startsWith("javascript:")
+                || normalized.startsWith("vbscript:")
+                || normalized.startsWith("data:text/html")
+                || normalized.startsWith("data:image/svg+xml");
+    }
+}

--- a/backend/src/test/java/com/example/lms/config/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/example/lms/config/JwtAuthenticationFilterTest.java
@@ -155,6 +155,7 @@ class JwtAuthenticationFilterTest {
 
         given(jwtService.extractUsername("valid-token")).willReturn("student@maritime.edu");
         given(userDetailsService.loadUserByUsername("student@maritime.edu")).willReturn(userDetails);
+        given(jwtService.isAccessToken("valid-token")).willReturn(true);
         given(jwtService.isTokenValid("valid-token", userDetails)).willReturn(true);
 
         filter.doFilter(request, response, chain);
@@ -162,6 +163,38 @@ class JwtAuthenticationFilterTest {
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(authenticationRef.get()).isNotNull();
         assertThat(authenticationRef.get().getName()).isEqualTo("student@maritime.edu");
+    }
+
+    @Test
+    @DisplayName("refresh token on protected route returns 401 and is not authenticated")
+    void refreshTokenOnProtectedRouteReturns401() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(
+                jwtService,
+                userDetailsService,
+                new PublicApiEndpointMatcher(),
+                testObjectMapper()
+        );
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v3/student/courses/enrolled");
+        request.addHeader("Authorization", "Bearer refresh-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+        FilterChain chain = (req, res) -> chainCalled.set(true);
+
+        UserDetails userDetails = User.withUsername("student@maritime.edu")
+                .password("ignored")
+                .authorities("ROLE_STUDENT")
+                .build();
+
+        given(jwtService.extractUsername("refresh-token")).willReturn("student@maritime.edu");
+        given(userDetailsService.loadUserByUsername("student@maritime.edu")).willReturn(userDetails);
+        given(jwtService.isAccessToken("refresh-token")).willReturn(false);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(chainCalled.get()).isFalse();
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
     }
 
     private ObjectMapper testObjectMapper() {

--- a/backend/src/test/java/com/example/lms/config/WebSocketAuthInterceptorTest.java
+++ b/backend/src/test/java/com/example/lms/config/WebSocketAuthInterceptorTest.java
@@ -1,0 +1,167 @@
+package com.example.lms.config;
+
+import com.example.lms.communication.domain.model.Conversation;
+import com.example.lms.communication.domain.model.ConversationId;
+import com.example.lms.communication.domain.repository.ConversationRepository;
+import com.example.lms.identity.infrastructure.security.JwtService;
+import com.example.lms.identity.infrastructure.security.UserDetailsServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WebSocketAuthInterceptorTest {
+
+    @Mock private JwtService jwtService;
+    @Mock private UserDetailsServiceImpl userDetailsService;
+    @Mock private ConversationRepository conversationRepository;
+
+    private WebSocketAuthInterceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        interceptor = new WebSocketAuthInterceptor(jwtService, userDetailsService, conversationRepository);
+    }
+
+    @Test
+    @DisplayName("Authenticates an access token on CONNECT")
+    void authenticatesAccessTokenOnConnect() {
+        UserDetails userDetails = testUserDetails();
+        when(jwtService.extractUsername("access-token")).thenReturn(userDetails.getUsername());
+        when(userDetailsService.loadUserByUsername(userDetails.getUsername())).thenReturn(userDetails);
+        when(jwtService.isTokenValid("access-token", userDetails)).thenReturn(true);
+        when(jwtService.isAccessToken("access-token")).thenReturn(true);
+
+        Message<byte[]> message = connectMessage("access-token");
+
+        interceptor.preSend(message, null);
+
+        assertThat(StompHeaderAccessor.getAccessor(message, StompHeaderAccessor.class).getUser())
+                .isNotNull()
+                .extracting(java.security.Principal::getName)
+                .isEqualTo(userDetails.getUsername());
+    }
+
+    @Test
+    @DisplayName("Does not authenticate a refresh token on CONNECT")
+    void doesNotAuthenticateRefreshTokenOnConnect() {
+        UserDetails userDetails = testUserDetails();
+        when(jwtService.extractUsername("refresh-token")).thenReturn(userDetails.getUsername());
+        when(userDetailsService.loadUserByUsername(userDetails.getUsername())).thenReturn(userDetails);
+        when(jwtService.isTokenValid("refresh-token", userDetails)).thenReturn(true);
+        when(jwtService.isAccessToken("refresh-token")).thenReturn(false);
+
+        Message<byte[]> message = connectMessage("refresh-token");
+
+        interceptor.preSend(message, null);
+
+        assertThat(StompHeaderAccessor.getAccessor(message, StompHeaderAccessor.class).getUser()).isNull();
+    }
+
+    @Test
+    @DisplayName("Allows a participant to subscribe to their conversation topic")
+    void allowsParticipantConversationSubscription() {
+        UUID userId = UUID.randomUUID();
+        UUID otherUserId = UUID.randomUUID();
+        UUID conversationId = UUID.randomUUID();
+        when(conversationRepository.findById(ConversationId.of(conversationId)))
+                .thenReturn(Optional.of(conversation(conversationId, userId, otherUserId)));
+
+        Message<byte[]> message = subscribeMessage(userId, "/topic/conversation/" + conversationId);
+
+        assertThat(interceptor.preSend(message, null)).isSameAs(message);
+    }
+
+    @Test
+    @DisplayName("Rejects a non-participant subscription to a private conversation topic")
+    void rejectsForeignConversationSubscription() {
+        UUID userId = UUID.randomUUID();
+        UUID participantA = UUID.randomUUID();
+        UUID participantB = UUID.randomUUID();
+        UUID conversationId = UUID.randomUUID();
+        when(conversationRepository.findById(ConversationId.of(conversationId)))
+                .thenReturn(Optional.of(conversation(conversationId, participantA, participantB)));
+
+        Message<byte[]> message = subscribeMessage(userId, "/topic/conversation/" + conversationId);
+
+        assertThatThrownBy(() -> interceptor.preSend(message, null))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("Rejects unauthenticated subscription to a private conversation topic")
+    void rejectsUnauthenticatedConversationSubscription() {
+        UUID conversationId = UUID.randomUUID();
+        Message<byte[]> message = subscribeMessage(null, "/topic/conversation/" + conversationId);
+
+        assertThatThrownBy(() -> interceptor.preSend(message, null))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("Leaves unrelated STOMP destinations unchanged")
+    void leavesUnrelatedDestinationsUnchanged() {
+        Message<byte[]> message = subscribeMessage(
+                UUID.randomUUID(),
+                "/topic/announcements/course/" + UUID.randomUUID()
+        );
+
+        assertThat(interceptor.preSend(message, null)).isSameAs(message);
+    }
+
+    private Message<byte[]> subscribeMessage(UUID userId, String destination) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination(destination);
+        if (userId != null) {
+            accessor.setUser(new UsernamePasswordAuthenticationToken(userId.toString(), null));
+        }
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    private Message<byte[]> connectMessage(String token) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        accessor.setNativeHeader("Authorization", "Bearer " + token);
+        accessor.setLeaveMutable(true);
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    private UserDetails testUserDetails() {
+        return User.withUsername("student@maritime.edu")
+                .password("ignored")
+                .authorities("ROLE_STUDENT")
+                .build();
+    }
+
+    private Conversation conversation(UUID conversationId, UUID participant1, UUID participant2) {
+        return Conversation.reconstitute(
+                ConversationId.of(conversationId),
+                participant1,
+                participant2,
+                null,
+                null,
+                false,
+                false,
+                Instant.now(),
+                Instant.now()
+        );
+    }
+}

--- a/backend/src/test/java/com/example/lms/course_authoring/application/usecase/ManageContentBlockUseCaseV3Test.java
+++ b/backend/src/test/java/com/example/lms/course_authoring/application/usecase/ManageContentBlockUseCaseV3Test.java
@@ -87,6 +87,22 @@ class ManageContentBlockUseCaseV3Test {
         }
 
         @Test
+        @DisplayName("Should sanitize dangerous HTML before adding a block")
+        void shouldSanitizeDangerousHtmlBeforeAddingBlock() {
+            when(lessonRepository.getContentBlocks(lessonId)).thenReturn(Optional.of(existingBlocks));
+            Map<String, Object> data = Map.of(
+                    "html", "<p onclick=\"steal()\">Safe</p><script>alert(1)</script>",
+                    "nested", Map.of("url", "javascript:alert(1)"));
+
+            ContentBlock result = useCase.addBlock(lessonId, "text", data, userId, true);
+
+            assertThat(result.getData().get("html").toString())
+                    .isEqualTo("<p>Safe</p>");
+            assertThat(((Map<?, ?>) result.getData().get("nested")).get("url"))
+                    .isEqualTo("about:blank");
+        }
+
+        @Test
         @DisplayName("Should add block as admin without ownership")
         void shouldAddBlockAsAdmin() {
             UUID adminId = UUID.randomUUID();

--- a/backend/src/test/java/com/example/lms/identity/application/usecase/RefreshTokenUseCaseV2Test.java
+++ b/backend/src/test/java/com/example/lms/identity/application/usecase/RefreshTokenUseCaseV2Test.java
@@ -81,12 +81,29 @@ class RefreshTokenUseCaseV2Test {
                 .build();
 
         when(tokenService.extractEmail(OLD_REFRESH_TOKEN)).thenReturn(TEST_EMAIL);
+        when(tokenService.isRefreshToken(OLD_REFRESH_TOKEN)).thenReturn(true);
         when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(disabledUser));
 
         assertThatThrownBy(() -> useCase.execute(OLD_REFRESH_TOKEN))
                 .isInstanceOfSatisfying(BusinessRuleException.class,
                         exception -> assertThat(exception.getRuleName()).isEqualTo("ACCOUNT_DISABLED"));
 
+        verify(tokenService, never()).isTokenValid(anyString(), anyString());
+        verify(tokenService, never()).generateAccessToken(any(), anyString(), anyString(), any());
+        verify(tokenService, never()).generateRefreshToken(any(), anyString(), anyString(), anyLong());
+    }
+
+    @Test
+    @DisplayName("Should reject access token replayed at refresh endpoint")
+    void shouldRejectAccessTokenUsedAsRefreshToken() {
+        when(tokenService.extractEmail(OLD_REFRESH_TOKEN)).thenReturn(TEST_EMAIL);
+        when(tokenService.isRefreshToken(OLD_REFRESH_TOKEN)).thenReturn(false);
+
+        assertThatThrownBy(() -> useCase.execute(OLD_REFRESH_TOKEN))
+                .isInstanceOfSatisfying(BusinessRuleException.class,
+                        exception -> assertThat(exception.getRuleName()).isEqualTo("INVALID_TOKEN_TYPE"));
+
+        verify(userRepository, never()).findByEmail(anyString());
         verify(tokenService, never()).isTokenValid(anyString(), anyString());
         verify(tokenService, never()).generateAccessToken(any(), anyString(), anyString(), any());
         verify(tokenService, never()).generateRefreshToken(any(), anyString(), anyString(), anyLong());
@@ -121,6 +138,7 @@ class RefreshTokenUseCaseV2Test {
                 .build();
 
         when(tokenService.extractEmail(OLD_REFRESH_TOKEN)).thenReturn(TEST_EMAIL);
+        when(tokenService.isRefreshToken(OLD_REFRESH_TOKEN)).thenReturn(true);
         when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(enabledUser));
         when(tokenService.isTokenValid(OLD_REFRESH_TOKEN, TEST_EMAIL)).thenReturn(true);
         when(tokenService.generateAccessToken(eq(userId.value()), eq(TEST_EMAIL), eq("STUDENT"), isNull()))

--- a/backend/src/test/java/com/example/lms/identity/infrastructure/security/TokenServiceAdapterTest.java
+++ b/backend/src/test/java/com/example/lms/identity/infrastructure/security/TokenServiceAdapterTest.java
@@ -1,5 +1,8 @@
 package com.example.lms.identity.infrastructure.security;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.userdetails.User;
@@ -8,6 +11,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,6 +43,56 @@ class TokenServiceAdapterTest {
 
         assertThat(adapter.extractEmail(signedByOtherSecret)).isNull();
         assertThat(adapter.isTokenValid(signedByOtherSecret, userDetails.getUsername())).isFalse();
+    }
+
+    @Test
+    @DisplayName("generated access and refresh tokens carry distinct token types")
+    void generatedTokensCarryDistinctTokenTypes() {
+        JwtService jwtService = jwtService(PRIMARY_SECRET);
+        UserDetails userDetails = User.withUsername("student@maritime.edu")
+                .password("")
+                .authorities("ROLE_USER")
+                .build();
+
+        String accessToken = jwtService.generateToken(userDetails);
+        String refreshToken = jwtService.generateRefreshToken(userDetails);
+
+        String accessType = jwtService.extractClaim(accessToken, claims -> claims.get("typ", String.class));
+        String refreshType = jwtService.extractClaim(refreshToken, claims -> claims.get("typ", String.class));
+
+        assertThat(accessType).isEqualTo("access");
+        assertThat(refreshType).isEqualTo("refresh");
+    }
+
+    @Test
+    @DisplayName("isRefreshToken accepts only tokens generated for refresh use")
+    void isRefreshTokenAcceptsOnlyRefreshTokens() {
+        TokenServiceAdapter adapter = new TokenServiceAdapter(jwtService(PRIMARY_SECRET));
+        UserDetails userDetails = User.withUsername("student@maritime.edu")
+                .password("")
+                .authorities("ROLE_USER")
+                .build();
+        JwtService jwtService = jwtService(PRIMARY_SECRET);
+        String accessToken = jwtService.generateToken(userDetails);
+        String refreshToken = jwtService.generateRefreshToken(userDetails);
+
+        assertThat(adapter.isRefreshToken(accessToken)).isFalse();
+        assertThat(adapter.isRefreshToken(refreshToken)).isTrue();
+    }
+
+    @Test
+    @DisplayName("tokens issued before token typing are neither access nor refresh tokens")
+    void legacyUntypedTokensAreRejectedByBothTokenTypeChecks() {
+        JwtService jwtService = jwtService(PRIMARY_SECRET);
+        String legacyToken = Jwts.builder()
+                .subject("student@maritime.edu")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 3_600_000L))
+                .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(PRIMARY_SECRET)))
+                .compact();
+
+        assertThat(jwtService.isAccessToken(legacyToken)).isFalse();
+        assertThat(jwtService.isRefreshToken(legacyToken)).isFalse();
     }
 
     private static JwtService jwtService(String secret) {

--- a/backend/src/test/java/com/example/lms/shared/domain/service/ContentBlockSanitizerTest.java
+++ b/backend/src/test/java/com/example/lms/shared/domain/service/ContentBlockSanitizerTest.java
@@ -1,0 +1,152 @@
+package com.example.lms.shared.domain.service;
+
+import com.example.lms.shared.domain.model.ContentBlock;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContentBlockSanitizerTest {
+
+    @Test
+    @DisplayName("keeps ordinary Vietnamese prose containing online equals")
+    void sanitizeDataKeepsOnlineEqualsProse() {
+        String text = "Học online = tốt cho học viên";
+
+        assertThat(ContentBlockSanitizer.sanitizeData(Map.of("caption", text)).get("caption"))
+                .isEqualTo(text);
+    }
+
+    @Test
+    @DisplayName("keeps plain assignments beginning with on")
+    void sanitizeDataKeepsPlainAssignments() {
+        String text = "only=1 và one=2";
+
+        assertThat(ContentBlockSanitizer.sanitizeData(Map.of("text", text)).get("text"))
+                .isEqualTo(text);
+    }
+
+    @Test
+    @DisplayName("keeps JavaScript language prose outside URL fields")
+    void sanitizeDataKeepsJavaScriptLanguageProse() {
+        String text = "JavaScript: ngôn ngữ lập trình";
+
+        assertThat(ContentBlockSanitizer.sanitizeData(Map.of("caption", text)).get("caption"))
+                .isEqualTo(text);
+    }
+
+    @Test
+    @DisplayName("keeps LaTeX containing an equals sign")
+    void sanitizeDataKeepsLatexWithEquals() {
+        String latex = "\\text{online = true} \\Rightarrow x = 1";
+
+        assertThat(ContentBlockSanitizer.sanitizeData(Map.of("formula", latex)).get("formula"))
+                .isEqualTo(latex);
+    }
+
+    @Test
+    @DisplayName("removes executable HTML while keeping ordinary markup")
+    void sanitizeHtmlRemovesExecutableBrowserFeatures() {
+        String unsafe = """
+                <p onclick="alert(1)">An toàn</p>
+                <script>alert(1)</script>
+                <img src="javascript:alert(2)" onerror="steal()">
+                <iframe src="https://evil.example"></iframe>
+                """;
+
+        String sanitized = ContentBlockSanitizer.sanitizeHtml(unsafe);
+
+        assertThat(sanitized).contains("<p>An toàn</p>");
+        assertThat(sanitized).doesNotContain("onclick", "<script", "onerror", "<iframe", "javascript:");
+    }
+
+    @Test
+    @DisplayName("removes onclick from anchor HTML")
+    void sanitizeDataRemovesAnchorOnclick() {
+        String sanitized = ContentBlockSanitizer.sanitizeData(
+                Map.of("html", "<a onclick=\"x()\">Link</a>"))
+                .get("html").toString();
+
+        assertThat(sanitized).isEqualTo("<a>Link</a>");
+    }
+
+    @Test
+    @DisplayName("removes onerror from image HTML")
+    void sanitizeDataRemovesImageOnerror() {
+        String sanitized = ContentBlockSanitizer.sanitizeData(
+                Map.of("html", "<img src=x onerror=alert(1)>"))
+                .get("html").toString();
+
+        assertThat(sanitized).isEqualTo("<img src=x>");
+    }
+
+    @Test
+    @DisplayName("removes script elements")
+    void sanitizeDataRemovesScriptElement() {
+        String sanitized = ContentBlockSanitizer.sanitizeData(
+                Map.of("html", "<p>Safe</p><script>alert(1)</script>"))
+                .get("html").toString();
+
+        assertThat(sanitized).isEqualTo("<p>Safe</p>");
+    }
+
+    @Test
+    @DisplayName("removes iframe elements carrying srcdoc")
+    void sanitizeDataRemovesIframeSrcdoc() {
+        String sanitized = ContentBlockSanitizer.sanitizeData(
+                Map.of("html", "<iframe srcdoc=\"<script>alert(1)</script>\"></iframe>"))
+                .get("html").toString();
+
+        assertThat(sanitized).doesNotContain("<iframe", "srcdoc", "<script");
+    }
+
+    @Test
+    @DisplayName("blocks javascript protocol in URL fields")
+    void sanitizeDataBlocksJavascriptUrl() {
+        assertThat(ContentBlockSanitizer.sanitizeData(
+                Map.of("url", " \tjavascript:alert(1)"))).containsEntry("url", "about:blank");
+    }
+
+    @Test
+    @DisplayName("blocks HTML data protocol in URL fields")
+    void sanitizeDataBlocksHtmlDataUrl() {
+        assertThat(ContentBlockSanitizer.sanitizeData(
+                Map.of("url", "data:text/html;base64,PHNjcmlwdD4=")))
+                .containsEntry("url", "about:blank");
+    }
+
+    @Test
+    @DisplayName("recursively sanitizes content block maps and lists")
+    void sanitizeBlocksRecursivelySanitizesNestedValues() {
+        ContentBlock block = ContentBlock.create("TEXT", Map.of(
+                "html", "<img src=x onerror=alert(1)>",
+                "items", List.of(Map.of("url", "javascript:alert(1)"))
+        ));
+
+        List<ContentBlock> sanitized = ContentBlockSanitizer.sanitizeBlocks(List.of(block));
+
+        String html = sanitized.getFirst().getData().get("html").toString();
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> items =
+                (List<Map<String, Object>>) sanitized.getFirst().getData().get("items");
+        assertThat(html).doesNotContain("onerror");
+        assertThat(items.getFirst().get("url").toString()).isEqualTo("about:blank");
+    }
+
+    @Test
+    @DisplayName("allows only internal simulation entry URLs")
+    void simulationUrlAllowlistRejectsExternalOrigins() {
+        assertThat(ContentBlockSanitizer.isAllowedSimulationUrl("/simulations/bridge/index.html")).isTrue();
+        assertThat(ContentBlockSanitizer.isAllowedSimulationUrl(
+                "https://holilihu.online/simulations/bridge/index.html")).isTrue();
+        assertThat(ContentBlockSanitizer.isAllowedSimulationUrl(
+                "https://media.holilihu.online/simulations/bridge/index.html")).isTrue();
+
+        assertThat(ContentBlockSanitizer.isAllowedSimulationUrl(
+                "https://evil.example/simulations/bridge/index.html")).isFalse();
+        assertThat(ContentBlockSanitizer.isAllowedSimulationUrl("javascript:alert(1)")).isFalse();
+    }
+}


### PR DESCRIPTION
Ba bản vá này đã tồn tại trong một cây làm việc cục bộ (chậm hơn `main` 16 commit) nhưng **chưa từng lên `main`**, nên hệ thống đang chạy vẫn còn cả ba. Đây là bản chuyển lên `main` hiện tại — không chép đè, giữ nguyên mọi thay đổi `main` đã có.

## 1. Đăng ký WebSocket không kiểm quyền (nghiêm trọng nhất)

Bất kỳ ai **đã đăng nhập** cũng đăng ký được `/topic/conversation/<id>` của người khác và đọc tin nhắn riêng. Không cần quyền gì đặc biệt, chỉ cần đoán hoặc biết id hội thoại.

Nay khi nhận lệnh `SUBSCRIBE`, interceptor phân giải conversation từ đích đăng ký, tra thành viên qua `ConversationRepository`, và ném `AccessDeniedException` nếu người dùng không thuộc hội thoại.

## 2. Refresh token dùng được như access token

Token nay mang claim `typ` phân biệt `access` / `refresh`. `JwtAuthenticationFilter` chỉ chấp nhận access token — **và bước `CONNECT` của WebSocket cũng vậy**. Vá một nửa thì tiêu đề nói một đằng mã làm một nẻo, nên cả hai đường vào siết cùng luật.

## 3. Nội dung bài giảng không được lọc

Nội dung do giảng viên soạn đi thẳng tới trình duyệt của học viên và quản trị → XSS lưu trữ có thể leo thang từ giảng viên lên quản trị. Thêm `ContentBlockSanitizer` chặn thẻ nguy hiểm, thuộc tính `on*`, `srcdoc`, giao thức `javascript:`/`vbscript:`, và data URL thực thi được.

**Một chi tiết đáng lưu ý về bộ lọc.** Bản đầu áp biểu thức chính quy lên *mọi* chuỗi, và một câu tiếng Việt bình thường như `"Học online = tốt"` khớp mẫu thuộc tính sự kiện nên **bị cắt âm thầm**. Đã kiểm chứng và sửa: chỉ bóc cấu trúc HTML khi chuỗi thật sự chứa HTML; với chuỗi thường thì chỉ chặn khi nó *bắt đầu bằng* giao thức nguy hiểm — đúng dạng tấn công qua trường `url` của khối ảnh/video. Có kiểm thử cả hai chiều.

## ⚠️ Lưu ý khi triển khai

Token phát hành **trước** thay đổi này không có claim `typ` nên sẽ bị từ chối. **Mọi người đang đăng nhập sẽ phải đăng nhập lại một lần.** Nên chọn thời điểm triển khai phù hợp.

## Kiểm chứng

`mvn -B test` tại máy: **1283 test, 0 failures, 0 errors, BUILD SUCCESS.**

## Việc còn lại (cố ý không gộp vào bản vá khẩn này)

| Mức | Việc |
|---|---|
| Trung bình | `/topic/announcements/course/<id>` **chưa** kiểm quyền. Chưa vá vì chưa rõ thông báo khoá học có phải dữ liệu riêng tư không — cần xác nhận hợp đồng nghiệp vụ. |
| Trung bình | Bộ lọc dùng regex, **không phải** bộ phân tích HTML theo allowlist. Payload mã hoá kiểu `java&#x73;cript:` vẫn có thể lọt. Nên thay bằng OWASP Java HTML Sanitizer hoặc jsoup Safelist — cần chốt trước danh sách thẻ được phép. **Đừng coi đây là biên XSS hoàn chỉnh.** |
| Thấp | Vẫn còn controller trả nội dung không qua bộ lọc (`PackageControllerV3`, `QuestionControllerV3`, `QuestionBankControllerV3`). Cách bền là làm sạch tại một biên kết xuất duy nhất thay vì thêm lời gọi rải rác. |

Ngoài ra, cây cục bộ nói trên còn một số bộ kiểm thử chưa lên `main` (Sepay, chia doanh thu, rubric, video bài giảng, tải tệp). Chúng phụ thuộc vào các thay đổi khác nên không đưa vào PR này; có thể làm PR riêng nếu cần.

🤖 Generated with [Claude Code](https://claude.com/claude-code)